### PR TITLE
Fixes #255 - started a Hook trait to allow users more flexibility with events

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/Hooks.php
+++ b/src/app/Http/Controllers/CrudFeatures/Hooks.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
+
+trait Hooks
+{
+    /**
+     * Runs before any storing takes place, allows modification to the request
+     *
+     * @param $request - provides access to the incoming request
+     *
+     * @return \Backpack\CRUD\app\Http\Requests\CrudRequest
+     */
+    public function beforeStore($request)
+    {
+        return $request;
+    }
+
+    /**
+     * Runs before any updating takes place, allows modification to the request
+     *
+     * @param $request - provides access to the incoming request
+     *
+     * @return \Backpack\CRUD\app\Http\Requests\CrudRequest
+     */
+    public function beforeUpdate($request)
+    {
+        return $request;
+    }
+
+    /**
+     * Runs before any create/update proccesses take place,
+     * but AFTER the beforeStore/beforeUpdate
+     *
+     * @param $request - provides access to the incoming request
+     *
+     * @return \Backpack\CRUD\app\Http\Requests\CrudRequest
+     */
+    public function beforeSave($request)
+    {
+        return $request;
+    }
+
+    /**
+     * Runs after the store action has succeeded,
+     * and provides access to the request and new item
+     *
+     * @param $request - provides access to the incoming request
+     * @param $item - the newly created model
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function afterStore($request, $item)
+    {
+        return $item;
+    }
+
+    /**
+     * Runs after the update action has succeeded,
+     * and provides access to the request and updated item
+     *
+     * @param $request - provides access to the incoming request
+     * @param $item - the updated model
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function afterUpdate($request, $item)
+    {
+        return $item;
+    }
+
+    /**
+     * Runs after the create/update action has succeeded,
+     * but AFTER the afterUpdate/afterStore
+     * and provides access to the request and updated item
+     *
+     * @param $request - provides access to the incoming request
+     * @param $item - the updated model
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function afterSave($request, $item)
+    {
+        return $item;
+    }
+}

--- a/src/app/Http/Controllers/CrudFeatures/Hooks.php
+++ b/src/app/Http/Controllers/CrudFeatures/Hooks.php
@@ -5,7 +5,7 @@ namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 trait Hooks
 {
     /**
-     * Runs before any storing takes place, allows modification to the request
+     * Runs before any storing takes place, allows modification to the request.
      *
      * @param $request - provides access to the incoming request
      *
@@ -17,7 +17,7 @@ trait Hooks
     }
 
     /**
-     * Runs before any updating takes place, allows modification to the request
+     * Runs before any updating takes place, allows modification to the request.
      *
      * @param $request - provides access to the incoming request
      *
@@ -30,7 +30,7 @@ trait Hooks
 
     /**
      * Runs before any create/update proccesses take place,
-     * but AFTER the beforeStore/beforeUpdate
+     * but AFTER the beforeStore/beforeUpdate.
      *
      * @param $request - provides access to the incoming request
      *
@@ -43,7 +43,7 @@ trait Hooks
 
     /**
      * Runs after the store action has succeeded,
-     * and provides access to the request and new item
+     * and provides access to the request and new item.
      *
      * @param $request - provides access to the incoming request
      * @param $item - the newly created model
@@ -57,7 +57,7 @@ trait Hooks
 
     /**
      * Runs after the update action has succeeded,
-     * and provides access to the request and updated item
+     * and provides access to the request and updated item.
      *
      * @param $request - provides access to the incoming request
      * @param $item - the updated model
@@ -72,7 +72,7 @@ trait Hooks
     /**
      * Runs after the create/update action has succeeded,
      * but AFTER the afterUpdate/afterStore
-     * and provides access to the request and updated item
+     * and provides access to the request and updated item.
      *
      * @param $request - provides access to the incoming request
      * @param $item - the updated model


### PR DESCRIPTION
Adds the ability to use hook like functions for basic crud actions. examples below

```php
class ProfanityCrudController extends CrudController
{
    public function store(StoreRequest $request)
    {
        return parent::storeCrud();
    }

    public function update(UpdateRequest $request)
    {
        return parent::updateCrud();
    }

    public function beforeStore($request)
    {
        $request->request->add(['user_id', Auth::user()->id]);
        return $request;
    }

    public function beforeUpdate($request)
    {
        $request->request->add(['user_id', Auth::user()->id]);
        return $request;
    }

    public function beforeSave($request)
    {
        $request->request->add(['user_id', Auth::user()->id]);
        return $request;
    }

    public function afterStore($request, $item)
    {
        $item->user_id = Auth::user()->id;
        $item->something_else = $request->get('something_else');
        $item->save();
        return $item;
    }

    public function afterUpdate($request, $item)
    {
        $item->user_id = Auth::user()->id;
        $item->something_else = $request->get('something_else');
        $item->save();
        return $item;
    }

    public function afterSave($request, $item)
    {
        $item->user_id = Auth::user()->id;
        $item->something_else = $request->get('something_else');
        $item->save();
        return $item;
    }
}
```