### PR TITLE
Allow for passing additional closures to filtering for when no filter is applied

### DIFF
--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -38,8 +38,8 @@ trait Filters
      *
      * @param array         $options        Name, type, label, etc.
      * @param array/closure $values         The HTML for the filter.
-     * @param closure       $filter_logic   Query modification (filtering) logic.
-     * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
+     * @param closure       $filter_logic   Query modification (filtering) logic when filter is active.
+     * @param closure       $fallback_logic  Query modification (filtering) logic when filter is not active.
      */
     public function addFilter($options, $values = false, $filter_logic = false, $fallback_logic = false)
     {
@@ -76,7 +76,7 @@ trait Filters
 	        } else {
 		        //if the filter is not active, but fallback logic was supplied
 		        if ( is_callable( $fallback_logic ) ) {
-			        // apply the default logic
+			        // apply the fallback logic
 			        $fallback_logic();
 		        }
 	        }

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -41,7 +41,7 @@ trait Filters
      * @param closure       $filter_logic   Query modification (filtering) logic.
      * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
      */
-    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false)
+    public function addFilter($options, $values = false, $filter_logic = false, $fallback_logic = false)
     {
         // if a closure was passed as "values"
         if (is_callable($values)) {
@@ -74,10 +74,10 @@ trait Filters
 			        $this->addDefaultFilterLogic( $filter->name, $filter_logic );
 		        }
 	        } else {
-		        //if the filter is not active, but default logic was supplied
-		        if ( is_callable( $default_logic ) ) {
+		        //if the filter is not active, but fallback logic was supplied
+		        if ( is_callable( $fallback_logic ) ) {
 			        // apply the default logic
-			        $default_logic();
+			        $fallback_logic();
 		        }
 	        }
         }

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -41,7 +41,7 @@ trait Filters
      * @param closure       $filter_logic   Query modification (filtering) logic.
      * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
      */
