### PR TITLE
Use Storage::url method on file paths for "upload" and "upload_multiple" fields

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -150,7 +150,7 @@ trait CrudTrait
             $file_path = $file->storeAs($destination_path, $new_file_name, $disk);
 
             // 3. Save the complete path to the database
-            $this->attributes[$attribute_name] = $file_path;
+            $this->attributes[$attribute_name] = Storage::disk($disk)->url($file_path);
         }
     }
 
@@ -198,7 +198,7 @@ trait CrudTrait
                     $file_path = $file->storeAs($destination_path, $new_file_name, $disk);
 
                     // 3. Add the public path to the database
-                    $attribute_value[] = $file_path;
+                    $attribute_value[] = Storage::disk($disk)->url($file_path);
                 }
             }
         }


### PR DESCRIPTION
Hello,

It seems to me that it would be more natural just to store the real URL on the database instead of storing a path that is dependent on the disk, because 1) the disk probably would change from time to time and 2) getting the real URL while rendering would quite tricky for those who use S3 or other storage backends.

I feel like this would be a breaking a lot of existing installs though, so do let me know your thoughts on this :)

Isaac