### PR TITLE
Fix default fields of the PageManager into last tab

### DIFF
--- a/src/PanelTraits/Tabs.php
+++ b/src/PanelTraits/Tabs.php
@@ -87,6 +87,17 @@ trait Tabs
         return $this->getLastTab() == $label;
     }
 
+    public function getFieldsWithoutATab()
+    {
+        $all_fields = $this->getCurrentFields();
+
+        $fields_without_a_tab = collect($all_fields)->filter(function ($value, $key) {
+            return ! isset($value['tab']);
+        });
+
+        return $fields_without_a_tab;
+    }
+
     public function getTabFields($label)
     {
         if ($this->tabExists($label)) {
@@ -95,14 +106,6 @@ trait Tabs
             $fields_for_current_tab = collect($all_fields)->filter(function ($value, $key) use ($label) {
                 return isset($value['tab']) && $value['tab'] == $label;
             });
-
-            if ($this->isLastTab($label)) {
-                $fields_without_a_tab = collect($all_fields)->filter(function ($value, $key) {
-                    return ! isset($value['tab']);
-                });
-
-                $fields_for_current_tab = $fields_for_current_tab->merge($fields_without_a_tab);
-            }
 
             return $fields_for_current_tab;
         }

--- a/src/resources/views/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/inc/show_tabbed_fields.blade.php
@@ -19,6 +19,8 @@
     </style>
 @endpush
 
+@include('crud::inc.show_fields', ['fields' => $crud->getFieldsWithoutATab()])
+
 <div class="tab-container {{ $horizontalTabs ? 'col-md-12' : 'col-md-3 m-t-10' }}">
 
     <div class="nav-tabs-custom" id="form_tabs">


### PR DESCRIPTION
The default fields of the page manager (Template, Page name, etc) were present at the end of the last tab. With this fix, fields that have no tab property, will stay over the tabs.