### PR TITLE
Fix date_picker initial display value offset

### DIFF
--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -49,7 +49,7 @@
     @endif
     <script>
         if (jQuery.ui) {
-            var datepicker = $.fn.datepicker.noConflict(); 
+            var datepicker = $.fn.datepicker.noConflict();
             $.fn.bootstrapDP = datepicker;
         } else {
             $.fn.bootstrapDP = $.fn.datepicker;
@@ -70,7 +70,15 @@
                 var $existingVal = $field.val();
 
                 if( $existingVal.length ){
-                    preparedDate = new Date($existingVal).format($customConfig.format);
+                    // Passing an ISO-8601 date string (YYYY-MM-DD) to the Date constructor results in
+                    // varying behavior across browsers. Splitting and passing in parts of the date
+                    // manually gives us more defined behavior.
+                    // See https://stackoverflow.com/questions/2587345/why-does-date-parse-give-incorrect-results
+                    var parts = $existingVal.split('-')
+                    var year = parts[0]
+                    var month = parts[1] - 1 // Date constructor expects a zero-indexed month
+                    var day = parts[2]
+                    preparedDate = new Date(year, month, day).format($customConfig.format);
                     $fake.val(preparedDate);
                     $picker.bootstrapDP('update', preparedDate);
                 }


### PR DESCRIPTION
The below, copied from the commit message, may be helpful:

> On Firefox, the initial value set in the date_picker could be a day off from the value stored in a user's database since browsers treat the ISO 8601 date short form differently. This could be quite confusing for users that see this bug, since the scenario would likely play out as follows:
> 
> 1. User sets date as 2017-07-01.
> 2. User saves and SQL updates to 2017-07-01.
> 3. User reopens form and sees 2017-06-30, the result of an improper date parse on the JS frontend.
> 4. Steps 1-3 are repeated until user realizes something is amiss and decides to submit a merge request.
> 
> In detail, Firefox sets the date in local time, and Chrome sets it as UTC when only a date string is passed. The fix involves setting each part of the date (year, month, date) explicitly.
> 
> The analysis above came from the help of a StackOverflow thread:
> https://stackoverflow.com/questions/2587345/why-does-date-parse-give-incorrect-results

I'll be willing to make revisions to this as necessary.