### PR TITLE
Ability to disable sorting for columns

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -44,11 +44,13 @@
 
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th>{{ $column['label'] }}</th>
+                  <th {{ isset($column['orderable']) ? 'data-orderable=' .var_export($column['orderable'], true) : '' }}>
+                    {{ $column['label'] }}
+                  </th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
-                  <th>{{ trans('backpack::crud.actions') }}</th>
+                  <th data-orderable="false">{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>
             </thead>


### PR DESCRIPTION
Ability to disable sorting for columns

Add option "orderable" to the columns. If you set it to false, the column will not be sorting.
```
$this->crud->addColumn([
       'label' => "Example",
       'name' => 'example',
       'orderable' => false,
]);
```

Also, I removed sorting for actions column.