### PR TITLE
fix select2 ajax filter clearing

### DIFF
--- a/src/resources/views/filters/select2_ajax.blade.php
+++ b/src/resources/views/filters/select2_ajax.blade.php
@@ -54,13 +54,13 @@
             $('#filter_{{ $filter->name }}').select2({
 			    minimumInputLength: 2,
             	allowClear: true,
-        	    placeholder: "{{ $filter->placeholder?$filter->placeholder:' ' }}",
+        	    placeholder: '{{ $filter->placeholder ? $filter->placeholder : ' ' }}',
 				closeOnSelect: false,
 			    // tags: [],
 			    ajax: {
-			        url: "{{ $filter->values }}",
+			        url: '{{ $filter->values }}',
 			        dataType: 'json',
-			        type: "GET",
+			        type: 'GET',
 			        quietMillis: 50,
 			        data: function (term) {
 			            return {
@@ -100,7 +100,7 @@
 					var current_url = normalizeAmpersand('{{ Request::fullUrl() }}');
 					var new_url = addOrUpdateUriParameter(current_url, parameter, val);
 					if (val_text) {
-						new_url = addOrUpdateUriParameter(new_url, parameter+"_text", val_text);
+						new_url = addOrUpdateUriParameter(new_url, parameter+'_text', val_text);
 					}
 
 					// refresh the page to the new_url
@@ -108,11 +108,11 @@
 			    	window.location.href = new_url;
 			    @else
 			    	// behaviour for ajax table
-					var ajax_table = $("#crudTable").DataTable();
+					var ajax_table = $('#crudTable').DataTable();
 					var current_url = ajax_table.ajax.url();
 					var new_url = addOrUpdateUriParameter(current_url, parameter, val);
 					if (val_text) {
-						new_url = addOrUpdateUriParameter(new_url, parameter+"_text", val_text);
+                        new_url = addOrUpdateUriParameter(new_url, parameter + '_text', val_text);
 					}
 					new_url = normalizeAmpersand(new_url.toString());
 
@@ -122,25 +122,23 @@
 
 					// mark this filter as active in the navbar-filters
 					if (URI(new_url).hasQuery('{{ $filter->name }}', true)) {
-						$("li[filter-name={{ $filter->name }}]").removeClass('active').addClass('active');
-					}
-					else
-					{
-						$("li[filter-name={{ $filter->name }}]").trigger("filter:clear");
+						$('li[filter-name={{ $filter->name }}]').removeClass('active').addClass('active');
+					} else {
+						$('li[filter-name={{ $filter->name }}]').trigger('filter:clear');
 					}
 			    @endif
 			});
 
 			// when the dropdown is opened, autofocus on the select2
-			$("li[filter-name={{ $filter->name }}]").on('shown.bs.dropdown', function () {
+			$('li[filter-name={{ $filter->name }}]').on('shown.bs.dropdown', function () {
 				$('#filter_{{ $filter->name }}').select2('open');
 			});
 
 			// clear filter event (used here and by the Remove all filters button)
-			$("li[filter-name={{ $filter->name }}]").on('filter:clear', function(e) {
+			$('li[filter-name={{ $filter->name }}]').on('filter:clear', function(e) {
 				// console.log('select2 filter cleared');
-				$("li[filter-name={{ $filter->name }}]").removeClass('active');
-                $('#filter_{{ $filter->name }}').select2("val", "");
+				$('li[filter-name={{ $filter->name }}]').removeClass('active');
+                $('#filter_{{ $filter->name }}').select2('val', '');
 			});
         });
     </script>

--- a/src/resources/views/filters/select2_ajax.blade.php
+++ b/src/resources/views/filters/select2_ajax.blade.php
@@ -140,7 +140,7 @@
 			$("li[filter-name={{ $filter->name }}]").on('filter:clear', function(e) {
 				// console.log('select2 filter cleared');
 				$("li[filter-name={{ $filter->name }}]").removeClass('active');
-				$("li[filter-name={{ $filter->name }}] .select2").select2("val", "");
+                $('#filter_{{ $filter->name }}').select2("val", "");
 			});
         });
     </script>


### PR DESCRIPTION
It wasn't clearing selected choice when Remove all filters clicked, because of the wrong selector.

To reproduce:
- Search and select some option
- Click "Remove all filters"
- The filter is not activated, but the last choice is still selected. Search and select the same choice, the filter will not be activated. Because the choice is the same.

`$("li[filter-name={{ $filter->name }}] .select2")` doesn't select anything. Changed selector to same selector as [initializing selector](https://github.com/alashow/CRUD/blob/dev/src/resources/views/filters/select2_ajax.blade.php#L54).