### PR TITLE
Add prefix for image field

### DIFF
--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -6,7 +6,7 @@
     <!-- Wrap the image or canvas element with a block element (container) -->
     <div class="row">
         <div class="col-sm-6" style="margin-bottom: 20px;">
-            <img id="mainImage" src="{{ url(old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') )) }}">
+            <img id="mainImage" src="{{ url(isset($field['prefix']) ? $field['prefix'] : '' . old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') )) }}">
         </div>
         @if(isset($field['crop']) && $field['crop'])
         <div class="col-sm-3">

--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -6,7 +6,7 @@
     <!-- Wrap the image or canvas element with a block element (container) -->
     <div class="row">
         <div class="col-sm-6" style="margin-bottom: 20px;">
-            <img id="mainImage" src="{{ url(isset($field['prefix']) ? $field['prefix'] : '' . old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') )) }}">
+            <img id="mainImage" src="{{ url( (isset($field['prefix']) ? $field['prefix'] : '') . (old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') ))) }}">
         </div>
         @if(isset($field['crop']) && $field['crop'])
         <div class="col-sm-3">


### PR DESCRIPTION
I save my images with only the name in the database column. 

With this pull request you are able to specify a prefix for the image field e.g. :
```
[
  'name' => 'image',
  'label' => 'Image',
  'type' => 'image',
  'prefix' => 'uploads/images/profile_pictures/'
],
```

Then the image loads from `http://localhost:8000/uploads/images/profile_pictures/1d359ddfcc98d1d1f58bbca74643feda.jpg`