### PR TITLE
Autofocus on first field - fixes #72

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -16,10 +16,11 @@ use Backpack\CRUD\PanelTraits\Read;
 use Backpack\CRUD\PanelTraits\Reorder;
 use Backpack\CRUD\PanelTraits\Update;
 use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
+use Backpack\CRUD\PanelTraits\AutoFocus;
 
 class CrudPanel
 {
-    use Create, Read, Update, Delete, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions;
+    use Create, Read, Update, Delete, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus;
 
     // --------------
     // CRUD variables

--- a/src/PanelTraits/AutoFocus.php
+++ b/src/PanelTraits/AutoFocus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait AutoFocus
+{
+    public $autoFocusOnFirstField = true;
+
+    public function getAutoFocusOnFirstField()
+    {
+        return $this->autoFocusOnFirstField;
+    }
+
+    public function setAutoFocusOnFirstField($value)
+    {
+        return $this->autoFocusOnFirstField = (bool) $value;
+    }
+
+    public function enableAutoFocus()
+    {
+        return $this->setAutoFocusOnFirstField(true);
+    }
+
+    public function disableAutoFocus()
+    {
+        return $this->setAutoFocusOnFirstField(false);
+    }
+}

--- a/src/resources/views/form_content.blade.php
+++ b/src/resources/views/form_content.blade.php
@@ -38,30 +38,32 @@
 	<script>
         jQuery('document').ready(function($){
 
-    		// Ctrl+S and Cmd+S trigger Save button click
-    		$(document).keydown(function(e) {
-    		    if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey))
-    		    {
-    		        e.preventDefault();
-    		        // alert("Ctrl-s pressed");
-    		        $("button[type=submit]").trigger('click');
-    		        return false;
-    		    }
-    		    return true;
-    		});
+      		// Ctrl+S and Cmd+S trigger Save button click
+      		$(document).keydown(function(e) {
+      		    if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey))
+      		    {
+      		        e.preventDefault();
+      		        // alert("Ctrl-s pressed");
+      		        $("button[type=submit]").trigger('click');
+      		        return false;
+      		    }
+      		    return true;
+      		});
 
-            @if( $crud->autoFocusOnFirstField )
-            //Focus first field
+          @if( $crud->autoFocusOnFirstField )
+            //Focus on first field
             @php
-            $focusField = array_first($fields, function($field){
-                return isset($field['auto_focus']) && $field['auto_focus'] == true;
-            })
+              $focusField = array_first($fields, function($field){
+                  return isset($field['auto_focus']) && $field['auto_focus'] == true;
+              })
             @endphp
+
             @if($focusField)
-            window.focusField = $('[name="{{$focusField['name']}}"]').eq(0),
+              window.focusField = $('[name="{{$focusField['name']}}"]').eq(0),
             @else
-            var focusField = $('form').find('input, textarea, select').not('[type="hidden"]').eq(0),
+              var focusField = $('form').find('input, textarea, select').not('[type="hidden"]').eq(0),
             @endif
+
             fieldOffset = focusField.offset().top,
             scrollTolerance = $(window).height() / 2;
 
@@ -70,7 +72,7 @@
             if( fieldOffset > scrollTolerance ){
                 $('html, body').animate({scrollTop: (fieldOffset - 30)});
             }
-            @endif
+          @endif
         });
 	</script>
 @endsection

--- a/src/resources/views/form_content.blade.php
+++ b/src/resources/views/form_content.blade.php
@@ -36,16 +36,41 @@
 	@stack('crud_fields_scripts')
 
 	<script>
-		// Ctrl+S and Cmd+S trigger Save button click
-		$(document).keydown(function(e) {
-		    if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey))
-		    {
-		        e.preventDefault();
-		        // alert("Ctrl-s pressed");
-		        $("button[type=submit]").trigger('click');
-		        return false;
-		    }
-		    return true;
-		});
+        jQuery('document').ready(function($){
+
+    		// Ctrl+S and Cmd+S trigger Save button click
+    		$(document).keydown(function(e) {
+    		    if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey))
+    		    {
+    		        e.preventDefault();
+    		        // alert("Ctrl-s pressed");
+    		        $("button[type=submit]").trigger('click');
+    		        return false;
+    		    }
+    		    return true;
+    		});
+
+            @if( $crud->autoFocusOnFirstField )
+            //Focus first field
+            @php
+            $focusField = array_first($fields, function($field){
+                return isset($field['auto_focus']) && $field['auto_focus'] == true;
+            })
+            @endphp
+            @if($focusField)
+            window.focusField = $('[name="{{$focusField['name']}}"]').eq(0),
+            @else
+            var focusField = $('form').find('input, textarea, select').not('[type="hidden"]').eq(0),
+            @endif
+            fieldOffset = focusField.offset().top,
+            scrollTolerance = $(window).height() / 2;
+
+            focusField.trigger('focus');
+
+            if( fieldOffset > scrollTolerance ){
+                $('html, body').animate({scrollTop: (fieldOffset - 30)});
+            }
+            @endif
+        });
 	</script>
 @endsection


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/CRUD/issues/72


- By default, will focus on the first field within the form.

- Force a field into focus using `’auto_focus’ => true` within the setup()

- disable autofocus functionality by `$this->crud->disableAutoFocus()`

- can call enableAutoFocus, disableAutoFocus, getAutoFocusOnFirstField, setAutoFocusOnFirstField
