### PR TITLE
Improvement for detail row

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -39,7 +39,7 @@
             <thead>
               <tr>
                 @if ($crud->details_row)
-                  <th></th> <!-- expand/minimize button column -->
+                  <th data-orderable="false"></th> <!-- expand/minimize button column -->
                 @endif
 
                 {{-- Table columns --}}
@@ -305,14 +305,14 @@
       @if ($crud->details_row)
       function register_details_row_button_action() {
         // Add event listener for opening and closing details
-        $('#crudTable tbody').on('click', 'td .details-row-button', function () {
+        $('#crudTable tbody').on('click', 'td.details-control', function () {
             var tr = $(this).closest('tr');
-            var btn = $(this);
+            var btn = $(this).find('.details-row-button');
             var row = table.row( tr );
 
             if ( row.child.isShown() ) {
                 // This row is already open - close it
-                $(this).removeClass('fa-minus-square-o').addClass('fa-plus-square-o');
+                btn.removeClass('fa-minus-square-o').addClass('fa-plus-square-o');
                 $('div.table_row_slider', row.child()).slideUp( function () {
                     row.child.hide();
                     tr.removeClass('shown');
@@ -320,7 +320,7 @@
             }
             else {
                 // Open this row
-                $(this).removeClass('fa-plus-square-o').addClass('fa-minus-square-o');
+                btn.removeClass('fa-plus-square-o').addClass('fa-minus-square-o');
                 // Get the details with ajax
                 $.ajax({
                   url: '{{ url($crud->route) }}/'+btn.data('entry-id')+'/details',


### PR DESCRIPTION
By default detail row will show only when you click on the icon, but all td.details-control has class .cursor-pointer. So, I think detail row should be show when user click on the td.details-control. Also, for td.details-control not need sorting. 