### PR TITLE
[4.1][Package / Custom Field] Input Address with Google API / Google Maps

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -113,4 +113,8 @@ return [
     'table_cant_add' => 'Cannot add new :entity',
     'table_max_reached' => 'Maximum number of :max reached',
 
+    // address_google field - notification bubbles
+    'address_google_error_title' => 'Oops something went wrong...',
+    'address_google_error_message' => 'Google doesn\'t know this address.'.PHP_EOL.'The fields must be filled manually... ',
+
 ];

--- a/src/resources/lang/it/crud.php
+++ b/src/resources/lang/it/crud.php
@@ -108,4 +108,11 @@ return [
     'internal_link_placeholder' => 'Slug interno. Es: \'admin/page\' (no quotes) for \':url\'',
     'external_link' => 'Link Esterno',
 
+    //Table field
+    'table_cant_add' => 'Impossibile aggiungere nuovo :entity',
+    'table_max_reached' => 'Massimo numero di :max reggiunto',
+
+    // address_google field - notification bubbles
+    'address_google_error_title' => 'Oops qualcosa è andato storto...',
+    'address_google_error_message' => 'Google non conosce questo indirizzo.'.PHP_EOL.'I campi devono essere riempiti manualmente... ',
 ];

--- a/src/resources/views/fields/address_form_google.blade.php
+++ b/src/resources/views/fields/address_form_google.blade.php
@@ -38,6 +38,24 @@
 
 @endforeach
 
