### PR TITLE
Retain selected filters on save and back action

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -83,6 +83,7 @@ class CrudController extends BaseController
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
+        $this->data['returnUrl'] = $this->getReturnUrl();
         $this->data['fields'] = $this->crud->getCreateFields();
         $this->data['title'] = trans('backpack::crud.add').' '.$this->crud->entity_name;
 
@@ -114,7 +115,7 @@ class CrudController extends BaseController
         }
 
         // insert item in the db
-        $item = $this->crud->create($request->except(['save_action', '_token', '_method']));
+        $item = $this->crud->create($request->except(['return_url', 'save_action', '_token', '_method']));
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message
@@ -141,6 +142,7 @@ class CrudController extends BaseController
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
+        $this->data['returnUrl'] = $this->getReturnUrl();
         $this->data['fields'] = $this->crud->getUpdateFields($id);
         $this->data['title'] = trans('backpack::crud.edit').' '.$this->crud->entity_name;
 
@@ -175,7 +177,7 @@ class CrudController extends BaseController
 
         // update the row in the db
         $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $request->except('save_action', '_token', '_method'));
+                            $request->except('return_url', 'save_action', '_token', '_method'));
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Http/Controllers/CrudFeatures/SaveActions.php
+++ b/src/app/Http/Controllers/CrudFeatures/SaveActions.php
@@ -67,6 +67,7 @@ trait SaveActions
     public function performSaveAction($itemId = null)
     {
         $saveAction = \Request::input('save_action', config('backback.crud.default_save_action', 'save_and_back'));
+        $returnUrl = \Request::input('return_url', $this->crud->route);
         $itemId = $itemId ? $itemId : \Request::input('id');
 
         switch ($saveAction) {
@@ -81,7 +82,7 @@ trait SaveActions
                 break;
             case 'save_and_back':
             default:
-                $redirectUrl = $this->crud->route;
+                $redirectUrl = $returnUrl;
                 break;
         }
 
@@ -108,4 +109,24 @@ trait SaveActions
                 break;
         }
     }
+
+    /**
+     * Get the referring URL if it is on the same site as backpack.
+     * Otherwise get the list all crud route.
+     * @return string the return url.
+     */
+     private function getReturnUrl()
+     {
+         if (!isset($_SERVER['HTTP_REFERER']) || !isset($_SERVER['HTTP_HOST'])) {
+             return $this->crud->route;
+         }
+
+         $referer = parse_url($_SERVER['HTTP_REFERER']);
+
+         if ($referer['host'] === $_SERVER['HTTP_HOST'] && stripos($referer['path'], $this->crud->route)) {
+             return $_SERVER['HTTP_REFERER'];
+         }
+
+         return $this->crud->route;
+     }
 }

--- a/src/resources/views/inc/form_save_buttons.blade.php
+++ b/src/resources/views/inc/form_save_buttons.blade.php
@@ -1,5 +1,6 @@
 <div id="saveActions" class="form-group">
 
+    <input type="hidden" name="return_url" value="{{ old('return_url') ? old('return_url') : $returnUrl }}">
     <input type="hidden" name="save_action" value="{{ $saveAction['active']['value'] }}">
 
     <div class="btn-group">


### PR DESCRIPTION
When returning from saving an item when you have active filters, they are lost.
This pull request aims to retain any saved filters when you return to the list view when using the save and back button.