### PR TITLE
[Bug Fix] prevent all btn groups from getting image margin

### DIFF
--- a/src/resources/views/fields/base64_image.blade.php
+++ b/src/resources/views/fields/base64_image.blade.php
@@ -53,7 +53,7 @@
             .hide {
                 display: none;
             }
-            .btn-group {
+            .image .btn-group {
                 margin-top: 10px;
             }
             img {

--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -52,7 +52,7 @@
             .hide {
                 display: none;
             }
-            .btn-group {
+            .image .btn-group {
                 margin-top: 10px;
             }
             img {


### PR DESCRIPTION
The "image uploader" field-type injects CSS, being

```css
.btn-group {
    margin-top: 10px;
}
```

this effects all btn-groups, including the new "save buttons" 

prefixing the class solves this global inheritance