+{{-- Modal window with an error message in case Google API doesn't provide the components for the address --}}
+<div class="modal fade" id ="modal_error" role="dialog" tabindex="-1" aria-labelledby="ModalLabel" style="display: none;"> 
+	<div class="modal-dialog modal-lg" role="document"> 
+		<div class="modal-content"> 
+			<div class="modal-header"> 
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">×</span>
+				</button> 
+				<h4 class="modal-title" id="ModalLabel">Oops something went wrong...</h4> 
+			</div>
+			<div class="modal-body">
+				<p>It looks like Google doesn't provide all the info for this address... </p>
+				<p>The fields must be filled manually...</p>
+			</div>
+		</div>
+	</div> 
+</div>
+
 {{-- Note: you can use  to only load some CSS/JS once, even though there are multiple instances of it --}}
 
 {{-- ########################################## --}}
@@ -69,22 +87,34 @@
 			  	// Get the place details from the autocomplete object.
 			 	var place = autocomplete.getPlace();
 			   	var val = [];
+
+			   	if (place.address_components){ // Google API provids the components for the address
 			  	
-			  	// Get each component of the address from the place details
-			  	for (var i = 0; i < place.address_components.length; i++) {
-			    	var addressType = place.address_components[i].types[0];
-			    	val[addressType] = place.address_components[i];
-			  	}
-				
-				// Fill the corresponding field on the form if it exists.
-			  	for (var component in field.components) {
-			    	document.getElementById(field.components[component].name).readOnly = false;
-			    	if (val[component]){
-			    		document.getElementById(field.components[component].name).value = typeof val[component][field.components[component].type] !== 'undefined' ? val[component][field.components[component].type] : val[component]['long_name'];	
-			    	} else {
-			    		document.getElementById(field.components[component].name).value = '';
-			    	}
-			  	}
+				  	// Get each component of the address from the place details
+				  	for (var i = 0; i < place.address_components.length; i++) {
+				    	var addressType = place.address_components[i].types[0];
+				    	val[addressType] = place.address_components[i];
+				  	}
+					
+					// Fill the corresponding field on the form if it exists.
+				  	for (var component in field.components) {
+				    	document.getElementById(field.components[component].name).readOnly = false;
+				    	if (val[component]){
+				    		document.getElementById(field.components[component].name).value = typeof val[component][field.components[component].type] !== 'undefined' ? val[component][field.components[component].type] : val[component]['long_name'];	
+				    	} else {
+				    		document.getElementById(field.components[component].name).value = '';
+				    	}
+				  	}
+
+				} else { // Google API doesn't provide the components for the address
+					
+					for (var component in field.components) {
+						document.getElementById(field.components[component].name).value = '';
+				    	document.getElementById(field.components[component].name).readOnly = false;
+				    }
+
+				    $('#modal_error').modal('show');	
+				}
 			}
 
         </script>

--- a/src/resources/views/fields/address_form_google.blade.php
+++ b/src/resources/views/fields/address_form_google.blade.php
@@ -80,7 +80,7 @@
 			  	for (var component in field.components) {
 			    	document.getElementById(field.components[component].name).readOnly = false;
 			    	if (val[component]){
-			    		document.getElementById(field.components[component].name).value = val[component][field.components[component].type];	
+			    		document.getElementById(field.components[component].name).value = typeof val[component][field.components[component].type] !== 'undefined' ? val[component][field.components[component].type] : val[component]['long_name'];	
 			    	} else {
 			    		document.getElementById(field.components[component].name).value = '';
 			    	}

--- a/src/resources/views/fields/address_form_google.blade.php
+++ b/src/resources/views/fields/address_form_google.blade.php
@@ -11,8 +11,8 @@
     <label>{!! $field['label'] !!}</label>       
     <input 
       	type="text" 
-      	name="{{$field['name']}}" 
-      	id="{{$field['name']}}"
+      	name="{{ $field['name'] }}" 
+      	id="{{ $field['name'] }}"
       	@include('crud::inc.field_attributes')   
     >
    
@@ -28,8 +28,8 @@
 	    <label>{!! $attribute['label'] !!}</label>
 	    <input 
 	      	type="text" 
-	      	name="{{$attribute['name']}}"
-	      	id="{{$attribute['name']}}"
+	      	name="{{ $attribute['name'] }}"
+	      	id="{{ $attribute['name'] }}"
 	      	value="{{ old($attribute['name'], isset($entity_column[$attribute['name']]) ? $entity_column[$attribute['name']] : null) }}"
 	      	readonly
 	      	@include('crud::inc.field_attributes')
@@ -88,16 +88,9 @@
 			}
 
         </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key={{ env('GOOGLE_API_KEY')}}&libraries=places&callback=initAutocomplete" async defer></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ $field['google_api_key'] }}&libraries=places&callback=initAutocomplete" async defer></script>
     @endpush
 
 @endif
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}
-
-
-
-
-
-
-

--- a/src/resources/views/fields/address_form_google.blade.php
+++ b/src/resources/views/fields/address_form_google.blade.php
@@ -1,0 +1,103 @@
+<?php
+    $entity_model = $crud->getModel();
+ 	
+ 	//for update form, get initial state of the entity
+    if( isset($id) && $id ){
+    	$entity_column = $entity_model::find($id)->getAttributes();
+	}
+?>
+
+<div @include('crud::inc.field_wrapper_attributes')>
+    <label>{!! $field['label'] !!}</label>       
+    <input 
+      	type="text" 
+      	name="{{$field['name']}}" 
+      	id="{{$field['name']}}"
+      	@include('crud::inc.field_attributes')   
+    >
+   
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+@foreach ($field['components'] as $attribute)
+
+	<div @include('crud::inc.field_wrapper_attributes') >
+	    <label>{!! $attribute['label'] !!}</label>
+	    <input 
+	      	type="text" 
+	      	name="{{$attribute['name']}}"
+	      	id="{{$attribute['name']}}"
+	      	value="{{ old($attribute['name'], isset($entity_column[$attribute['name']]) ? $entity_column[$attribute['name']] : null) }}"
+	      	readonly
+	      	@include('crud::inc.field_attributes')
+	    >
+	</div>
+
+@endforeach
+
+{{-- Note: you can use  to only load some CSS/JS once, even though there are multiple instances of it --}}
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    
+    {{-- @push('crud_fields_styles')
+        <!-- no styles -->
+    @endpush --}}
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <script>
+
+			var field = <?php echo json_encode($field); ?>;
+
+			function initAutocomplete() {
+  
+			 	if(document.getElementById(field.name)){
+			    	var autocomplete = new google.maps.places.Autocomplete((document.getElementById(field.name)),{types: ['address']});
+			    	autocomplete.addListener('place_changed', function(){fillInAddress(autocomplete)});
+			  	}
+			}
+
+			function fillInAddress(autocomplete) {
+			  	// Get the place details from the autocomplete object.
+			 	var place = autocomplete.getPlace();
+			   	var val = [];
+			  	
+			  	// Get each component of the address from the place details
+			  	for (var i = 0; i < place.address_components.length; i++) {
+			    	var addressType = place.address_components[i].types[0];
+			    	val[addressType] = place.address_components[i];
+			  	}
+				
+				// Fill the corresponding field on the form if it exists.
+			  	for (var component in field.components) {
+			    	document.getElementById(field.components[component].name).readOnly = false;
+			    	if (val[component]){
+			    		document.getElementById(field.components[component].name).value = val[component][field.components[component].type];	
+			    	} else {
+			    		document.getElementById(field.components[component].name).value = '';
+			    	}
+			  	}
+			}
+
+        </script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ env('GOOGLE_API_KEY')}}&libraries=places&callback=initAutocomplete" async defer></script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}
+
+
+
+
+
+
+

