### PR TITLE
fixes select2 multiple filter from sending empty arrays or showing acti…

### DIFF
--- a/src/resources/views/filters/select2_multiple.blade.php
+++ b/src/resources/views/filters/select2_multiple.blade.php
@@ -77,7 +77,15 @@
     <script>
 		jQuery(document).ready(function($) {
 			$("select[name=filter_{{ $filter->name }}]").change(function() {
-				var value = JSON.stringify($(this).val());
+                var value;
+                if ($(this).val() !== null) {
+                    // clean array from undefined, null, "".
+                    var values = $(this).val().filter(function(e){ return e === 0 || e });
+                    // stringify only if values is not empty. otherwise it will be '[]'.
+                    value = values.length !== 0 ? JSON.stringify(values) : '';
+                } else {
+                    value = '';
+                }
 				var parameter = '{{ $filter->name }}';
 
 				@if (!$crud->ajaxTable())


### PR DESCRIPTION
fixes `select2_multiple` filter from sending empty arrays and/or showing active filter when nothing is selected. 
`$(this).val()` returns `[""]` or `["", 'foo', 'bar']`, when you select and deselect items randomly. Then it was altering URL with empty JSON which makes filter active, even when nothing is selected.
I'm not sure whether it's the cleanest way to do it.