### PR TITLE
Added a helper classes to form groups

### DIFF
--- a/src/resources/views/inc/field_wrapper_attributes.blade.php
+++ b/src/resources/views/inc/field_wrapper_attributes.blade.php
@@ -6,8 +6,8 @@
     @endforeach
 
     @if (!isset($field['wrapperAttributes']['class']))
-		class="form-group col-md-12"
+		class="form-group col-md-12{{ isset($field['attributes']['required']) ? ' required' : '' }}"
     @endif
 @else
-	class="form-group col-md-12"
+	class="form-group col-md-12{{ isset($field['attributes']['required']) ? ' required' : '' }}"
 @endif


### PR DESCRIPTION
This simply adds the "required" class to the form group - which will enable fields to automatically gain a red * to signify that it is required

![edit_category____al_shirawi_admin](https://user-images.githubusercontent.com/1094740/28933414-dfb6eee0-7874-11e7-9906-a6271dca3e2a.jpg)

![edit_category____al_shirawi_admin](https://user-images.githubusercontent.com/1094740/28933426-ec17f1ca-7874-11e7-800a-2e1aef1d81a8.jpg)
