### PR TITLE
Add missing step to publish the view files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ composer require backpack/crud
 ```bash
 $ php artisan elfinder:publish #published elfinder assets
 $ php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="public" #publish CRUD assets
+$ php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="views" #publish the view files
 $ php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="lang" #publish the lang files
 $ php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="config" #publish the config file
 $ php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="elfinder" #publish overwritten elFinder assets


### PR DESCRIPTION
I just started using this project and noticed the CRUD view files were missing in my public/views/vendor directory. 

Then I realised they were missing because that step was missing from the documentation. So I added it 😉 

```bash
php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="views"
```

PS: Thanks for this awesome project!