### PR TITLE
Change env() to config() call

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -16,8 +16,11 @@ trait CrudTrait
 
     public static function getPossibleEnumValues($field_name)
     {
+        $default_connection = Config::get('database.default');
+        $table_prefix = Config::get('database.connections.'. $default_connection .'.prefix');
+
         $instance = new static(); // create an instance of the model to be able to get the table name
-        $type = DB::select(DB::raw('SHOW COLUMNS FROM `'.Config::get('database.connections.'.env('DB_CONNECTION').'.prefix').$instance->getTable().'` WHERE Field = "'.$field_name.'"'))[0]->Type;
+        $type = DB::select(DB::raw('SHOW COLUMNS FROM `'.$table_prefix.$instance->getTable().'` WHERE Field = "'.$field_name.'"'))[0]->Type;
         preg_match('/^enum\((.*)\)$/', $type, $matches);
         $enum = [];
         foreach (explode(',', $matches[1]) as $value) {


### PR DESCRIPTION
Switching from using `env()` call to `config()` call to avoid issues with cache:config as mentioned in issue #753 