### PR TITLE
removed data tables live control package and fixed the ajax table trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,55 +1,55 @@
 {
-    "name": "backpack/crud",
-    "description": "Quickly build an admin interface for your Eloquent models, using Laravel 5. Build a CMS in a matter of minutes.",
-    "keywords": [
-        "CRUD",
-        "create",
-        "update",
-        "delete",
-        "read",
-        "admin panel",
-        "admin interface",
-        "CMS"
-    ],
-    "homepage": "https://github.com/laravel-backpack/CRUD",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Cristian tabacitu",
-            "email": "hello@tabacitu.ro",
-            "homepage": "http://www.tabacitu.ro",
-            "role": "Chief Architect & Lead Developer"
-        }
-    ],
-    "require": {
-        "backpack/base": "^0.7.15",
-        "laravelcollective/html": "~5.0",
-        "barryvdh/laravel-elfinder": "^0.3.10",
-        "livecontrol/eloquent-datatable": "^0.1.5",
-        "doctrine/dbal": "^2.5",
-        "venturecraft/revisionable": "1.*",
-        "intervention/image": "^2.3"
-    },
-    "require-dev": {
-        "phpunit/phpunit" : "4.*",
-        "scrutinizer/ocular": "~1.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "Backpack\\CRUD\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Backpack\\CRUD\\Test\\": "tests"
-        }
-    },
-    "scripts": {
-        "test": "phpunit"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0-dev"
-        }
+  "name": "backpack/crud",
+  "description": "Quickly build an admin interface for your Eloquent models, using Laravel 5. Build a CMS in a matter of minutes.",
+  "keywords": [
+    "CRUD",
+    "create",
+    "update",
+    "delete",
+    "read",
+    "admin panel",
+    "admin interface",
+    "CMS",
+    "laravel",
+  ],
+  "homepage": "https://github.com/laravel-backpack/CRUD",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Cristian tabacitu",
+      "email": "hello@tabacitu.ro",
+      "homepage": "http://www.tabacitu.ro",
+      "role": "Chief Architect & Lead Developer"
     }
+  ],
+  "require": {
+    "backpack/base": "^0.7.15",
+    "laravelcollective/html": "~5.0",
+    "barryvdh/laravel-elfinder": "^0.3.10",
+    "doctrine/dbal": "^2.5",
+    "venturecraft/revisionable": "1.*",
+    "intervention/image": "^2.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "4.*",
+    "scrutinizer/ocular": "~1.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Backpack\\CRUD\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Backpack\\CRUD\\Test\\": "tests"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0-dev"
+    }
+  }
 }

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -83,9 +83,9 @@ trait Read
                 foreach ($this->columns as $column) {
                     if ($this->getColumnQuery($column) !== null) {
                         $query->orWhere(
-                            new Expression($this->getColumnQuery($column)),
+                            $this->getColumnQuery($column),
                             'like',
-                            '%' . $filter . '%'
+                            '%' .$filter. '%'
                         );
                     }
                 }
@@ -102,13 +102,11 @@ trait Read
             $entries = $this->query->orderBy($orderBy, $orderDirection);
         }
 
-
         if ($modifiers == 0) {
             $entries = $this->query->get();
         } else {
             $entries = $entries->get();
         }
