### PR TITLE
Issue #280 - Allow re-ordering of fields and cols via CrudController

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -58,13 +58,12 @@ trait Columns
             $column = ['name' => $column];
         }
 
-        // make sure the column has a type
-        $column_with_details = $this->addDefaultTypeToColumn($column);
-
         // make sure the column has a label
         $column_with_details = $this->addDefaultLabel($column);
 
-        return array_filter($this->columns[] = $column_with_details);
+        array_filter($this->columns[] = $column_with_details);
+
+        return $this;
     }
 
     /**
@@ -77,6 +76,34 @@ trait Columns
         if (count($columns)) {
             foreach ($columns as $key => $column) {
                 $this->addColumn($column);
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added column to 'before' the $target_col
+     *
+     * @param $target_col
+     */
+    public function beforeColumn($target_col) {
+        foreach ($this->columns as $column => $value) {
+            if ($value['name'] == $target_col) {
+                array_splice($this->columns, $column, 0, array(array_pop($this->columns)));
+                break;
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added column to 'after' the $target_col
+     *
+     * @param $target
+     */
+    public function afterColumn($target_col) {
+        foreach ($this->columns as $column => $value) {
+            if ($value['name'] == $target_col) {
+                array_splice($this->columns, $column + 1, 0, array(array_pop($this->columns)));
+                break;
             }
         }
     }

--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -48,6 +48,8 @@ trait Fields
                 $this->update_fields[$complete_field_array['name']] = $complete_field_array;
                 break;
         }
+
+        return $this;
     }
 
     public function addFields($fields, $form = 'both')
@@ -56,6 +58,50 @@ trait Fields
             foreach ($fields as $field) {
                 $this->addField($field, $form);
             }
+        }
+    }
+
+    /**
+     * Moves the recently added field to 'after' the $target_field
+     *
+     * @param $target_field
+     */
+    public function afterField($target_field) {
+        foreach ($this->create_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                array_splice($this->create_fields, $field + 1, 0, [$field => array_pop($this->create_fields)]);
+                break;
+            }
+        }
+        foreach ($this->update_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                array_splice($this->update_fields, $field + 1, 0, [$field => array_pop($this->update_fields)]);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added field to 'before' the $target_field
+     *
+     * @param $target_field
+     */
+    public function beforeField($target_field) {
+        $key = 0;
+        foreach ($this->create_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                array_splice($this->create_fields, $key, 0, [$field => array_pop($this->create_fields)]);
+                break;
+            }
+            $key++;
+        }
+        $key = 0;
+        foreach ($this->update_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                array_splice($this->update_fields, $key, 0, [$field => array_pop($this->update_fields)]);
+                break;
+            }
+            $key++;
         }
     }
 


### PR DESCRIPTION
As mentioned in Issue #280 this will allow developers to place columns and fields where they want. 
Most beneficial when `$this->crud->setFromDb();` is used and only 1 or 2 fields need to be altered.
Usage should only be via chaining ie.
```
$this->crud->addColumn([
            'name'  => 'phone',
            'label' => 'Phone Number',
            'type'  => 'text',
])->beforeColumn('email');
```