### PR TITLE
Allow sending a default class attribute to field wrappers

### DIFF
--- a/src/resources/views/inc/field_wrapper_attributes.blade.php
+++ b/src/resources/views/inc/field_wrapper_attributes.blade.php
@@ -6,8 +6,16 @@
     @endforeach
 
     @if (!isset($field['wrapperAttributes']['class']))
-		class="form-group col-md-12"
+      @if (isset($default_class))
+        class="{{ $default_class }}"
+      @else
+        class="form-group col-md-12"
+      @endif
     @endif
 @else
-	class="form-group col-md-12"
+  @if (isset($default_class))
+    class="{{ $default_class }}"
+  @else
+    class="form-group col-md-12"
+  @endif
 @endif


### PR DESCRIPTION
Works in the same way you can pass a default class to the fields themselves.