### PR TITLE
adds callback for filtering reorder entries

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -5,7 +5,7 @@ namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 trait Reorder
 {
     /**
-     * Filters entries collection before rendering the reorder view
+     * Filters entries collection before rendering the reorder view.
      */
     protected $reorder_filter_callback = null;
 
@@ -57,7 +57,7 @@ trait Reorder
     }
 
     /**
-     * Set a callable for filtering the items to reorder
+     * Set a callable for filtering the items to reorder.
      *
      * @param callable $callable
      * @internal param callable $reorder_filter_callback

--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -5,6 +5,11 @@ namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 trait Reorder
 {
     /**
+     * Filters entries collection before rendering the reorder view
+     */
+    protected $reorder_filter_callback = null;
+
+    /**
      *  Reorder the items in the database using the Nested Set pattern.
      *
      *  Database columns needed: id, parent_id, lft, rgt, depth, name/title
@@ -21,6 +26,7 @@ trait Reorder
 
         // get all results for that entity
         $this->data['entries'] = $this->crud->getEntries();
+        $this->data['entries'] = $this->data['entries']->filter($this->reorder_filter_callback);
         $this->data['crud'] = $this->crud;
         $this->data['title'] = trans('backpack::crud.reorder').' '.$this->crud->entity_name;
 
@@ -48,5 +54,16 @@ trait Reorder
         }
 
         return 'success for '.$count.' items';
+    }
+
+    /**
+     * Set a callable for filtering the items to reorder
+     *
+     * @param callable $callable
+     * @internal param callable $reorder_filter_callback
+     */
+    public function setReorderFilterCallback(callable $callable)
+    {
+        $this->reorder_filter_callback = $callable;
     }
 }

--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -27,7 +27,7 @@ trait Reorder
         // get all results for that entity
         $this->data['entries'] = $this->crud->getEntries();
 
-        if(is_callable($this->reorder_filter_callback)) {
+        if (is_callable($this->reorder_filter_callback)) {
             $this->data['entries'] = $this->data['entries']->filter($this->reorder_filter_callback);
         }
 

--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -26,7 +26,11 @@ trait Reorder
 
         // get all results for that entity
         $this->data['entries'] = $this->crud->getEntries();
-        $this->data['entries'] = $this->data['entries']->filter($this->reorder_filter_callback);
+
+        if(is_callable($this->reorder_filter_callback)) {
+            $this->data['entries'] = $this->data['entries']->filter($this->reorder_filter_callback);
+        }
+
         $this->data['crud'] = $this->crud;
         $this->data['title'] = trans('backpack::crud.reorder').' '.$this->crud->entity_name;
 


### PR DESCRIPTION
Hello guys,

It would be great to be able to filter the result of the "getEntries()" method before rendering the "reorderView". We have a case where we only need to reorder some items, for instance: items belonging to a category. I use this feature within the crudController:

```php
        $this->crud->allowAccess('reorder');
        $this->crud->enableReorder('fieldname', 1);
        $this->setReorderFilterCallback(function ($value, $key) {
            //filtering stuff here....
        });
```

I would appreciate any feedback.

