### PR TITLE
New column and field types for managing permissions and roles with permissions

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 
+use Illuminate\Support\Collection;
+
 trait AjaxTable
 {
     /**
@@ -13,7 +15,7 @@ trait AjaxTable
         $this->crud->hasAccessOrFail('list');
 
         // create an array with the names of the searchable columns
-        $columns = $this->searchableColumns();
+        $columns = $this->searchableColumns()->toArray();
 
         // structure the response in a DataTable-friendly way
         $dataTable = new \LiveControl\EloquentDataTable\DataTable($this->crud->query, $columns);
@@ -48,7 +50,7 @@ trait AjaxTable
     /**
      * Gets the searchable columns.
      *
-     * @return array
+     * @return Collection
      */
     protected function searchableColumns()
     {
@@ -68,8 +70,7 @@ trait AjaxTable
             })
             ->pluck('name')
             // add the primary key, otherwise the buttons won't work
-            ->merge($this->crud->model->getKeyName())
-            ->toArray();
+            ->merge($this->crud->model->getKeyName());
 
         return $columns;
     }

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -46,7 +46,7 @@ trait AjaxTable
     }
 
     /**
-     * Gets the searchable columns
+     * Gets the searchable columns.
      *
      * @return array
      */

--- a/src/resources/views/columns/permissions.blade.php
+++ b/src/resources/views/columns/permissions.blade.php
@@ -1,0 +1,51 @@
+{{-- relationships with pivot table (n-n) --}}
+<td>
+    <?php
+
+    // Gets the attribute to display the permission name
+    $attribute = array_get($column, 'attribute');
+
+    $permissions = $entry->{$column['entity']};
+
+    // Groups permissions by prefix, sorted alphabetically
+    $permissionsByPrefix = collect($permissions)
+        ->sortBy(function($permission) {
+            return $permission->prefix() ?: PHP_INT_MAX; // Use PHP_INT_MAX as a little trick for sorting permissions without prefix at the end
+        })
+        ->groupBy(function($permission) {
+            return $permission->prefix();
+        });
+    ?>
+
+    @if ($permissionsByPrefix->isNotEmpty())
+
+        @foreach ($permissionsByPrefix as $prefix => $permissions)
+
+            @if (!$loop->first)
+                @if (array_get($column, 'inline'))
+                    ,
+                @else
+                    <br />
+                @endif
+            @endif
+
+            {{ $prefix }}
+
+            <em>
+                ({{ $permissions->map(function($permission) use ($attribute) {
+                    if (is_callable($attribute)) {
+                        return $attribute($permission);
+                    } elseif (is_string($attribute)) {
+                        return $permission->$attribute;
+                    } else {
+                        return $permission->item();
+                    }
+                })->implode(', ') }})
+            </em>
+
+        @endforeach
+
+    @else
+        -
+    @endif
+</td>

--- a/src/resources/views/fields/permissions.blade.php
+++ b/src/resources/views/fields/permissions.blade.php
@@ -1,0 +1,50 @@
+<!-- select2 -->
+<div @include('crud::inc.field_wrapper_attributes') >
+
+    @if (!empty($field['label']))
+    <label>{!! $field['label'] !!}</label>
+    @endif
+
+    @include('crud::inc.field_translatable_icon')
+
+    @foreach ($field['model']::all()->groupBy(function($permission) { return $permission->prefix(); }) as $prefix => $permissions)
+        <hr/>
+        <div class="row">
+                <div class="col-sm-3">
+                    <label class="no-margin">
+                        <strong>{{ $prefix }}</strong>
+                    </label>
+                </div>
+                <div class="col-sm-7">
+                    @foreach ($permissions as $permission)
+                        <div class="checkbox inline no-margin">
+                            <label>
+                                <input type="checkbox"
+                                       name="{{ $field['name'] }}[]"
+                                       value="{{ $permission->getKey() }}"
+                                       @if( ( old( $field["name"] ) && in_array($permission->getKey(), old( $field["name"])) ) || (isset($field['value']) && in_array($permission->getKey(), $field['value']->pluck($permission->getKeyName(), $permission->getKeyName())->toArray())))
+                                       checked = "checked"
+                                       @endif > {!! $permission->item() !!} &nbsp;
+                            </label>
+                        </div>
+                    @endforeach
+                </div>
+                <div class="col-sm-2">
+                    <div class="pull-right">
+                        <a href="" class="btn btn-default btn-xs" title="Uncheck all">
+                            <i class="fa fa-square-o"></i>&nbsp; None
+                        </a>
+                        &nbsp;
+                        <a href="" class="btn btn-default btn-xs" title="Check all">
+                            <i class="fa fa-check-square-o"></i>&nbsp; All
+                        </a>
+                    </div>
+                </div>
+        </div>
+    @endforeach
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/fields/permissions.blade.php
+++ b/src/resources/views/fields/permissions.blade.php
@@ -1,11 +1,25 @@
 <!-- permissions -->
