### PR TITLE
model's $fillable attributes available in crud views

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -21,7 +21,7 @@ trait AjaxTable
                     ->pluck('name')
                     // add the primary key, otherwise the buttons won't work
                     ->merge($this->crud->model->getKeyName())
-                    // make $fillable attributes availables  in views
+                    // make $fillable attributes available in views
                     ->merge($this->crud->model->getFillable())
                     ->toArray();
 

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -21,6 +21,8 @@ trait AjaxTable
                     ->pluck('name')
                     // add the primary key, otherwise the buttons won't work
                     ->merge($this->crud->model->getKeyName())
+                    // make $fillable attributes availables  in views
+                    ->merge($this->crud->model->getFillable())
                     ->toArray();
 
         // structure the response in a DataTable-friendly way


### PR DESCRIPTION
#800 so there's no need to add unnecesary fake columns if you want to, lets say, hide the Edit/Delete button if `$entry->trashed()` or `$entry->deleted_at !== null`