### PR TITLE
Prettify model preview page

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -14,6 +14,7 @@ trait AutoSet
      */
     public function setFromDb()
     {
+        $this->setDoctrineTypesMapping();
         $this->getDbColumnTypes();
 
         array_map(function ($field) {
@@ -102,6 +103,9 @@ trait AutoSet
             break;
 
             case 'text':
+                return 'textarea';
+            break;
+
             case 'mediumtext':
             case 'longtext':
                 return 'textarea';
@@ -122,6 +126,18 @@ trait AutoSet
             default:
                 return 'text';
             break;
+        }
+    }
+
+    // Fix for DBAL not supporting enum
+    public function setDoctrineTypesMapping()
+    {
+        $types = ['enum' => 'string'];
+        $platform = \DB::getDoctrineConnection()->getDatabasePlatform();
+        foreach ($types as $type_key => $type_value) {
+            if (!$platform->hasDoctrineTypeMappingFor($type_key)) {
+                $platform->registerDoctrineTypeMapping($type_key, $type_value);
+            }
         }
     }
 

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -198,10 +198,29 @@ class CrudController extends BaseController
     {
         $this->crud->hasAccessOrFail('show');
 
+        // set columns from db
+        $this->crud->setFromDb();
+
+        // cycle through old columns for removal
+        foreach($this->crud->columns as $old_id => $column) {
+            // replace any relationship columns
+            if(array_key_exists('model', $column)) {
+                $this->crud->columns[$column['name']] = $this->crud->columns[$old_id];
+            }
+            // remove old numbered columns
+            if(is_integer($old_id)) {
+                unset($this->crud->columns[$old_id]);
+            }
+
+        }
+
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
         $this->data['title'] = trans('backpack::crud.preview').' '.$this->crud->entity_name;
+
+        // remove preview button from stack:line
+        $this->crud->removeButton('preview');
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getShowView(), $this->data);

--- a/src/resources/views/columns/textarea.blade.php
+++ b/src/resources/views/columns/textarea.blade.php
@@ -1,0 +1,2 @@
+{{-- regular object attribute --}}
+<td>{!! $entry->{$column['name']} !!}</td>

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -3,7 +3,7 @@
 @section('content-header')
 	<section class="content-header">
 	  <h1>
-	    {{ trans('backpack::crud.preview') }} <span>{{ $crud->entity_name }}</span>
+	    {{ trans('backpack::crud.preview') }} <span class="text-lowercase">{{ $crud->entity_name }}</span>
 	  </h1>
 	  <ol class="breadcrumb">
 	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
@@ -15,7 +15,7 @@
 
 @section('content')
 	@if ($crud->hasAccess('list'))
-		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
+		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span class="text-lowercase">{{ $crud->entity_name_plural }}</span></a><br><br>
 	@endif
 
 	<!-- Default box -->
@@ -23,11 +23,42 @@
 	    <div class="box-header with-border">
 	      <h3 class="box-title">
             {{ trans('backpack::crud.preview') }}
-            <span>{{ $crud->entity_name }}</span>
+            <span class="text-lowercase">{{ $crud->entity_name }}</span>
           </h3>
 	    </div>
 	    <div class="box-body">
-	      {{ dump($entry) }}
+			<table class="table table-striped table-bordered">
+		        <tbody>
+		        @foreach ($crud->columns as $column)
+		            <tr>
+		                <td>
+		                    <strong>{{ $column['label'] }}</strong>
+		                </td>
+							@if (!isset($column['type']))
+		                      @include('crud::columns.text')
+		                    @else
+		                      @if(view()->exists('vendor.backpack.crud.columns.'.$column['type']))
+		                        @include('vendor.backpack.crud.columns.'.$column['type'])
+		                      @else
+		                        @if(view()->exists('crud::columns.'.$column['type']))
+		                          @include('crud::columns.'.$column['type'])
+		                        @else
+		                          @include('crud::columns.text')
+		                        @endif
+		                      @endif
+		                    @endif
+		            </tr>
+		        @endforeach
+				@if ($crud->buttons->where('stack', 'line')->count())
+					<tr>
+						<td><strong>Actions</td>
+						<td>
+							@include('crud::inc.button_stack', ['stack' => 'line'])
+						</td>
+					</tr>
+				@endif
+		        </tbody>
+			</table>
 	    </div><!-- /.box-body -->
 	  </div><!-- /.box -->
 
@@ -36,10 +67,8 @@
 
 @section('after_styles')
 	<link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/crud.css') }}">
-	<link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/show.css') }}">
 @endsection
 
 @section('after_scripts')
 	<script src="{{ asset('vendor/backpack/crud/js/crud.js') }}"></script>
-	<script src="{{ asset('vendor/backpack/crud/js/show.js') }}"></script>
 @endsection


### PR DESCRIPTION
As discussed in PR #750 simplified the preview page. Automatically pulls all columns from the database using `setFromDB()` removes any previously set columns within `setup()` function.

Also added small fix for `setFromDB()` to solve DBAL to fix enum issue. Code from issue #236.