### PR TITLE
Fixes #291 - less strict filter check

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -2,22 +2,22 @@
 
 namespace Backpack\CRUD;
 
+use Backpack\CRUD\PanelTraits\Read;
+use Backpack\CRUD\PanelTraits\Query;
 use Backpack\CRUD\PanelTraits\Access;
+use Backpack\CRUD\PanelTraits\Create;
+use Backpack\CRUD\PanelTraits\Delete;
+use Backpack\CRUD\PanelTraits\Fields;
+use Backpack\CRUD\PanelTraits\Update;
 use Backpack\CRUD\PanelTraits\AutoSet;
 use Backpack\CRUD\PanelTraits\Buttons;
 use Backpack\CRUD\PanelTraits\Columns;
-use Backpack\CRUD\PanelTraits\Create;
-use Backpack\CRUD\PanelTraits\Delete;
-use Backpack\CRUD\PanelTraits\FakeColumns;
-use Backpack\CRUD\PanelTraits\FakeFields;
-use Backpack\CRUD\PanelTraits\Fields;
-use Backpack\CRUD\PanelTraits\Query;
-use Backpack\CRUD\PanelTraits\Read;
-use Backpack\CRUD\PanelTraits\Reorder;
-use Backpack\CRUD\PanelTraits\Update;
-use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
-use Backpack\CRUD\PanelTraits\AutoFocus;
 use Backpack\CRUD\PanelTraits\Filters;
+use Backpack\CRUD\PanelTraits\Reorder;
+use Backpack\CRUD\PanelTraits\AutoFocus;
+use Backpack\CRUD\PanelTraits\FakeFields;
+use Backpack\CRUD\PanelTraits\FakeColumns;
+use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Backpack\CRUD;
 
-use Illuminate\Support\ServiceProvider;
 use Route;
+use Illuminate\Support\ServiceProvider;
 
 class CrudServiceProvider extends ServiceProvider
 {
@@ -30,7 +30,6 @@ class CrudServiceProvider extends ServiceProvider
 
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
 
-
         // PUBLISH FILES
 
         // publish lang files
@@ -50,7 +49,6 @@ class CrudServiceProvider extends ServiceProvider
                             __DIR__.'/config/elfinder.php'      => config_path('elfinder.php'),
                             __DIR__.'/resources/views-elfinder' => resource_path('views/vendor/elfinder'),
                             ], 'elfinder');
-
 
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -3,8 +3,8 @@
 namespace Backpack\CRUD;
 
 use DB;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Database\Eloquent\Model;
 
 trait CrudTrait
 {

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -46,9 +46,7 @@ trait Filters
 
         // if a closure was passed as "filter_logic"
         if ($this->doingListOperation() &&
-            $this->request->input($options['name']) &&
-            $this->request->input($options['name']) != null &&
-            $this->request->input($options['name']) != 'null') {
+            $this->request->has($options['name'])) {
             if (is_callable($filter_logic)) {
                 // apply it
                 $filter_logic($this->request->input($options['name']));
@@ -192,7 +190,7 @@ class CrudFilter
         $this->options = $options;
         $this->view = 'crud::filters.'.$this->type;
 
-        if (\Request::input($this->name)) {
+        if (\Request::has($this->name)) {
             $this->currentValue = \Request::input($this->name);
         }
     }
@@ -215,7 +213,7 @@ class CrudFilter
 
     public function isActive()
     {
-        if (\Request::input($this->name)) {
+        if (\Request::has($this->name)) {
             return true;
         }
 

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -2,18 +2,18 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
-use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Support\Facades\Form as Form;
+use Backpack\CRUD\CrudPanel;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Form as Form;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Backpack\CRUD\app\Http\Controllers\CrudFeatures\Reorder;
+use Backpack\CRUD\app\Http\Controllers\CrudFeatures\AjaxTable;
+// CRUD Traits for non-core features
+use Backpack\CRUD\app\Http\Controllers\CrudFeatures\Revisions;
 use Backpack\CRUD\app\Http\Requests\CrudRequest as StoreRequest;
 use Backpack\CRUD\app\Http\Requests\CrudRequest as UpdateRequest;
-use Backpack\CRUD\CrudPanel;
-// CRUD Traits for non-core features
-use Backpack\CRUD\app\Http\Controllers\CrudFeatures\AjaxTable;
-use Backpack\CRUD\app\Http\Controllers\CrudFeatures\Reorder;
-use Backpack\CRUD\app\Http\Controllers\CrudFeatures\Revisions;
 use Backpack\CRUD\app\Http\Controllers\CrudFeatures\ShowDetailsRow;
 
 class CrudController extends BaseController

--- a/src/resources/lang/ro/crud.php
+++ b/src/resources/lang/ro/crud.php
@@ -88,7 +88,6 @@ return [
     'insert_success' => 'Intrarea a fost adăugată cu succes.',
     'update_success' => 'Intrarea a fost modificată cu succes.',
 
-
     // CRUD reorder view
     'reorder'                      => 'Reordonare',
     'reorder_text'                 => 'Folosește drag&drop pentru a reordona.',


### PR DESCRIPTION
Instead of checking the field contents (we’ve no idea what the user
wants to test for) we just check that they’re using it.

Previously if we wanted to search for entities with either 0 or null as their values the checks would fail.

So instead just checking that the filter has been activated should be enough.