### PR TITLE
Allow Callable to Format Column/Field Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 
 ## [3.2.12] - 2017-05-19 EDT
 
-- Added a PHP callable to the `PanelTraits\Autoset` trait to allow developers to customise label fields
-- Moved hard coded `ucfirst($field)` down to the commented out `makeLabel($value)` method
-    - this change means that this method may be overridden globally reducing the need to pass a PHP callable each time, if desired
+- Added a PHP callable to the `PanelTraits\Autoset` trait to allow developers
+  to customise label fields
+- Moved hard coded `ucfirst($field)` down to the commented out
+  `makeLabel($value)` method
+    - this change means that this method may be overridden globally reducing
+      the need to pass a PHP callable each time, if desired
 
 ## [3.2.11] - 2017-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 ### Security
 - Nothing
 
+## [3.2.12] - 2017-05-19 EDT
+
+- Added a PHP callable to the `PanelTraits\Autoset` trait to allow developers to customise label fields
+- Moved hard coded `ucfirst($field)` down to the commented out `makeLabel($value)` method
+    - this change means that this method may be overridden globally reducing the need to pass a PHP callable each time, if desired
 
 ## [3.2.11] - 2017-04-21
 

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -24,7 +24,7 @@ trait AutoSet
             if (isset($labeller) && is_callable($labeller)) {
                 $label = $labeller($field);
             } else {
-                $label = $this->makeLabel();
+                $label = $this->makeLabel($field);
             }
 
             $new_field = [

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -11,17 +11,25 @@ trait AutoSet
     /**
      * For a simple CRUD Panel, there should be no need to add/define the fields.
      * The public columns in the database will be converted to be fields.
+     *
+     * @param [Callable]  $labeller If present, a function that should return a
+     *                              formatted label to be displayed.
+     * @return [void]
      */
-    public function setFromDb()
+    public function setFromDb($labeller = null)
     {
         $this->getDbColumnTypes();
 
-        array_map(function ($field) {
-            // $this->labels[$field] = $this->makeLabel($field);
+        array_map(function ($field) use ($labeller) {
+            if (isset($labeller) && is_callable($labeller)) {
+                $label = $labeller($field);
+            } else {
+                $label = $this->makeLabel();
+            }
 
             $new_field = [
                 'name'       => $field,
-                'label'      => ucfirst($field),
+                'label'      => $label,
                 'value'      => null,
                 'type'       => $this->getFieldTypeFromDbColumnType($field),
                 'values'     => [],
@@ -33,7 +41,7 @@ trait AutoSet
             if (! in_array($field, $this->model->getHidden())) {
                 $this->columns[$field] = [
                     'name'  => $field,
-                    'label' => ucfirst($field),
+                    'label' => $label,
                     'type'  => $this->getFieldTypeFromDbColumnType($field),
                 ];
             }
@@ -128,13 +136,18 @@ trait AutoSet
     /**
      * Turn a database column name or PHP variable into a pretty label to be shown to the user.
      *
-     * @param  [string]
+     * @note A value **should** be passed; however if one is not passed a
+     *       simple empty string is returned.
      *
-     * @return [string]
+     * @param  [string] The value.
+     *
+     * @return [string] The transformed value.
      */
-    public function makeLabel($value)
+    public function makeLabel($value = null)
     {
-        return trim(preg_replace('/(id|at|\[\])$/i', '', ucfirst(str_replace('_', ' ', $value))));
+        $value = isset($value) ? $value : '';
+
+        return ucfirst($value);
     }
 
     /**


### PR DESCRIPTION

Proposed fix for https://github.com/Laravel-Backpack/CRUD/issues/642.

1. Add a non-required, non-crashing `Callable` to allow end users to specify their own label naming functionality;
2. Reinstate the use of `makeLabel($field)` so that this may more easily be overridden; and
3. Change `makeLabel($field)` (which is currently not used anyway - it's commented out) to just do `ucfirst($value)` as this is the current behaviour.

Also referenced (duplicated) in https://github.com/Laravel-Backpack/CRUD/issues/685.