### PR TITLE
[feature] column "year"

### DIFF
--- a/src/resources/views/columns/year.blade.php
+++ b/src/resources/views/columns/year.blade.php
@@ -1,0 +1,6 @@
+{{-- localized date using jenssegers/date --}}
+<td data-order="{{ $entry->{$column['name']} }}">
+    @if (!empty($entry->{$column['name']}))
+	{{ Date::parse($entry->{$column['name']})->format('Y') }}
+    @endif
+</td>


### PR DESCRIPTION
I needed a column to show just the "year" from (year-)mysql-column.

Existing 'date' column just showed the year formatted as '1. January 2016', soooo...

... I created a copy using fixed format 'Y'. No magic at all.

If you want to add, do so. If I just missed the correct way of creating a year column, thanks for pointing out to me! :)