### PR TITLE
Fixed missing use ($name) in reject calls

### DIFF
--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -76,14 +76,14 @@ trait Buttons
 
     public function removeButton($name)
     {
-        $this->buttons->reject(function ($button) {
+        $this->buttons->reject(function ($button) use ($name) {
             return $button->name == $name;
         });
     }
 
     public function removeButtonFromStack($name, $stack)
     {
-        $this->buttons->reject(function ($button) {
+        $this->buttons->reject(function ($button) use($name) {
             return $button->name == $name && $button->stack == $stack;
         });
     }

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -76,14 +76,14 @@ trait Buttons
 
     public function removeButton($name)
     {
-        $this->buttons->reject(function ($button) use ($name) {
+        $this->buttons = $this->buttons->reject(function ($button) use ($name) {
             return $button->name == $name;
         });
     }
 
     public function removeButtonFromStack($name, $stack)
     {
-        $this->buttons->reject(function ($button) use ($name, $stack) {
+        $this->buttons = $this->buttons->reject(function ($button) use ($name, $stack) {
             return $button->name == $name && $button->stack == $stack;
         });
     }

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -83,7 +83,7 @@ trait Buttons
 
     public function removeButtonFromStack($name, $stack)
     {
-        $this->buttons->reject(function ($button) use($name) {
+        $this->buttons->reject(function ($button) use ($name) {
             return $button->name == $name && $button->stack == $stack;
         });
     }

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -83,7 +83,7 @@ trait Buttons
 
     public function removeButtonFromStack($name, $stack)
     {
-        $this->buttons->reject(function ($button) use ($name) {
+        $this->buttons->reject(function ($button) use ($name, $stack) {
             return $button->name == $name && $button->stack == $stack;
         });
     }


### PR DESCRIPTION
Without use($name) it was not avaliable in lambda and causing fatal error when trying to removeButton or removeButtonFromStack