### PR TITLE
[Feature] CrudRoute Abstraction for extensibility

### DIFF
--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Backpack\CRUD;
+
+use Route;
+
+class CrudRouter
+{
+    protected $requiredInjectables = [];
+
+    protected $name = null;
+    protected $options = null;
+    protected $controller = null;
+
+    public function __construct($name, $controller, $options)
+    {
+        $this->name = $name;
+        $this->options = $options;
+        $this->controller = $controller;
+
+        // CRUD routes
+        Route::post($this->name.'/search', [
+            'as' => 'crud.'.$this->name.'.search',
+            'uses' => $this->controller.'@search',
+        ]);
+
+        Route::get($this->name.'/reorder', [
+            'as' => 'crud.'.$this->name.'.reorder',
+            'uses' => $this->controller.'@reorder',
+        ]);
+
+        Route::post($this->name.'/reorder', [
+            'as' => 'crud.'.$this->name.'.save.reorder',
+            'uses' => $this->controller.'@saveReorder',
+        ]);
+
+        Route::get($this->name.'/{id}/details', [
+            'as' => 'crud.'.$this->name.'.showDetailsRow',
+            'uses' => $this->controller.'@showDetailsRow',
+        ]);
+
+        Route::get($this->name.'/{id}/translate/{lang}', [
+            'as' => 'crud.'.$this->name.'.translateItem',
+            'uses' => $this->controller.'@translateItem',
+        ]);
+
+        Route::get($this->name.'/{id}/revisions', [
+            'as' => 'crud.'.$this->name.'.listRevisions',
+            'uses' => $this->controller.'@listRevisions',
+        ]);
+
+        Route::post($this->name.'/{id}/revisions/{revisionId}/restore', [
+            'as' => 'crud.'.$this->name.'.restoreRevision',
+            'uses' => $this->controller.'@restoreRevision',
+        ]);
+
+        $options_with_default_route_names = array_merge([
+            'names' => [
+                'index'     => 'crud.'.$this->name.'.index',
+                'create'    => 'crud.'.$this->name.'.create',
+                'store'     => 'crud.'.$this->name.'.store',
+                'edit'      => 'crud.'.$this->name.'.edit',
+                'update'    => 'crud.'.$this->name.'.update',
+                'show'      => 'crud.'.$this->name.'.show',
+                'destroy'   => 'crud.'.$this->name.'.destroy',
+            ],
+        ], $this->options);
+
+        Route::resource($this->name, $this->controller, $options_with_default_route_names);
+    }
+
+    public function with($injectables)
+    {
+        if (is_string($injectables)) {
+            $this->requiredInjectables[] = 'with'.ucwords($injectables);
+        } elseif (is_array($injectables)) {
+            foreach ($injectables as $injectable) {
+                $this->requiredInjectables[] = 'with'.ucwords($injectable);
+            }
+        } else {
+            $reflection = new \ReflectionFunction($injectables);
+
+            if ($reflection->isClosure()) {
+                $this->requiredInjectables[] = $injectables;
+            }
+        }
+
+        return $this->inject();
+    }
+
+    private function inject()
+    {
+        foreach ($this->requiredInjectables as $injectable) {
+            if( is_string($injectable) ){
+                $this->{$injectable}();
+            } else {
+                $injectable();
+            }
+        }
+    }
+
+    public function __call($method, $parameters = null)
+    {
+        if (method_exists($this, $method)) {
+            $this->{$method}($parameters);
+        }
+    }
+}

--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -91,7 +91,7 @@ class CrudRouter
     private function inject()
     {
         foreach ($this->requiredInjectables as $injectable) {
-            if( is_string($injectable) ){
+            if (is_string($injectable)) {
                 $this->{$injectable}();
             } else {
                 $injectable();

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD;
 
 use Illuminate\Support\ServiceProvider;
-use Backpack\CRUD\CrudRouter;
 
 class CrudServiceProvider extends ServiceProvider
 {

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Backpack\CRUD;
 
 use Illuminate\Support\ServiceProvider;
-use Route;
+use Backpack\CRUD\CrudRouter;
 
 class CrudServiceProvider extends ServiceProvider
 {
@@ -85,48 +85,6 @@ class CrudServiceProvider extends ServiceProvider
 
     public static function resource($name, $controller, array $options = [])
     {
-        // CRUD routes
-        Route::post($name.'/search', [
-            'as' => 'crud.'.$name.'.search',
-            'uses' => $controller.'@search',
-          ]);
-        Route::get($name.'/reorder', [
-            'as' => 'crud.'.$name.'.reorder',
-            'uses' => $controller.'@reorder',
-          ]);
-        Route::post($name.'/reorder', [
-            'as' => 'crud.'.$name.'.save.reorder',
-            'uses' => $controller.'@saveReorder',
-          ]);
-        Route::get($name.'/{id}/details', [
-            'as' => 'crud.'.$name.'.showDetailsRow',
-            'uses' => $controller.'@showDetailsRow',
-          ]);
-        Route::get($name.'/{id}/translate/{lang}', [
-            'as' => 'crud.'.$name.'.translateItem',
-            'uses' => $controller.'@translateItem',
-          ]);
-        Route::get($name.'/{id}/revisions', [
-            'as' => 'crud.'.$name.'.listRevisions',
-            'uses' => $controller.'@listRevisions',
-          ]);
-        Route::post($name.'/{id}/revisions/{revisionId}/restore', [
-            'as' => 'crud.'.$name.'.restoreRevision',
-            'uses' => $controller.'@restoreRevision',
-          ]);
-
-        $options_with_default_route_names = array_merge([
-            'names' => [
-                'index'     => 'crud.'.$name.'.index',
-                'create'    => 'crud.'.$name.'.create',
-                'store'     => 'crud.'.$name.'.store',
-                'edit'      => 'crud.'.$name.'.edit',
-                'update'    => 'crud.'.$name.'.update',
-                'show'      => 'crud.'.$name.'.show',
-                'destroy'   => 'crud.'.$name.'.destroy',
-                ],
-            ], $options);
-
-        Route::resource($name, $controller, $options_with_default_route_names);
+        return new CrudRouter($name, $controller, $options);
     }
 }

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -136,6 +136,7 @@ trait Filters
                     $this->request->getMethod() == 'PATCH') {
                     return false;
                 }
+
                 return true;
                 break;
 


### PR DESCRIPTION
Instead of having a static CRUD::resource within the service provider I’ve abstracted it out into CrudRouter.

This then returns from the original resource allowing people to add extra closures, and will permit us to add extra routes to resources.

e.g

```php

CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->withUniqueCheck(); // more of these are added via traits

//or

CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with(function(){
    // I can be used to run call backs, or add extra routes to this resource
});

//or

CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with(['uniqueCheck','allImages']);

//or

CRUD::resource(‘teams’, ‘Admin\TeamCrudController’)->with('uniqueCheck');
```

The first example is what I imagine to be the most used method, it will allow us to have lighter weight routes, then extend them when desired. This would allow us to implement things like the unicity checks etc.

As its backwards compatible, would be nice to get this in asap :P especially as we're using it currently :D