### PR TITLE
New column type for images

### DIFF
--- a/src/resources/views/columns/image.blade.php
+++ b/src/resources/views/columns/image.blade.php
@@ -1,0 +1,18 @@
+<td>
+    @if (!isset($column['link']) or $column['link'] != False)
+    <a href="{{ $entry->{$column['name']} }}" target="_blank">
+    @endif
+    <img src="{{ $entry->{$column['name']} }}"
+    @if (isset($column['attributes']))
+        @foreach ($column['attributes'] as $attribute => $value)
+            @if (is_string($attribute))
+            {{ $attribute }}="{{ $value }}"
+            @endif
+        @endforeach
+    @else
+        style="height: 48px;"
+    @endif />
+    @if (!isset($column['link']) or $column['link'] != False)
+    </a>
+    @endif
+</td>


### PR DESCRIPTION
Added a new column type for images that uses the full image path with link and attributes as optional

````php
$this->crud->addColumn([
        'name' => 'avatar',
        'type' => 'image',
        'attributes' => [ // Optional (style by default is height: 48px;)
            'alt' => 'User avatar',
            'class' => 'img_rounded',
            'style' => 'width: 50px; height: 50px'
        ],
        'link' => True // Optional, this define if the image should have a link to be opened in new tab (default) or not
    ]
);
````