### PR TITLE
Fix details request called twice on ajax table list

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -304,6 +304,10 @@
 
       @if ($crud->details_row)
       function register_details_row_button_action() {
+        var crudTable = $('#crudTable tbody');
+        // Remove any previously registered event handlers from draw.dt event callback
+        $(crudTable).off('click', 'td .details-row-button');
+
         // Add event listener for opening and closing details
         $('#crudTable tbody').on('click', 'td .details-row-button', function () {
             var tr = $(this).closest('tr');

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -306,10 +306,10 @@
       function register_details_row_button_action() {
         var crudTable = $('#crudTable tbody');
         // Remove any previously registered event handlers from draw.dt event callback
-        $(crudTable).off('click', 'td .details-row-button');
+        crudTable.off('click', 'td .details-row-button');
 
         // Add event listener for opening and closing details
-        $('#crudTable tbody').on('click', 'td .details-row-button', function () {
+        crudTable.on('click', 'td .details-row-button', function () {
             var tr = $(this).closest('tr');
             var btn = $(this);
             var row = table.row( tr );


### PR DESCRIPTION
This fix address the same issue mentioned in #193 

Origin of the issue was the fact that in the handler of ```draw.dt``` event the ```register_details_row_button_action``` was called again which was registering the same click handler on the details button resulting duplicated ajax calls.

For example the aforementioned ```draw.dt``` event is fired on page change or initially on page load when ```$this->crud->enableAjaxTable();``` is enabled from the CRUD controller.

