### PR TITLE
Fixed OO typo for attributes

### DIFF
--- a/src/resources/views/columns/model_function_attribute.blade.php
+++ b/src/resources/views/columns/model_function_attribute.blade.php
@@ -1,6 +1,6 @@
 {{-- custom return value via attribute --}}
 <td>
 	<?php
-	    echo $entry->{$column['function_name']}()->{$column['attribute']};
+	    echo $entry->{$column['function_name']}()->first()->{$column['attribute']};
     ?>
 </td>


### PR DESCRIPTION
Hi, when using select 2, existing objects can not be shown due to this typo.