### PR TITLE
removing relational fields from ajax table query

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -324,8 +324,11 @@ class CrudController extends BaseController
 
         // add the primary key, even though you don't show it,
         // otherwise the buttons won't work
-        $columns = collect($this->crud->columns)->pluck('name')->merge($this->crud->model->getKeyName())->toArray();
-
+        //we also need to remove relational fields from the columns
+        $columns = collect($this->crud->columns)->filter(function($column, $key){
+            return !isset($column['entity']) && !isset($column['model']); //we assume this is a relational field
+        })->pluck('name')->merge($this->crud->model->getKeyName())->toArray();
+        
         // structure the response in a DataTable-friendly way
         $dataTable = new DataTable($this->crud->query, $columns);
 

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -325,10 +325,10 @@ class CrudController extends BaseController
         // add the primary key, even though you don't show it,
         // otherwise the buttons won't work
         //we also need to remove relational fields from the columns
-        $columns = collect($this->crud->columns)->filter(function($column, $key){
-            return !isset($column['entity']) && !isset($column['model']); //we assume this is a relational field
+        $columns = collect($this->crud->columns)->filter(function ($column, $key) {
+            return ! isset($column['entity']) && ! isset($column['model']); //we assume this is a relational field
         })->pluck('name')->merge($this->crud->model->getKeyName())->toArray();
-        
+
         // structure the response in a DataTable-friendly way
         $dataTable = new DataTable($this->crud->query, $columns);
 

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -322,12 +322,16 @@ class CrudController extends BaseController
     {
         $this->crud->hasAccessOrFail('list');
 
-        // add the primary key, even though you don't show it,
-        // otherwise the buttons won't work
-        $columns = collect($this->crud->columns)->filter(function ($column, $key) {
-            // we also need to remove relational fields from the columns
-            return ! isset($column['entity']) && ! isset($column['model']);
-        })->pluck('name')->merge($this->crud->model->getKeyName())->toArray();
+        // crate an array with the names of the searchable columns
+        $columns = collect($this->crud->columns)
+                    ->reject(function ($column, $key) {
+                    // the select_multiple columns are not searchable
+                        return isset($column['type']) && $column['type']=='select_multiple';
+                    })
+                    ->pluck('name')
+                    // add the primary key, otherwise the buttons won't work
+                    ->merge($this->crud->model->getKeyName())
+                    ->toArray();
 
         // structure the response in a DataTable-friendly way
         $dataTable = new DataTable($this->crud->query, $columns);

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -324,9 +324,9 @@ class CrudController extends BaseController
 
         // add the primary key, even though you don't show it,
         // otherwise the buttons won't work
-        //we also need to remove relational fields from the columns
         $columns = collect($this->crud->columns)->filter(function ($column, $key) {
-            return ! isset($column['entity']) && ! isset($column['model']); //we assume this is a relational field
+            // we also need to remove relational fields from the columns
+            return ! isset($column['entity']) && ! isset($column['model']);
         })->pluck('name')->merge($this->crud->model->getKeyName())->toArray();
 
         // structure the response in a DataTable-friendly way


### PR DESCRIPTION
DataTable cant accept the fake/relational columns, so they need
stripping from the collection first, however there might be a better way to detect these fakeish columns?