### PR TITLE
Fix to allow removing of last row in a table field type

### DIFF
--- a/src/resources/views/fields/table.blade.php
+++ b/src/resources/views/fields/table.blade.php
@@ -140,13 +140,13 @@
                         }
                     }
 
-                    if( typeof $scope.items != 'undefined' && $scope.items.length ){
+                    if( typeof $scope.items != 'undefined' ){
 
                         if( typeof $scope.field != 'undefined'){
                             if( typeof $scope.field == 'string' ){
                                 $scope.field = $($scope.field);
                             }
-                            $scope.field.val( angular.toJson($scope.items) );
+                            $scope.field.val( $scope.items.length ? angular.toJson($scope.items) : null );
                         }
                     }
                 }, true);


### PR DESCRIPTION
This fixes a bug where you would never be able to remove the last table row in a table field type. This was caused by the JavaScript only updating the hidden value field whenever the number of rows was > 0. This fix will update the hidden field value to null whenever all rows are removed, as intended.