### PR TITLE
Dropdown filter triggers separator on 0 index

### DIFF
--- a/src/resources/views/filters/dropdown.blade.php
+++ b/src/resources/views/filters/dropdown.blade.php
@@ -9,7 +9,7 @@
 		<li role="separator" class="divider"></li>
 		@if (is_array($filter->values) && count($filter->values))
 			@foreach($filter->values as $key => $value)
-				@if ($key == 'dropdown-separator')
+				@if ($key === 'dropdown-separator')
 					<li role="separator" class="divider"></li>
 				@else
 					<li class="{{ ($filter->isActive() && $filter->currentValue == $key)?'active':'' }}">


### PR DESCRIPTION
When you have a drop down filter with a value index of 0 it triggers the dropdown-separator.

```
$this->crud->addFilter(
            [
              'type'  => 'dropdown',
              'name'  => 'active_flag',
              'label' => 'Active',
            ],
            [
                0 => 'Inactive',
                1 => 'Active'
            ],
            function ($value) {
                $this->crud->addClause('where', 'active_flag', $value);
            });
```