### PR TITLE
added view input field

### DIFF
--- a/src/resources/views/fields/view.blade.php
+++ b/src/resources/views/fields/view.blade.php
@@ -1,0 +1,5 @@
+<!-- view field -->
+
+<div @include('crud::inc.field_wrapper_attributes') >
+  @include($field['view'], compact('crud', 'entry', 'field'))
+</div>


### PR DESCRIPTION
This PR adds a input field of type `view`. The idea here is to be able to add custom form inputs outside of what Backpack provides. The actual use case I am using this for is to add behavior buttons to one of my models. For example:

*resources/views/partials/send-password-reset.blade.php:*
```php
  <a href="{{ url($crud->route, [ $entry->id, 'send-password-reset']) }}" class="btn btn-primary ladda-button">Send Password Reset</a>
```

*app/Http/Controllers/Admin/UserCrudController.php:*
```php
class UserCrudController extends CrudController {

    public function __construct() {
        parent::__construct();

        // ... stuff ...
        $this->crud->addField([
            'name' => 'send-password-reset',
            'type' => 'view',
            'view' => 'partials/send-password-reset'
        ],'update');

       // ... more stuff ...
    }
}
```

Which gives us this!
![screen shot 2016-09-09 at 4 55 30 pm](https://cloud.githubusercontent.com/assets/314009/18406156/456138dc-76ae-11e6-8c46-8734a72cf711.png)
