### PR TITLE
Use entry getKey and revision old_value in restoreRevision

### DIFF
--- a/src/PanelTraits/ViewsAndRestoresRevisions.php
+++ b/src/PanelTraits/ViewsAndRestoresRevisions.php
@@ -47,7 +47,7 @@ trait ViewsAndRestoresRevisions
         $revision = Revision::findOrFail($revisionId);
 
         // Update the revisioned field with the old value
-        $this->update($entry->id, [$revision->key => $revision->oldValue()]);
+        $this->update($entry->getKey(), [$revision->key => $revision->old_value]);
 
         // Reload the entry so we have the latest revisions
         $entry = $this->getEntry($id);


### PR DESCRIPTION
In restoreRevision method get defined Primary Key for model instead hard coded "id" for $entry and for revision get old_value field instead of using oldValue() method that returns the text value for foreign keys relationships.