### PR TITLE
bug when deleting fake fields

### DIFF
--- a/src/PanelTraits/FakeFields.php
+++ b/src/PanelTraits/FakeFields.php
@@ -24,10 +24,10 @@ trait FakeFields
         // go through each defined field
         foreach ($fields as $k => $field) {
             // if it's a fake field and the field is included in the request
-            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true && isset($request[$fields[$k]['name']])) {
+            if (isset($fields[$k]['fake']) && $fields[$k]['fake'] == true && array_key_exists($fields[$k]['name'], $request)) {
                 // add it to the request in its appropriate variable - the one defined, if defined
                 if (isset($fields[$k]['store_in'])) {
-                    $request[$fields[$k]['store_in']][$fields[$k]['name']] = $request[$fields[$k]['name']];
+                    $request[$fields[$k]['store_in']][$fields[$k]['name']] = $request[$fields[$k]['name']] ? $request[$fields[$k]['name']] : '';
 
                     // remove the fake field
                     array_pull($request, $fields[$k]['name']);
@@ -37,8 +37,7 @@ trait FakeFields
                     }
                 } else {
                     //otherwise in the one defined in the $crud variable
-
-                    $request['extras'][$fields[$k]['name']] = $request[$fields[$k]['name']];
+                    $request['extras'][$fields[$k]['name']] = $request[$fields[$k]['name']] ? $request[$fields[$k]['name']] : '';
 
                     // remove the fake field
                     array_pull($request, $fields[$k]['name']);


### PR DESCRIPTION
I noticed that if I tried to clear all my fake fields, they were not deleted. That is because

    isset($request['someFieldName'])

returns false if $request['someFieldName'] = null

So I changed it with
    array_key_exists('someFieldName', $request)