### PR TITLE
Update Update.php

### DIFF
--- a/src/PanelTraits/Update.php
+++ b/src/PanelTraits/Update.php
@@ -21,9 +21,10 @@ trait Update
     public function update($id, $data)
     {
         $item = $this->model->findOrFail($id);
+        
+        $this->syncPivot($item, $data, 'update');
+        
         $updated = $item->update($this->compactFakeFields($data, 'update'));
-
-        /*if ($updated) */$this->syncPivot($item, $data, 'update');
 
         return $item;
     }


### PR DESCRIPTION
Wondering if it would cause issues if $this->syncPivot() gets called just before $item->update?

Background: I'm using Algolia Search and their Laravel integration. If this is used with n:n relations, the updated attributes on a relation are ignored (or outdated) as they are refer to the current Model attributes (in $this) which has not yet "received" the updated attributes.

https://www.algolia.com/doc/api-client/laravel/relationships#relationships