-<div @include('crud::inc.field_wrapper_attributes') >
+<div class="form-group col-md-12 checklist" @include('crud::inc.field_wrapper_attributes') >
 
     @if (!empty($field['label']))
         <label>{!! $field['label'] !!}</label>
     @endif
 
     @include('crud::inc.field_translatable_icon')
+
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="pull-right">
+                <button class="btn btn-default btn-xs uncheck-all" title="Uncheck all">
+                    <i class="fa fa-square-o"></i>&nbsp; None
+                </button>
+                &nbsp;
+                <button href="" class="btn btn-default btn-xs check-all" title="Check all">
+                    <i class="fa fa-check-square-o"></i>&nbsp; All
+                </button>
+            </div>
+        </div>
+    </div>
 
     @foreach ($field['model']::all()->groupBy(function($permission) { return $permission->prefix(); }) as $prefix => $permissions)
         <hr/>
@@ -32,13 +46,13 @@
                 </div>
                 <div class="col-sm-2">
                     <div class="pull-right">
-                        <a href="" class="btn btn-default btn-xs" title="Uncheck all">
+                        <button href="" class="btn btn-default btn-xs uncheck-row" title="Uncheck all" class="">
                             <i class="fa fa-square-o"></i>&nbsp; None
-                        </a>
+                        </button>
                         &nbsp;
-                        <a href="" class="btn btn-default btn-xs" title="Check all">
+                        <button href="" class="btn btn-default btn-xs check-row" title="Check all">
                             <i class="fa fa-check-square-o"></i>&nbsp; All
-                        </a>
+                        </button>
                     </div>
                 </div>
         </div>
@@ -49,3 +63,54 @@
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
 </div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include checklist js-->
