### PR TITLE
Autoset column key instead of db name

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -31,7 +31,7 @@ trait AutoSet
             $this->update_fields[$field] = $new_field;
 
             if (! in_array($field, $this->model->getHidden())) {
-                $this->columns[$field] = [
+                $this->columns[] = [
                     'name'  => $field,
                     'label' => ucfirst($field),
                     'type'  => $this->getFieldTypeFromDbColumnType($field),


### PR DESCRIPTION
Currently using `setFromDB()` it defines a key for the column based on the name of the database column. The problem with this is that it makes `beforeColumn()` and `afterColumn()` no longer work due to `arraySplice` requiring it to use integers not strings. This came up in a Gitter discussion where there were a lot of columns, and simply wanted to overwrite a single column. I tested this in my own application and is not causing any issues.