### PR TITLE
Split AjaxTable::search() into several methods.

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -2,54 +2,94 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 
+use Backpack\CRUD\CrudPanel;
+use LiveControl\EloquentDataTable\DataTable;
+
+/**
+ * Trait AjaxTable
+ * @package Backpack\CRUD\app\Http\Controllers\CrudFeatures
+ *
+ * @property CrudPanel $crud
+ */
 trait AjaxTable
 {
     /**
      * Respond with the JSON of one or more rows, depending on the POST parameters.
-     * @return JSON Array of cells in HTML form.
+     * @return array Array of cells in HTML form.
      */
     public function search()
     {
         $this->crud->hasAccessOrFail('list');
 
         // create an array with the names of the searchable columns
-        $columns = collect($this->crud->columns)
-                    ->reject(function ($column, $key) {
-                        // the select_multiple, model_function and model_function_attribute columns are not searchable
-            return isset($column['type']) && ($column['type'] == 'select_multiple' || $column['type'] == 'model_function' || $column['type'] == 'model_function_attribute');
-                    })
-                    ->pluck('name')
-                    // add the primary key, otherwise the buttons won't work
-                    ->merge($this->crud->model->getKeyName())
-                    ->toArray();
+        $columns = $this->tAjaxTableGetColumns();
 
         // structure the response in a DataTable-friendly way
-        $dataTable = new \LiveControl\EloquentDataTable\DataTable($this->crud->query, $columns);
+        $dataTable = $this->tAjaxTableGetDataTable($columns);
+
+        return $dataTable->make();
+    }
+
+    /**
+     * @return array
+     */
+    protected function tAjaxTableGetColumns()
+    {
+        return collect($this->crud->columns)
+            ->reject(function ($column) {
+                return $this->tAjaxTableIsColumnSearchable($column);
+            })
+            ->pluck('name')
+            // add the primary key, otherwise the buttons won't work
+            ->merge($this->crud->model->getKeyName())
+            ->toArray();
+    }
+
+    /**
+     * @param array $column
+     * @return bool
+     */
+    protected function tAjaxTableIsColumnSearchable($column)
+    {
+        // the select_multiple, model_function and model_function_attribute columns are not searchable
+        return isset($column['type'])
+            && ($column['type'] == 'select_multiple'
+                || $column['type'] == 'model_function'
+                || $column['type'] == 'model_function_attribute');
+    }
+
+    /**
+     * @param array $columns
+     * @return DataTable
+     */
+    protected function tAjaxTableGetDataTable($columns)
+    {
+        $dataTable = new DataTable($this->crud->query, $columns);
 
         // make the datatable use the column types instead of just echoing the text
         $dataTable->setFormatRowFunction(function ($entry) {
             // get the actual HTML for each row's cell
-            $row_items = $this->crud->getRowViews($entry, $this->crud);
+            $row_items = $this->crud->getRowViews($entry);
 
             // add the buttons as the last column
             if ($this->crud->buttons->where('stack', 'line')->count()) {
                 $row_items[] = \View::make('crud::inc.button_stack', ['stack' => 'line'])
-                                ->with('crud', $this->crud)
-                                ->with('entry', $entry)
-                                ->render();
+                    ->with('crud', $this->crud)
+                    ->with('entry', $entry)
+                    ->render();
             }
 
             // add the details_row buttons as the first column
             if ($this->crud->details_row) {
                 array_unshift($row_items, \View::make('crud::columns.details_row_button')
-                                ->with('crud', $this->crud)
-                                ->with('entry', $entry)
-                                ->render());
+                    ->with('crud', $this->crud)
+                    ->with('entry', $entry)
+                    ->render());
             }
 
             return $row_items;
         });
 
-        return $dataTable->make();
+        return $dataTable;
     }
 }

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -21,10 +21,10 @@ trait AjaxTable
         $this->crud->hasAccessOrFail('list');
 
         // create an array with the names of the searchable columns
-        $columns = $this->tAjaxTableGetColumns();
+        $columns = $this->ajaxTableGetColumns();
 
         // structure the response in a DataTable-friendly way
-        $dataTable = $this->tAjaxTableGetDataTable($columns);
+        $dataTable = $this->ajaxTableGetDataTable($columns);
 
         return $dataTable->make();
     }
@@ -32,11 +32,11 @@ trait AjaxTable
     /**
      * @return array
      */
-    protected function tAjaxTableGetColumns()
+    protected function ajaxTableGetColumns()
     {
         return collect($this->crud->columns)
             ->reject(function ($column) {
-                return $this->tAjaxTableIsColumnSearchable($column);
+                return $this->ajaxTableIsColumnSearchable($column);
             })
             ->pluck('name')
             // add the primary key, otherwise the buttons won't work
@@ -48,7 +48,7 @@ trait AjaxTable
      * @param array $column
      * @return bool
      */
-    protected function tAjaxTableIsColumnSearchable($column)
+    protected function ajaxTableIsColumnSearchable($column)
     {
         // the select_multiple, model_function and model_function_attribute columns are not searchable
         return isset($column['type'])
@@ -61,7 +61,7 @@ trait AjaxTable
      * @param array $columns
      * @return DataTable
      */
-    protected function tAjaxTableGetDataTable($columns)
+    protected function ajaxTableGetDataTable($columns)
     {
         $dataTable = new DataTable($this->crud->query, $columns);
 

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -6,8 +6,7 @@ use Backpack\CRUD\CrudPanel;
 use LiveControl\EloquentDataTable\DataTable;
 
 /**
- * Trait AjaxTable
- * @package Backpack\CRUD\app\Http\Controllers\CrudFeatures
+ * Trait AjaxTable.
  *
  * @property CrudPanel $crud
  */


### PR DESCRIPTION
It can help users override small method instead whole 'search' method if they want add customized columns to 'dataTable' eg.