### PR TITLE
Better sorting effect on "table" fields

### DIFF
--- a/src/resources/views/fields/table.blade.php
+++ b/src/resources/views/fields/table.blade.php
@@ -95,13 +95,7 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-sortable/0.14.3/sortable.min.js"></script>
         <script>
-            var fixHelper = function(e, ui) {
-                ui.children().each(function() {
-                    $(this).width($(this).width());
-                });
-                return ui;
-            };
-            
+          
             window.angularApp = window.angularApp || angular.module('backPackTableApp', ['ui.sortable'], function($interpolateProvider){
                 $interpolateProvider.startSymbol('<%');
                 $interpolateProvider.endSymbol('%>');
@@ -112,7 +106,12 @@
                 $scope.sortableOptions = {
                     handle: '.sort-handle',
                     axis: 'y',
-                    helper: fixHelper,
+                    helper: function(e, ui) {
+                        ui.children().each(function() {
+                            $(this).width($(this).width());
+                        });
+                        return ui;
+                    },
                 };
 
                 $scope.addItem = function(){

--- a/src/resources/views/fields/table.blade.php
+++ b/src/resources/views/fields/table.blade.php
@@ -95,7 +95,13 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-sortable/0.14.3/sortable.min.js"></script>
         <script>
-
+            var fixHelper = function(e, ui) {
+                ui.children().each(function() {
+                    $(this).width($(this).width());
+                });
+                return ui;
+            };
+            
             window.angularApp = window.angularApp || angular.module('backPackTableApp', ['ui.sortable'], function($interpolateProvider){
                 $interpolateProvider.startSymbol('<%');
                 $interpolateProvider.endSymbol('%>');
@@ -104,7 +110,9 @@
             window.angularApp.controller('tableController', function($scope){
 
                 $scope.sortableOptions = {
-                    handle: '.sort-handle'
+                    handle: '.sort-handle',
+                    axis: 'y',
+                    helper: fixHelper,
                 };
 
                 $scope.addItem = function(){


### PR DESCRIPTION
Sortable doesn't respect table rows size, as per https://github.com/angular-ui/ui-sortable/issues/237 

This fixes the effect, and add a vertical y-axis constraint so the sorting method is clearer.