+    <script>
+        jQuery(document).ready(function($) {
+
+            $('.checklist').each(function(index, item) {
+                var $field = $(this);
+
+                /**
+                 * Check/uncheck all
+                 */
+                $field.find('.check-row').on('click', function(event) {
+                    event.preventDefault();
+                    $(this).closest('.row').find('.checkbox input').prop('checked', true);
+                    return false;
+                });
+                $field.find('.uncheck-row').on('click', function(event) {
+                    event.preventDefault();
+                    $(this).closest('.row').find('.checkbox input').prop('checked', false);
+                    return false;
+                });
+                $field.find('.check-all').on('click', function(event) {
+                    event.preventDefault();
+                    $field.find('.checkbox input').prop('checked', true);
+                    return false;
+                });
+                $field.find('.uncheck-all').on('click', function(event) {
+                    event.preventDefault();
+                    $field.find('.checkbox input').prop('checked', false);
+                    return false;
+                });
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/fields/permissions.blade.php
+++ b/src/resources/views/fields/permissions.blade.php
@@ -1,8 +1,8 @@
-<!-- select2 -->
+<!-- permissions -->
 <div @include('crud::inc.field_wrapper_attributes') >
 
     @if (!empty($field['label']))
-    <label>{!! $field['label'] !!}</label>
+        <label>{!! $field['label'] !!}</label>
     @endif
 
     @include('crud::inc.field_translatable_icon')
@@ -19,12 +19,13 @@
                     @foreach ($permissions as $permission)
                         <div class="checkbox inline no-margin">
                             <label>
-                                <input type="checkbox"
-                                       name="{{ $field['name'] }}[]"
-                                       value="{{ $permission->getKey() }}"
-                                       @if( ( old( $field["name"] ) && in_array($permission->getKey(), old( $field["name"])) ) || (isset($field['value']) && in_array($permission->getKey(), $field['value']->pluck($permission->getKeyName(), $permission->getKeyName())->toArray())))
-                                       checked = "checked"
-                                       @endif > {!! $permission->item() !!} &nbsp;
+                                <input
+                                    type="checkbox"
+                                    name="{{ $field['name'] }}[]"
+                                    value="{{ $permission->getKey() }}"
+                                    @if( ( old( $field["name"] ) && in_array($permission->getKey(), old( $field["name"])) ) || (isset($field['value']) && in_array($permission->getKey(), $field['value']->pluck($permission->getKeyName(), $permission->getKeyName())->toArray())))
+                                        checked = "checked"
+                                    @endif > {!! $permission->item() !!} &nbsp;
                             </label>
                         </div>
                     @endforeach

--- a/src/resources/views/fields/permissions_with_roles.blade.php
+++ b/src/resources/views/fields/permissions_with_roles.blade.php
@@ -117,7 +117,13 @@
                             @if ((is_array($field['value']) && ($field['value'][0]->pluck('id')->contains($role->id))) || (old($fieldRole["name"]) && in_array($role->id, old($fieldRole["name"]))))
                                 checked = "checked"
                             @endif >
-                            {{ $role->{$fieldRole['attribute']} }}
+                            @if (is_callable($fieldRole['attribute']))
+                                {{ $fieldRole['attribute']($role) }}
+                            @elseif (is_string($fieldRole['attribute']))
+                                {{ $role->{$fieldRole['attribute']} }}
+                            @else
+                                {{ $role->name }}
+                            @endif
                     </label>
                     {{ $roleColumns === true ? '&nbsp;' : '' }}
                 </div>
@@ -203,7 +209,13 @@
                                             disabled = disabled
                                         @endif
                                     >
-                                    {{ is_callable($fieldPermission['attribute']) ? $fieldPermission['attribute']($permission) : $permission->{$fieldPermission['attribute']} }} &nbsp;
+                                    @if (is_callable($fieldPermission['attribute']))
+                                        {{ $fieldPermission['attribute']($permission) }}
+                                    @elseif (is_string($fieldPermission['attribute']))
+                                        {{ $permission->{$fieldPermission['attribute']} }}
+                                    @else
+                                        {{ $permission->item() }}
+                                    @endif
                                 </label>
                             </div>
                         @endforeach

--- a/src/resources/views/fields/permissions_with_roles.blade.php
+++ b/src/resources/views/fields/permissions_with_roles.blade.php
@@ -126,13 +126,13 @@
         </div>
         <div class="col-sm-2">
             <div class="pull-right">
-                <a href="" class="btn btn-default btn-xs uncheck-row" title="Uncheck all" class="">
+                <button class="btn btn-default btn-xs uncheck-all" title="Uncheck all">
                     <i class="fa fa-square-o"></i>&nbsp; None
-                </a>
+                </button>
                 &nbsp;
-                <a href="" class="btn btn-default btn-xs check-row" title="Check all">
+                <button href="" class="btn btn-default btn-xs check-all" title="Check all">
                     <i class="fa fa-check-square-o"></i>&nbsp; All
-                </a>
+                </button>
             </div>
         </div>
 
@@ -196,13 +196,13 @@
                     </div>
                     <div class="col-sm-2">
                         <div class="pull-right">
-                            <a href="" class="btn btn-default btn-xs uncheck-row" title="Uncheck all" class="">
+                            <button href="" class="btn btn-default btn-xs uncheck-row" title="Uncheck all" class="">
                                 <i class="fa fa-square-o"></i>&nbsp; None
-                            </a>
+                            </button>
                             &nbsp;
-                            <a href="" class="btn btn-default btn-xs check-row" title="Check all">
+                            <button href="" class="btn btn-default btn-xs check-row" title="Check all">
                                 <i class="fa fa-check-square-o"></i>&nbsp; All
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -253,7 +253,7 @@
                     });
                     return false;
                 });
