### PR TITLE
Add cache to getDbColumnTypes() function to improve performances

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\PanelTraits;
 
+use Illuminate\Support\Facades\Cache;
+
 trait AutoSet
 {
     // ------------------------------------------------------
@@ -50,7 +52,10 @@ trait AutoSet
         $table_columns = $this->model->getConnection()->getSchemaBuilder()->getColumnListing($this->model->getTable());
 
         foreach ($table_columns as $key => $column) {
-            $column_type = $this->model->getConnection()->getSchemaBuilder()->getColumnType($this->model->getTable(), $column);
+            $cacheNameSuffix= $this->model->getConnection()->getDatabaseName().'-'.$this->model->getTable().'-'.$column;
+            $column_type = Cache::rememberForever('backpack_crud::column_type::'.$cacheNameSuffix, function () use ($column) {
+                return $this->model->getConnection()->getSchemaBuilder()->getColumnType($this->model->getTable(), $column);
+            });
             $this->db_column_types[$column]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
             $this->db_column_types[$column]['default'] = ''; // no way to do this using DBAL?!
         }

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -52,7 +52,7 @@ trait AutoSet
         $table_columns = $this->model->getConnection()->getSchemaBuilder()->getColumnListing($this->model->getTable());
 
         foreach ($table_columns as $key => $column) {
-            $cacheNameSuffix= $this->model->getConnection()->getDatabaseName().'-'.$this->model->getTable().'-'.$column;
+            $cacheNameSuffix = $this->model->getConnection()->getDatabaseName().'-'.$this->model->getTable().'-'.$column;
             $column_type = Cache::rememberForever('backpack_crud::column_type::'.$cacheNameSuffix, function () use ($column) {
                 return $this->model->getConnection()->getSchemaBuilder()->getColumnType($this->model->getTable(), $column);
             });


### PR DESCRIPTION
If `$this->crud->setFromDb()` is called, application will do one database request per column to get type.
If table has 40 columns, the listing of items can take more than 5 seconds.

We can use Cache to improve application performances (do the requests once).