### PR TITLE
Better support for ajax store/update actions

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/SaveActions.php
+++ b/src/app/Http/Controllers/CrudFeatures/SaveActions.php
@@ -66,9 +66,17 @@ trait SaveActions
      */
     public function performSaveAction($itemId = null)
     {
-        $saveAction = \Request::input('save_action', config('backpack.crud.default_save_action', 'save_and_back'));
         $itemId = $itemId ? $itemId : \Request::input('id');
 
+        if($this->request->acceptsJson()){
+            return [
+                "success" => true,
+                "data" => $this->crud->entry
+            ];
+        }
+
+        $saveAction = \Request::input('save_action', config('backpack.crud.default_save_action', 'save_and_back'));
+        
         switch ($saveAction) {
             case 'save_and_new':
                 $redirectUrl = $this->crud->route.'/create';


### PR DESCRIPTION
Validation via `FormRequest` returns json or redirect depends on `Accept` request header.
So, it will be nice if store/update actions do the same