### PR TITLE
In edit.blade.php, use the fields variable passed to the view

### DIFF
--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -31,7 +31,7 @@
 		      @if(view()->exists('vendor.backpack.crud.form_content'))
 		      	@include('vendor.backpack.crud.form_content')
 		      @else
-		      	@include('crud::form_content', ['fields' => $fields)
+		      	@include('crud::form_content', ['fields' => $fields])
 		      @endif
 		    </div><!-- /.box-body -->
 		    <div class="box-footer">

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -31,7 +31,7 @@
 		      @if(view()->exists('vendor.backpack.crud.form_content'))
 		      	@include('vendor.backpack.crud.form_content')
 		      @else
-		      	@include('crud::form_content', ['fields' => $crud->getFields('update', $entry->getKey())])
+		      	@include('crud::form_content', ['fields' => $fields)
 		      @endif
 		    </div><!-- /.box-body -->
 		    <div class="box-footer">


### PR DESCRIPTION
I noticed in CrudController.php line 146:

`$this->data['fields'] = $this->crud->getUpdateFields($id);`

and this is passed to the edit.blade.php view.

Now I want to make a seperate edit page for a particular model that only shows certain edit fields.
However edit.blade.php does not use the `$fields` variable passed into it. Instead it creates them from a function again. So this is double handling.

Instead it should use the `$fields` passed into the view.