### PR TITLE
Fix: Bug when using multiple filters + Ajax Datatables

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -209,7 +209,7 @@
           "processing": true,
           "serverSide": true,
           "ajax": {
-              "url": "{{ url($crud->route.'/search').'?'.Request::getQueryString() }}",
+              "url": "{!! url($crud->route.'/search').'?'.Request::getQueryString() !!}",
               "type": "POST"
           },
           @endif


### PR DESCRIPTION
When using multiple filters via URL + ajax datatables, everything after the first param gets urlencoded via blade template tags, when it is building the ajax datatables URL. That defeats the purpose of filters, and make impossible to use more than one at the same time.

Example:

- URL: `http://www.domain.dev/admin/model?FILTER1=1&FILTER2=41`
- Gets converted to: `http://www.domain.dev/admin/model?FILTER1=1&amp;FILTER2=41`
- Search returns no or incorrect results, as only the first param is taken into account

This fix changes blade template tags to raw html, so it works fine.

![captura de pantalla de 2017-03-15 05-22-21](https://cloud.githubusercontent.com/assets/389801/23933563/b0280bcc-093f-11e7-8e68-fc2f309e359d.png)
