### PR TITLE
Allow mixed simple and complex column definitions

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -22,7 +22,7 @@ trait Columns
         if (is_array($columns) && count($columns)) {
             foreach ($columns as $key => $column) {
                 // if label and other details have been defined in the array
-                if (is_array($columns[0])) {
+                if (is_array($column)) {
                     $this->addColumn($column);
                 } else {
                     $this->addColumn([


### PR DESCRIPTION
This is a bugfix. At present, the following is not possible:

```
        $this->crud->setColumns([
            'name',
            [
                'name' => 'created_at',
                'label' => 'Created At',
            ],
        ]);
```

The reason being that the first element in the array (indexed at 0) is always inspected to determine if the current value is a string, or an array. If all elements are strings:
```
['name', 'created_at']
```
or all are arrays:
```
[
    [
        'name' => 'name',
        'label' => 'Name',
    ],
    [
        'name' => 'created_at',
        'label' => 'Created At',
    ]
]
```

Then this doesn't matter, but if simple and complex values are mixed, it breaks.