### PR TITLE
Specific image uploader with previews

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -189,7 +189,7 @@ trait CrudTrait
     }
 
     /**
-     * Handles the retrieval of an image by variant:
+     * Handles the retrieval of an image by variant:.
      *
      * @param  [type] $attribute        Name of the attribute within the model that contains the json
      * @param  [type] $variant          Name of the variant you want to extract
@@ -200,19 +200,18 @@ trait CrudTrait
         $image = $this->attributes['image'];
         $url = null;
 
-        if( !empty($image) ){
-
-            if( !is_array($image) ){
+        if (! empty($image)) {
+            if (! is_array($image)) {
                 $image = json_decode($image);
             }
 
-            if( $disk ){
+            if ($disk) {
                 $url = \Storage::disk($disk)->url(trim($image->{$variant}, '/'));
-            }
-            else {
+            } else {
                 $url = url($image->{$variant});
             }
         }
+
         return $url;
     }
 
@@ -235,18 +234,18 @@ trait CrudTrait
      */
     public function uploadImageToDisk($value, $attribute_name, $disk, $destination_path, $variations = null)
     {
-        if (!$variations || !is_array($variations)) {
-            $variations = ['original' => null, 'thumb' => [150,150]];
+        if (! $variations || ! is_array($variations)) {
+            $variations = ['original' => null, 'thumb' => [150, 150]];
         }
 
         //Needed for the original image
-        if( !array_key_exists('original', $variations) ){
+        if (! array_key_exists('original', $variations)) {
             $variations['original'] = null;
         }
 
         //Needed for admin thumbnails
-        if( !array_key_exists('thumb', $variations) ){
-            $variations['thumb'] = [150,150];
+        if (! array_key_exists('thumb', $variations)) {
+            $variations['thumb'] = [150, 150];
         }
 
         $request = \Request::instance();
@@ -257,10 +256,9 @@ trait CrudTrait
         $disk_root = $disk_config['root'];
 
         //if the disk is public, we need to know the public path
-        if( $disk_config['visibility'] == 'public' ){
+        if ($disk_config['visibility'] == 'public') {
             $public_path = str_replace(public_path(), '', $disk_root);
-        }
-        else {
+        } else {
             $public_path = $disk_root;
         }
 
@@ -268,7 +266,7 @@ trait CrudTrait
         if ($request->hasFile($attribute_name) &&
             $this->{$attribute_name} &&
             is_array($this->{$attribute_name})) {
-            foreach($this->{$attribute_name} as $variant){
+            foreach ($this->{$attribute_name} as $variant) {
                 \Storage::disk($disk)->delete($variant);
             }
             $this->attributes[$attribute_name] = null;
@@ -276,9 +274,10 @@ trait CrudTrait
 
         // if the file input is empty, delete the file from the disk
         if (empty($value) && is_array($this->{$attribute_name})) {
-            foreach($this->{$attribute_name} as $variant){
+            foreach ($this->{$attribute_name} as $variant) {
                 \Storage::disk($disk)->delete($variant);
             }
+
             return $this->attributes[$attribute_name] = null;
         }
 
@@ -295,37 +294,32 @@ trait CrudTrait
             $image_variations = [];
 
             // 3. but only if they have the ability to crop/handle images
-            if(class_exists('\Intervention\Image\ImageManagerStatic')){
-
+            if (class_exists('\Intervention\Image\ImageManagerStatic')) {
                 $img = \Intervention\Image\ImageManagerStatic::make($file);
 
-                foreach( $variations as $variant => $dimensions ){
-
+                foreach ($variations as $variant => $dimensions) {
                     $variant_name = $new_file_name.'-'.$variant.'.'.$file->getClientOriginalExtension();
-                    $variant_file = $destination_path . '/' . $variant_name;
+                    $variant_file = $destination_path.'/'.$variant_name;
 
-                    if( $dimensions ){
-                        $width  = $dimensions[0];
+                    if ($dimensions) {
+                        $width = $dimensions[0];
                         $height = $dimensions[1];
 
-                        if( $img->width() > $width || $img->height() > $height ){
-                            $img->resize($width, $height, function($constraint){
+                        if ($img->width() > $width || $img->height() > $height) {
+                            $img->resize($width, $height, function ($constraint) {
                                 $constraint->aspectRatio();
                             })
                             ->save($disk_root.'/'.$variant_file);
-                        }
-                        else {
+                        } else {
                             $img->save($disk_root.'/'.$variant_file);
                         }
 
                         $image_variations[$variant] = $public_path.'/'.$variant_file;
-                    }
-                    else {
+                    } else {
                         $image_variations['original'] = $public_path.'/'.$file_path;
                     }
                 }
-            }
-            else {
+            } else {
                 $image_variations['original'] = $public_path.'/'.$file_path;
                 $image_variations['thumb'] = $public_path.'/'.$file_path;
             }

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -187,4 +187,151 @@ trait CrudTrait
 
         $this->attributes[$attribute_name] = json_encode($attribute_value);
     }
+
+    /**
+     * Handles the retrieval of an image by variant:
+     *
+     * @param  [type] $attribute        Name of the attribute within the model that contains the json
+     * @param  [type] $variant          Name of the variant you want to extract
+     * @param  [type] $disk             Filesystem disk used to store files.
+     */
+    public function getUploadedImageFromDisk($attribute, $variant = 'original', $disk = null)
+    {
+        $image = $this->attributes['image'];
+        $url = null;
+
+        if( !empty($image) ){
+
+            if( !is_array($image) ){
+                $image = json_decode($image);
+            }
+
+            if( $disk ){
+                $url = \Storage::disk($disk)->url(trim($image->{$variant}, '/'));
+            }
+            else {
+                $url = url($image->{$variant});
+            }
+        }
+        return $url;
+    }
+
+    /**
+     * Handle image upload and DB storage for a image:
+     * - on CREATE
+     *     - stores the image at the destination path
+     *     - generates a name
+     *     - creates image variations
+     *     - stores json object into database with variations and paths
+     * - on UPDATE
+     *     - if the value is null, deletes the file and sets null in the DB
+     *     - if the value is different, stores the different file and updates DB value.
+     *
+     * @param  [type] $value            Value for that column sent from the input.
+     * @param  [type] $attribute_name   Model attribute name (and column in the db).
+     * @param  [type] $disk             Filesystem disk used to store files.
+     * @param  [type] $destination_path Path in disk where to store the files.
+     * @param  [type] $variations       Array of variations and their dimensions
+     */
+    public function uploadImageToDisk($value, $attribute_name, $disk, $destination_path, $variations = null)
+    {
+        if (!$variations || !is_array($variations)) {
+            $variations = ['original' => null, 'thumb' => [150,150]];
+        }
+
+        //Needed for the original image
+        if( !array_key_exists('original', $variations) ){
+            $variations['original'] = null;
+        }
+
+        //Needed for admin thumbnails
+        if( !array_key_exists('thumb', $variations) ){
+            $variations['thumb'] = [150,150];
+        }
+
+        $request = \Request::instance();
+
+        //We need to setup the disk paths as they're handled differently
+        //depending if you need a public path or internal storage
+        $disk_config = config('filesystems.disks.'.$disk);
+        $disk_root = $disk_config['root'];
+
+        //if the disk is public, we need to know the public path
+        if( $disk_config['visibility'] == 'public' ){
+            $public_path = str_replace(public_path(), '', $disk_root);
+        }
+        else {
+            $public_path = $disk_root;
+        }
+
+        // if a new file is uploaded, delete the file from the disk
+        if ($request->hasFile($attribute_name) &&
+            $this->{$attribute_name} &&
+            is_array($this->{$attribute_name})) {
+            foreach($this->{$attribute_name} as $variant){
+                \Storage::disk($disk)->delete($variant);
+            }
+            $this->attributes[$attribute_name] = null;
+        }
+
+        // if the file input is empty, delete the file from the disk
+        if (empty($value) && is_array($this->{$attribute_name})) {
+            foreach($this->{$attribute_name} as $variant){
+                \Storage::disk($disk)->delete($variant);
+            }
+            return $this->attributes[$attribute_name] = null;
+        }
+
+        // if a new file is uploaded, store it on disk and its filename in the database
+        if ($request->hasFile($attribute_name) && $request->file($attribute_name)->isValid()) {
+
+            // 1. Generate a new file name
+            $file = $request->file($attribute_name);
+            $new_file_name = md5($file->getClientOriginalName().time());
+            $new_file = $new_file_name.'.'.$file->getClientOriginalExtension();
+
+            // 2. Move the new file to the correct path
+            $file_path = $file->storeAs($destination_path, $new_file, $disk);
+            $image_variations = [];
+
+            // 3. but only if they have the ability to crop/handle images
+            if(class_exists('\Intervention\Image\ImageManagerStatic')){
+
+                $img = \Intervention\Image\ImageManagerStatic::make($file);
+
+                foreach( $variations as $variant => $dimensions ){
+
+                    $variant_name = $new_file_name.'-'.$variant.'.'.$file->getClientOriginalExtension();
+                    $variant_file = $destination_path . '/' . $variant_name;
+
+                    if( $dimensions ){
+                        $width  = $dimensions[0];
+                        $height = $dimensions[1];
+
+                        if( $img->width() > $width || $img->height() > $height ){
+                            $img->resize($width, $height, function($constraint){
+                                $constraint->aspectRatio();
+                            })
+                            ->save($disk_root.'/'.$variant_file);
+                        }
+                        else {
+                            $img->save($disk_root.'/'.$variant_file);
+                        }
+
+                        $image_variations[$variant] = $public_path.'/'.$variant_file;
+                    }
+                    else {
+                        $image_variations['original'] = $public_path.'/'.$file_path;
+                    }
+                }
+            }
+            else {
+                $image_variations['original'] = $public_path.'/'.$file_path;
+                $image_variations['thumb'] = $public_path.'/'.$file_path;
+            }
+
+            // 3. Save the complete path to the database
+            $this->attributes[$attribute_name] = json_encode($image_variations);
+        }
+    }
 }

--- a/src/resources/views/columns/upload_image.blade.php
+++ b/src/resources/views/columns/upload_image.blade.php
@@ -1,0 +1,8 @@
+{{-- regular object attribute --}}
+<td>
+    @if ( isset($entry->{$column['name']}) && is_array($entry->{$column['name']}) )
+    <img src="{{ $entry->getUploadedImageFromDisk($column['name'], 'thumb') }}" alt="entry image preview" style="height: 25px;" />
+    @else
+    n/a
+    @endif
+</td>

--- a/src/resources/views/fields/upload_image.blade.php
+++ b/src/resources/views/fields/upload_image.blade.php
@@ -1,0 +1,53 @@
+<!-- text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+	{{-- Show the file name and a "Clear" button on EDIT form. --}}
+    @if (isset($field['value']) && is_array($field['value']) && isset($field['value']['original']))
+    <div class="well well-sm">
+    	<a title="Click to view original image" target="_blank" href="{{ $entry->getUploadedImageFromDisk($field['name']) }}">
+            <img src="{{ $entry->getUploadedImageFromDisk($field['name'], 'thumb') }}" alt="{{$field['name']}} preview" />
+        </a>
+    	<a id="{{ $field['name'] }}_file_clear_button" href="#" class="btn btn-default btn-xs pull-right" title="Clear file"><i class="fa fa-remove"></i></a>
+    	<div class="clearfix"></div>
+    </div>
+    @endif
+
+	{{-- Show the file picker on CREATE form. --}}
+	<input
+        type="file"
+        id="{{ $field['name'] }}_file_input"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) && isset($field['value']['original']) ? $field['value']['original'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes', ['default_class' =>  isset($field['value']) && is_array($field['value']) && isset($field['value']['original']) ? 'form-control hidden' : 'form-control'])
+    >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- FIELD EXTRA JS --}}
+{{-- push things in the after_scripts section --}}
+
+    @push('crud_fields_scripts')
+        <!-- no scripts -->
+        <script>
+	        $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
+	        	e.preventDefault();
+	        	$(this).parent().addClass('hidden');
+
+	        	var input = $("#{{ $field['name'] }}_file_input");
+	        	input.removeClass('hidden');
+	        	input.attr("value", "").replaceWith(input.clone(true));
+	        	// add a hidden input with the same name, so that the setXAttribute method is triggered
+	        	$("<input type='hidden' name='{{ $field['name'] }}' value=''>").insertAfter("#{{ $field['name'] }}_file_input");
+	        });
+
+	        $("#{{ $field['name'] }}_file_input").change(function() {
+	        	console.log($(this).val());
+	        	// remove the hidden input, so that the setXAttribute method is no longer triggered
+	        	$(this).next("input[type=hidden]").remove();
+	        });
+        </script>
+    @endpush


### PR DESCRIPTION
Based off the new file uploader component, this is more highly tuned for more strict image uploaders e.g "profile picture" it allows enough functionality to be highly useful, but not overly complicated to use compared to setting up dynamic drives in elfinder or generating thumbnails etc, it also allows for a handy image variation retrieval easily.

For full functionality it requires `Intervention\Image\ImageManagerStatic` however works enough without it.

Database columns marked for image storage need to be of data type TEXT or JSON as variants are stored

Usage is similar to that of `uploadFileToDisk` however this accepts a 3rd optional parameter for image variants.

Example usage would be within the Model

```php
protected $casts = [‘image’ => ‘array’];

public function setImageAttribute($value)
{
    $attribute_name = "image";
    $disk = "uploads";
    $destination_path = "folder_1/subfolder_1";

    $this->uploadImageToDisk($value, $attribute_name, $disk, $destination_path);
}
```

Then the Controller

```php
$this->crud->setColumnDetails('image', ['type' => 'upload_image']);

$this->crud->addField([
    'name'  => 'image',
    'label' => 'photo',
    'type'  => 'upload_image',
    'upload' => true
]);

```

# TODO
- [ ] Collaborate to make sure all methods of processing are agreed as the best for the end user
- [x] StyleCI Compatibility