### PR TITLE
Fix: select2 fields styling

### DIFF
--- a/src/resources/views/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/fields/select2_from_ajax.blade.php
@@ -43,7 +43,7 @@
     @push('crud_fields_styles')
     <!-- include select2 css-->
     <link href="{{ asset('vendor/adminlte/plugins/select2/select2.min.css') }}" rel="stylesheet" type="text/css" />
-    {{-- <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" /> --}}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}

--- a/src/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -45,7 +45,7 @@
     @push('crud_fields_styles')
     <!-- include select2 css-->
     <link href="{{ asset('vendor/adminlte/plugins/select2/select2.min.css') }}" rel="stylesheet" type="text/css" />
-    {{-- <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" /> --}}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}

--- a/src/resources/views/fields/select2_from_array.blade.php
+++ b/src/resources/views/fields/select2_from_array.blade.php
@@ -39,7 +39,7 @@
     @push('crud_fields_styles')
     <!-- include select2 css-->
     <link href="{{ asset('vendor/adminlte/plugins/select2/select2.min.css') }}" rel="stylesheet" type="text/css" />
-    {{-- <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" /> --}}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}

--- a/src/resources/views/fields/select2_multiple.blade.php
+++ b/src/resources/views/fields/select2_multiple.blade.php
@@ -35,7 +35,7 @@
     @push('crud_fields_styles')
         <!-- include select2 css-->
         <link href="{{ asset('vendor/adminlte/plugins/select2/select2.min.css') }}" rel="stylesheet" type="text/css" />
-        {{-- <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" /> --}}
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}


### PR DESCRIPTION
Hi there,

This PR aims to fix the styling issues with select2 fields as described in #740.

Looks like the select2-bootstrap-theme file was updated to use v0.1.0-beta.10 from cloudflare's CDN, but the update had only been made to the regular select2 field, but not its variants.

This fixes the problem by using the same css file for all of the field types.

Thanks!