### PR TITLE
[4.1][Feature][Needs testing] possibility to save additional data to pivot table

### DIFF
--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -84,9 +84,11 @@ trait Create
                 $model->{$field['name']}()->sync($values);
 
                 if (isset($field['pivotFields'])) {
-                    foreach ($field['pivotFields'] as $pivotField) {
-                        foreach ($data[$pivotField] as $pivot_id =>  $field) {
-                            $model->{$field['name']}()->updateExistingPivot($pivot_id, [$pivotField => $field]);
+                    $pivotFields = array_keys($field['pivotFields']);
+
+                    foreach ($pivotFields as $pivotField) {
+                        foreach ($data[$pivotField] as $pivot_id => $pivotValue) {
+                            $model->{$field['name']}()->updateExistingPivot($pivot_id, [$pivotField => $pivotValue]);
                         }
                     }
                 }

--- a/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
+++ b/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
@@ -1,0 +1,56 @@
+<div @include('crud::inc.field_wrapper_attributes') >
+
+    <h3>{!! $field['label'] !!}</h3>
+
+    @if (isset($field['model']))
+
+        <?php
+            $pivot_entries = $entry->{$field['entity']}->keyBy(function($item) {
+                return $item->getKey();
+            });
+        ?>
+
+        @foreach ($field['model']::all() as $connected_entity_entry)
+            <div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="{{ $field['name'] }}[{{ $connected_entity_entry->getKey() }}]" value="{{ $connected_entity_entry->getKey() }}"
+                            @if ( (isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())) || ( old( $field["name"] ) && in_array($connected_entity_entry->getKey(), old( $field["name"])) ) )
+                                checked="checked"
+                            @endif
+                        />
+                        {!! $connected_entity_entry->{$field['attribute']} !!}
+                    </label>
+                </div>
+
+                @if(isset($field['pivotFields']))
+                    <div class="container-fluid">
+                        @foreach(array_chunk($field['pivotFields'], 2, true) as $pivot_chunk)
+                            <div class="row">
+                                @foreach ($pivot_chunk as $pivot_field => $pivot_name)
+                                    <?php
+                                        $pivot_attr = null;
+                                        if ($pivot_entries->has($connected_entity_entry->getKey())) {
+                                            $pivot = $pivot_entries->get($connected_entity_entry->getKey())->pivot;
+                                            $pivot_attr = $pivot->getAttribute($pivot_field);
+                                        }
+                                    ?>
+
+                                    <div class="col-sm-6">
+                                        <label>{!! $pivot_name !!}</label>
+                                        <input type="text" name="{!! $pivot_field !!}[{{ $connected_entity_entry->getKey() }}]" value="{{ $pivot_attr or null }}" @include('crud::inc.field_attributes') />
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        @endforeach
+    @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
+++ b/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
@@ -5,44 +5,68 @@
     @if (isset($field['model']))
 
         <?php
-            $pivot_entries = $entry->{$field['entity']}->keyBy(function($item) {
-                return $item->getKey();
-            });
+        $pivot_entries = $entry->{$field['entity']}->keyBy(function($item) {
+            return $item->getKey();
+        });
         ?>
+
+        @if(isset($field['pivotFields']))
+            <a class="btn btn-default" role="button" data-toggle="collapse" id="trigger-toggle-all" aria-expanded="false">
+                <span class="caret"></span> {{ trans('Toggle all') }}
+            </a>
+
+            @push('crud_fields_scripts')
+            <script>
+                jQuery(document).ready(function($) {
+                    $('#trigger-toggle-all').on('click', function () {
+                        $('div.collapse').collapse('toggle');
+                    });
+                });
+            </script>
+            @endpush
+        @endif
 
         @foreach ($field['model']::all() as $connected_entity_entry)
             <div>
                 <div class="checkbox">
-                    <label>
+                    <label style="vertical-align: middle;">
                         <input type="checkbox" name="{{ $field['name'] }}[{{ $connected_entity_entry->getKey() }}]" value="{{ $connected_entity_entry->getKey() }}"
-                            @if ( (isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())) || ( old( $field["name"] ) && in_array($connected_entity_entry->getKey(), old( $field["name"])) ) )
-                                checked="checked"
-                            @endif
-                        />
+                               @if ( (isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())) || ( old( $field["name"] ) && in_array($connected_entity_entry->getKey(), old( $field["name"])) ) )
+                               checked="checked"
+                                @endif
+                                />
                         {!! $connected_entity_entry->{$field['attribute']} !!}
                     </label>
+
+                    @if(isset($field['pivotFields']))
+                        <a class="btn btn-default btn-xs" role="button" data-toggle="collapse" href="#toggle-pivot-{{ $connected_entity_entry->getKey() }}" aria-expanded="false">
+                            <span class="caret"></span>
+                        </a>
+                    @endif
                 </div>
 
                 @if(isset($field['pivotFields']))