-
 
         // add the fake columns for each entry
         foreach ($entries as $key => $entry) {
@@ -119,9 +117,7 @@ trait Read
     }
 
     /**
-     * Receives a filter and tries to get all the columns to be filtered by that filter *Work in progress*
-     *
-     * TODO: Move this to a more appropriate place
+     * Receives a filter and tries to get all the columns to be filtered by that filter *Work in progress*.
      *
      * @param $column
      * @return null|string
@@ -137,7 +133,6 @@ trait Read
         }
 
         return Model::resolveConnection()->getQueryGrammar()->wrap($column);
-
     }
 
     /**
@@ -268,21 +263,25 @@ trait Read
     /**
      * Get the HTML of a cell, using the column types.
      * @param  array $column
-     * @param  Entity $entry   A db entry of the current entity;
+     * @param  Entity $entry A db entry of the current entity;
      * @return HTML
      */
     public function getCellView($column, $entry)
     {
-        if (! isset($column['type'])) {
-            return \View::make('crud::columns.text')->with('crud', $this)->with('column', $column)->with('entry', $entry)->render();
+        if (!isset($column['type'])) {
+            return \View::make('crud::columns.text')->with('crud', $this)->with('column', $column)->with('entry',
+                $entry)->render();
         } else {
-            if (view()->exists('vendor.backpack.crud.columns.'.$column['type'])) {
-                return \View::make('vendor.backpack.crud.columns.'.$column['type'])->with('crud', $this)->with('column', $column)->with('entry', $entry)->render();
+            if (view()->exists('vendor.backpack.crud.columns.' . $column['type'])) {
+                return \View::make('vendor.backpack.crud.columns.' . $column['type'])->with('crud',
+                    $this)->with('column', $column)->with('entry', $entry)->render();
             } else {
-                if (view()->exists('crud::columns.'.$column['type'])) {
-                    return \View::make('crud::columns.'.$column['type'])->with('crud', $this)->with('column', $column)->with('entry', $entry)->render();
+                if (view()->exists('crud::columns.' . $column['type'])) {
+                    return \View::make('crud::columns.' . $column['type'])->with('crud', $this)->with('column',
+                        $column)->with('entry', $entry)->render();
                 } else {
-                    return \View::make('crud::columns.text')->with('crud', $this)->with('column', $column)->with('entry', $entry)->render();
+                    return \View::make('crud::columns.text')->with('crud', $this)->with('column',
+                        $column)->with('entry', $entry)->render();
                 }
             }
         }

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -58,6 +58,89 @@ trait Read
     }
 
     /**
+     * Get all entries from the database with conditions.
+     *
+     * @param string $length the number of records requested
+     * @param string $skip how many to skip
+     * @param string $orderBy the column to order by
+     * @param string $orderDirection how to order asc/desc
+     * @param string $filter what string to filter the name by
+     *
+     * @return [Collection of your model]
+     */
+    public function getEntriesWithConditions(
+        $length = null,
+        $skip = 0,
+        $orderBy = null,
+        $orderDirection = 'asc',
+        $filter = null
+    ) {
+        $modifiers = 0;
+
+        if ($filter !== null) {
+            $modifiers = 1;
+            $entries = $this->query->where(function ($query) use ($filter) {
+                foreach ($this->columns as $column) {
+                    if ($this->getColumnQuery($column) !== null) {
+                        $query->orWhere(
+                            new Expression($this->getColumnQuery($column)),
+                            'like',
+                            '%' . $filter . '%'
+                        );
+                    }
+                }
+            });
+        }
+
+        if ($length !== null) {
+            $modifiers = 1;
+            $entries = $this->query->skip($skip)->take($length);
+        }
+
+        if ($orderBy !== null) {
+            $modifiers = 1;
+            $entries = $this->query->orderBy($orderBy, $orderDirection);
+        }
+
+
+        if ($modifiers == 0) {
+            $entries = $this->query->get();
+        } else {
+            $entries = $entries->get();
+        }
+
+
+        // add the fake columns for each entry
+        foreach ($entries as $key => $entry) {
+            $entry->addFakes($this->getFakeColumnsAsArray());
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Receives a filter and tries to get all the columns to be filtered by that filter *Work in progress*
+     *
+     * TODO: Move this to a more appropriate place
+     *
+     * @param $column
+     * @return null|string
+     */
+    private function getColumnQuery($column)
+    {
+        if (isset($column['type']) && $column['type'] == 'model_function') {
+            return null;
+        }
+
+        if (is_array($column)) {
+            return $column['name'];
+        }
+
+        return Model::resolveConnection()->getQueryGrammar()->wrap($column);
+
+    }
+
+    /**
      * Get the fields for the create or update forms.
      *
      * @param  [form] create / update / both - defaults to 'both'

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -24,18 +24,18 @@ trait AjaxTable
     {
         $this->crud->hasAccessOrFail('list');
 
-        $this->input = Input::all();
+        $this->input = $_REQUEST;
         $this->totalRows = $this->filteredRows = $this->crud->getEntries()->count();
 
         $data = $this->crud->getEntriesWithConditions(
             $this->input['length'],
             $this->input['start'],
-            $this->addOrderBy()[0],
-            $this->addOrderBy()[1],
-            $this->addFilters()
+            $this->addAjaxOrderBy()[0],
+            $this->addAjaxOrderBy()[1],
+            $this->addSearchConditions()
         );
 
-        if ($this->addFilters() !== null) {
+        if ($this->addSearchConditions() !== null) {
             $this->filteredRows = $data->count();
         }
 
@@ -94,11 +94,11 @@ trait AjaxTable
 
     /**
      * Checks of teh user has anything written in the search bar and if so a string with the filtered is returned.
-     * In case no filter is detected null is returned
+     * In case no filter is detected null is returned.
      *
      * @return null | string $filter
      */
-    private function addFilters()
+    private function addSearchConditions()
     {
         if (isset($this->input['search']) && isset($this->input['search']['value'])) {
             $filter = $this->input['search']['value'];
@@ -116,7 +116,7 @@ trait AjaxTable
      *
      * @return array [column, direction]
      */
-    public function addOrderBy()
+    public function addAjaxOrderBy()
     {
         if (isset($this->input['order']) && isset($this->input['order'][0])) {
             $orderBy = $this->input['order'][0]['column'];

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -8,48 +8,122 @@ trait AjaxTable
      * Respond with the JSON of one or more rows, depending on the POST parameters.
      * @return JSON Array of cells in HTML form.
      */
+    public $data;
+
+    private $input;
+    private $totalRows = 0;
+    private $filteredRows = 0;
+    private $versionTransformer;
+
+    /**
+     * The search function. This function it's called by the data table
+     *
+     * @return array
+     */
     public function search()
     {
         $this->crud->hasAccessOrFail('list');
 
-        // create an array with the names of the searchable columns
-        $columns = collect($this->crud->columns)
-                    ->reject(function ($column, $key) {
-                        // the select_multiple columns are not searchable
-                        return isset($column['type']) && $column['type'] == 'select_multiple';
-                    })
-                    ->pluck('name')
-                    // add the primary key, otherwise the buttons won't work
-                    ->merge($this->crud->model->getKeyName())
-                    ->toArray();
+        $this->input = Input::all();
+        $this->totalRows = $this->filteredRows = $this->crud->getEntries()->count();
 
-        // structure the response in a DataTable-friendly way
-        $dataTable = new \LiveControl\EloquentDataTable\DataTable($this->crud->query, $columns);
+        $data = $this->crud->getEntriesWithConditions(
+            $this->input['length'],
+            $this->input['start'],
+            $this->addOrderBy()[0],
+            $this->addOrderBy()[1],
+            $this->addFilters()
+        );
 
-        // make the datatable use the column types instead of just echoing the text
-        $dataTable->setFormatRowFunction(function ($entry) {
-            // get the actual HTML for each row's cell
-            $row_items = $this->crud->getRowViews($entry, $this->crud);
+        if ($this->addFilters() !== null) {
+            $this->filteredRows = $data->count();
+        }
 
-            // add the buttons as the last column
-            if ($this->crud->buttons->where('stack', 'line')->count()) {
-                $row_items[] = \View::make('crud::inc.button_stack', ['stack' => 'line'])
+        return $this->make($data);
+    }
+
+    /**
+     * Formats the row of the table from the entry(instance of a model)
+     *
+     * @param $entry
+     * @return array
+     */
+    private function format($entry)
+    {
+        $row_items = $this->crud->getRowViews($entry, $this->crud);
+
+        // add the buttons as the last column
+        if ($this->crud->buttons->where('stack', 'line')->count()) {
+            $row_items[] = \View::make('crud::inc.button_stack', ['stack' => 'line'])
                                 ->with('crud', $this->crud)
                                 ->with('entry', $entry)
                                 ->render();
+        }
+
+        // add the details_row buttons as the first column
+        if ($this->crud->details_row) {
+            array_unshift($row_items, \View::make('crud::columns.details_row_button')
+                                           ->with('crud', $this->crud)
+                                           ->with('entry', $entry)
+                                           ->render());
+        }
+
+        return $row_items;
+    }
+
+    /**
+     * Created the array to be fed to the data table
+     * @param $data
+     * @return array
+     */
+    private function make($data)
+    {
+        $rows = [];
+        foreach ($data as $row) {
+            $rows[] = $this->format($row);
+        }
+
+        return [
+            'draw'            => (isset($this->input['draw']) ? (int)$this->input['draw'] : 0),
+            'recordsTotal'    => $this->totalRows,
+            'recordsFiltered' => $this->filteredRows,
+            'data'            => $rows,
+        ];
+
+    }
+
+    /**
+     * Checks of teh user has anything written in the search bar and if so a string with the filtered is returned.
+     * In case no filter is detected null is returned
+     *
+     * @return null | string $filter
+     */
+    private function addFilters()
+    {
+        if (isset($this->input['search']) && isset($this->input['search']['value'])) {
+            $filter = $this->input['search']['value'];
+            if ($filter !== '') {
+                return $filter;
             }
+        }
+        return null;
+    }
 
-            // add the details_row buttons as the first column
-            if ($this->crud->details_row) {
-                array_unshift($row_items, \View::make('crud::columns.details_row_button')
-                                ->with('crud', $this->crud)
-                                ->with('entry', $entry)
-                                ->render());
+
+    /**
+     * Checks if the user tried to order a column and if so an array with the
+     * column to be order and the direction are returned
+     *
+     * @return array [column, direction]
+     */
+    public function addOrderBy()
+    {
+        if (isset($this->input['order']) && isset($this->input['order'][0])) {
+            $orderBy = $this->input['order'][0]['column'];
+            if (isset($this->crud->columns[(int)$orderBy]['name'])) {
+                return [$this->crud->columns[(int)$orderBy]['name'], $this->input['order'][0]['dir']];
             }
-
-            return $row_items;
-        });
-
-        return $dataTable->make();
+        }
+        return [null, null];
     }
 }


### PR DESCRIPTION
- I removed \LiveControl\EloquentDataTable\DataTable library that was failing for model functions and ordering the table
- created getEntriesWithConditions in the Read trait. The method receives these arguments 
```
$length = null,
$skip = 0,
$orderBy = null,
$orderDirection = 'asc',
$filter = null
```
The function returns the entries with the conditions stated. Any pf them can be skipped

- still working on ordering and searching through entries generated by a model function