### PR TITLE
#100 - Added missing French and undo translations

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -37,6 +37,7 @@ return [
     'restore_this_value'   => 'Restore this value',
     'from'                 => 'from',
     'to'                   => 'to',
+    'undo'                 => 'Undo',
     'revision_restored'    => 'Revision successfully restored',
 
     // CRUD table view

--- a/src/resources/lang/es/crud.php
+++ b/src/resources/lang/es/crud.php
@@ -37,6 +37,7 @@ return [
     'restore_this_value'   => 'restaurar este valor',
     'from'                 => 'de',
     'to'                   => 'a',
+    'undo'                 => 'Deshacer',
     'revision_restored'    => 'Revisión restaurado correctamente',
 
     // CRUD table view

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -29,6 +29,17 @@ return [
     'edit'                 => 'Modifier',
     'save'                 => 'Enregistrer',
 
+    // Revisions
+    'revisions'            => 'Révisions',
+    'no_revisions'         => 'Pas de révisions',
+    'created_this'          => 'Créé Cette',
+    'changed_the'          => 'Modifié le',
+    'restore_this_value'   => 'Restaurer Cette valeur',
+    'from'                 => 'De',
+    'to'                   => 'À',
+    'undo'                 => 'annuler',
+    'revision_restored'    => 'révision Restauré',
+
     // CRUD table view
     'all'                       => 'Tous les ',
     'in_the_database'           => 'en base de donnée',

--- a/src/resources/lang/it/crud.php
+++ b/src/resources/lang/it/crud.php
@@ -37,6 +37,7 @@ return [
     'restore_this_value'   => 'ripristinare questo valore',
     'from'                 => 'de parte di',
     'to'                   => 'a',
+    'undo'                 => 'Disfare',
     'revision_restored'    => 'Revisione successo restaurato',
 
     // CRUD table view

--- a/src/resources/lang/ro/crud.php
+++ b/src/resources/lang/ro/crud.php
@@ -37,6 +37,7 @@ return [
     'restore_this_value'   => 'a restabili această valoare',
     'from'                 => 'din',
     'to'                   => 'la',
+    'undo'                 => 'Anula',
     'revision_restored'    => 'Revizia restaurat cu succes',
 
     // CRUD table view


### PR DESCRIPTION
Noticed someone had added French between my last PR and it being merged, here are the translations.

Also 'undo' was missing, it has been added.