### PR TITLE
Use of id (primary key) is hardcoded in select_multiple column

### DIFF
--- a/src/resources/views/columns/select_multiple.blade.php
+++ b/src/resources/views/columns/select_multiple.blade.php
@@ -2,9 +2,10 @@
 <td>
     <?php
         $results = $entry->{$column['entity']};
+        $primary_key = ( new $column['model'])->getKeyName();
 
         if ($results && $results->count()) {
-            $results_array = $results->pluck($column['attribute'], 'id');
+            $results_array = $results->pluck($column['attribute'], $primary_key);
             echo implode(', ', $results_array->toArray());
         } else {
             echo '-';


### PR DESCRIPTION
Not all setups have id as the primary key. Instead get the primary
key name from the given model and use that in the pluck method.