### PR TITLE
Always use setFromDB, define columns/fields within model.

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -38,7 +38,9 @@ class CrudController extends BaseController
                 $this->crud->request = $request;
                 $this->setup();
 
-                $this->crud->setFromDb();
+                if(config('backpack.crud.setFromDB', false)) {
+                    $this->crud->setFromDb();
+                }
 
                 return $next($request);
             });

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -38,6 +38,8 @@ class CrudController extends BaseController
                 $this->crud->request = $request;
                 $this->setup();
 
+                $this->crud->setFromDb();
+
                 return $next($request);
             });
         }
@@ -61,6 +63,8 @@ class CrudController extends BaseController
 
         $this->data['crud'] = $this->crud;
         $this->data['title'] = ucfirst($this->crud->entity_name_plural);
+
+        $this->crud->removeColumns($this->crud->model->crudListHidden);
 
         // get all entries if AJAX is not enabled
         if (! $this->data['crud']->ajaxTable()) {

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -12,6 +12,8 @@ trait AjaxTable
     {
         $this->crud->hasAccessOrFail('list');
 
+        $this->crud->removeColumns($this->crud->model->crudListHidden);
+
         // create an array with the names of the searchable columns
         $columns = collect($this->crud->columns)
                     ->reject(function ($column, $key) {

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -8,6 +8,9 @@ return [
     |--------------------------------------------------------------------------
     */
 
+    // Do you want to automatically set columns and fields? Can be customized via models.
+    'setFromDB' => true,
+
     /*
     |------------
     | CREATE & UPDATE


### PR DESCRIPTION
Automatically define all columns and fields based on DB schema with customizations available via Models. It also supports backwards compatibility using new config option.

Example setup of how the model functionality would work:

**$crudTypes:** Is the same basic setup as current `addColumn` and `addField` except for instead of having to define the name, it automatically uses the key for the name. 

**$crudFakeFields:** Exactly what you expect it to be, because fake fields are not actual db columns you can define them here, such as `tags`.

**$crudListHidden:** Because we do not want everything showing on the `list` view we allow the option to define items that you would like hidden.

```php
    public $crudTypes = [
        'date' => 'date',
        'featured' => 'check',
        'category_id' => [
            'label' => 'Category Id',
            'entity' => 'category',
            'attribute' => 'name',
            'type' => 'select',
            'model' => "Backpack\NewsCRUD\app\Models\Category",
        ],
        'content' => 'ckeditor',
        'status' => 'enum',
        'image' => 'browse',
        'slug' => [
            'type' => 'text',
            'hint' => 'Will be automatically generated from your title, if left empty.',
        ],
    ];

    public $crudFakeFields = [
        'tags' => [       // Select2Multiple = n-n relationship (with pivot table)
            'label' => 'Tags',
            'type' => 'select2_multiple',
            'entity' => 'tags', // the method that defines the relationship in your Model
            'attribute' => 'name', // foreign key attribute that is shown to user
            'model' => "Backpack\NewsCRUD\app\Models\Tag", // foreign key model
            'pivot' => true, // on create&update, do you need to add/delete pivot table entries?
        ],
    ];

    public $crudListHidden = [
        'content',
        'image',
        'tags'
    ];
```