### PR TITLE
Fixes #259 Allowed for mutating form data so laravel casting can work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - Nothing
 
 
+## [3.1.48] - 2016-12-14
+
+### Fixed
+- Prevent double-json-encoding on complicated field types, when using attribute casting; Fixes #259;
+
+
 ## [3.1.47] - 2016-12-14
 
 ### Fixed

--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -19,8 +19,10 @@ trait Create
      */
     public function create($data)
     {
-        $values_to_store = $this->compactFakeFields($data, 'create');
-        $item = $this->model->create($values_to_store);
+        $data = $this->decodeJsonCastedAttributes($data, 'create');
+        $data = $this->compactFakeFields($data, 'create');
+
+        $item = $this->model->create($data);
 
         // if there are any relationships available, also sync those
         $this->syncPivot($item, $data);

--- a/src/PanelTraits/FakeColumns.php
+++ b/src/PanelTraits/FakeColumns.php
@@ -13,15 +13,7 @@ trait FakeColumns
         $fake_field_columns_to_encode = [];
 
         // get the right fields according to the form type (create/update)
-        switch (strtolower($form)) {
-            case 'update':
-                $fields = $this->update_fields;
-                break;
-
-            default:
-                $fields = $this->create_fields;
-                break;
-        }
+        $fields = $this->getFields($form);
 
         foreach ($fields as $k => $field) {
             // if it's a fake field

--- a/src/PanelTraits/FakeFields.php
+++ b/src/PanelTraits/FakeFields.php
@@ -14,20 +14,12 @@ trait FakeFields
      *
      * @return array
      */
-    public function compactFakeFields($request, $form = 'create')
+    public function compactFakeFields($request, $form = 'create', $id = false)
     {
         $fake_field_columns_to_encode = [];
 
         // get the right fields according to the form type (create/update)
-        switch (strtolower($form)) {
-            case 'update':
-                $fields = $this->update_fields;
-                break;
-
-            default:
-                $fields = $this->create_fields;
-                break;
-        }
+        $fields = $this->getFields($form, $id);
 
         // go through each defined field
         foreach ($fields as $k => $field) {

--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -200,7 +200,7 @@ trait Fields
                 $jsonCastables = ['array', 'object', 'json'];
                 $fieldCasting = $this->model->getCasts()[$field['name']];
 
-                if (in_array($fieldCasting, $jsonCastables) && isset($data[$field['name']]) && ! empty($data[$field['name']]) && !is_array($data[$field['name']])) {
+                if (in_array($fieldCasting, $jsonCastables) && isset($data[$field['name']]) && ! empty($data[$field['name']]) && ! is_array($data[$field['name']])) {
                     try {
                         $data[$field['name']] = json_decode($data[$field['name']]);
                     } catch (Exception $e) {
@@ -222,6 +222,4 @@ trait Fields
     {
         $this->setSort('fields', (array) $order);
     }
-
-
 }

--- a/src/PanelTraits/Update.php
+++ b/src/PanelTraits/Update.php
@@ -20,11 +20,13 @@ trait Update
      */
     public function update($id, $data)
     {
+        $data = $this->decodeJsonCastedAttributes($data, 'update', $id);
+        $data = $this->compactFakeFields($data, 'update', $id);
+
         $item = $this->model->findOrFail($id);
 
         $this->syncPivot($item, $data, 'update');
-
-        $updated = $item->update($this->compactFakeFields($data, 'update'));
+        $updated = $item->update($data);
 
         return $item;
     }
@@ -58,10 +60,10 @@ trait Update
 
         // always have a hidden input for the entry id
         $fields['id'] = [
-                        'name'  => $entry->getKeyName(),
-                        'value' => $entry->getKey(),
-                        'type'  => 'hidden',
-                    ];
+            'name'  => $entry->getKeyName(),
+            'value' => $entry->getKey(),
+            'type'  => 'hidden',
+        ];
 
         return $fields;
     }


### PR DESCRIPTION
Enabled automatic mutating of form data without developer interaction, allowing them to use default laravel functionality