--- a/src/resources/views/fields/google_address.blade.php
+++ b/src/resources/views/fields/google_address.blade.php
@@ -5,6 +5,12 @@
     if( isset($id) && $id ){
     	$entity_column = $entity_model::find($id)->getAttributes();
 	}
+
+	$googleApiKey = isset( $field['google_api_key'] ) ? $field['google_api_key']  : ( config('backpack.google_api_key', env('GOOGLE_API_KEY', null)));
+
+	$notification = new stdClass();
+	$notification->title = trans('backpack::crud.address_google_error_title');
+	$notification->message = trans('backpack::crud.address_google_error_message');
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes')>
@@ -38,24 +44,6 @@
 
 @endforeach
 
-{{-- Modal window with an error message in case Google API doesn't provide the components for the address --}}
-<div class="modal fade" id ="modal_error" role="dialog" tabindex="-1" aria-labelledby="ModalLabel" style="display: none;"> 
-	<div class="modal-dialog modal-lg" role="document"> 
-		<div class="modal-content"> 
-			<div class="modal-header"> 
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">×</span>
-				</button> 
-				<h4 class="modal-title" id="ModalLabel">Oops something went wrong...</h4> 
-			</div>
-			<div class="modal-body">
-				<p>It looks like Google doesn't provide all the info for this address... </p>
-				<p>The fields must be filled manually...</p>
-			</div>
-		</div>
-	</div> 
-</div>
-
 {{-- Note: you can use  to only load some CSS/JS once, even though there are multiple instances of it --}}
 
 {{-- ########################################## --}}
@@ -72,8 +60,9 @@
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
     @push('crud_fields_scripts')
         <script>
-
+    
 			var field = <?php echo json_encode($field); ?>;
+			var notification = <?php echo json_encode($notification); ?>;
 
 			function initAutocomplete() {
   
@@ -113,12 +102,18 @@
 				    	document.getElementById(field.components[component].name).readOnly = false;
 				    }
 
-				    $('#modal_error').modal('show');	
+				    $(function(){
+				        new PNotify({
+				            title: notification['title'],
+				            text: notification['message'],
+				            icon: false,
+				        });
+				    });	
 				}
 			}
 
         </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key={{ $field['google_api_key'] }}&libraries=places&callback=initAutocomplete" async defer></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ $googleApiKey }}&libraries=places&callback=initAutocomplete" async defer></script>
     @endpush
 
 @endif

--- a/src/resources/views/fields/google_address.blade.php
+++ b/src/resources/views/fields/google_address.blade.php
@@ -61,8 +61,8 @@
     @push('crud_fields_scripts')
         <script>
     
-			var field = <?php echo json_encode($field); ?>;
-			var notification = <?php echo json_encode($notification); ?>;
+			var field = {!! json_encode($field) !!}  
+			var notification = {!! json_encode($notification) !!}
 
 			function initAutocomplete() {
   
@@ -113,7 +113,7 @@
 			}
 
         </script>
-        <script src="https://maps.googleapis.com/maps/api/js?key={{ $googleApiKey }}&libraries=places&callback=initAutocomplete" async defer></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ $googleApiKey }}&amp;libraries=places&amp;callback=initAutocomplete" async defer></script>
     @endpush
 
 @endif


