### PR TITLE
[Bug Fix] Prevented the validation notification firing on datepicker when no value is present

### DIFF
--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -73,28 +73,30 @@
                 });
 
                 $picker.on('show hide change', function(e){
-                     if( e.date ){
-                         var sqlDate = e.format('yyyy-mm-dd');
-                     } else {
-                         try {
-                             var sqlDate = $fake.val();
+                    if( e.date ){
+                        var sqlDate = e.format('yyyy-mm-dd');
+                    } else {
+                        try {
+                            var sqlDate = $fake.val();
 
-                             if( $customConfig.format === 'dd/mm/yyyy' ){
-                                 sqlDate = new Date(sqlDate.split('/')[2], sqlDate.split('/')[1] - 1, sqlDate.split('/')[0]).format('yyyy-mm-dd');
-                             }
-                         } catch(e){
-                             PNotify.removeAll();
-                             new PNotify({
-                                title: 'Whoops!',
-                                text: 'Sorry we did not recognise that date format, please make sure it uses a yyyy mm dd combination',
-                                type: 'error',
-                                icon: false
-                            });
-                         }
-                     }
-                     $field.val(sqlDate);
+                            if( $customConfig.format === 'dd/mm/yyyy' ){
+                                sqlDate = new Date(sqlDate.split('/')[2], sqlDate.split('/')[1] - 1, sqlDate.split('/')[0]).format('yyyy-mm-dd');
+                            }
+                        } catch(e){
+                            if( $fake.val() ){
+                                PNotify.removeAll();
+                                new PNotify({
+                                    title: 'Whoops!',
+                                    text: 'Sorry we did not recognise that date format, please make sure it uses a yyyy mm dd combination',
+                                    type: 'error',
+                                    icon: false
+                                });
+                            }
+                        }
+                    }
+
+                    $field.val(sqlDate);
                 });
-
             });
         });
     </script>


### PR DESCRIPTION
the datepicker would try parse a date, but if there is no value in the field, the error will fire.

it now will only try validate if there is any value in the field