-                    <div class="container-fluid">
-                        @foreach(array_chunk($field['pivotFields'], 2, true) as $pivot_chunk)
-                            <div class="row">
-                                @foreach ($pivot_chunk as $pivot_field => $pivot_name)
-                                    <?php
+                    <div class="collapse" id="toggle-pivot-{{ $connected_entity_entry->getKey() }}">
+                        <div class="container-fluid">
+                            @foreach(array_chunk($field['pivotFields'], 2, true) as $pivot_chunk)
+                                <div class="row">
+                                    @foreach ($pivot_chunk as $pivot_field => $pivot_name)
+                                        <?php
                                         $pivot_attr = null;
                                         if ($pivot_entries->has($connected_entity_entry->getKey())) {
                                             $pivot = $pivot_entries->get($connected_entity_entry->getKey())->pivot;
                                             $pivot_attr = $pivot->getAttribute($pivot_field);
                                         }
-                                    ?>
+                                        ?>
 
-                                    <div class="col-sm-6">
-                                        <label>{!! $pivot_name !!}</label>
-                                        <input type="text" name="{!! $pivot_field !!}[{{ $connected_entity_entry->getKey() }}]" value="{{ $pivot_attr or null }}" @include('crud::inc.field_attributes') />
-                                    </div>
-                                @endforeach
-                            </div>
-                        @endforeach
+                                        <div class="col-sm-6">
+                                            <label>{!! $pivot_name !!}</label>
+                                            <input type="text" name="{!! $pivot_field !!}[{{ $connected_entity_entry->getKey() }}]" value="{{ $pivot_attr or null }}" @include('crud::inc.field_attributes') />
+                                        </div>
+                                    @endforeach
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 @endif
             </div>

--- a/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
+++ b/src/resources/views/fields/checkbox_multiple_with_pivot.blade.php
@@ -5,9 +5,12 @@
     @if (isset($field['model']))
 
         <?php
-        $pivot_entries = $entry->{$field['entity']}->keyBy(function($item) {
-            return $item->getKey();
-        });
+            $pivot_entries = null;
+            if (isset($entry)) {
+                $pivot_entries = $entry->{$field['entity']}->keyBy(function($item) {
+                    return $item->getKey();
+                });
+            }
         ?>
 
         @if(isset($field['pivotFields']))
@@ -16,13 +19,13 @@
             </a>
 
             @push('crud_fields_scripts')
-            <script>
-                jQuery(document).ready(function($) {
-                    $('#trigger-toggle-all').on('click', function () {
-                        $('div.collapse').collapse('toggle');
+                <script>
+                    jQuery(document).ready(function($) {
+                        $('#trigger-toggle-all').on('click', function () {
+                            $('div.collapse').collapse('toggle');
+                        });
                     });
-                });
-            </script>
+                </script>
             @endpush
         @endif
 
@@ -52,16 +55,18 @@
                                 <div class="row">
                                     @foreach ($pivot_chunk as $pivot_field => $pivot_name)
                                         <?php
-                                        $pivot_attr = null;
-                                        if ($pivot_entries->has($connected_entity_entry->getKey())) {
-                                            $pivot = $pivot_entries->get($connected_entity_entry->getKey())->pivot;
-                                            $pivot_attr = $pivot->getAttribute($pivot_field);
-                                        }
+                                            $pivot_attr = null;
+                                            if ($pivot_entries) {
+                                                if ($pivot_entries->has($connected_entity_entry->getKey())) {
+                                                    $pivot = $pivot_entries->get($connected_entity_entry->getKey())->pivot;
+                                                    $pivot_attr = $pivot->getAttribute($pivot_field);
+                                                }
+                                            }
                                         ?>
 
                                         <div class="col-sm-6">
                                             <label>{!! $pivot_name !!}</label>
-                                            <input type="text" name="{!! $pivot_field !!}[{{ $connected_entity_entry->getKey() }}]" value="{{ $pivot_attr or null }}" @include('crud::inc.field_attributes') />
+                                            <input type="text" name="{!! $pivot_field !!}[{{ $connected_entity_entry->getKey() }}]" value="{{ $pivot_attr }}" @include('crud::inc.field_attributes') />
                                         </div>
                                     @endforeach
                                 </div>


### PR DESCRIPTION
Tables:

Table user:
 - user_id
 - user_name
 - email
 - etc ...

Table module:
 - module_id
 - module_name

Table user_has_module
 - user_id
 - module_id
 - custom_field1
 - custom_field2
 - custom_field3 ...

There are situations where in n-n realtionship is necessary to save custom_field information. I created field checkbox_multiple_with_pivot to be able to manage those custom fields and also edited slightly CreateTrait.

Field definition looks like this:

```php
[
            'label' => 'Modules',
            'type' => 'checkbox_multiple_with_pivot',
            'name' => 'modules',
            'entity' => 'modules', // the method that defines the relationship in your Model
            'attribute' => 'module_name', // foreign key attribute that is shown to user
            'model' => 'App\Models\Module', // foreign key model
            'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
            'pivotFields' => [
                'custom_field1' => 'This is label for custom field1',
                'custom_field2' => 'This is label for custom field2',
                'custom_field3' => 'This is label for custom field3',
            ],
]
```

Feel free to edit field blade file to your needs.