-    public function addFilter($options, $values = false, $filter_logic = false, $default_logic)
+    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false)
     {
         // if a closure was passed as "values"
         if (is_callable($values)) {

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -39,8 +39,9 @@ trait Filters
      * @param array         $options        Name, type, label, etc.
      * @param array/closure $values         The HTML for the filter.
      * @param closure       $filter_logic   Query modification (filtering) logic.
+     * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
      */
-    public function addFilter($options, $values = false, $filter_logic = false)
+    public function addFilter($options, $values = false, $filter_logic = false, $default_logic)
     {
         // if a closure was passed as "values"
         if (is_callable($values)) {
@@ -64,14 +65,21 @@ trait Filters
         $this->filters->push($filter);
 
         // if a closure was passed as "filter_logic"
-        if ($this->doingListOperation() &&
-            $this->request->has($options['name'])) {
-            if (is_callable($filter_logic)) {
-                // apply it
-                $filter_logic($this->request->input($options['name']));
-            } else {
-                $this->addDefaultFilterLogic($filter->name, $filter_logic);
-            }
+        if ($this->doingListOperation()){
+        	if($this->request->has($options['name'])) {
+		        if (is_callable($filter_logic)) {
+			        // apply it
+			        $filter_logic($this->request->input($options['name']));
+		        } else {
+			        $this->addDefaultFilterLogic($filter->name, $filter_logic);
+		        }
+	        } else {
+        		//if the filter is not active, but default logic was supplied
+		        if (is_callable($default_logic)) {
+			        // apply the default logic
+			        $default_logic();
+		        }
+	        }
         }
     }
 

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -65,8 +65,8 @@ trait Filters
         $this->filters->push($filter);
 
         // if a closure was passed as "filter_logic"
-        if ($this->doingListOperation()){
-        	if($this->request->has($options['name'])) {
+        if ($this->doingListOperation()) {
+        	if ($this->request->has($options['name'])) {
 		        if (is_callable($filter_logic)) {
 			        // apply it
 			        $filter_logic($this->request->input($options['name']));

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -41,46 +41,48 @@ trait Filters
      * @param closure       $filter_logic   Query modification (filtering) logic.
      * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
      */
-    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false) {
-	    // if a closure was passed as "values"
-	    if ( is_callable( $values ) ) {
-		    // get its results
-		    $values = $values();
-	    }
+    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false)
+    {
+        // if a closure was passed as "values"
+        if (is_callable($values)) {
+            // get its results
+            $values = $values();
+        }
 
-	    // enable the filters functionality
-	    $this->enableFilters();
+        // enable the filters functionality
+        $this->enableFilters();
 
-	    // check if another filter with the same name exists
-	    if ( ! isset( $options['name'] ) ) {
-		    abort( 500, 'All your filters need names.' );
-	    }
-	    if ( $this->filters->contains( 'name', $options['name'] ) ) {
-		    abort( 500, "Sorry, you can't have two filters with the same name." );
-	    }
+        // check if another filter with the same name exists
+        if (! isset($options['name'])) {
+            abort(500, 'All your filters need names.');
+        }
+        if ($this->filters->contains('name', $options['name'])) {
+            abort(500, "Sorry, you can't have two filters with the same name.");
+        }
 
-	    // add a new filter to the interface
-	    $filter = new CrudFilter( $options, $values, $filter_logic );
-	    $this->filters->push( $filter );
+        // add a new filter to the interface
+        $filter = new CrudFilter($options, $values, $filter_logic);
+        $this->filters->push($filter);
 
-	    // if a closure was passed as "filter_logic"
-	    if ( $this->doingListOperation() ) {
-		    if ( $this->request->has( $options['name'] ) ) {
-			    if ( is_callable( $filter_logic ) ) {
-				    // apply it
-				    $filter_logic( $this->request->input( $options['name'] ) );
-			    } else {
-				    $this->addDefaultFilterLogic( $filter->name, $filter_logic );
-			    }
-		    } else {
-			    //if the filter is not active, but default logic was supplied
-			    if ( is_callable( $default_logic ) ) {
-				    // apply the default logic
-				    $default_logic();
-			    }
-		    }
-	    }
+        // if a closure was passed as "filter_logic"
+        if ($this->doingListOperation()) {
+	        if ( $this->request->has( $options['name'] ) ) {
+		        if ( is_callable( $filter_logic ) ) {
+			        // apply it
+			        $filter_logic( $this->request->input( $options['name'] ) );
+		        } else {
+			        $this->addDefaultFilterLogic( $filter->name, $filter_logic );
+		        }
+	        } else {
+		        //if the filter is not active, but default logic was supplied
+		        if ( is_callable( $default_logic ) ) {
+			        // apply the default logic
+			        $default_logic();
+		        }
+	        }
+        }
     }
+
 
     public function addDefaultFilterLogic($name, $operator)
     {

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -41,46 +41,45 @@ trait Filters
      * @param closure       $filter_logic   Query modification (filtering) logic.
      * @param closure       $default_logic  Query modification (filtering) logic when filter is not active.
      */
-    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false)
-    {
-        // if a closure was passed as "values"
-        if (is_callable($values)) {
-            // get its results
-            $values = $values();
-        }
+    public function addFilter($options, $values = false, $filter_logic = false, $default_logic = false) {
+	    // if a closure was passed as "values"
+	    if ( is_callable( $values ) ) {
+		    // get its results
+		    $values = $values();
+	    }
 
-        // enable the filters functionality
-        $this->enableFilters();
+	    // enable the filters functionality
+	    $this->enableFilters();
 
-        // check if another filter with the same name exists
-        if (! isset($options['name'])) {
-            abort(500, 'All your filters need names.');
-        }
-        if ($this->filters->contains('name', $options['name'])) {
-            abort(500, "Sorry, you can't have two filters with the same name.");
-        }
+	    // check if another filter with the same name exists
+	    if ( ! isset( $options['name'] ) ) {
+		    abort( 500, 'All your filters need names.' );
+	    }
+	    if ( $this->filters->contains( 'name', $options['name'] ) ) {
+		    abort( 500, "Sorry, you can't have two filters with the same name." );
+	    }
 
-        // add a new filter to the interface
-        $filter = new CrudFilter($options, $values, $filter_logic);
-        $this->filters->push($filter);
+	    // add a new filter to the interface
+	    $filter = new CrudFilter( $options, $values, $filter_logic );
+	    $this->filters->push( $filter );
 
-        // if a closure was passed as "filter_logic"
-        if ($this->doingListOperation()) {
-        	if ($this->request->has($options['name'])) {
-		        if (is_callable($filter_logic)) {
-			        // apply it
-			        $filter_logic($this->request->input($options['name']));
-		        } else {
-			        $this->addDefaultFilterLogic($filter->name, $filter_logic);
-		        }
-	        } else {
-        		//if the filter is not active, but default logic was supplied
-		        if (is_callable($default_logic)) {
-			        // apply the default logic
-			        $default_logic();
-		        }
-	        }
-        }
+	    // if a closure was passed as "filter_logic"
+	    if ( $this->doingListOperation() ) {
+		    if ( $this->request->has( $options['name'] ) ) {
+			    if ( is_callable( $filter_logic ) ) {
+				    // apply it
+				    $filter_logic( $this->request->input( $options['name'] ) );
+			    } else {
+				    $this->addDefaultFilterLogic( $filter->name, $filter_logic );
+			    }
+		    } else {
+			    //if the filter is not active, but default logic was supplied
+			    if ( is_callable( $default_logic ) ) {
+				    // apply the default logic
+				    $default_logic();
+			    }
+		    }
+	    }
     }
 
     public function addDefaultFilterLogic($name, $operator)


### PR DESCRIPTION
I have a use case where I need to be able to apply a query clause when no filter is applied.  Basically, I have a select multiple filter for "Status" which allows users to see entries with a particular status.  But if no status is selected, there are a few statuses I'd like to exclude by default.  This change would be non-breaking and useful, I think.