### PR TITLE
added json and jsonb support for postgres

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -49,8 +49,10 @@ trait CrudTrait
         $conn = DB::connection($instance->getConnectionName());
         $table = Config::get('database.connections.'.env('DB_CONNECTION').'.prefix').$instance->getTable();
 
-        // register the enum column type, because Doctrine doesn't support it
+        // register the enum, json and jsonb column type, because Doctrine doesn't support it
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
 
         return ! $conn->getDoctrineColumn($table, $column_name)->getNotnull();
     }


### PR DESCRIPTION
I tried it with Laravel 5.3, PostgresSQL 9.6.1 with doctrine 2.5.10. Without this fix, I was not able to use any select field without this hack. So, I think it would be better if I added this on CRUD, so that other people can use this as well.

Later, I checked it with mysql as well, and it works perfectly.


