### PR TITLE
Fix conflict bootstrap-datepicker & jquery-ui

### DIFF
--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -47,6 +47,9 @@
         <script charset="UTF-8" src="{{ asset('vendor/adminlte/plugins/datepicker/locales/bootstrap-datepicker.'.$field_language.'.js') }}"></script>
     @endif
     <script>
+        var datepicker = $.fn.datepicker.noConflict(); 
+        $.fn.bootstrapDP = datepicker;
+
         var dateFormat=function(){var a=/d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZ]|"[^"]*"|'[^']*'/g,b=/\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,c=/[^-+\dA-Z]/g,d=function(a,b){for(a=String(a),b=b||2;a.length<b;)a="0"+a;return a};return function(e,f,g){var h=dateFormat;if(1!=arguments.length||"[object String]"!=Object.prototype.toString.call(e)||/\d/.test(e)||(f=e,e=void 0),e=e?new Date(e):new Date,isNaN(e))throw SyntaxError("invalid date");f=String(h.masks[f]||f||h.masks.default),"UTC:"==f.slice(0,4)&&(f=f.slice(4),g=!0);var i=g?"getUTC":"get",j=e[i+"Date"](),k=e[i+"Day"](),l=e[i+"Month"](),m=e[i+"FullYear"](),n=e[i+"Hours"](),o=e[i+"Minutes"](),p=e[i+"Seconds"](),q=e[i+"Milliseconds"](),r=g?0:e.getTimezoneOffset(),s={d:j,dd:d(j),ddd:h.i18n.dayNames[k],dddd:h.i18n.dayNames[k+7],m:l+1,mm:d(l+1),mmm:h.i18n.monthNames[l],mmmm:h.i18n.monthNames[l+12],yy:String(m).slice(2),yyyy:m,h:n%12||12,hh:d(n%12||12),H:n,HH:d(n),M:o,MM:d(o),s:p,ss:d(p),l:d(q,3),L:d(q>99?Math.round(q/10):q),t:n<12?"a":"p",tt:n<12?"am":"pm",T:n<12?"A":"P",TT:n<12?"AM":"PM",Z:g?"UTC":(String(e).match(b)||[""]).pop().replace(c,""),o:(r>0?"-":"+")+d(100*Math.floor(Math.abs(r)/60)+Math.abs(r)%60,4),S:["th","st","nd","rd"][j%10>3?0:(j%100-j%10!=10)*j%10]};return f.replace(a,function(a){return a in s?s[a]:a.slice(1,a.length-1)})}}();dateFormat.masks={default:"ddd mmm dd yyyy HH:MM:ss",shortDate:"m/d/yy",mediumDate:"mmm d, yyyy",longDate:"mmmm d, yyyy",fullDate:"dddd, mmmm d, yyyy",shortTime:"h:MM TT",mediumTime:"h:MM:ss TT",longTime:"h:MM:ss TT Z",isoDate:"yyyy-mm-dd",isoTime:"HH:MM:ss",isoDateTime:"yyyy-mm-dd'T'HH:MM:ss",isoUtcDateTime:"UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"},dateFormat.i18n={dayNames:["Sun","Mon","Tue","Wed","Thu","Fri","Sat","Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],monthNames:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec","January","February","March","April","May","June","July","August","September","October","November","December"]},Date.prototype.format=function(a,b){return dateFormat(this,a,b)};
 
         jQuery(document).ready(function($){
@@ -57,14 +60,14 @@
                 $customConfig = $.extend({
                     format: 'dd/mm/yyyy'
                 }, $fake.data('bs-datepicker'));
-                $picker = $fake.datepicker($customConfig);
+                $picker = $fake.bootstrapDP($customConfig);
 
                 var $existingVal = $field.val();
 
                 if( $existingVal.length ){
                     preparedDate = new Date($existingVal).format($customConfig.format);
                     $fake.val(preparedDate);
-                    $picker.datepicker('update', preparedDate);
+                    $picker.bootstrapDP('update', preparedDate);
                 }
 
                 $fake.on('keydown', function(e){


### PR DESCRIPTION
Fix to avoid conflict between bootstrap-datepicker & jquery-ui libraries.

When a field type "date_picker" is created before a field type "table", there's a conflict between the libraries.

For this reason, the datepicker is shown without styles.

![bootstrap-datepicker-conflict](https://cloud.githubusercontent.com/assets/234170/22508706/db77e8b6-e869-11e6-9df2-fda1fae6c5f3.png)

```
        $this->crud->addField([
            'label' => 'Service date',
            'type' => 'date_picker',
            'name' => 'service_date',
        ]);

        $this->crud->addField([
            'name' => 'services',
            'label' => 'Services',
            'type' => 'table',
            'entity_singular' => 'service',
            'columns' => [
                'name' => 'Detail',
            ],
            'min' => 0
        ]);
```