### PR TITLE
Customizable details

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -9,6 +9,7 @@ use Backpack\CRUD\PanelTraits\Views;
 use Backpack\CRUD\PanelTraits\Access;
 use Backpack\CRUD\PanelTraits\Create;
 use Backpack\CRUD\PanelTraits\Delete;
+use Backpack\CRUD\PanelTraits\Details;
 use Backpack\CRUD\PanelTraits\Errors;
 use Backpack\CRUD\PanelTraits\Fields;
 use Backpack\CRUD\PanelTraits\Update;
@@ -24,7 +25,7 @@ use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {
-    use Create, Read, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Update, Delete, Details, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
 
     // --------------
     // CRUD variables
@@ -54,6 +55,10 @@ class CrudPanel
     public $columns = []; // Define the columns for the table view as an array;
     public $create_fields = []; // Define the fields for the "Add new entry" view as an array;
     public $update_fields = []; // Define the fields for the "Edit entry" view as an array;
+
+
+    public $statistics_array = []; // Define the details to display on a side, best used for info boxes with quick stats.
+    public $details_array = []; // Define the details to display within a table format
 
     public $query;
     public $entry;

--- a/src/PanelTraits/Details.php
+++ b/src/PanelTraits/Details.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers;
+
+trait Details
+{
+
+    // ------------
+    // DETAILS
+    // ------------
+
+    /**
+     * Add a detail to display.
+     */
+    public function addDetail($detail, $type = 'details')
+    {
+        // if the complete_detail_array array is a string, it means the programmer was lazy and has only passed the name
+        // set some default values, so the detail will still work
+        if (is_string($detail)) {
+            $complete_detail_array['name'] = $detail;
+        } else {
+            $complete_detail_array = $detail;
+        }
+
+        // if the label is missing, we should set it
+        if (! isset($complete_detail_array['label'])) {
+            $complete_detail_array['label'] = ucfirst($complete_detail_array['name']);
+        }
+
+        // store the field information into the correct variable on the CRUD object
+        switch (strtolower($type)) {
+            case 'statistic':
+                $this->statistics_array[$complete_detail_array['name']] = $complete_detail_array;
+                break;
+
+            default:
+                $this->details_array[$complete_detail_array['name']] = $complete_detail_array;
+                break;
+        }
+
+        return $this;
+    }
+
+    public function addDetails($details)
+    {
+        if (count($details)) {
+            foreach ($details as $detail) {
+                $this->addDetail($detail);
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added detail to 'after' the $target_detail.
+     *
+     * @param $target_detail
+     */
+    public function afterDetail($target_detail)
+    {
+        foreach ($this->details_array as $detail => $value) {
+            if ($value['name'] == $target_detail) {
+                array_splice($this->details_array, $detail + 1, 0, [$detail => array_pop($this->details_array)]);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added detail to 'before' the $target_detail.
+     *
+     * @param $target_detail
+     */
+    public function beforeDetail($target_detail)
+    {
+        $key = 0;
+        foreach ($this->details_array as $detail => $value) {
+            if ($value['name'] == $target_detail) {
+                array_splice($this->details_array, $key, 0, [$detail => array_pop($this->details_array)]);
+                break;
+            }
+            $key++;
+        }
+    }
+
+    /**
+     * Remove a certain detail from the create/update/both forms by its name.
+     *
+     * @param string $name detail name (as defined with the addDetail() procedure)
+     * @param string $form update/create/both
+     */
+    public function removeDetail($name)
+    {
+        array_forget($this->details_array, $name);
+    }
+
+    /**
+     * Remove many details from the create/update/both forms by their name.
+     *
+     * @param array  $array_of_names A simple array of the names of the details to be removed.
+     */
+    public function removeDetails($array_of_names)
+    {
+        if (! empty($array_of_names)) {
+            foreach ($array_of_names as $name) {
+                $this->removeDetail($name);
+            }
+        }
+    }
+
+    /**
+     * Get the relationships used in the CRUD columns.
+     * @return [array] Relationship names
+     */
+    public function getDetailRelationships()
+    {
+        $columns = $this->getColumns();
+
+        return collect($columns)->pluck('entity')->reject(function ($value, $key) {
+            return $value == null;
+        })->toArray();
+    }
+
+    public function getDetails($section = 'details')
+    {
+        if($section == 'statistics') {
+            return $this->statistics_array;
+        }
+
+        return $this->details_array;
+    }
+}

--- a/src/PanelTraits/Details.php
+++ b/src/PanelTraits/Details.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace Backpack\CRUD\PanelTraits;
 
 trait Details
 {

--- a/src/resources/views/details/date.blade.php
+++ b/src/resources/views/details/date.blade.php
@@ -1,0 +1,10 @@
+<!--
+$this->addDetail([
+    'label' => "Report Date",
+    'type' => "date",
+    'name' => 'created_at',
+]);
+-->
+@if (!empty($entry->{$detail['name']}))
+    {{ Date::parse($entry->{$detail['name']})->format(config('backpack.base.default_date_format')) }}
+@endif

--- a/src/resources/views/details/info_box.blade.php
+++ b/src/resources/views/details/info_box.blade.php
@@ -1,0 +1,22 @@
+<!--
+$this->addDetail([
+    'label' => "Total Favorites",
+    'type' => "info_box",
+    'name' => 'test',
+    'value' => 2,
+
+    'info_box_options' => [
+        'color' => 'green',
+        'icon' => 'fa fa-star',
+    ]
+], 'statistic');
+-->
+<div @include('crud::inc.detail_wrapper_attributes.blade') >
+    <div class="info-box bg-{!! $detail['info_box_options']['color'] !!}">
+        <span class="info-box-icon"><i class="{!! $detail['info_box_options']['icon'] !!}"></i></span>
+        <div class="info-box-content">
+            <span class="info-box-text">{!! $detail['label'] !!}</span>
+            <span class="info-box-number">{!! $detail['value'] !!}</span>
+        </div>
+    </div>
+</div>

--- a/src/resources/views/details/info_box_link.blade.php
+++ b/src/resources/views/details/info_box_link.blade.php
@@ -1,0 +1,26 @@
+<!--
+$this->addDetail([
+    'name' => 'view_link',
+    'label' => 'View Original Item',
+    'type' => 'small_box_link',
+
+    'route_name' => 'article.view',
+    'attribute' => "user_id",
+
+    'small_box_options' => [
+        'color' => 'teal',
+        'icon' => 'fa fa-eye',
+    ],
+], 'statistic');
+-->
+<div @include('crud::inc.detail_wrapper_attributes.blade') >
+    <div class="info-box bg-{!! $detail['info_box_options']['color'] !!}">
+        <span class="info-box-icon"><i class="{!! $detail['info_box_options']['icon'] !!}"></i></span>
+        <div class="info-box-content">
+            <span class="info-box-text">{!! $detail['label'] !!}</span>
+            @if(isset($detail['value']))
+            <span class="info-box-number">{!! $detail['value'] !!}</span>
+            @endif
+        </div>
+    </div>
+</div>

--- a/src/resources/views/details/info_box_select.blade.php
+++ b/src/resources/views/details/info_box_select.blade.php
@@ -1,0 +1,43 @@
+<!--
+$this->addDetail([
+    'label' => "Thread Responses",
+    'type' => "info_box_select",
+    'name' => 'response_count',
+    'entity' => 'thread',
+    'model' => "App\DiscussThread",
+    'attribute' => 'replies',
+    'count' => true,
+    'info_box_options' => [
+        'color' => 'purple',
+        'icon' => 'fa fa-comments',
+    ]
+], 'statistic');
+-->
+
+@php
+    $count = false;
+
+    if(isset($detail['count'])) {
+        $count = true;
+    }
+
+    if(isset($detail['value'])) {
+        $value = $detail['value'];
+    } else {
+        if($count) {
+            $value = count($entry->{$detail['entity']}->{$detail['attribute']});
+        } else {
+            $value = $entry->{$detail['entity']}->{$detail['attribute']};
+        }
+    }
+@endphp
+
+<div @include('crud::inc.detail_wrapper_attributes.blade') >
+    <div class="info-box bg-{!! $detail['info_box_options']['color'] !!}">
+        <span class="info-box-icon"><i class="{!! $detail['info_box_options']['icon'] !!}"></i></span>
+        <div class="info-box-content">
+            <span class="info-box-text">{!! $detail['label'] !!}</span>
+            <span class="info-box-number">{!! $value !!}</span>
+        </div>
+    </div>
+</div>

--- a/src/resources/views/details/link.blade.php
+++ b/src/resources/views/details/link.blade.php
@@ -1,0 +1,35 @@
+<!-- link option -->
+
+<!--
+$this->addDetail([
+    'label' => "Test",
+    'type' => "link",
+    'name' => 'thread_id',
+    'entity' => 'thread',
+    'attribute' => "id",
+
+    'full_link' => $this->data['entry']->thread->getfullLink(), // define the entire link manually
+
+    // 'route_attribute' => 'slug' // automatically define a single param name and value to be the url
+    // 'route_params' => ['var1' => 'foo', 'var2' => 'bar'], // definine each param individually
+]);
+-->
+
+@php
+    if(isset($detail['full_link'])) {
+        $link = $detail['full_link'];
+    } elseif(isset($detail['route_params'])) {
+        $link = route($detail['route_name'], $detail['route_params']);
+    } else {
+        if(isset($detail['route_attribute'])) {
+            $route_params = [$detail['route_attribute'] => $entry->{$detail['route_attribute']}];
+        } else {
+            $route_params = ['id' => $entry->{$detail['attribute']}];
+        }
+        $link = route($detail['route_name'], $route_params);
+    }
+@endphp
+
+<a href="{{ $link }}">
+    {{ str_limit(strip_tags($entry->{$detail['attribute']}), 80, "[...]") }}
+</a>

--- a/src/resources/views/details/link_select.blade.php
+++ b/src/resources/views/details/link_select.blade.php
@@ -1,0 +1,40 @@
+<!--
+$this->addDetail([
+    'label' => "View Thread Live",
+    'type' => "link_select",
+    'name' => 'thread_id',
+    'entity' => 'thread',
+    'attribute' => "title",
+    'model' => "App\DiscussThread",
+
+    'full_link' => $this->data['entry']->thread->getfullLink(), // define the entire link manually
+
+    // 'route_name' => 'discuss.show' // laravel friendly name of the route
+    // 'route_attribute' => 'slug' // automatically define a single param name and value to be the url
+    // 'route_params' => ['var1' => 'foo', 'var2' => 'bar'], // definine each param individually
+]);
+-->
+
+<!-- link option -->
+  @php
+    if(isset($detail['full_link'])) {
+        $link = $detail['full_link'];
+    } elseif(isset($detail['route_params'])) {
+        $link = route($detail['route_name'], $detail['route_params']);
+    } else {
+        if(isset($detail['route_attribute'])) {
+            $route_params = [$detail['route_attribute'] => $entry->{$detail['entity']}->{$detail['route_attribute']}];
+        } else {
+            $route_params = ['id' => $entry->{$detail['attribute']}];
+        }
+        $link = route($detail['route_name'], $route_params);
+    }
+  @endphp
+
+<a href="{{ $link }}">
+    @if ($entry->{$detail['entity']})
+        {{ $entry->{$detail['entity']}->{$detail['attribute']} }}
+    @else
+        {{ str_limit(strip_tags($entry->{$detail['attribute']}), 80, "[...]") }}
+    @endif
+</a>

--- a/src/resources/views/details/select.blade.php
+++ b/src/resources/views/details/select.blade.php
@@ -1,0 +1,32 @@
+{{-- single relationships (1-1, 1-n) --}}
+
+<!--
+$this->addDetail([
+    'label' => "Reported By",
+    'type' => "select",
+    'name' => 'user_id',
+    'entity' => 'reporter',
+    'attribute' => 'name',
+    'model' => "App\User",
+]);
+-->
+
+@php
+    $count = false;
+
+    if(isset($detail['count'])) {
+        $count = true;
+    }
+
+    if(isset($detail['value'])) {
+        $value = $detail['value'];
+    } else {
+        if($count) {
+            $value = count($entry->{$detail['entity']}->{$detail['attribute']});
+        } else {
+            $value = $entry->{$detail['entity']}->{$detail['attribute']};
+        }
+    }
+@endphp
+
+{!! $value !!}

--- a/src/resources/views/details/small_box_link.blade.php
+++ b/src/resources/views/details/small_box_link.blade.php
@@ -1,0 +1,51 @@
+<!--
+$this->addDetail([
+    'name' => 'view_link',
+    'label' => 'View Thread',
+    'type' => 'small_box_link',
+
+    'route_name' => 'article.view',
+    'attribute' => "user_id",
+
+    'small_box_options' => [
+        'color' => 'teal',
+        'icon' => 'fa fa-eye',
+    ],
+
+    'full_link' => $this->data['entry']->thread->getfullLink(), // define the entire link manually
+
+    // 'route_attribute' => 'slug' // automatically define a single param name and value to be the url
+    // 'route_params' => ['var1' => 'foo', 'var2' => 'bar'], // definine each param individually
+], 'statistic');
+-->
+
+@php
+    if(isset($detail['full_link'])) {
+        $link = $detail['full_link'];
+    } elseif(isset($detail['route_params'])) {
+        $link = route($detail['route_name'], $detail['route_params']);
+    } else {
+        if(isset($detail['route_attribute'])) {
+            $route_params = [$detail['route_attribute'] => $entry->{$detail['route_attribute']}];
+        } else {
+            $route_params = ['id' => $entry->{$detail['attribute']}];
+        }
+        $link = route($detail['route_name'], $route_params);
+    }
+@endphp
+
+<div @include('crud::inc.detail_wrapper_attributes.blade') >
+  <a href="{{ $link }}">
+  <div class="small-box bg-{!! $detail['small_box_options']['color'] !!}">
+    <div class="inner">
+      @if(isset($detail['value']))
+      <h3>{!! $detail['value'] !!}</h3>
+      @endif
+      <p>{!! $detail['label'] !!}</p>
+    </div>
+    <div class="icon" style="font-size: 30px; float:right;margin: 0;margin-top:13px;">
+      <i class="{!! $detail['small_box_options']['icon'] !!}"></i>
+    </div>
+  </div>
+  </a>
+</div>

--- a/src/resources/views/details/text.blade.php
+++ b/src/resources/views/details/text.blade.php
@@ -1,0 +1,9 @@
+<!-- text option -->
+<!--
+$this->addDetail([
+    'label' => "Text Detail",
+    'type' => "text",
+    'name' => 'Test',
+]);
+-->
+{{ str_limit(strip_tags($detail['name']), 80, "[...]") }}

--- a/src/resources/views/inc/detail_wrapper_attributes.blade.php
+++ b/src/resources/views/inc/detail_wrapper_attributes.blade.php
@@ -1,0 +1,13 @@
+@if (isset($detail['wrapperAttributes']))
+    @foreach ($detail['wrapperAttributes'] as $attribute => $value)
+        @if (is_string($attribute))
+        {{ $attribute }}="{{ $value }}"
+        @endif
+    @endforeach
+
+    @if (!isset($detail['wrapperAttributes']['class']))
+        class="col-md-12"
+    @endif
+@else
+    class="col-md-12"
+@endif

--- a/src/resources/views/inc/show_details.blade.php
+++ b/src/resources/views/inc/show_details.blade.php
@@ -1,0 +1,45 @@
+{{-- Show the details --}}
+<div class="row">
+@if(isset($currentStatistics))
+    <div class="col-md-3">
+        <div class="row">
+        @foreach ($currentStatistics as $detail)
+            <!-- load the view from the application if it exists, otherwise load the one in the package -->
+            @php if(isset($detail['type'])) { $detailType = $detail['type']; } else { $detailType = 'text'; } @endphp
+            @if(view()->exists('vendor.backpack.crud.details.'.$detailType))
+                @include('vendor.backpack.crud.details.'.$detailType, array('detail' => $detail))
+            @else
+                @include('crud::details.'.$detailType, array('detail' => $detail))
+            @endif
+
+            <div class="clearfix"></div>
+
+        @endforeach
+        </div>
+    </div>
+@endif
+
+<div class="col-md-9">
+    <table class="table table-striped table-bordered">
+        <tbody>
+        @foreach ($details as $detail)
+            <tr>
+                <td>
+                    <strong>{{ $detail['label'] }}</strong>
+                </td>
+                <td>
+                <!-- load the view from the application if it exists, otherwise load the one in the package -->
+                @php if(isset($detail['type'])) { $detailType = $detail['type']; } else { $detailType = 'text'; } @endphp
+                @if(view()->exists('vendor.backpack.crud.details.'.$detailType))
+                    @include('vendor.backpack.crud.details.'.$detailType, array('detail' => $detail))
+                @else
+                    @include('crud::details.'.$detailType, array('detail' => $detail))
+                @endif
+                </td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+</div>
+
+</div>

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -3,7 +3,7 @@
 @section('content-header')
 	<section class="content-header">
 	  <h1>
-	    {{ trans('backpack::crud.preview') }} <span>{{ $crud->entity_name }}</span>
+	    {{ trans('backpack::crud.preview') }} <span class="text-lowercase">{{ $crud->entity_name }}</span>
 	  </h1>
 	  <ol class="breadcrumb">
 	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
@@ -15,7 +15,7 @@
 
 @section('content')
 	@if ($crud->hasAccess('list'))
-		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
+		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span class="text-lowercase">{{ $crud->entity_name_plural }}</span></a><br><br>
 	@endif
 
 	<!-- Default box -->
@@ -23,11 +23,15 @@
 	    <div class="box-header with-border">
 	      <h3 class="box-title">
             {{ trans('backpack::crud.preview') }}
-            <span>{{ $crud->entity_name }}</span>
+            <span class="text-lowercase">{{ $crud->entity_name }}</span>
           </h3>
 	    </div>
 	    <div class="box-body">
-	      {{ dump($entry) }}
+			@if(view()->exists('vendor.backpack.crud.inc.show_details'))
+			    @include('vendor.backpack.crud.inc.show_details', ['details' => $currentDetails])
+			@else
+				@include('crud::inc.show_details', [ 'details' => $currentDetails])
+			@endif
 	    </div><!-- /.box-body -->
 	  </div><!-- /.box -->
 


### PR DESCRIPTION
Similar to customizable fields within Backpack this allows you to customize the 'show' views with two options (statistics and details)

Statistics are free flowing small info boxes on the left, regular details are placed within a table. If no statistics are defined the table is full-width.

see issue #749 for discussion

<img width="1201" alt="screen shot 2017-06-20 at 6 35 22 pm" src="https://user-images.githubusercontent.com/487798/27363093-3f782778-55e7-11e7-98ca-038ec8fa3dc7.png">

Information on how to define each detail option is located within the `view` until we get better documentation for it.