-                $field.find('.uncheck-row').on('click', function() {
+                $field.find('.uncheck-row').on('click', function(event) {
                     event.preventDefault();
                     $(this).closest('.row').find('.secondary_list').each(function() {
                         var $input = $(this);
@@ -269,18 +269,18 @@
                     $field.find('.secondary_list').each(function() {
                         var $input = $(this);
                         $input.prop('checked', true);
-                        removeInputHidden($input);
+                        addInputHidden($input);
                     });
                     return false;
                 });
-                $field.find('.uncheck-all').on('click', function() {
+                $field.find('.uncheck-all').on('click', function(event) {
                     event.preventDefault();
                     $field.find('.secondary_list').each(function() {
                         var $input = $(this);
                         if (!$input.is(':disabled')) {
                             $input.prop('checked', false);
                         }
-                        addInputHidden($input);
+                        removeInputHidden($input);
                     });
                     return false;
                 });
@@ -353,7 +353,6 @@
                  */
                 $field.find('.secondary_list').each(function() {
                     var $input = $(this);
-                    var idCurrent = $input.data('id');
 
                     // Handles click on a permission
                     $input.on('click update', function () {

--- a/src/resources/views/fields/permissions_with_roles.blade.php
+++ b/src/resources/views/fields/permissions_with_roles.blade.php
@@ -1,0 +1,312 @@
+<!-- dependencyJson -->
+<div class="form-group col-md-12 checklist_dependency"  data-entity ="{{ $field['field_unique_name'] }}" @include('crud::inc.field_wrapper_attributes')>
+
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    <?php
+    $fieldRole = $field['subfields']['primary'];
+    $fieldPermission = $field['subfields']['secondary'];
+
+    $entity_model = $crud->getModel();
+
+    $roles = $fieldRole['model']::with($fieldRole['entity_secondary'])->get();
+
+    // Gets the entity roles and permissions
+    $entityRoles = collect(isset($field['value']) && is_array($field['value']) ? array_get($field, 'value.0', []) : []);
+    $entityPermissions = collect(isset($field['value']) && is_array($field['value']) ? array_get($field, 'value.1', []) : []);
+
+    // Gets the permissions granted by the entity roles (update form only)
+    $entityRolesPermissions = collect();
+
+    // Gets the entity with roles and permissions
+    $entityWithDependencies = $entity_model->with($fieldRole['entity'])
+        ->with($fieldRole['entity'].'.'.$fieldRole['entity_secondary'])
+        ->find($id);
+
+    // Creates secondary dependency from primary relation, used to check which checkbox must be checked from second checklist
+    if (old($fieldRole['name'])) {
+        foreach (old($fieldRole['name']) as $role_item) {
+            $entityRolesPermissions = $entityRolesPermissions->merge($roles->search(function($role) use ($role_item) {
+                return $role->id;
+            }) ?: []);
+        }
+    }
+    // Creates dependencies from relation if not from validate error
+    else {
+        foreach ($entityWithDependencies->{$fieldRole['entity']} as $role) {
+            $entityRolesPermissions = $entityRolesPermissions->merge($role->{$fieldPermission['entity']}->pluck('id'));
+        }
+    }
+
+    // Builds a simple matrix of roles and permissions (role id as key and array of permission ids as value)
+    $rolesPermissions = $roles->pluck($fieldRole['entity_secondary'], 'id')->map(function($permissions) {
+        return $permissions->pluck('id');
+    });
+
+    ?>
+    <script>
+        var  {{ $field['field_unique_name'] }} = {!! $rolesPermissions->toJson() !!};
+    </script>
+
+    <div class="row" >
+
+        <div class="col-xs-12">
+            <label>{!! $fieldRole['label'] !!}</label>
+        </div>
+
+        <div class="hidden_fields_primary" data-name = "{{ $fieldRole['name'] }}">
+            @if (isset($field['value']))
+                @if (old($fieldRole['name']))
+                    @foreach(old($fieldRole['name']) as $item)
+                        <input type="hidden" class="primary_hidden" name="{{ $fieldRole['name'] }}[]" value="{{ $item }}">
+                    @endforeach
+                @else
+                    @foreach($field['value'][0]->pluck('id', 'id')->toArray() as $item)
+                        <input type="hidden" class="primary_hidden" name="{{ $fieldRole['name'] }}[]" value="{{ $item }}">
+                    @endforeach
+                @endif
+            @endif
+        </div>
+
+        <?php $columns = array_get($fieldRole, 'columns') ?>
+
+        @if (is_bool($columns))
+        <div class="col-sm-12">
+        @endif
+
+        @foreach ($fieldRole['model']::all() as $role)
+            @if (is_int($columns))
+            <div class="col-sm-{{ is_int($columns) ? intval(12 / $columns) : '12' }}">
+            @endif
+                <div class="checkbox {{ $columns === true ? 'inline' : '' }}">
+                    <label>
+                        <input
+                            type="checkbox"
+                            data-id = "{{ $role->id }}"
+                            class="primary_list"
+                            @foreach ($fieldRole as $attribute => $value)
+                                @if (is_string($attribute) && $attribute != 'value')
+                                    @if ($attribute=='name')
+                                    {{ $attribute }}="{{ $value }}_show[]"
+                                    @else
+                                    {{ $attribute }}="{{ $value }}"
+                                    @endif
+                                @endif
+                            @endforeach
+                            value="{{ $role->id }}"
+                            @if (
+                                (isset($field['value']) && is_array($field['value']) && in_array($role->id, $field['value'][0]->pluck('id', 'id')->toArray()))
+                                 || (old($fieldRole["name"]) && in_array($role->id, old($fieldRole["name"])))
+                             )
+                            checked = "checked"
+                            @endif >
+                            {{ $role->{$fieldRole['attribute']} }}
+                    </label>
+                    {{ $columns === true ? '&nbsp;' : '' }}
+                </div>
+            @if (is_int($columns))
+            </div>
+            @endif
+        @endforeach
+
+        @if (is_bool($columns))
+        </div>
+        @endif
+
+    </div>
+
+    <div class="row">
+        <div class="col-xs-12">
+            <label>{!! $fieldPermission['label'] !!}</label>
+        </div>
+
+        <div class="hidden_fields_secondary" data-name="{{ $fieldPermission['name'] }}">
+          @if (isset($field['value']))
+            @if (old($fieldPermission['name']))
+              @foreach(old($fieldPermission['name']) as $item)
+                <input type="hidden" class="secondary_hidden" name="{{ $fieldPermission['name'] }}[]" value="{{ $item }}">
+              @endforeach
+            @else
+              @foreach($field['value'][1]->pluck('id', 'id')->toArray() as $item)
+                <input type="hidden" class="secondary_hidden" name="{{ $fieldPermission['name'] }}[]" value="{{ $item }}">
+              @endforeach
+            @endif
+          @endif
+        </div>
+
+        <div class="col-sm-12">
+            @foreach ($fieldPermission['model']::all()->groupBy(function($permission) { return $permission->prefix(); }) as $prefix => $permissions)
+                <hr/>
+                <div class="row">
+                    <div class="col-sm-3">
+                        <label class="no-margin">
+                            <strong>{{ $prefix }}</strong>
+                        </label>
+                    </div>
+                    <div class="col-sm-7">
+                        @foreach ($permissions as $permission)
+                            <div class="checkbox inline no-margin">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        class = 'secondary_list'
+                                        data-id = "{{ $permission->id }}"
+                                        value="{{ $permission->id }}"
+                                        @foreach ($fieldPermission as $attribute => $value)
+                                            @if (is_string($attribute) && $attribute != 'value' && !is_callable($value))
+                                                @if ($attribute=='name')
+                                                    {{ $attribute }}="{{ $value }}_show[]"
+                                                @else
+                                                    {{ $attribute }}="{{ $value }}"
+                                                @endif
+                                            @endif
+                                        @endforeach
+                                        @if (
+                                            (!empty($field['value']) && is_array($field['value']) && ($field['value'][1]->pluck('id')->contains($permission->id)))
+                                            || (old($fieldPermission['name']) && in_array($permission->id, old($fieldPermission['name'])))
+                                            || $entityRolesPermissions->contains($permission->id))
+                                            checked = "checked"
+                                            @if ($entityRolesPermissions->contains($permission->id))
+                                                disabled = disabled
+                                            @endif
+                                        @endif >
+                                    {{ is_callable($fieldPermission['attribute']) ? $fieldPermission['attribute']($permission) : $permission->{$fieldPermission['attribute']} }} &nbsp;
+                                </label>
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="col-sm-2">
+                        <div class="pull-right">
+                            <a href="" class="btn btn-default btn-xs" title="Uncheck all">
+                                <i class="fa fa-square-o"></i>&nbsp; None
+                            </a>
+                            &nbsp;
+                            <a href="" class="btn btn-default btn-xs" title="Check all">
+                                <i class="fa fa-check-square-o"></i>&nbsp; All
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+  </div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include checklist_dependency js-->
+    <script>
+        jQuery(document).ready(function($) {
+
+            $('.checklist_dependency').each(function(index, item) {
+                var $field = $(this);
+
+                var unique_name = $field.data('entity');
+
+                // Gets the permissions granted by each role
+                var rolesPermissions = window[unique_name];
+
+                /**
+                 * Handles click on a role
+                 */
+                $field.find('.primary_list').change(function() {
+                    var $input = $(this);
+                    var roleId = $input.data('id');
+
+                    // Check
+                    if ($input.is(':checked')) {
+                        //add hidden field with this value
+                        var nameInput = $field.find('.hidden_fields_primary').data('name');
+                        var inputToAdd = $('<input type="hidden" class="primary_hidden" name="'+nameInput+'[]" value="'+roleId+'">');
+                        $field.find('.hidden_fields_primary').append(inputToAdd);
+
+                        if ($.isArray(rolesPermissions[roleId])) {
+                            $.each(rolesPermissions[roleId], function (key, permissionId) {
+                                //check and disable secondaries checkboxes
+                                $field.find('input.secondary_list[value="' + permissionId + '"]').prop("checked", true).prop("disabled", true);
+                                //remove hidden fields with secondary dependency if was setted
+                                var hidden = $field.find('input.secondary_hidden[value="' + permissionId + '"]');
+                                if (hidden)
+                                    hidden.remove();
+                            });
+                        }
+                    }
+                    // Uncheck
+                    else {
+                        // Remove hidden field with this value
+                        $field.find('input.primary_hidden[value="'+roleId+'"]').remove();
+
+                        // Uncheck and active secondary checkboxs if are not in other selected primary.
+                        var selectedRoles = [];
+                        $field.find('input.primary_hidden').each(function(index, input) {
+                            selectedRoles.push($(this).val());
+                        });
+
+                        if ($.isArray(rolesPermissions[roleId])) {
+                            $.each(rolesPermissions[roleId], function (index, permissionId) {
+
+                                // Searches if the permission is granted by another role
+                                var inOtherRoles = $.grep(selectedRoles, function (otherRoleId) {
+                                    return $.isArray(rolesPermissions[otherRoleId]) && rolesPermissions[otherRoleId].indexOf(permissionId) !== -1;
+                                });
+
+                                // If not granted by another role, removes the disabled state and resets to the last checked state
+                                if (inOtherRoles.length === 0) {
+                                    var $input = $field.find('input.secondary_list[value="' + permissionId + '"]');
+                                    $input.prop('checked', $input.data('last-checked-state')).prop('disabled', false);
+                                }
+                            });
+                        }
+                    }
+                });
+
+                /**
+                 * Handles click on a permission
+                 */
+                $field.find('.secondary_list').each(function() {
+                    var $input = $(this);
+
+                    $input.data('last-checked-state', $input.is(':checked') && !$input.is(':disabled'));
+
+                    $input.click(function () {
+                        var idCurrent = $input.data('id');
+
+                        if ($input.is(':checked')) {
+                            // Add hidden field with this value
+                            var nameInput = $field.find('.hidden_fields_secondary').data('name');
+                            var inputToAdd = $('<input type="hidden" class="secondary_hidden" name="' + nameInput + '[]" value="' + idCurrent + '">');
+                            $field.find('.hidden_fields_secondary').append(inputToAdd);
+                        } else {
+                            // Remove hidden field with this value
+                            $field.find('input.secondary_hidden[value="' + idCurrent + '"]').remove();
+                        }
+
+                        $input.data('last-checked-state', $input.is(':checked'));
+                    })
+                });
+
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/fields/permissions_with_roles.blade.php
+++ b/src/resources/views/fields/permissions_with_roles.blade.php
@@ -1,5 +1,5 @@
 <!-- permissions and roles -->
-<div class="form-group col-md-12 checklist_dependency"  data-entity ="{{ $field['field_unique_name'] }}" @include('crud::inc.field_wrapper_attributes')>
+<div class="col-md-12 checklist_dependency"  data-entity ="{{ $field['field_unique_name'] }}" @include('crud::inc.field_wrapper_attributes')>
 
     @if (!empty($field['label']))
         <label>{!! $field['label'] !!}</label>
@@ -56,7 +56,7 @@
         var  {{ $field['field_unique_name'] }} = {!! $rolesPermissions->toJson() !!};
     </script>
 
-    <div class="row" >
+    <div class="row form-group">
 
         <div class="col-xs-12">
             <label>{!! $fieldRole['label'] !!}</label>
@@ -120,7 +120,7 @@
 
     </div>
 
-    <div class="row">
+    <div class="row form-group">
         <div class="col-xs-10">
             <label>{!! $fieldPermission['label'] !!}</label>
         </div>


### PR DESCRIPTION
Hi,

This PR implements 2 new types of field and a column to display and manage permissions and roles with permissions in a more efficient way. These are intended to be used by the permission manager in replacement of the `checklist` and `checklist_dependency` types. I used the views of these ones as a code base, so there are similarities in the code, although I have refactored a lot.

I would have liked to implement these new fields and column directly in the permissions manager but I didn't found a clean way to implement a new field type from another package. I think this could be implemented with little changes in the code, but I will see another time, there are many other more interesting things to do in my opinion.

#### See in images

<img src="https://user-images.githubusercontent.com/2183266/30184956-f63aa30c-941f-11e7-91df-15f1d834a618.png" alt="alt text" width="auto" height="130px"> &nbsp; <img src="https://user-images.githubusercontent.com/2183266/30184650-07631e4e-941f-11e7-9260-14e8a4b8ce9d.png" alt="alt text" width="auto" height="130px"> &nbsp; <img src="https://user-images.githubusercontent.com/2183266/30208356-542b6b0e-9493-11e7-8c87-1263bde2dd4f.png" alt="alt text" width="auto" height="130px">

#### Main features
- groups of permissions by prefix (see #928) for fields and column
- buttons to check/uncheck all the permissions or a group of permissions
- permissions granted by a role no longer overwrite the permissions granted directly to the user, this is intended to avoid loosing permissions when checking and then unchecking a role. See below how it works now :
![laravel-backpack-pr-field-type-role-permission-demo1](https://user-images.githubusercontent.com/2183266/30179037-5508c270-940b-11e7-9a89-8eed13c7f385.gif)

#### Usage

```php
$this->crud->setColumns([
    'label'     => trans('backpack::permissionmanager.extra_permissions'), // Table column heading
    'type'      => 'permissions',
    'name'      => 'permissions', // the method that defines the relationship in your Model
    'entity'    => 'permissions', // the method that defines the relationship in your Model
    //'attribute' => 'name', // foreign key attribute that is shown as the permission name (string, callback or null for default value)
    'model'     => config('laravel-permission.models.permission'), // foreign key model
    'inline'    => false, // true for all groups of permission on the same row or false for each on a row
]);

$this->crud->addField([
    // two interconnected entities
    'label'             => false,
    'field_unique_name' => 'user_role_permission',
    'type'              => 'permissions_with_roles',
    'name'              => 'roles_and_permissions', // the methods that defines the relationship in your Model
    'subfields'         => [
        'primary' => [
            'label'            => trans('backpack::permissionmanager.roles'),
            'name'             => 'roles', // the method that defines the relationship in your Model
            'entity'           => 'roles', // the method that defines the relationship in your Model
            'entity_secondary' => 'permissions', // the method that defines the relationship in your Model
            'attribute'        => null, // foreign key attribute that is shown to user (string, callback or null for default value)
            'model'            => config('laravel-permission.models.role'), // foreign key model
            'pivot'            => true, // on create&update, do you need to add/delete pivot table entries?]
            'columns'          => true, // Number of columns (1,2,3,4,6) or "true" for all on same line or "false" for each on a single line
        ],
        'secondary' => [
            'label'          => ucfirst(trans('backpack::permissionmanager.permission_singular')),
            'name'           => 'permissions', // the method that defines the relationship in your Model
            'entity'         => 'permissions', // the method that defines the relationship in your Model
            'entity_primary' => 'roles', // the method that defines the relationship in your Model
            'attribute'      => null, // foreign key attribute that is shown to user (string, callback or null for default value)
            'model'          => \Backpack\PermissionManager\app\Models\Permission::class, // foreign key model
            'pivot'          => true, // on create&update, do you need to add/delete pivot table entries?]
        ],
    ],
]);
```

Todos:
- [x] add a new column type to display permissions grouped by prefix 
- [x] sort groups of permissions in alphabetical order
- [ ] create a pull request to use these field types by default in the permission manager