### PR TITLE
Add hidden columns and change export function to suit CRUD architecture

### DIFF
--- a/src/resources/views/columns/hidden.blade.php
+++ b/src/resources/views/columns/hidden.blade.php
@@ -1,2 +1,2 @@
 {{-- regular object attribute --}}
-<td class="hidden">{{ strip_tags($entry->{$column['name']}) }}</td>
+<td style="border: none !important; width: 0 !important; max-width: 0 !important; font-size:0 !important; padding:0 !important;">{{ strip_tags($entry->{$column['name']}) }}</td>

--- a/src/resources/views/columns/hidden.blade.php
+++ b/src/resources/views/columns/hidden.blade.php
@@ -1,0 +1,2 @@
+{{-- regular object attribute --}}
+<td class="hidden">{{ strip_tags($entry->{$column['name']}) }}</td>

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -48,7 +48,7 @@
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
-                  <th>{{ trans('backpack::crud.actions') }}</th>
+                  <th class="actions">{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>
             </thead>

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -44,7 +44,7 @@
 
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th class="{{ isset($column['exportable']) && $column['exportable'] ? 'exportable' : '' }}{{ isset($column['type']) && $column['type'] === 'hidden' ? ' hidden' : '' }}">{{ $column['label'] }}</th>
+                  <th style="{{ isset($column['type']) && $column['type'] === 'hidden' ? 'border: none !important; width: 0 !important; max-width: 0 !important; font-size:0 !important; padding:0 !important;' : '' }}">{{ $column['label'] }}</th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
@@ -99,7 +99,7 @@
 
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th class="{{ isset($column['type']) && $column['type'] === 'hidden' ? 'hidden' : '' }}">{{ $column['label'] }}</th>
+                  <th style="{{ isset($column['type']) && $column['type'] === 'hidden' ? 'border: none !important; width: 0 !important; max-width: 0 !important; font-size:0 !important; padding:0 !important;' : '' }}">{{ $column['label'] }}</th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
@@ -163,7 +163,7 @@
           var item = {
               extend: buttons[i],
               exportOptions: {
-              columns: ['.exportable']
+              columns: [':visible:not(.actions)']
               }
           };
           switch(buttons[i]){

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -44,7 +44,7 @@
 
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th>{{ $column['label'] }}</th>
+                  <th class="{{ isset($column['exportable']) && $column['exportable'] ? 'exportable' : '' }}{{ isset($column['type']) && $column['type'] === 'hidden' ? ' hidden' : '' }}">{{ $column['label'] }}</th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
@@ -99,7 +99,7 @@
 
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th>{{ $column['label'] }}</th>
+                  <th class="{{ isset($column['type']) && $column['type'] === 'hidden' ? 'hidden' : '' }}">{{ $column['label'] }}</th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
@@ -163,7 +163,7 @@
           var item = {
               extend: buttons[i],
               exportOptions: {
-              columns: [':visible']
+              columns: ['.exportable']
               }
           };
           switch(buttons[i]){


### PR DESCRIPTION
This [issue](https://github.com/Laravel-Backpack/CRUD/issues/169) still may be up for discussion.  
What ive done here is made the export functionality suit the Backpack CRUD architecture rather than its native Datatables architecture.
The export will now look for columns with a given class rather than those that are visible.
The CRUD setup would be:
```
$this->crud->addColumn([
    'name' => "Name",
    'type' => 'text',
    'exportable' => true
]);
```
I have also added a `hidden` column template, so columns may be included in the export but not visible in the listing.
```
$this->crud->addColumn([
    'name' => "Name",
    'type' => 'hidden',
    'exportable' => true
]);
```