### PR TITLE
Read-only text field

### DIFF
--- a/src/resources/views/fields/read_only.blade.php
+++ b/src/resources/views/fields/read_only.blade.php
@@ -1,0 +1,22 @@
+<!-- read-only text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-addon">{!! $field['prefix'] !!}</div> @endif
+            <input
+                type="text"
+                name="{{ $field['name'] }}"
+                value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+                @include('crud::inc.field_attributes')
+                @if(isset($field['value'])) readonly="readonly" @endif
+            >
+        @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>


### PR DESCRIPTION
A field that is enabled when creating a model, but _disabled_ when updating it. It is really set as readonly, so the value will be still sent with the form. Useful for values that should only be set when creating and never updated, or when users have no permission to update that field but must be able to see their value. 