### PR TITLE
 Preserve the original image format when uploading cropped image (fix #505)

### DIFF
--- a/src/resources/views/fields/base64_image.blade.php
+++ b/src/resources/views/fields/base64_image.blade.php
@@ -184,7 +184,7 @@
                                     $mainImage.cropper(options).cropper("reset", true).cropper("replace", this.result);
                                     // Override form submit to copy canvas to hidden input before submitting
                                     $('form').submit(function() {
-                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL();
+                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL(file.type);
                                         $hiddenImage.val(imageURL);
                                         return true; // return false to cancel form action
                                     });

--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -174,7 +174,7 @@
                                     $mainImage.cropper(options).cropper("reset", true).cropper("replace", this.result);
                                     // Override form submit to copy canvas to hidden input before submitting
                                     $('form').submit(function() {
-                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL();
+                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL(file.type);
                                         $hiddenImage.val(imageURL);
                                         return true; // return false to cancel form action
                                     });


### PR DESCRIPTION
If a JPG image is uploaded using the cropper tool in the image fields, its always sent to the server as image/png even if the original was image/jpeg - this can increase file size dramatically (for example a 4MB jpeg was being sent as a 10MB png to the server).

toDataURL is a canvas function which by default uses image/png
but we can just pass the file type to the function so if we originally had a jpeg it stays that way.

Fixes #505 