### PR TITLE
Changed revisions sort based on key

### DIFF
--- a/src/PanelTraits/ViewsAndRestoresRevisions.php
+++ b/src/PanelTraits/ViewsAndRestoresRevisions.php
@@ -30,7 +30,7 @@ trait ViewsAndRestoresRevisions
         }
 
         // Sort the array by timestamp descending (so that the most recent are at the top)
-        arsort($revisions);
+        krsort($revisions);
 
         return $revisions;
     }


### PR DESCRIPTION
The order of revisions based on date was broken since arsort is not working as expected for multidimensional arrays. I've updated to order the array based on key since we used the date as key.