### PR TITLE
Fixing a bug where array key is used but not set

### DIFF
--- a/src/resources/views/fields/select_from_array.blade.php
+++ b/src/resources/views/fields/select_from_array.blade.php
@@ -14,9 +14,8 @@
             @if (count($field['options']))
                 @foreach ($field['options'] as $key => $value)
                     <option value="{{ $key }}"
-                        @if ((isset($field['value']) && $key==$field['value'])
-                            || ( ! is_null( old($field['name']) ) && old($field['name']) == $key)
-                            || (is_array($field['value']) && in_array($key, $field['value'])) )
+                        @if (isset($field['value']) && ($key==$field['value'] || (is_array($field['value']) && in_array($key, $field['value'])))
+                            || ( ! is_null( old($field['name']) ) && old($field['name']) == $key))
                              selected
                         @endif
                     >{{ $value }}</option>


### PR DESCRIPTION
Line 19 from the previous version attempts to use `$field['value']` without first checking if it exists.

Since line 17 from the previous version does so the check to see if `$field['value']` is set, I combined line 17 and 18.