### PR TITLE
Fix 'in_the_database' french translation

### DIFF
--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -42,7 +42,7 @@ return [
 
     // CRUD table view
     'all'                       => 'Tous les ',
-    'in_the_database'           => 'en base de donnée',
+    'in_the_database'           => 'en base de données',
     'list'                      => 'Liste',
     'actions'                   => 'Actions',
     'preview'                   => 'Aperçu',


### PR DESCRIPTION
In french, we have to write "base de données" instead of  "base de donnée" (plural).

Example: https://fr.wikipedia.org/wiki/Base_de_donn%C3%A9es