### PR TITLE
Fixed missing database prefix on isColumnNullable Method

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -49,7 +49,7 @@ trait CrudTrait
         // register the enum column type, because Doctrine doesn't support it
         DB::connection()->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
-        return ! DB::connection()->getDoctrineColumn($instance->getTable(), $column_name)->getNotnull();
+        return ! DB::connection()->getDoctrineColumn(Config::get('database.connections.'.env('DB_CONNECTION').'.prefix').$instance->getTable(), $column_name)->getNotnull();
     }
 
     /*


### PR DESCRIPTION
Was throwing an error on select fields that related to another model at the isColumnNullable call in select.blade and select2.blade