### PR TITLE
Remove the border of elFinder when in full screen

### DIFF
--- a/src/public/elfinder/elfinder.backpack.theme.css
+++ b/src/public/elfinder/elfinder.backpack.theme.css
@@ -5,7 +5,8 @@
  * @author Cristian Tabacitu [hello@tabacitu.ro]
  **/
 
- body.elfinder { margin:0; }
+body.elfinder { margin:0; }
+body.elfinder #elfinder.ui-widget-content { border:none; }
 
 /* input textarea */
 .elfinder input,

--- a/src/resources/views-elfinder/ckeditor4.php
+++ b/src/resources/views-elfinder/ckeditor4.php
@@ -58,7 +58,7 @@
             }).elfinder('instance');
         });
         $(window).resize(function(){
-            var h = ($(window).height())-2;
+            var h = ($(window).height());
             if($('#elfinder').height() != h){
                 $('#elfinder').height(h).resize();
             }

--- a/src/resources/views-elfinder/filepicker.php
+++ b/src/resources/views-elfinder/filepicker.php
@@ -89,7 +89,7 @@
             }).elfinder('instance');
         });
         $(window).resize(function(){
-            var h = ($(window).height())-2;
+            var h = ($(window).height());
             if($('#elfinder').height() != h){
                 $('#elfinder').height(h).resize();
             }

--- a/src/resources/views-elfinder/standalonepopup.php
+++ b/src/resources/views-elfinder/standalonepopup.php
@@ -52,7 +52,7 @@
             }).elfinder('instance');
         });
         $(window).resize(function(){
-            var h = ($(window).height())-2;
+            var h = ($(window).height());
             if($('#elfinder').height() != h){
                 $('#elfinder').height(h).resize();
             }

--- a/src/resources/views-elfinder/tinymce.php
+++ b/src/resources/views-elfinder/tinymce.php
@@ -80,7 +80,7 @@
             }).elfinder('instance');
         });
         $(window).resize(function(){
-            var h = ($(window).height())-2;
+            var h = ($(window).height());
             if($('#elfinder').height() != h){
                 $('#elfinder').height(h).resize();
             }

--- a/src/resources/views-elfinder/tinymce4.php
+++ b/src/resources/views-elfinder/tinymce4.php
@@ -60,7 +60,7 @@
             }).elfinder('instance');
         });
         $(window).resize(function(){
-            var h = ($(window).height())-2;
+            var h = ($(window).height());
             if($('#elfinder').height() != h){
                 $('#elfinder').height(h).resize();
             }


### PR DESCRIPTION
PR #185 attempted (commit 4b0e7ff) attempted to make the elFinder popup windows full screen. However, it neglected to take into account the border leaving the browser's scroll bar visible. Commit a8e474a fixed this issue by removing two pixels from the new height of the in the javascript. This proposed fix, removes that 2 pixel adjust in the javascript in favor of removing the border from the full screen windows.