### PR TITLE
Permissions features

### DIFF
--- a/src/Console/PermissionsCommand.php
+++ b/src/Console/PermissionsCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Backpack\CRUD\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Route;
+
+class PermissionsCommand extends Command
+{
+    protected $signature = 'permissions:generate';
+
+    protected $description = 'Insert in database permissions for each CRUD controllers.';
+
+    public function handle()
+    {
+        if (!$this->permissionsSystemAvailable()) {
+            return $this->error('Pemissions system not available.');
+        }
+
+        $routes = collect(Route::getRoutes());
+        $routes->each(function($route, $key) {
+            if (str_contains($route->getName(), 'crud') ) {
+                $controller = $route->getController();
+                if (!empty($controller->crud) && method_exists($controller->crud, 'initPermissions')) {
+                    $controller->crud->initPermissions(get_class($controller));
+                }
+            }
+        });
+
+        return $this->info('Permissions successfully installed.');
+    }
+
+    /**
+     * Is the system of automatic permissions available ?
+     *
+     * @return bool
+     */
+    protected function permissionsSystemAvailable()
+    {
+        return class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider') &&
+            config('backpack.crud.activate_permissions_system', false);
+    }
+}

--- a/src/Console/PermissionsCommand.php
+++ b/src/Console/PermissionsCommand.php
@@ -2,9 +2,9 @@
 
 namespace Backpack\CRUD\Console;
 
