### PR TITLE
fix order by and ajax working together

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -29,7 +29,7 @@ trait AjaxTable
         $default_orders = $this->crud->query->getQuery()->orders;
         $this->crud->query->getQuery()->orders = null;
         $order = $request->input('order');
-        if (!$order) {
+        if (! $order) {
             $order = [];
             foreach ($default_orders as $default_order) {
                 $order[] = ['column' => (string) array_search($default_order['column'], $columns), 'dir' => $default_order['direction']];


### PR DESCRIPTION
This is my attempt to fix one of the issues with the AjaxDataTable functionality.

If you set an order by on your crud, and then enable ajax, aka:

```
        $this->crud->orderBy('name');
        $this->crud->enableAjaxTable();
```

The table does not load at all because it causes the LiveControl EloquentDatatable class to create an invalid query (must use column in group by clause).

This PR removes the order by from the crud query and instead passes it as a normal column that would be expected by the datatable.