### PR TITLE
Make use of column defaults

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -57,6 +57,7 @@ trait AutoSet
             $this->db_column_types[$column]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
             $this->db_column_types[$column]['default'] = $conn->getDoctrineSchemaManager()->listTableDetails($table)->getColumn($column)->getDefault();
         }
+
         return $this->db_column_types;
     }
 

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -48,14 +48,15 @@ trait AutoSet
      */
     public function getDbColumnTypes()
     {
-        $table_columns = $this->model->getConnection()->getSchemaBuilder()->getColumnListing($this->model->getTable());
+        $table = $this->model->getTable();
+        $conn = $this->model->getConnection();
+        $table_columns = $conn->getSchemaBuilder()->getColumnListing($table);
 
         foreach ($table_columns as $key => $column) {
-            $column_type = $this->model->getConnection()->getSchemaBuilder()->getColumnType($this->model->getTable(), $column);
+            $column_type = $conn->getSchemaBuilder()->getColumnType($table, $column);
             $this->db_column_types[$column]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
-            $this->db_column_types[$column]['default'] = $this->model->getConnection()->getDoctrineSchemaManager()->listTableDetails($this->model->getTable())->getColumn($column)->getDefault();
+            $this->db_column_types[$column]['default'] = $conn->getDoctrineSchemaManager()->listTableDetails($table)->getColumn($column)->getDefault();
         }
-
         return $this->db_column_types;
     }
 

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -23,6 +23,7 @@ trait AutoSet
                 'name'       => $field,
                 'label'      => ucfirst($field),
                 'value'      => null,
+                'default'    => isset($this->db_column_types[$field]['default']) ? $this->db_column_types[$field]['default'] : null,
                 'type'       => $this->getFieldTypeFromDbColumnType($field),
                 'values'     => [],
                 'attributes' => [],
@@ -52,7 +53,7 @@ trait AutoSet
         foreach ($table_columns as $key => $column) {
             $column_type = $this->model->getConnection()->getSchemaBuilder()->getColumnType($this->model->getTable(), $column);
             $this->db_column_types[$column]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
-            $this->db_column_types[$column]['default'] = ''; // no way to do this using DBAL?!
+            $this->db_column_types[$column]['default'] = $this->model->getConnection()->getDoctrineSchemaManager()->listTableDetails($this->model->getTable())->getColumn($column)->getDefault();
         }
 
         return $this->db_column_types;


### PR DESCRIPTION
Make use of default values in the database for columns.

This has only been tested on MySQL 5.7.16