### PR TITLE
Fix edit forms to use default value

### DIFF
--- a/src/Crud.php
+++ b/src/Crud.php
@@ -939,7 +939,7 @@ class Crud
             $new_field = [
                                 'name'       => $field,
                                 'label'      => ucfirst($field),
-                                'value'      => '', 'default' => $this->field_types[$field]['default'],
+                                'value'      => null, 'default' => $this->field_types[$field]['default'],
                                 'type'       => $this->getFieldTypeFromDbColumnType($field),
                                 'values'     => [],
                                 'attributes' => [],


### PR DESCRIPTION
There was an issue where the getUpdateFields would not properly grab the value from the model as the value is defaulted to '' instead of null when using setFromDb().

Defaulting the value to null fixed the issue in our basic test application.