### PR TITLE
A crud field type to output a VUE.JS component

### DIFF
--- a/src/resources/views/fields/vue_component.js
+++ b/src/resources/views/fields/vue_component.js
@@ -1,0 +1,23 @@
+<div @include('crud::inc.field_wrapper_attributes') >
+<?php
+if (in_array('label', $field)) {
+    if ($field['label'] != '') {
+        echo '<label>'.$field['label'].'</label>';
+    }
+}
+
+$component = '<'.$field['name'];
+
+
+foreach ($field as $key => $value) {
+    if (! in_array($key, ['name', 'type', 'label'])) {
+        $encoded = json_encode($value, true);
+        $component .= ' :'.$key."='".$encoded."'";
+    }
+}
+
+
+$component .= '></'.$field['name'].'>';
+echo $component;
+?>
+</div>


### PR DESCRIPTION
The goal here is to interface "easily" a CRUD field with a VUE.JS component to be able to do client-side stuff. It supports passing any number of parameters (called "props" in vue JS)

Usage:
`$this->crud->addField([
	'type' => 'vue_component',
	'name' => 'my_vue_js_component',
	'parameter1' => ['test1', 'test2', 'test3'],
	'parameter2' => User::find(1)->toArray()
]);`

In the form page with all the fields, the field will be outputed like that:
`<my_vue_js_component :parameter1:'...' :parameter2:'....'></my_vue_js_component>`

Parameters will be automatically converted to json arrays. 

**Note: All field keys except: 'label', 'name', and 'type' are passed as parameters to the vue.js components.**

Then, in your single-file component, use the parameters you passed as props:
`export default {
        props: ['parameter1', 'parameter2']
	(...)
}`

Reminder, your single-file component should be loaded from app.js:
`Vue.component('my_vue_js_component',  require('./components/my_vue_js_component.vue') );`

Then it will be the responsability of your vue.js component to output what is needed (a dedicated field, or other).