### PR DESCRIPTION
**Summary**

Creates an _**address form**_ composed by:
- an autocomplete field based on Google Places API 
- several other fields, choosen by the user, that will contain the components of the address

The fields will be filled automatically 

**Preview**

![address](https://cloud.githubusercontent.com/assets/7859305/19452080/e1b7d21c-94af-11e6-9bf0-9550ff914011.gif)

**Usage**

``` php
$this->crud->addField([
            'name'              => 'address',
            'label'             => 'Indirizzo',
            'type'              => 'address_form_google',
            'google_api_key'    => env('GOOGLE_API_KEY'),

            'components' =>  [
                'COMPONENT' => [   
                    'name'  => 'address_line_1',
                    'label' => 'Via',
                    'type'  => 'long_name', // Optional
                ],
                // Other components
            ],
        ]);
```

This field needs a Google API Key that can be retrived [here](https://developers.google.com/places/web-service/get-api-key)

The components that can be used are:
- 'route'
- 'street_number'
- 'postal_code'
- 'locality'
- 'administrative_area_level_1'
- 'administrative_area_level_2' 
- 'country'

so a complete field would look like this:

``` php
$this->crud->addField([
            'name'              => 'address',
            'label'             => 'Indirizzo',
            'type'              => 'address_form_google',
            'google_api_key'    => env('GOOGLE_API_KEY'),

            'components' =>  [
                'route' => [   
                    'name'  => 'address_line_1',
                    'label' => 'Via',
                    'type'  => 'long_name',
                ],
                'street_number' => [   
                    'name'  => 'address_line_2',
                    'label' => 'Civico',
                    'type'  => 'short_name',
                ],
                'postal_code' => [   
                    'name'  => 'postal_code',
                    'label' => 'CAP',
                    'type'  => 'short_name',
                ],
                'locality' => [  
                    'name'  => 'city',
                    'label' => 'Città',
                    'type'  => 'long_name',
                ],    
                'administrative_area_level_1' => [    
                    'name'  => 'region',
                    'label' => 'Regione',
                    'type'  => 'long_name',
                ],
                'administrative_area_level_2' => [   
                    'name'  => 'province',
                    'label' => 'Provincia',
                    'type'  => 'short_name',
                ],
                'country' => [  
                    'name'  => 'country',
                    'label' => 'Nazione',
                    'type'  => 'short_name',
                ],
            ],
        ]);
```

the 'type' attribute is optional and can be set to 'short_name' or 'long_name'. 
The default value is 'long_name'.

**_Each component needs a column in the table_**. 
The autocomplete field is not stored so it doesn't need a column in the table.

A complete migration would look like this:

``` php
public function up()
    {
        Schema::create('addresses', function (Blueprint $table) {
            $table->increments('id');
            $table->string('address_line_1');
            $table->string('address_line_2');
            $table->string('city');
            $table->string('region');
            $table->string('province');
            $table->string('postal_code');
            $table->string('country');
            $table->timestamps();
        });
    }
```

All the fields can be **validated** with their **own** rules like every standard field.
