### PR TITLE
Upload field : add validator rule + bugfix input type

### DIFF
--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -4,6 +4,8 @@ namespace Backpack\CRUD;
 
 use Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Validator;
 
 class CrudServiceProvider extends ServiceProvider
 {
@@ -63,6 +65,19 @@ class CrudServiceProvider extends ServiceProvider
             __DIR__.'/config/backpack/crud.php',
             'backpack.crud'
         );
+
+        // Add a validation rule for "upload" field type
+        // Example of usage: 'document' => 'file_upload_crud:pdf,jpg',
+        Validator::extend('file_upload_crud', function ($attribute, $value, $parameters, $validator) {
+            $isValidFile = false;
+            if (is_a($value, UploadedFile::class)) {
+                $rules = [$attribute => 'mimes:'.implode(',', $parameters)];
+                $input = [$attribute => $value];
+                $isValidFile = Validator::make($input, $rules)->passes();
+            }
+
+            return is_string($value) || $isValidFile;
+        });
     }
 
     /**

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Backpack\CRUD;
 
 use Route;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Validator;
 
 class CrudServiceProvider extends ServiceProvider

--- a/src/app/Http/Requests/CrudRequest.php
+++ b/src/app/Http/Requests/CrudRequest.php
@@ -29,6 +29,13 @@ class CrudRequest extends FormRequest
         ];
     }
 
+    public function messages()
+    {
+        return [
+            'file_upload_crud' => trans('backpack::crud.validation_file_upload_crud'),
+        ];
+    }
+
     // OPTIONAL OVERRIDE
     // public function forbiddenResponse()
     // {

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -137,4 +137,7 @@ return [
 
     // File manager
     'file_manager' => 'File Manager',
+
+    // Validations
+    'validation_file_upload_crud' => 'The :attribute must be a valid file.',
 ];

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -113,4 +113,6 @@ return [
         'external_link' => 'Lien externe',
         'choose_file' => 'Choisissez un fichier',
 
+    // Validations
+    'validation_file_upload_crud' => 'Le :attribute doit être un fichier valide.',
 ];

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -13,7 +13,7 @@
     @endif
 
     <div class="js-parent-input">
-        @if (isset($field['value']) && $field['value']!=null)
+        @if (!empty($field['value']))
             {{-- Display an hidden file an fill it with DB value. --}}
             <input
                     type="hidden"
@@ -27,8 +27,15 @@
                     type="file"
                     id="{{ $field['name'] }}_file_input"
                     name="{{ $field['name'] }}"
-                    value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                    value=""
                     @include('crud::inc.field_attributes', ['default_class' => 'form-control']) />
+            @if (!empty($field['default']))
+                <input
+                        type="hidden"
+                        name="{{ $field['name'] }}"
+                        value="{{ $field['default'] }}"
+                />
+            @endif
         @endif
     </div>
 

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -12,14 +12,24 @@
     </div>
     @endif
 
-	{{-- Show the file picker on CREATE form. --}}
-	<input
-        type="file"
-        id="{{ $field['name'] }}_file_input"
-        name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
-        @include('crud::inc.field_attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'form-control hidden':'form-control'])
-    >
+
+    @if (isset($field['value']) && $field['value']!=null)
+        {{-- Display an hidden file an fill it with DB value. --}}
+        <input
+                type="hidden"
+                id="{{ $field['name'] }}_file_input"
+                name="{{ $field['name'] }}"
+                value="{{ $field['value'] }}"
+                @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
+    @else
+        {{-- Show the file picker on CREATE form or on UPDATE form without file. --}}
+        <input
+                type="file"
+                id="{{ $field['name'] }}_file_input"
+                name="{{ $field['name'] }}"
+                value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                @include('crud::inc.field_attributes', ['default_class' => 'form-control']) />
+    @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))
@@ -33,21 +43,12 @@
     @push('crud_fields_scripts')
         <!-- no scripts -->
         <script>
-	        $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
-	        	e.preventDefault();
-	        	$(this).parent().addClass('hidden');
-
-	        	var input = $("#{{ $field['name'] }}_file_input");
-	        	input.removeClass('hidden');
-	        	input.attr("value", "").replaceWith(input.clone(true));
-	        	// add a hidden input with the same name, so that the setXAttribute method is triggered
-	        	$("<input type='hidden' name='{{ $field['name'] }}' value=''>").insertAfter("#{{ $field['name'] }}_file_input");
-	        });
-
-	        $("#{{ $field['name'] }}_file_input").change(function() {
-	        	console.log($(this).val());
-	        	// remove the hidden input, so that the setXAttribute method is no longer triggered
-	        	$(this).next("input[type=hidden]").remove();
-	        });
+            $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
+                e.preventDefault();
+                $(this).parent().addClass('hidden');
+                // Replace input hidden by an input file and show it
+                var $input = $("#{{ $field['name'] }}_file_input");
+                $input.replaceWith($input.clone().attr('type', 'file').val('').removeClass('hidden'));
+            });
         </script>
     @endpush

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -44,7 +44,7 @@
     @push('crud_fields_scripts')
         <!-- no scripts -->
         <script>
-            $("#{{ $field['name'] }}_file_clear_button").click(function(e) {
+            $("#{{ $field['name'] }}_file_clear_button").click(function (e) {
                 e.preventDefault();
                 $(this).parent().addClass('hidden');
                 // Replace input hidden by an input file and show it
@@ -52,13 +52,13 @@
                 var $parent = $input.parent();
                 var $newInput = $('<input type="file" name="{{ $field['name'] }}" />');
                 $newInput.addClass($input.attr('class')).attr('id', $input.attr('id'));
-                $parent.append( $newInput );
+                $parent.append($newInput);
                 $input.remove(); // Remove to force browser to clear val()
                 // Add an hidden input with the same name, so that the setXAttribute method is triggered by the Eloquent Model
-                $parent.append( $("<input type='hidden' name='{{ $field['name'] }}' value=''>") );
+                $parent.append($("<input type='hidden' name='{{ $field['name'] }}' value=''>"));
             });
 
-            $('.js-parent-input').on('change', 'input[type="file"]', function(){
+            $('.js-parent-input').on('change', 'input[type="file"]', function () {
                 // Remove hidden file if user browse a file
                 $(this).next("input[type=hidden]").remove();
             });

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -12,24 +12,25 @@
     </div>
     @endif
 
-
-    @if (isset($field['value']) && $field['value']!=null)
-        {{-- Display an hidden file an fill it with DB value. --}}
-        <input
-                type="hidden"
-                id="{{ $field['name'] }}_file_input"
-                name="{{ $field['name'] }}"
-                value="{{ $field['value'] }}"
-                @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
-    @else
-        {{-- Show the file picker on CREATE form or on UPDATE form without file. --}}
-        <input
-                type="file"
-                id="{{ $field['name'] }}_file_input"
-                name="{{ $field['name'] }}"
-                value="{{ isset($field['default']) ? $field['default'] : '' }}"
-                @include('crud::inc.field_attributes', ['default_class' => 'form-control']) />
-    @endif
+    <div class="js-parent-input">
+        @if (isset($field['value']) && $field['value']!=null)
+            {{-- Display an hidden file an fill it with DB value. --}}
+            <input
+                    type="hidden"
+                    id="{{ $field['name'] }}_file_input"
+                    name="{{ $field['name'] }}"
+                    value="{{ $field['value'] }}"
+                    @include('crud::inc.field_attributes', ['default_class' =>  'form-control']) />
+        @else
+            {{-- Show the file picker on CREATE form or on UPDATE form without file. --}}
+            <input
+                    type="file"
+                    id="{{ $field['name'] }}_file_input"
+                    name="{{ $field['name'] }}"
+                    value="{{ isset($field['default']) ? $field['default'] : '' }}"
+                    @include('crud::inc.field_attributes', ['default_class' => 'form-control']) />
+        @endif
+    </div>
 
     {{-- HINT --}}
     @if (isset($field['hint']))
@@ -48,7 +49,18 @@
                 $(this).parent().addClass('hidden');
                 // Replace input hidden by an input file and show it
                 var $input = $("#{{ $field['name'] }}_file_input");
-                $input.replaceWith($input.clone().attr('type', 'file').val('').removeClass('hidden'));
+                var $parent = $input.parent();
+                var $newInput = $('<input type="file" name="{{ $field['name'] }}" />');
+                $newInput.addClass($input.attr('class')).attr('id', $input.attr('id'));
+                $parent.append( $newInput );
+                $input.remove(); // Remove to force browser to clear val()
+                // Add an hidden input with the same name, so that the setXAttribute method is triggered by the Eloquent Model
+                $parent.append( $("<input type='hidden' name='{{ $field['name'] }}' value=''>") );
+            });
+
+            $('.js-parent-input').on('change', 'input[type="file"]', function(){
+                // Remove hidden file if user browse a file
+                $(this).next("input[type=hidden]").remove();
             });
         </script>
     @endpush


### PR DESCRIPTION
**Bugfixes :** 

If you save a file ("upload" field") on a Model and go back to its CRUD, the value will be put in input of type file. 
With this PR, the value is now filled in hidden input. 

Furthermore, the default value doesn't works.
You have to change your documentation : https://laravel-backpack.readme.io/docs/crud-fields#section-upload

```php
public function setImageAttribute($value)
{
        $attribute_name = "image";
        $disk = "public";
        $destination_path = "folder_1/subfolder_1";

        $this->uploadFileToDisk($value, $attribute_name, $disk, $destination_path);
}
```

to 

```php
public function setImageAttribute($value)
{
        $attribute_name = "image";
        $disk = "public";
        $destination_path = "folder_1/subfolder_1";

        if (is_a($value, UploadedFile::class)) {
            $this->uploadFileToDisk($value, $attribute_name, $disk, $destination_path);
        } else {
            $this->attributes[$attribute_name] = $value;
        }
}
```

**New feature :** 

A validation rule was added to easily validate CRUD request with "upload" field.

Example of usage :
```php
public function rules()
    {
        return [
            'name' => 'required|min:2|max:191',           
            'document' => 'file_upload_crud:pdf,docx', // the parameters must be valid mime types
        ];
    }
```
