### PR TITLE
Check that the Fake field is included in the request before trying to use it

### DIFF
--- a/src/PanelTraits/FakeFields.php
+++ b/src/PanelTraits/FakeFields.php
@@ -23,8 +23,8 @@ trait FakeFields
 
         // go through each defined field
         foreach ($fields as $k => $field) {
-            // if it's a fake field
-            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true) {
+            // if it's a fake field and the field is included in the request
+            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true && isset($request[$fields[$k]])) {
                 // add it to the request in its appropriate variable - the one defined, if defined
                 if (isset($fields[$k]['store_in'])) {
                     $request[$fields[$k]['store_in']][$fields[$k]['name']] = $request[$fields[$k]['name']];

--- a/src/PanelTraits/FakeFields.php
+++ b/src/PanelTraits/FakeFields.php
@@ -24,7 +24,7 @@ trait FakeFields
         // go through each defined field
         foreach ($fields as $k => $field) {
             // if it's a fake field and the field is included in the request
-            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true && isset($request[$fields[$k]])) {
+            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true && isset($request[$fields[$k]['name']])) {
                 // add it to the request in its appropriate variable - the one defined, if defined
                 if (isset($fields[$k]['store_in'])) {
                     $request[$fields[$k]['store_in']][$fields[$k]['name']] = $request[$fields[$k]['name']];


### PR DESCRIPTION
When a Fake field was not returned in the form request, eg if a multiple select input didn't have any selections, then an error like

```
in FakeFields.php line 30
at HandleExceptions->handleError('8', 'Undefined index: featured', '......\vendor\backpack\crud\src\PanelTraits\FakeFields.php', '30', array('request' =>
```