-use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Route;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
 
 class PermissionsCommand extends Command
 {
@@ -20,7 +20,7 @@ class PermissionsCommand extends Command
     public function handle()
     {
         // Checks if the PermissionManagerServiceProvider exists
-        if (!class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
+        if (! class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
             return $this->error('Requires the package Backpack\PermissionManager.');
         }
 
@@ -28,18 +28,19 @@ class PermissionsCommand extends Command
         collect(Route::getRoutes())
 
             // Groups routes by controller
-            ->groupBy(function($route) {
+            ->groupBy(function ($route) {
                 list($controller) = explode('@', array_get($route->getAction(), 'controller'));
+
                 return $controller;
             })
 
             // Keeps only the routes handled by a CRUD controller
-            ->filter(function($routes, $controller) {
+            ->filter(function ($routes, $controller) {
                 return !empty($controller) && is_subclass_of($controller, CrudController::class);
             })
 
             // Creates the permissions
-            ->each(function($routes) {
+            ->each(function ($routes) {
                 $route = $routes->first();
                 if (method_exists($route->getController()->crud, 'createMissingPermissions')) {
                     $route->getController()->crud->createMissingPermissions();

--- a/src/Console/PermissionsCommand.php
+++ b/src/Console/PermissionsCommand.php
@@ -36,7 +36,7 @@ class PermissionsCommand extends Command
 
             // Keeps only the routes handled by a CRUD controller
             ->filter(function ($routes, $controller) {
-                return !empty($controller) && is_subclass_of($controller, CrudController::class);
+                return ! empty($controller) && is_subclass_of($controller, CrudController::class);
             })
 
             // Creates the permissions

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -20,8 +20,8 @@ use Backpack\CRUD\PanelTraits\Reorder;
 use Backpack\CRUD\PanelTraits\AutoFocus;
 use Backpack\CRUD\PanelTraits\FakeFields;
 use Backpack\CRUD\PanelTraits\FakeColumns;
-use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 use Backpack\CRUD\PanelTraits\Permissions;
+use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -21,6 +21,9 @@ use Backpack\CRUD\PanelTraits\AutoFocus;
 use Backpack\CRUD\PanelTraits\FakeFields;
 use Backpack\CRUD\PanelTraits\FakeColumns;
 use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 
 class CrudPanel
 {
@@ -63,6 +66,9 @@ class CrudPanel
 
     // TONE FIELDS - TODO: find out what he did with them, replicate or delete
     public $sort = [];
+
+    protected $availablePermissions = ['list', 'create', 'update', 'delete'];
+    protected $permissionsPrefix;
 
     // The following methods are used in CrudController or your EntityCrudController to manipulate the variables above.
 
@@ -248,5 +254,133 @@ class CrudPanel
         }, $this->model);
 
         return get_class($result);
+    }
+
+    /**
+     * Init permissions system to current CRUD
+     * Available only if Backpack\PermissionManager is installed and "activate_permissions_system" configuration set to true
+     *
+     * @return bool
+     */
+    public function initPermissions()
+    {
+        if (!$this->permissionsSystemAvailable()) {
+            return false;
+        }
+
+        $routeDetails = request()->route()->getAction();
+        $controllerDetails = explode('@', array_get($routeDetails, 'controller'));
+        $controllerNamespace = array_shift($controllerDetails);
+        $permissionsPrefix = $this->getPermissionsPrefix($controllerNamespace);
+
+        // Create permissions of current CRUD Controller if not exists
+        $this->createPermissionsIfNotExists($permissionsPrefix);
+        // Deny or allow access of this CRUD from user permissions
+        $this->initCrudWithPermissions($permissionsPrefix);
+
+        return true;
+    }
+
+    /**
+     * Gives the possibility to override permissions prefix for the CRUD (in setup() method of CrudController)
+     *
+     * @param $permissionsPrefix
+     */
+    public function setPermissionsPrefix($permissionsPrefix)
+    {
+        $this->permissionsPrefix = (string) $permissionsPrefix;
+    }
+
+    /**
+     * Is the system of automatic permissions available ?
+     *
+     * @return bool
+     */
+    protected function permissionsSystemAvailable()
+    {
+        return class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider') &&
+            config('backpack.crud.activate_permissions_system', false);
+    }
+
+    /**
+     * Get the permission prefix of this CRUD
+     *
+     * @param $controllerNamespace
+     * @return string
+     */
+    protected function getPermissionsPrefix($controllerNamespace)
+    {
+        $prefix = $this->permissionsPrefix;
+        if (empty($prefix)) {
+            $prefix = str_replace(['controller', 'crud'], '', strtolower(class_basename($controllerNamespace)));
+        }
+
+        return (string) $prefix;
+    }
+
+    /**
+     * Insert available permissions of current CRUD to DB if not exists
+     *
+     * @param string $permissionsPrefix
+     */
+    protected function createPermissionsIfNotExists($permissionsPrefix)
+    {
+        $availablePermissions = $this->getPermissions($permissionsPrefix);
+        $permissions = \Backpack\PermissionManager\app\Models\Permission::where('name', 'like', $permissionsPrefix.'::%')
+            ->get(['name'])
+            ->pluck('name');
+        // Get permissions not created in DB
+        $permissionsToInsert = $availablePermissions->diff($permissions);
+
+        if (!empty($permissionsToInsert)) {
+            // Add missing permissions to DB
+            $datas = $permissionsToInsert->map(function ($permissionName, $key) {
+                return ['name' => $permissionName, 'created_at' => Carbon::now()];
+            });
+
+            \Backpack\PermissionManager\app\Models\Permission::insert($datas->toArray());
+
+            // Forget permissions cache
+            app(\Backpack\PermissionManager\app\Models\Permission::class)->forgetCachedPermissions();
+
+            if (config('backpack.crud.apply_new_permissions_to_connected_user', false)) {
+                // Gives to connected user the new permissions
+                $user = Auth::user();
+                $permissionsToInsert->each(function ($permissionName, $key) use ($user) {
+                    $user->givePermissionTo($permissionName);
+                });
+            }
+        }
+    }
+
+    /**
+     * @param string $permissionsPrefix
+     * @return Collection
+     */
+    protected function getPermissions($permissionsPrefix)
+    {
+        $availablePermissions = collect($this->availablePermissions)->map(function ($item, $key) use ($permissionsPrefix) {
+            return $permissionsPrefix.'::'.$item;
+        });
+
+        return $availablePermissions;
+    }
+
+    /**
+     * Call deny access if user has not the permission to current action
+     *
+     * @param string $permissionsPrefix
+     */
+    protected function initCrudWithPermissions($permissionsPrefix)
+    {
+        $availablePermissions = $this->getPermissions($permissionsPrefix);
+        $user = Auth::user();
+
+        $availablePermissions->each(function ($permissionName, $key) use ($user) {
+            if (!$user->hasPermissionTo($permissionName)) {
+                $permissionToDeny = str_after($permissionName, '::');
+                $this->denyAccess($permissionToDeny);
+            }
+        });
     }
 }

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD;
 
+use Backpack\CRUD\Console\PermissionsCommand;
 use Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -92,6 +93,12 @@ class CrudServiceProvider extends ServiceProvider
         // map the elfinder prefix
         if (! \Config::get('elfinder.route.prefix')) {
             \Config::set('elfinder.route.prefix', \Config::get('backpack.base.route_prefix').'/elfinder');
+        }
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                PermissionsCommand::class,
+            ]);
         }
     }
 

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Backpack\CRUD;
 
-use Backpack\CRUD\Console\PermissionsCommand;
 use Route;
 use Illuminate\Support\ServiceProvider;
+use Backpack\CRUD\Console\PermissionsCommand;
 
 class CrudServiceProvider extends ServiceProvider
 {

--- a/src/PanelTraits/Permissions.php
+++ b/src/PanelTraits/Permissions.php
@@ -24,7 +24,7 @@ trait Permissions
     public function initPermissions()
     {
         // Checks if the PermissionManagerServiceProvider exists
-        if (!class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
+        if (! class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
             return false;
         }
 
@@ -36,7 +36,7 @@ trait Permissions
         // Gives the current's CRUD permissions to the currently connected user
         if (config('backpack.crud.give_permissions_to_current_user_while_browsing', false)) {
             $user = Auth::user();
-            if (!empty($user)) {
+            if (! empty($user)) {
                 $this->givePermissionsToUser($user);
             }
         }
@@ -59,10 +59,11 @@ trait Permissions
         // Assigns all permissions to user
         $this->getPermissions()->each(function ($permission, $key) use ($user) {
             try {
-                if (!$user->hasPermissionTo($permission)) {
+                if (! $user->hasPermissionTo($permission)) {
                     $user->givePermissionTo($permission);
                 }
-            } catch (PermissionDoesNotExist $e) {}
+            } catch (PermissionDoesNotExist $e) {
+            }
         });
 
         // Reloads user permissions
@@ -80,7 +81,7 @@ trait Permissions
     }
 
     /**
-     * Gets the permission prefix
+     * Gets the permission prefix.
      *
      * @return string
      */
@@ -96,18 +97,18 @@ trait Permissions
     }
 
     /**
-     * Get the default permission prefix (derived from the controller's namespace)
+     * Get the default permission prefix (derived from the controller's namespace).
      *
      * @param bool $cached
      * @return string
      */
     public function getDefaultPermissionPrefix($cached = true)
     {
-        if (is_null($this->defaultPermissionPrefix) || !$cached) {
+        if (is_null($this->defaultPermissionPrefix) || ! $cached) {
 
             $this->defaultPermissionPrefix = '';
 
-            if (!empty($this->controller)) {
+            if (! empty($this->controller)) {
 
                 // Splits the controller's namespace and extracts the class name
                 $namespaceParts = collect(explode('\\', trim(get_class($this->controller), '\\')));
@@ -158,7 +159,7 @@ trait Permissions
     }
 
     /**
-     * Gets the prefixed permission item
+     * Gets the prefixed permission item.
      *
      * @param $item
      * @return string
@@ -169,7 +170,7 @@ trait Permissions
 
         // Adds the prefix
         $prefix = $this->getPermissionPrefix();
-        if (!empty($prefix)) {
+        if (! empty($prefix)) {
             $permission = $prefix.'::'.$permission;
         }
 
@@ -197,7 +198,7 @@ trait Permissions
     }
 
     /**
-     * Creates the missing permissions in database
+     * Creates the missing permissions in database.
      *
      * @return Collection
      */
@@ -212,7 +213,7 @@ trait Permissions
     }
 
     /**
-     * Creates the specified permissions in database
+     * Creates the specified permissions in database.
      *
      * @param Collection $permissions
      * @return bool
@@ -233,7 +234,7 @@ trait Permissions
     }
 
     /**
-     * Initializes the CRUD access from the current user's permissions
+     * Initializes the CRUD access from the current user's permissions.
      */
     protected function initCrudAccessFromUserPermissions()
     {
@@ -249,7 +250,7 @@ trait Permissions
         // Denies access for each permission that the user has not
         $permissions->each(function ($permission, $key) use ($user) {
             try {
-                if (!$user->hasPermissionTo($permission)) {
+                if (! $user->hasPermissionTo($permission)) {
                     $this->denyAccess($this->extractPermissionKey($permission));
                 }
             } catch (PermissionDoesNotExist $e) {
@@ -260,7 +261,7 @@ trait Permissions
     }
 
     /**
-     * Extracts the permission key
+     * Extracts the permission key.
      *
      * @param $permission
      * @return string

--- a/src/PanelTraits/Permissions.php
+++ b/src/PanelTraits/Permissions.php
@@ -105,7 +105,6 @@ trait Permissions
     public function getDefaultPermissionPrefix($cached = true)
     {
         if (is_null($this->defaultPermissionPrefix) || ! $cached) {
-
             $this->defaultPermissionPrefix = '';
 
             if (! empty($this->controller)) {

--- a/src/PanelTraits/Permissions.php
+++ b/src/PanelTraits/Permissions.php
@@ -87,7 +87,7 @@ trait Permissions
      */
     public function getPermissionPrefix()
     {
-        if (!is_null($this->permissionsPrefix)) {
+        if (! is_null($this->permissionsPrefix)) {
             $prefix = $this->permissionsPrefix;
         } else {
             $prefix = $this->getDefaultPermissionPrefix();
@@ -135,7 +135,7 @@ trait Permissions
                 // Builds the prefix
                 $prefix = implode('.', array_merge($namespaceParts->toArray(), [$className]));
 
-                $this->defaultPermissionPrefix = (string)$prefix;
+                $this->defaultPermissionPrefix = (string) $prefix;
             }
         }
 

--- a/src/PanelTraits/Permissions.php
+++ b/src/PanelTraits/Permissions.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+trait Permissions
+{
+    protected $availablePermissions = ['list', 'create', 'update', 'delete'];
+    protected $permissionsPrefix;
+    protected $defaultPermissionPrefix;
+
+    /**
+     * Initializes the permissions for the current CRUD controller.
+     *
+     * Available only if Backpack\PermissionManager is installed.
+     *
+     * @return bool
+     */
+    public function initPermissions()
+    {
+        // Checks if the PermissionManagerServiceProvider exists
+        if (!class_exists('Backpack\PermissionManager\PermissionManagerServiceProvider')) {
+            return false;
+        }
+
+        // Creates the permissions that doesn't already exists
+        if (config('backpack.crud.create_permissions_while_browsing', false)) {
+            $this->createMissingPermissions();
+        }
+
+        // Gives the current's CRUD permissions to the currently connected user
+        if (config('backpack.crud.give_permissions_to_current_user_while_browsing', false)) {
+            $user = Auth::user();
+            if (!empty($user)) {
+                $this->givePermissionsToUser($user);
+            }
+        }
+
+        // Applies permissions on the CRUD (denies/allows access from user permissions)
+        if (config('backpack.crud.apply_permissions', false)) {
+            $this->initCrudAccessFromUserPermissions();
+        }
+
+        return true;
+    }
+
+    /**
+     * Gives all the permissions of the current CRUD to the specified user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    public function givePermissionsToUser($user)
+    {
+        // Assigns all permissions to user
+        $this->getPermissions()->each(function ($permission, $key) use ($user) {
+            if (!$user->hasPermissionTo($permission)) {
+                $user->givePermissionTo($permission);
+            }
+        });
+
+        // Reloads user permissions
+        $user->load('permissions');
+    }
+
+    /**
+     * Sets the permission prefix (instead of the default one).
+     *
+     * @param string|null $prefix
+     */
+    public function setPermissionsPrefix($prefix)
+    {
+        $this->permissionsPrefix = $prefix;
+    }
+
+    /**
+     * Gets the permission prefix
+     *
+     * @return string
+     */
+    public function getPermissionPrefix()
+    {
+        if (!is_null($this->permissionsPrefix)) {
+            $prefix = $this->permissionsPrefix;
+        } else {
+            $prefix = $this->getDefaultPermissionPrefix();
+        }
+
+        return $prefix;
+    }
+
+    /**
+     * Get the default permission prefix (derived from the controller's namespace)
+     *
+     * @param bool $cached
+     * @return string
+     */
+    public function getDefaultPermissionPrefix($cached = true)
+    {
+        if (is_null($this->defaultPermissionPrefix) || !$cached) {
+
+            $this->defaultPermissionPrefix = '';
+
+            if (!empty($this->controller)) {
+
+                // Splits the controller's namespace and extracts the class name
+                $namespaceParts = collect(explode('\\', trim(get_class($this->controller), '\\')));
+                $className = $namespaceParts->pop();
+
+                $namespaceParts = $namespaceParts->map(function ($value) {
+                    return mb_strtolower($value);
+                });
+
+                // Removes the app/vendor prefix from namespace
+                $namespaceParts = $namespaceParts->slice($namespaceParts->first() === 'app' ? 1 : 2);
+
+                // Prepends "admin" to the prefix if present in the namespace or if it's a CRUD controller.
+                // Redundant words like "crud" or "backpack" are also removed.
+                if (is_subclass_of($this->controller, CrudController::class) || $namespaceParts->contains('admin')) {
+                    $namespaceParts = $namespaceParts->diff(['backpack', 'admin', 'crud'])->prepend('admin');
+                }
+
+                // Removes excluded words from namespace and class name
+                $excludedWords = config('backpack.crud.excluded_words_from_default_permission_prefix', []);
+                $namespaceParts = $namespaceParts->diff($excludedWords);
+                $className = collect(explode('_', snake_case($className)))->diff($excludedWords)->implode('.');
+
+                // Builds the prefix
+                $prefix = implode('.', array_merge($namespaceParts->toArray(), [$className]));
+
+                $this->defaultPermissionPrefix = (string)$prefix;
+            }
+        }
+
+        return $this->defaultPermissionPrefix;
+    }
+
+    /**
+     * Gets the permissions.
+     *
+     * @return Collection
+     */
+    public function getPermissions()
+    {
+        $prefix = $this->getPermissionPrefix();
+
+        $permissions = collect($this->availablePermissions)->map(function ($item, $key) use ($prefix) {
+            return $this->getPrefixedPermission($item);
+        });
+
+        return $permissions;
+    }
+
+    /**
+     * Gets the prefixed permission item
+     *
+     * @param $item
+     * @return string
+     */
+    protected function getPrefixedPermission($item)
+    {
+        $permission = $item;
+
+        // Adds the prefix
+        $prefix = $this->getPermissionPrefix();
+        if (!empty($prefix)) {
+            $permission = $prefix.'::'.$permission;
+        }
+
+        return $permission;
+    }
+
+    /**
+     * Gets the permissions that are missing in database.
+     *
+     * @return Collection
+     */
+    public function getMissingPermissions()
+    {
+        $prefix = $this->getPermissionPrefix();
+
+        // Gets the existing permissions
+        $databasePermissions = \Backpack\PermissionManager\app\Models\Permission::where('name', 'like', $prefix.'::%')
+            ->get(['name'])
+            ->pluck('name');
+
+        // Gets the diff with available permissions
+        $missingPermissions = $this->getPermissions()->diff($databasePermissions);
+
+        return $missingPermissions;
+    }
+
+    /**
+     * Creates the missing permissions in database
+     *
+     * @return Collection
+     */
+    public function createMissingPermissions()
+    {
+        $permissions = $this->getMissingPermissions();
+        if ($permissions->isNotEmpty()) {
+            $this->createPermissions($permissions);
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * Creates the specified permissions in database
+     *
+     * @param Collection $permissions
+     * @return bool
+     */
+    protected function createPermissions($permissions)
+    {
+        // Add missing permissions to DB
+        $datas = $permissions->map(function ($permissionName, $key) {
+            return ['name' => $permissionName, 'created_at' => Carbon::now()];
+        });
+
+        $inserted = \Backpack\PermissionManager\app\Models\Permission::insert($datas->toArray());
+
+        // Forget permissions cache
+        app(\Backpack\PermissionManager\app\Models\Permission::class)->forgetCachedPermissions();
+
+        return $inserted;
+    }
+
+    /**
+     * Initializes the CRUD access from the current user's permissions
+     */
+    protected function initCrudAccessFromUserPermissions()
+    {
+        // Gets the CRUD permissions
+        $permissions = $this->getPermissions();
+
+        // Gets the current user
+        $user = Auth::user();
+        if (empty($user)) {
+            return;
+        }
+
+        // Denies access for each permission that the user has not
+        $permissions->each(function ($permission, $key) use ($user) {
+            if (!$user->hasPermissionTo($permission)) {
+                $this->denyAccess($this->extractPermissionKey($permission));
+            }
+        });
+    }
+
+    /**
+     * Extracts the permission key
+     *
+     * @param $permission
+     * @return string
+     */
+    protected function extractPermissionKey($permission)
+    {
+        return str_after($permission, '::');
+    }
+}

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -49,7 +49,6 @@ class CrudController extends BaseController
      */
     public function setup()
     {
-
     }
 
     /**
@@ -222,5 +221,4 @@ class CrudController extends BaseController
 
         return $this->crud->delete($id);
     }
-
 }

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -29,7 +29,6 @@ class CrudController extends BaseController
     public function __construct()
     {
         if (! $this->crud) {
-
             $this->crud = app()->make(CrudPanel::class);
 
             // Stores a reference to the current controller

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -29,8 +29,8 @@ class CrudController extends BaseController
     public function __construct()
     {
         if (! $this->crud) {
-            $this->crud = app()->make(CrudPanel::class);
 
+            $this->crud = app()->make(CrudPanel::class);
             // call the setup function inside this closure to also have the request there
             // this way, developers can use things stored in session (auth variables, etc)
             $this->middleware(function ($request, $next) {

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -31,13 +31,23 @@ class CrudController extends BaseController
         if (! $this->crud) {
 
             $this->crud = app()->make(CrudPanel::class);
+
+            // Stores a reference to the current controller
+            $this->crud->controller = $this;
+
             // call the setup function inside this closure to also have the request there
             // this way, developers can use things stored in session (auth variables, etc)
             $this->middleware(function ($request, $next) {
-                $this->request = $request;
-                $this->crud->request = $request;
+
+                // Stores a reference to the current request
+                $this->crud->request = $this->request = $request;
+
                 $this->setup();
-                $this->crud->initPermissions();
+
+                // Initializes the CRUD permissions
+                if (method_exists($this->crud, 'initPermissions')) {
+                    $this->crud->initPermissions();
+                }
 
                 return $next($request);
             });

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -37,6 +37,7 @@ class CrudController extends BaseController
                 $this->request = $request;
                 $this->crud->request = $request;
                 $this->setup();
+                $this->crud->initPermissions();
 
                 return $next($request);
             });
@@ -48,6 +49,7 @@ class CrudController extends BaseController
      */
     public function setup()
     {
+
     }
 
     /**
@@ -220,4 +222,5 @@ class CrudController extends BaseController
 
         return $this->crud->delete($id);
     }
+
 }

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -57,6 +57,14 @@ return [
     */
 
     /*
+    |------------
+    | PERMISSIONS
+    |------------
+    */
+    'activate_permissions_system' => false, // Set to true if you want activate permission system (require PermissionManager)
+    'apply_new_permissions_to_connected_user' => true, // Set to false in production environment
+
+    /*
     |-------------------
     | TRANSLATABLE CRUDS
     |-------------------

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -61,8 +61,24 @@ return [
     | PERMISSIONS
     |------------
     */
-    'activate_permissions_system' => false, // Set to true if you want activate permission system (require PermissionManager)
-    'apply_new_permissions_to_connected_user' => true, // Set to false in production environment
+
+    // Automatically applies permissions to CRUD controllers. Requires the Backpack/PermissionManager package.
+    //
+    // Each CRUD controller should have a unique prefix for its permission keys. By default the prefix is automatically
+    // derived from the controller's namespace but you can set your own (see the setPermissionsPrefix() method).
+    //
+    // This prefix will then be used to match the permissions handled by the permission manager.
+    //
+    'apply_permissions' => false,
+
+    // Creates the CRUD's permissions in database while browsing in admin.
+    'create_permissions_while_browsing' => false,
+
+    // Gives the CRUD's permissions to the currently connected user while browsing in admin. Should be disabled in production.
+    'give_permissions_to_current_user_while_browsing' => false,
+
+    // Words that are excluded from the auto generated permission prefix (based on route's controller namespace).
+    'excluded_words_from_default_permission_prefix' => ['app', 'http', 'controllers', 'controller', 'crud'],
 
     /*
     |-------------------


### PR DESCRIPTION
Today Backpack is frustrating because packages doesn't communicate with each other. 
Backpack gives [Laravel-Backpack/PermissionManager package](https://github.com/Laravel-Backpack/PermissionManager) but after installation no permission are created / used. 
Would it be perfect that this package was compatible and usable with CRUD isn't it ?
This is what this PR offers ! :champagne: 

**Summary**
- Permissions can now be applied automatically to CRUD Controllers : deny access if user hasn't the permission linked to the route => `apply_permissions` option
- Permissions can now be automatically created for all Crud Controllers used in you application (4 permissions will be created : list, update, create, delete) => `create_permissions_while_browsing` option
- Permissions can be automatically given to the logged user (useful in local environment)  => `give_permissions_to_current_user_while_browsing` option

**Configuration**
By default these features are disabled. There is no breaking change :smile: !
You can enable them in ` config/backpack/crud.php`.

**Command**
An artisan command is available to generate automatically CRUD permissions :
`php artisan permissions:generate`