### PR TITLE
Add show field view functionality

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD;
 
 use Backpack\CRUD\PanelTraits\Read;
+use Backpack\CRUD\PanelTraits\Show;
 use Backpack\CRUD\PanelTraits\Tabs;
 use Backpack\CRUD\PanelTraits\Query;
 use Backpack\CRUD\PanelTraits\Views;
@@ -24,7 +25,7 @@ use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {
-    use Create, Read, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, Show;
 
     // --------------
     // CRUD variables
@@ -41,7 +42,7 @@ class CrudPanel
     public $entity_name_plural = 'entries'; // what name will show up on the buttons, in plural (ex: Delete 5 entities)
     public $request;
 
-    public $access = ['list', 'create', 'update', 'delete'/* 'revisions', reorder', 'show', 'details_row' */];
+    public $access = ['show', 'list', 'create', 'update', 'delete'/* 'revisions', reorder', 'details_row' */];
 
     public $reorder = false;
     public $reorder_label = false;
@@ -54,6 +55,7 @@ class CrudPanel
     public $columns = []; // Define the columns for the table view as an array;
     public $create_fields = []; // Define the fields for the "Add new entry" view as an array;
     public $update_fields = []; // Define the fields for the "Edit entry" view as an array;
+    public $show_fields = []; // Define the fields for the "Show entry" view as an array;
 
     public $query;
     public $entry;

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -29,6 +29,7 @@ trait AutoSet
             ];
             $this->create_fields[$field] = $new_field;
             $this->update_fields[$field] = $new_field;
+            $this->show_fields[$field] = $new_field;
 
             if (! in_array($field, $this->model->getHidden())) {
                 $this->columns[] = [

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -65,7 +65,7 @@ trait Buttons
         $this->buttons = collect();
 
         // line stack
-        $this->addButton('line', 'preview', 'view', 'crud::buttons.preview', 'end');
+        $this->addButton('line', 'show', 'view', 'crud::buttons.show', 'end');
         $this->addButton('line', 'update', 'view', 'crud::buttons.update', 'end');
         $this->addButton('line', 'revisions', 'view', 'crud::buttons.revisions', 'end');
         $this->addButton('line', 'delete', 'view', 'crud::buttons.delete', 'end');

--- a/src/PanelTraits/Show.php
+++ b/src/PanelTraits/Show.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait Show
+{
+    /*
+    |--------------------------------------------------------------------------
+    |                                   SHOW
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Add field to the show view
+     *
+     * @param $field
+     * @return $this
+     */
+    public function addShowField($field)
+    {
+        // if the field_definition_array array is a string, it means the programmer was lazy and has only passed the name
+        // set some default values, so the field will still work
+        if (is_string($field)) {
+            $complete_field_array['name'] = $field;
+        } else {
+            $complete_field_array = $field;
+        }
+
+        // if this is a relation type field and no corresponding model was specified, get it from the relation method
+        // defined in the main model
+        if (isset($complete_field_array['entity']) && ! isset($complete_field_array['model'])) {
+            $complete_field_array['model'] = $this->getRelationModel($complete_field_array['entity']);
+        }
+
+        // if the label is missing, we should set it
+        if (! isset($complete_field_array['label'])) {
+            $complete_field_array['label'] = ucfirst($complete_field_array['name']);
+        }
+
+        // if the field type is missing, we should set it
+        if (! isset($complete_field_array['type'])) {
+            $complete_field_array['type'] = $this->getFieldTypeFromDbColumnType($complete_field_array['name']);
+        }
+
+        // if a tab was mentioned, we should enable it
+        if (isset($complete_field_array['tab'])) {
+            if (! $this->tabsEnabled()) {
+                $this->enableTabs();
+            }
+        }
+
+        // store the field information into the correct variable on the CRUD object
+        // default fields are already handled in addField()
+        $this->show_fields[$complete_field_array['name']] = $complete_field_array;
+
+        return $this;
+    }
+
+    /**
+     * Add multiple fields to the show view
+     *
+     * @param $fields
+     */
+    public function addShowFields($fields)
+    {
+        if (count($fields)) {
+            foreach ($fields as $field) {
+                $this->addShowField($field);
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added field to 'after' the $target_field.
+     *
+     * @param $target_field
+     */
+    public function afterShowField($target_field)
+    {
+        foreach ($this->show_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                $offset = array_search($field, array_keys($this->show_fields));
+                array_splice($this->show_fields, $offset + 1, 0, [$field => array_pop($this->create_fields)]);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Moves the recently added field to 'before' the $target_field.
+     *
+     * @param $target_field
+     */
+    public function beforeShowField($target_field)
+    {
+        $key = 0;
+        foreach ($this->show_fields as $field => $value) {
+            if ($value['name'] == $target_field) {
+                array_splice($this->show_fields, $key, 0, [$field => array_pop($this->show_fields)]);
+                break;
+            }
+            $key++;
+        }
+    }
+
+    /**
+     * Remove a certain field from the show view by its name.
+     *
+     * @param string $name Field name (as defined with the addField() procedure)
+     */
+    public function removeShowField($name)
+    {
+        array_forget($this->show_fields, $name);
+    }
+
+    /**
+     * Remove many fields from the show view by their names.
+     *
+     * @param array  $array_of_names A simple array of the names of the fields to be removed.
+     */
+    public function removeShowFields($array_of_names)
+    {
+        if (! empty($array_of_names)) {
+            foreach ($array_of_names as $name) {
+                $this->removeField($name);
+            }
+        }
+    }
+
+    /**
+     * Get all fields needed for the EDIT ENTRY form.
+     *
+     * @param  [integer] The id of the entry that is being edited.
+     * @param int $id
+     *
+     * @return [array] The fields with attributes, fake attributes and values.
+     */
+    public function getShowFields($id)
+    {
+        $fields = $this->show_fields;
+        $entry = $this->getEntry($id);
+
+        foreach ($fields as $k => $field) {
+            // set the value
+            if (! isset($fields[$k]['value'])) {
+                if (isset($field['subfields'])) {
+                    $fields[$k]['value'] = [];
+                    foreach ($field['subfields'] as $key => $subfield) {
+                        $fields[$k]['value'][] = $entry->{$subfield['name']};
+                    }
+                } else {
+                    $fields[$k]['value'] = $entry->{$field['name']};
+                }
+            }
+        }
+
+        // always have a hidden input for the entry id
+        if (! array_key_exists('id', $fields)) {
+            $fields['id'] = [
+                'name'  => $entry->getKeyName(),
+                'value' => $entry->getKey(),
+                'type'  => 'hidden',
+            ];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Allow access to the show crud functionality
+     */
+    public function enableShow() {
+        $this->allowAccess(['show']);
+    }
+}

--- a/src/PanelTraits/Tabs.php
+++ b/src/PanelTraits/Tabs.php
@@ -110,6 +110,28 @@ trait Tabs
         return [];
     }
 
+    public function getTabShowFields($label) {
+        if ($this->tabExists($label)) {
+            $all_fields = $this->getShowFields($this->entry->getKey());
+
+            $fields_for_current_tab = collect($all_fields)->filter(function ($value, $key) use ($label) {
+                return isset($value['tab']) && $value['tab'] == $label;
+            });
+
+            if ($this->isLastTab($label)) {
+                $fields_without_a_tab = collect($all_fields)->filter(function ($value, $key) {
+                    return ! isset($value['tab']);
+                });
+
+                $fields_for_current_tab = $fields_for_current_tab->merge($fields_without_a_tab);
+            }
+
+            return $fields_for_current_tab;
+        }
+
+        return [];
+    }
+
     public function getTabs()
     {
         $tabs = [];

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -201,8 +201,8 @@ class CrudController extends BaseController
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = trans('backpack::crud.preview').' '.$this->crud->entity_name;
-
+        $this->data['fields'] = $this->crud->getShowFields($id);
+        $this->data['title'] = trans('backpack::crud.show').' '.$this->crud->entity_name;
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getShowView(), $this->data);
     }

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -51,6 +51,7 @@ return [
     'list'                      => 'List',
     'actions'                   => 'Actions',
     'preview'                   => 'Preview',
+    'show'                      => 'Show',
     'delete'                    => 'Delete',
     'admin'                     => 'Admin',
     'details_row'               => 'This is the details row. Modify as you please.',

--- a/src/resources/views/buttons/show.blade.php
+++ b/src/resources/views/buttons/show.blade.php
@@ -1,0 +1,3 @@
+@if ($crud->hasAccess('show'))
+    <a href="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-xs btn-default"><i class="fa fa-eye"></i> {{ trans('backpack::crud.show') }}</a>
+@endif

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -1,45 +1,57 @@
 @extends('backpack::layout')
 
-@section('content-header')
-	<section class="content-header">
-	  <h1>
-	    {{ trans('backpack::crud.preview') }} <span>{{ $crud->entity_name }}</span>
-	  </h1>
-	  <ol class="breadcrumb">
-	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
-	    <li><a href="{{ url($crud->route) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
-	    <li class="active">{{ trans('backpack::crud.preview') }}</li>
-	  </ol>
-	</section>
+@section('header')
+    <section class="content-header">
+        <h1>
+            {{ trans('backpack::crud.show') }} <span class="text-lowercase">{{ $crud->entity_name }}</span>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ url($crud->route) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
+            <li class="active">{{ trans('backpack::crud.show') }}</li>
+        </ol>
+    </section>
 @endsection
 
 @section('content')
-	@if ($crud->hasAccess('list'))
-		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
-	@endif
-
-	<!-- Default box -->
-	  <div class="box">
-	    <div class="box-header with-border">
-	      <h3 class="box-title">
-            {{ trans('backpack::crud.preview') }}
-            <span>{{ $crud->entity_name }}</span>
-          </h3>
-	    </div>
-	    <div class="box-body">
-	      {{ dump($entry) }}
-	    </div><!-- /.box-body -->
-	  </div><!-- /.box -->
-
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            @if ($crud->hasAccess('list'))
+                <a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span class="text-lowercase">{{ $crud->entity_name_plural }}</span></a><br><br>
+            @endif
+        <!-- Default box -->
+            <div class="box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">
+                        {{ trans('backpack::crud.show') }}
+                        <span class="text-lowercase">{{ $crud->entity_name }}</span>
+                    </h3>
+                </div>
+                <div class="box-body row">
+                    @if(view()->exists('vendor.backpack.crud.show.show_content'))
+                        @include('vendor.backpack.crud.show.show_content', ['fields' => $fields])
+                    @else
+                        @include('crud::show.show_content', ['fields' => $fields])
+                    @endif
+                </div><!-- /.box-body -->
+                @if($crud->hasAccess('update'))
+                    <div class="box-footer">
+                        <div class="form-group">
+                            <a href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}" class="btn btn-default"><i class="fa fa-edit"></i> {{ trans('backpack::crud.edit') }}</a>
+                        </div>
+                    </div>
+                @endif
+            </div><!-- /.box -->
+        </div>
+    </div>
 @endsection
 
 
 @section('after_styles')
-	<link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/crud.css') }}">
-	<link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/show.css') }}">
+    <link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/crud.css') }}">
+    <link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/show.css') }}">
 @endsection
 
 @section('after_scripts')
-	<script src="{{ asset('vendor/backpack/crud/js/crud.js') }}"></script>
-	<script src="{{ asset('vendor/backpack/crud/js/show.js') }}"></script>
+    <script src="{{ asset('vendor/backpack/crud/js/crud.js') }}"></script>
+    <script src="{{ asset('vendor/backpack/crud/js/show.js') }}"></script>
 @endsection

--- a/src/resources/views/show/fields/address.blade.php
+++ b/src/resources/views/show/fields/address.blade.php
@@ -1,0 +1,108 @@
+<!-- text input -->
+
+<?php
+
+// the field should work whether or not Laravel attribute casting is used
+if (isset($field['value']) && (is_array($field['value']) || is_object($field['value']))) {
+    $field['value'] = json_encode($field['value']);
+}
+
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input type="hidden" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}" name="{{ $field['name'] }}">
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-addon">{!! $field['prefix'] !!}</div> @endif
+        @if(isset($field['store_as_json']) && $field['store_as_json'])
+        <input
+            type="text"
+            data-address="{&quot;field&quot;: &quot;{{$field['name']}}&quot;, &quot;full&quot;: {{isset($field['store_as_json']) && $field['store_as_json'] ? 'true' : 'false'}} }"
+            @include('crud::inc.field_attributes')
+        >
+        @else
+        <input
+            type="text"
+            data-address="{&quot;field&quot;: &quot;{{$field['name']}}&quot;, &quot;full&quot;: {{isset($field['store_as_json']) && $field['store_as_json'] ? 'true' : 'false'}} }"
+            name="{{ $field['name'] }}"
+            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            @include('crud::inc.field_attributes')
+        >
+        @endif
+        @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- Note: you can use  to only load some CSS/JS once, even though there are multiple instances of it --}}
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <style>
+            .ap-input-icon.ap-icon-pin {
+                right: 5px !important; }
+            .ap-input-icon.ap-icon-clear {
+                right: 10px !important; }
+        </style>
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <script src="https://cdn.jsdelivr.net/places.js/1/places.min.js"></script>
+    <script>
+        jQuery(document).ready(function($){
+            window.AlgoliaPlaces = window.AlgoliaPlaces || {};
+
+            $('[data-address]').each(function(){
+
+                var $this      = $(this),
+                $addressConfig = $this.data('address'),
+                $field = $('[name="'+$addressConfig.field+'"]'),
+                $place = places({
+                    container: $this[0]
+                });
+
+                function clearInput() {
+                    if( !$this.val().length ){
+                        $field.val('');
+                    }
+                }
+
+                if( $addressConfig.full ){
+
+                    $place.on('change', function(e){
+                        var result = JSON.parse(JSON.stringify(e.suggestion));
+                        delete(result.highlight); delete(result.hit); delete(result.hitIndex);
+                        delete(result.rawAnswer); delete(result.query);
+                        $field.val( JSON.stringify(result) );
+                    });
+
+                    $this.on('change blur', clearInput);
+                    $place.on('clear', clearInput);
+
+                    if( $field.val().length ){
+                        var existingData = JSON.parse($field.val());
+                        $this.val(existingData.value);
+                    }
+                }
+
+                window.AlgoliaPlaces[ $addressConfig.field ] = $place;
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/base64_image.blade.php
+++ b/src/resources/views/show/fields/base64_image.blade.php
@@ -1,0 +1,232 @@
+  <div class="form-group col-md-12 image" data-preview="#{{ $field['name'] }}" data-aspectRatio="{{ isset($field['aspect_ratio']) ? $field['aspect_ratio'] : 0 }}" data-crop="{{ isset($field['crop']) ? $field['crop'] : false }}" @include('crud::inc.field_wrapper_attributes')>
+    <div>
+        <label>{!! $field['label'] !!}</label>
+        @include('crud::inc.field_translatable_icon')
+    </div>
+    <!-- Wrap the image or canvas element with a block element (container) -->
+    <div class="row">
+        <div class="col-sm-6" style="margin-bottom: 20px;">
+            <img id="mainImage" src="{{ isset($field['src']) ? $entry->find($entry->id)->{$field['src']}() : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}">
+        </div>
+        @if(isset($field['crop']) && $field['crop'])
+        <div class="col-sm-3">
+            <div class="docs-preview clearfix">
+                <div id="{{ $field['name'] }}" class="img-preview preview-lg">
+                    <img src="" style="display: block; min-width: 0px !important; min-height: 0px !important; max-width: none !important; max-height: none !important; margin-left: -32.875px; margin-top: -18.4922px; transform: none;">
+                </div>
+            </div>
+        </div>
+        @endif
+        <input type="hidden" id="hiddenFilename" name="{{ $field['filename'] }}" value="">
+    </div>
+    <div class="btn-group">
+        <label class="btn btn-primary btn-file">
+            Choose file <input type="file" accept="image/*" id="uploadImage" @include('crud::inc.field_attributes', ['default_class' => 'hide'])>
+            <input type="hidden" id="hiddenImage" name="{{ $field['name'] }}">
+        </label>
+        @if(isset($field['crop']) && $field['crop'])
+        <button class="btn btn-default" id="rotateLeft" type="button" style="display: none;"><i class="fa fa-rotate-left"></i></button>
+        <button class="btn btn-default" id="rotateRight" type="button" style="display: none;"><i class="fa fa-rotate-right"></i></button>
+        <button class="btn btn-default" id="zoomIn" type="button" style="display: none;"><i class="fa fa-search-plus"></i></button>
+        <button class="btn btn-default" id="zoomOut" type="button" style="display: none;"><i class="fa fa-search-minus"></i></button>
+        <button class="btn btn-warning" id="reset" type="button" style="display: none;"><i class="fa fa-times"></i></button>
+        @endif
+        <button class="btn btn-danger" id="remove" type="button"><i class="fa fa-trash"></i></button>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+  </div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        {{-- YOUR CSS HERE --}}
+        <link href="{{ asset('vendor/backpack/cropper/dist/cropper.min.css') }}" rel="stylesheet" type="text/css" />
+        <style>
+            .hide {
+                display: none;
+            }
+            .image .btn-group {
+                margin-top: 10px;
+            }
+            img {
+                max-width: 100%; /* This rule is very important, please do not ignore this! */
+            }
+            .img-container, .img-preview {
+                width: 100%;
+                text-align: center;
+            }
+            .img-preview {
+                float: left;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                overflow: hidden;
+            }
+            .preview-lg {
+                width: 263px;
+                height: 148px;
+            }
+
+            .btn-file {
+                position: relative;
+                overflow: hidden;
+            }
+            .btn-file input[type=file] {
+                position: absolute;
+                top: 0;
+                right: 0;
+                min-width: 100%;
+                min-height: 100%;
+                font-size: 100px;
+                text-align: right;
+                filter: alpha(opacity=0);
+                opacity: 0;
+                outline: none;
+                background: white;
+                cursor: inherit;
+                display: block;
+            }
+        </style>
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        {{-- YOUR JS HERE --}}
+        <script src="{{ asset('vendor/backpack/cropper/dist/cropper.min.js') }}"></script>
+        <script>
+            jQuery(document).ready(function($) {
+                // Loop through all instances of the image field
+                $('.form-group.image').each(function(index){
+                    // Find DOM elements under this form-group element
+                    var $mainImage = $(this).find('#mainImage');
+                    var $uploadImage = $(this).find("#uploadImage");
+                    var $hiddenImage = $(this).find("#hiddenImage");
+                    var $hiddenFilename = $(this).find("#hiddenFilename");
+                    var $rotateLeft = $(this).find("#rotateLeft")
+                    var $rotateRight = $(this).find("#rotateRight")
+                    var $zoomIn = $(this).find("#zoomIn")
+                    var $zoomOut = $(this).find("#zoomOut")
+                    var $reset = $(this).find("#reset")
+                    var $remove = $(this).find("#remove")
+                    // Options either global for all image type fields, or use 'data-*' elements for options passed in via the CRUD controller
+                    var options = {
+                        viewMode: 2,
+                        checkOrientation: false,
+                        autoCropArea: 1,
+                        responsive: true,
+                        preview : $(this).attr('data-preview'),
+                        aspectRatio : $(this).attr('data-aspectRatio')
+                    };
+                    var crop = $(this).attr('data-crop');
+
+                    // Hide 'Remove' button if there is no image saved
+                    if (!$mainImage.attr('src')){
+                        $remove.hide();
+                    }
+                    // Initialise hidden form input in case we submit with no change
+                    $hiddenImage.val($mainImage.attr('src'));
+
+
+                    // Only initialize cropper plugin if crop is set to true
+                    if(crop){
+
+                        $remove.click(function() {
+                            $mainImage.cropper("destroy");
+                            $mainImage.attr('src','');
+                            $hiddenImage.val('');
+                            if (filename == "true"){
+                                $hiddenFilename.val('removed');
+                            }
+                            $rotateLeft.hide();
+                            $rotateRight.hide();
+                            $zoomIn.hide();
+                            $zoomOut.hide();
+                            $reset.hide();
+                            $remove.hide();
+                        });
+                    } else {
+
+                        $(this).find("#remove").click(function() {
+                            $mainImage.attr('src','');
+                            $hiddenImage.val('');
+                            $hiddenFilename.val('removed');
+                            $remove.hide();
+                        });
+                    }
+
+                    //Set hiddenFilename field to 'removed' if image has been removed.
+                    //Otherwise hiddenFilename will be null if no changes have been made.
+
+                    $uploadImage.change(function() {
+                        var fileReader = new FileReader(),
+                                files = this.files,
+                                file;
+
+                        if (!files.length) {
+                            return;
+                        }
+                        file = files[0];
+
+                        if (/^image\/\w+$/.test(file.type)) {
+                            $hiddenFilename.val(file.name);
+                            fileReader.readAsDataURL(file);
+                            fileReader.onload = function () {
+                                $uploadImage.val("");
+                                if(crop){
+                                    $mainImage.cropper(options).cropper("reset", true).cropper("replace", this.result);
+                                    // Override form submit to copy canvas to hidden input before submitting
+                                    $('form').submit(function() {
+                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL(file.type);
+                                        $hiddenImage.val(imageURL);
+                                        return true; // return false to cancel form action
+                                    });
+                                    $rotateLeft.click(function() {
+                                        $mainImage.cropper("rotate", 90);
+                                    });
+                                    $rotateRight.click(function() {
+                                        $mainImage.cropper("rotate", -90);
+                                    });
+                                    $zoomIn.click(function() {
+                                        $mainImage.cropper("zoom", 0.1);
+                                    });
+                                    $zoomOut.click(function() {
+                                        $mainImage.cropper("zoom", -0.1);
+                                    });
+                                    $reset.click(function() {
+                                        $mainImage.cropper("reset");
+                                    });
+                                    $rotateLeft.show();
+                                    $rotateRight.show();
+                                    $zoomIn.show();
+                                    $zoomOut.show();
+                                    $reset.show();
+                                    $remove.show();
+
+                                } else {
+                                    $mainImage.attr('src',this.result);
+                                    $hiddenImage.val(this.result);
+                                    $remove.show();
+                                }
+                            };
+                        } else {
+                            alert("Please choose an image file.");
+                        }
+                    });
+
+                });
+            });
+        </script>
+
+
+    @endpush
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/browse.blade.php
+++ b/src/resources/views/show/fields/browse.blade.php
@@ -1,0 +1,85 @@
+<!-- browse server input -->
+
+<div @include('crud::inc.field_wrapper_attributes') >
+
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+	<input
+		type="text"
+		id="{{ $field['name'] }}-filemanager"
+
+		name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+
+		@if(!isset($field['readonly']) || $field['readonly']) readonly @endif
+	>
+
+	<div class="btn-group" role="group" aria-label="..." style="margin-top: 3px;">
+	  <button type="button" data-inputid="{{ $field['name'] }}-filemanager" class="btn btn-default popup_selector">
+		<i class="fa fa-cloud-upload"></i> {{ trans('backpack::crud.browse_uploads') }}</button>
+		<button type="button" data-inputid="{{ $field['name'] }}-filemanager" class="btn btn-default clear_elfinder_picker">
+		<i class="fa fa-eraser"></i> {{ trans('backpack::crud.clear') }}</button>
+	</div>
+
+	@if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+	{{-- FIELD CSS - will be loaded in the after_styles section --}}
+	@push('crud_fields_styles')
+		<!-- include browse server css -->
+		<link href="{{ asset('vendor/backpack/colorbox/example2/colorbox.css') }}" rel="stylesheet" type="text/css" />
+		<style>
+			#cboxContent, #cboxLoadedContent, .cboxIframe {
+				background: transparent;
+			}
+		</style>
+	@endpush
+
+	@push('crud_fields_scripts')
+		<!-- include browse server js -->
+		<script src="{{ asset('vendor/backpack/colorbox/jquery.colorbox-min.js') }}"></script>
+	@endpush
+
+@endif
+
+{{-- FIELD JS - will be loaded in the after_scripts section --}}
+@push('crud_fields_scripts')
+	<script>
+		$(document).on('click','.popup_selector[data-inputid={{ $field['name'] }}-filemanager]',function (event) {
+		    event.preventDefault();
+
+		    // trigger the reveal modal with elfinder inside
+		    var triggerUrl = "{{ url(config('elfinder.route.prefix').'/popup/'.$field['name']."-filemanager") }}";
+		    $.colorbox({
+		        href: triggerUrl,
+		        fastIframe: true,
+		        iframe: true,
+		        width: '80%',
+		        height: '80%'
+		    });
+		});
+
+		// function to update the file selected by elfinder
+		function processSelectedFile(filePath, requestingField) {
+		    $('#' + requestingField).val(filePath);
+		}
+
+		$(document).on('click','.clear_elfinder_picker[data-inputid={{ $field['name'] }}-filemanager]',function (event) {
+		    event.preventDefault();
+		    var updateID = $(this).attr('data-inputid'); // Btn id clicked
+		    $("#"+updateID).val("");
+		});
+	</script>
+@endpush
+
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/checkbox.blade.php
+++ b/src/resources/views/show/fields/checkbox.blade.php
@@ -1,0 +1,11 @@
+<!-- checkbox field -->
+
+<div @include('crud::inc.field_wrapper_attributes') >
+        <label>{!! $field['label'] !!}</label>
+
+        @if((int) $field['value'] == 1)
+            <p>True</p>
+        @else
+            <p>False</p>
+        @endif
+</div>

--- a/src/resources/views/show/fields/checklist.blade.php
+++ b/src/resources/views/show/fields/checklist.blade.php
@@ -1,0 +1,29 @@
+<!-- select2 -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <?php $entity_model = $crud->getModel(); ?>
+
+    <div class="row">
+        @foreach ($field['model']::all() as $connected_entity_entry)
+            <div class="col-sm-4">
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox"
+                      name="{{ $field['name'] }}[]"
+                      value="{{ $connected_entity_entry->id }}"
+
+                      @if( ( old( $field["name"] ) && in_array($connected_entity_entry->id, old( $field["name"])) ) || (isset($field['value']) && in_array($connected_entity_entry->id, $field['value']->pluck('id', 'id')->toArray())))
+                             checked = "checked"
+                      @endif > {!! $connected_entity_entry->{$field['attribute']} !!}
+                  </label>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/checklist_dependency.blade.php
+++ b/src/resources/views/show/fields/checklist_dependency.blade.php
@@ -1,0 +1,81 @@
+<!-- dependencyJson -->
+<div class="form-group col-md-12 checklist_dependency"  data-entity ="{{ $field['field_unique_name'] }}" @include('crud::inc.field_wrapper_attributes')>
+    @include('crud::inc.field_translatable_icon')
+    <?php
+        $entity_model = $crud->getModel();
+
+        //short name for dependency fields
+        $primary_dependency = $field['subfields']['primary'];
+        $secondary_dependency = $field['subfields']['secondary'];
+
+
+        //all items with relation
+        $dependencies = $primary_dependency['model']::with($primary_dependency['entity_secondary'])->get();
+
+        $dependencyArray = [];
+
+        //convert dependency array to simple matrix ( prymary id as key and array with secondaries id )
+        foreach ($dependencies as $primary) {
+            $dependencyArray[$primary->id] = [];
+            foreach ($primary->{$primary_dependency['entity_secondary']} as $secondary) {
+                $dependencyArray[$primary->id][] = $secondary->id;
+            }
+        }
+
+      //for update form, get initial state of the entity
+      if( isset($id) && $id ){
+
+        //get entity with relations for primary dependency
+        $entity_dependencies = $entity_model->with($primary_dependency['entity'])
+          ->with($primary_dependency['entity'].'.'.$primary_dependency['entity_secondary'])
+          ->find($id);
+
+            $secondaries_from_primary = [];
+
+            //convert relation in array
+            $primary_array = $entity_dependencies->{$primary_dependency['entity']}->toArray();
+
+            $secondary_ids = [];
+
+            //create secondary dependency from primary relation, used to check what chekbox must be check from second checklist
+            if (old($primary_dependency['name'])) {
+                foreach (old($primary_dependency['name']) as $primary_item) {
+                    foreach ($dependencyArray[$primary_item] as $second_item) {
+                        $secondary_ids[$second_item] = $second_item;
+                    }
+                }
+            } else { //create dependecies from relation if not from validate error
+                foreach ($primary_array as $primary_item) {
+                    foreach ($primary_item[$secondary_dependency['entity']] as $second_item) {
+                        $secondary_ids[$second_item['id']] = $second_item['id'];
+                    }
+                }
+            }
+        }
+
+        //json encode of dependency matrix
+        $dependencyJson = json_encode($dependencyArray);
+    ?>
+
+    <div class="row" >
+        <div class="col-xs-12">
+            <label>{!! $primary_dependency['label'] !!}</label>
+            @foreach ($primary_dependency['model']::all() as $connected_entity_entry)
+                @if( ( isset($field['value']) && is_array($field['value']) && in_array($connected_entity_entry->id, $field['value'][0]->pluck('id', 'id')->toArray())) || ( old($primary_dependency["name"]) && in_array($connected_entity_entry->id, old( $primary_dependency["name"])) ) )
+                    <p>{{ $connected_entity_entry->{$primary_dependency['attribute']} }}</p>
+                @endif
+            @endforeach
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-xs-12">
+            <label>{!! $secondary_dependency['label'] !!}</label>
+            @foreach ($secondary_dependency['model']::all() as $connected_entity_entry)
+                @if( ( isset($field['value']) && is_array($field['value']) && (  in_array($connected_entity_entry->id, $field['value'][1]->pluck('id', 'id')->toArray()) || isset( $secondary_ids[$connected_entity_entry->id])) || ( old($secondary_dependency['name']) &&   in_array($connected_entity_entry->id, old($secondary_dependency['name'])) )))
+                    {{ $connected_entity_entry->{$secondary_dependency['attribute']} }}
+                @endif
+            @endforeach
+        </div>
+    </div>
+  </div>

--- a/src/resources/views/show/fields/ckeditor.blade.php
+++ b/src/resources/views/show/fields/ckeditor.blade.php
@@ -1,0 +1,6 @@
+<!-- CKeditor -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <p>{!! $field['value'] !!}</p>
+</div>

--- a/src/resources/views/show/fields/color.blade.php
+++ b/src/resources/views/show/fields/color.blade.php
@@ -1,0 +1,16 @@
+<!-- html5 color input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+    	type="color"
+    	name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+    	>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/color_picker.blade.php
+++ b/src/resources/views/show/fields/color_picker.blade.php
@@ -1,0 +1,55 @@
+<!-- configurable color picker -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <div class="input-group colorpicker-component">
+
+        <input
+        	type="text"
+        	name="{{ $field['name'] }}"
+            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            @include('crud::inc.field_attributes')
+        	>
+        <div class="input-group-addon">
+            <i class="color-preview-{{ $field['name'] }}"></i>
+        </div>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-colorpicker/2.3.5/css/bootstrap-colorpicker.min.css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-colorpicker/2.3.5/js/bootstrap-colorpicker.min.js"></script>
+    @endpush
+
+@endif
+
+@push('crud_fields_scripts')
+<script type="text/javascript">
+    jQuery('document').ready(function($){
+        //https://itsjaviaguilar.com/bootstrap-colorpicker/
+        var config = jQuery.extend({}, {!! isset($field['color_picker_options']) ? json_encode($field['color_picker_options']) : '{}' !!});
+        var picker = $('[name="{{ $field['name'] }}"]').parents('.colorpicker-component').colorpicker(config);
+        $('[name="{{ $field['name'] }}"]').on('focus', function(){
+            picker.colorpicker('show');
+        });
+    })
+</script>
+@endpush
+
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/custom_html.blade.php
+++ b/src/resources/views/show/fields/custom_html.blade.php
@@ -1,0 +1,4 @@
+<!-- used for heading, separators, etc -->
+<div @include('crud::inc.field_wrapper_attributes') >
+	{!! $field['value'] !!}
+</div>

--- a/src/resources/views/show/fields/date.blade.php
+++ b/src/resources/views/show/fields/date.blade.php
@@ -1,0 +1,25 @@
+<!-- html5 date input -->
+
+<?php
+// if the column has been cast to Carbon or Date (using attribute casting)
+// get the value as a date string
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    $field['value'] = $field['value']->toDateString();
+}
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+        type="date"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+        >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/date_picker.blade.php
+++ b/src/resources/views/show/fields/date_picker.blade.php
@@ -1,0 +1,112 @@
+<!-- bootstrap datepicker input -->
+
+<?php
+// if the column has been cast to Carbon or Date (using attribute casting)
+// get the value as a date string
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    $field['value'] = $field['value']->format('Y-m-d');
+}
+
+$field_language = isset($field['date_picker_options']['language'])?$field['date_picker_options']['language']:\App::getLocale();
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}">
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <div class="input-group date">
+        <input
+                data-bs-datepicker="{{ isset($field['date_picker_options']) ? json_encode($field['date_picker_options']) : '{}'}}"
+                type="text"
+                @include('crud::inc.field_attributes')
+        >
+        <div class="input-group-addon">
+            <span class="glyphicon glyphicon-calendar"></span>
+        </div>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/plugins/datepicker/datepicker3.css') }}">
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script src="{{ asset('vendor/adminlte/plugins/datepicker/bootstrap-datepicker.js') }}"></script>
+    <script>
+        var datepicker = $.fn.datepicker.noConflict();
+        $.fn.bootstrapDP = datepicker;
+
+        var dateFormat=function(){var a=/d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZ]|"[^"]*"|'[^']*'/g,b=/\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,c=/[^-+\dA-Z]/g,d=function(a,b){for(a=String(a),b=b||2;a.length<b;)a="0"+a;return a};return function(e,f,g){var h=dateFormat;if(1!=arguments.length||"[object String]"!=Object.prototype.toString.call(e)||/\d/.test(e)||(f=e,e=void 0),e=e?new Date(e):new Date,isNaN(e))throw SyntaxError("invalid date");f=String(h.masks[f]||f||h.masks.default),"UTC:"==f.slice(0,4)&&(f=f.slice(4),g=!0);var i=g?"getUTC":"get",j=e[i+"Date"](),k=e[i+"Day"](),l=e[i+"Month"](),m=e[i+"FullYear"](),n=e[i+"Hours"](),o=e[i+"Minutes"](),p=e[i+"Seconds"](),q=e[i+"Milliseconds"](),r=g?0:e.getTimezoneOffset(),s={d:j,dd:d(j),ddd:h.i18n.dayNames[k],dddd:h.i18n.dayNames[k+7],m:l+1,mm:d(l+1),mmm:h.i18n.monthNames[l],mmmm:h.i18n.monthNames[l+12],yy:String(m).slice(2),yyyy:m,h:n%12||12,hh:d(n%12||12),H:n,HH:d(n),M:o,MM:d(o),s:p,ss:d(p),l:d(q,3),L:d(q>99?Math.round(q/10):q),t:n<12?"a":"p",tt:n<12?"am":"pm",T:n<12?"A":"P",TT:n<12?"AM":"PM",Z:g?"UTC":(String(e).match(b)||[""]).pop().replace(c,""),o:(r>0?"-":"+")+d(100*Math.floor(Math.abs(r)/60)+Math.abs(r)%60,4),S:["th","st","nd","rd"][j%10>3?0:(j%100-j%10!=10)*j%10]};return f.replace(a,function(a){return a in s?s[a]:a.slice(1,a.length-1)})}}();dateFormat.masks={default:"ddd mmm dd yyyy HH:MM:ss",shortDate:"m/d/yy",mediumDate:"mmm d, yyyy",longDate:"mmmm d, yyyy",fullDate:"dddd, mmmm d, yyyy",shortTime:"h:MM TT",mediumTime:"h:MM:ss TT",longTime:"h:MM:ss TT Z",isoDate:"yyyy-mm-dd",isoTime:"HH:MM:ss",isoDateTime:"yyyy-mm-dd'T'HH:MM:ss",isoUtcDateTime:"UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"},dateFormat.i18n={dayNames:["Sun","Mon","Tue","Wed","Thu","Fri","Sat","Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],monthNames:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec","January","February","March","April","May","June","July","August","September","October","November","December"]},Date.prototype.format=function(a,b){return dateFormat(this,a,b)};
+
+        jQuery(document).ready(function($){
+            const $calendar = $('.input-group-addon');
+            $calendar.click(function() {
+                $('[data-bs-datepicker]').focus();
+            });
+            $('[data-bs-datepicker]').each(function(){
+
+                var $fake = $(this),
+                    $field = $fake.parents('.form-group').find('input[type="hidden"]'),
+                    $customConfig = $.extend({
+                        format: 'dd/mm/yyyy'
+                    }, $fake.data('bs-datepicker'));
+                $picker = $fake.bootstrapDP($customConfig);
+
+                var $existingVal = $field.val();
+
+                if( $existingVal.length ){
+                    preparedDate = new Date($existingVal).format($customConfig.format);
+                    $fake.val(preparedDate);
+                    $picker.bootstrapDP('update', preparedDate);
+                }
+
+                $fake.on('keydown', function(e){
+                    e.preventDefault();
+                    return false;
+                });
+
+                $picker.on('show hide change', function(e){
+                    if( e.date ){
+                        var sqlDate = e.format('yyyy-mm-dd');
+                    } else {
+                        try {
+                            var sqlDate = $fake.val();
+
+                            if( $customConfig.format === 'dd/mm/yyyy' ){
+                                sqlDate = new Date(sqlDate.split('/')[2], sqlDate.split('/')[1] - 1, sqlDate.split('/')[0]).format('yyyy-mm-dd');
+                            }
+                        } catch(e){
+                            if( $fake.val() ){
+                                PNotify.removeAll();
+                                new PNotify({
+                                    title: 'Whoops!',
+                                    text: 'Sorry we did not recognise that date format, please make sure it uses a yyyy mm dd combination',
+                                    type: 'error',
+                                    icon: false
+                                });
+                            }
+                        }
+                    }
+
+                    $field.val(sqlDate);
+                });
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}

--- a/src/resources/views/show/fields/date_range.blade.php
+++ b/src/resources/views/show/fields/date_range.blade.php
@@ -1,0 +1,86 @@
+<!-- bootstrap daterange picker input -->
+
+<?php
+    // if the column has been cast to Carbon or Date (using attribute casting)
+    // get the value as a date string
+    if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+        $field['value'] = $field['value']->format( 'Y-m-d H:i:s' );
+    }
+
+    //Do the same as the above but for the range end field
+    if ( isset($entry) && ($entry->{$field['end_name']} instanceof \Carbon\Carbon || $entry->{$field['end_name']} instanceof \Jenssegers\Date\Date) ) {
+        $end_name = $entry->{$field['end_name']}->format( 'Y-m-d H:i:s' );
+    } else {
+        $end_name = null;
+    }
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <input class="datepicker-range-start" type="hidden" name="{{ $field['start_name'] }}" value="{{ old($field['start_name']) ? old($field['start_name']) : (isset($field['value']) ? $field['value'] : (isset($field['start_default']) ? $field['start_default'] : '' )) }}">
+    <input class="datepicker-range-end" type="hidden" name="{{ $field['end_name'] }}" value="{{ old($field['end_name']) ? old($field['end_name']) : (!empty($end_name) ? $end_name : (isset($field['end_default']) ? $field['end_default'] : '' )) }}">
+    <label>{!! $field['label'] !!}</label>
+    <div class="input-group date">
+        <input
+            data-bs-daterangepicker="{{ isset($field['date_range_options']) ? json_encode($field['date_range_options']) : '{}'}}"
+            type="text"
+            @include('crud::inc.field_attributes')
+            >
+        <div class="input-group-addon">
+            <span class="glyphicon glyphicon-calendar"></span>
+        </div>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <link rel="stylesheet" href="{{ asset('/vendor/adminlte/plugins/daterangepicker/daterangepicker.css') }}">
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <script src="{{ asset('/vendor/adminlte/plugins/daterangepicker/moment.min.js') }}"></script>
+    <script src="{{ asset('/vendor/adminlte/plugins/daterangepicker/daterangepicker.js') }}"></script>
+    <script>
+        jQuery(document).ready(function($){
+            $('[data-bs-daterangepicker]').each(function(){
+
+                var $fake = $(this),
+                $start = $fake.parents('.form-group').find('.datepicker-range-start'),
+                $end = $fake.parents('.form-group').find('.datepicker-range-end'),
+                $customConfig = $.extend({
+                    format: 'dd/mm/yyyy',
+                    autoApply: true,
+                    startDate: moment($start.val()),
+                    endDate: moment($end.val())
+                }, $fake.data('bs-daterangepicker'));
+
+                $fake.daterangepicker($customConfig);
+                $picker = $fake.data('daterangepicker');
+
+                $fake.on('keydown', function(e){
+                    e.preventDefault();
+                    return false;
+                });
+
+                $fake.on('apply.daterangepicker hide.daterangepicker', function(e, picker){
+                    $start.val( picker.startDate.format('YYYY-MM-DD HH:mm:ss') );
+                    $end.val( picker.endDate.format('YYYY-MM-DD H:mm:ss') );
+                });
+
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}

--- a/src/resources/views/show/fields/datetime.blade.php
+++ b/src/resources/views/show/fields/datetime.blade.php
@@ -1,0 +1,25 @@
+<!-- html5 datetime input -->
+
+<?php
+// if the column has been cast to Carbon or Date (using attribute casting)
+// get the value as a date string
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    $field['value'] = $field['value']->toDateTimeString();
+}
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+        type="datetime-local"
+        name="{{ $field['name'] }}"
+        value="{{ strftime('%Y-%m-%dT%H:%M:%S', strtotime(old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )))) }}"
+        @include('crud::inc.field_attributes')
+        >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/datetime_picker.blade.php
+++ b/src/resources/views/show/fields/datetime_picker.blade.php
@@ -1,0 +1,87 @@
+<!-- bootstrap datetimepicker input -->
+
+<?php
+// if the column has been cast to Carbon or Date (using attribute casting)
+// get the value as a date string
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    $field['value'] = $field['value']->format('Y-m-d H:i:s');
+}
+
+    $field_language = isset($field['datetime_picker_options']['language'])?$field['datetime_picker_options']['language']:\App::getLocale();
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}">
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <div class="input-group date">
+        <input
+            data-bs-datetimepicker="{{ isset($field['datetime_picker_options']) ? json_encode($field['datetime_picker_options']) : '{}'}}"
+            type="text"
+            @include('crud::inc.field_attributes')
+            >
+        <div class="input-group-addon">
+            <span class="glyphicon glyphicon-calendar"></span>
+        </div>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/plugins/datepicker/datepicker3.css') }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/bootstrap.datetimepicker/4.17.42/css/bootstrap-datetimepicker.min.css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <script src="{{ asset('vendor/adminlte/plugins/datepicker/bootstrap-datepicker.js') }}"></script>
+    <script type="text/javascript" src="{{ asset('vendor/adminlte/plugins/daterangepicker/moment.min.js') }}"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/bootstrap.datetimepicker/4.17.42/js/bootstrap-datetimepicker.min.js"></script>
+    @if ($field_language !== 'en')
+        <script charset="UTF-8" src="{{ asset('vendor/adminlte/plugins/datepicker/locales/bootstrap-datepicker.'.$field_language.'.js') }}"></script>
+        <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.15.1/locale/{{$field_language}}.js"></script>
+    @endif
+    <script>
+        var dateFormat=function(){var a=/d{1,4}|m{1,4}|yy(?:yy)?|([HhMsTt])\1?|[LloSZ]|"[^"]*"|'[^']*'/g,b=/\b(?:[PMCEA][SDP]T|(?:Pacific|Mountain|Central|Eastern|Atlantic) (?:Standard|Daylight|Prevailing) Time|(?:GMT|UTC)(?:[-+]\d{4})?)\b/g,c=/[^-+\dA-Z]/g,d=function(a,b){for(a=String(a),b=b||2;a.length<b;)a="0"+a;return a};return function(e,f,g){var h=dateFormat;if(1!=arguments.length||"[object String]"!=Object.prototype.toString.call(e)||/\d/.test(e)||(f=e,e=void 0),e=e?new Date(e):new Date,isNaN(e))throw SyntaxError("invalid date");f=String(h.masks[f]||f||h.masks.default),"UTC:"==f.slice(0,4)&&(f=f.slice(4),g=!0);var i=g?"getUTC":"get",j=e[i+"Date"](),k=e[i+"Day"](),l=e[i+"Month"](),m=e[i+"FullYear"](),n=e[i+"Hours"](),o=e[i+"Minutes"](),p=e[i+"Seconds"](),q=e[i+"Milliseconds"](),r=g?0:e.getTimezoneOffset(),s={d:j,dd:d(j),ddd:h.i18n.dayNames[k],dddd:h.i18n.dayNames[k+7],m:l+1,mm:d(l+1),mmm:h.i18n.monthNames[l],mmmm:h.i18n.monthNames[l+12],yy:String(m).slice(2),yyyy:m,h:n%12||12,hh:d(n%12||12),H:n,HH:d(n),M:o,MM:d(o),s:p,ss:d(p),l:d(q,3),L:d(q>99?Math.round(q/10):q),t:n<12?"a":"p",tt:n<12?"am":"pm",T:n<12?"A":"P",TT:n<12?"AM":"PM",Z:g?"UTC":(String(e).match(b)||[""]).pop().replace(c,""),o:(r>0?"-":"+")+d(100*Math.floor(Math.abs(r)/60)+Math.abs(r)%60,4),S:["th","st","nd","rd"][j%10>3?0:(j%100-j%10!=10)*j%10]};return f.replace(a,function(a){return a in s?s[a]:a.slice(1,a.length-1)})}}();dateFormat.masks={default:"ddd mmm dd yyyy HH:MM:ss",shortDate:"m/d/yy",mediumDate:"mmm d, yyyy",longDate:"mmmm d, yyyy",fullDate:"dddd, mmmm d, yyyy",shortTime:"h:MM TT",mediumTime:"h:MM:ss TT",longTime:"h:MM:ss TT Z",isoDate:"yyyy-mm-dd",isoTime:"HH:MM:ss",isoDateTime:"yyyy-mm-dd'T'HH:MM:ss",isoUtcDateTime:"UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"},dateFormat.i18n={dayNames:["Sun","Mon","Tue","Wed","Thu","Fri","Sat","Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],monthNames:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec","January","February","March","April","May","June","July","August","September","October","November","December"]},Date.prototype.format=function(a,b){return dateFormat(this,a,b)};
+
+        jQuery(document).ready(function($){
+            $('[data-bs-datetimepicker]').each(function(){
+
+                var $fake = $(this),
+                $field = $fake.parents('.form-group').find('input[type="hidden"]'),
+                $customConfig = $.extend({
+                    format: 'DD/MM/YYYY HH:mm',
+                    defaultDate: $field.val()
+                }, $fake.data('bs-datetimepicker'));
+
+                $customConfig.locale = $customConfig['language'];
+                delete($customConfig['language']);
+                $picker = $fake.datetimepicker($customConfig);
+
+                $fake.on('keydown', function(e){
+                    e.preventDefault();
+                    return false;
+                });
+
+                $picker.on('dp.change', function(e){
+                    var sqlDate = e.date ? e.date.format('YYYY-MM-DD HH:mm:ss') : null;
+                    $field.val(sqlDate);
+                });
+
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}

--- a/src/resources/views/show/fields/email.blade.php
+++ b/src/resources/views/show/fields/email.blade.php
@@ -1,0 +1,6 @@
+<!-- text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <p>{{ $field['value'] }}</p>
+</div>

--- a/src/resources/views/show/fields/enum.blade.php
+++ b/src/resources/views/show/fields/enum.blade.php
@@ -1,0 +1,30 @@
+<!-- enum -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <?php $entity_model = $crud->model; ?>
+    <select
+        name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes')
+        >
+
+        @if ($entity_model::isColumnNullable($field['name']))
+            <option value="">-</option>
+        @endif
+
+            @if (count($entity_model::getPossibleEnumValues($field['name'])))
+                @foreach ($entity_model::getPossibleEnumValues($field['name']) as $possible_value)
+                    <option value="{{ $possible_value }}"
+                        @if (( old($field['name']) &&  old($field['name']) == $possible_value) || (isset($field['value']) && $field['value']==$possible_value))
+                            selected
+                        @endif
+                    >{{ $possible_value }}</option>
+                @endforeach
+            @endif
+    </select>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/hidden.blade.php
+++ b/src/resources/views/show/fields/hidden.blade.php
@@ -1,0 +1,9 @@
+<!-- hidden input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+  <input
+  	type="hidden"
+    name="{{ $field['name'] }}"
+    value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+    @include('crud::inc.field_attributes')
+  	>
+</div>

--- a/src/resources/views/show/fields/icon_picker.blade.php
+++ b/src/resources/views/show/fields/icon_picker.blade.php
@@ -1,0 +1,144 @@
+<!-- icon picker input -->
+
+<?php
+// if no iconset was provided, set the default iconset to Font-Awesome
+if (!isset($field['iconset'])) {
+    $field['iconset'] = 'fontawesome';
+}
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    <div>
+        <button class="btn btn-default " role="iconpicker" data-icon="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}" data-iconset="{{ $field['iconset'] }}"></button>
+        <input
+            type="hidden"
+            name="{{ $field['name'] }}"
+            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            @include('crud::inc.field_attributes')
+        >
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    @if($field['iconset'] == 'glyphicon')
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Glyphicon -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-glyphicon.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'ionicon')
+        @push('crud_fields_styles')
+            <!-- Ionicons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/ionicons-1.5.2/css/ionicons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Ionicons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-ionicon-1.5.2.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'weathericon')
+        @push('crud_fields_styles')
+            <!-- Weather Icons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/weather-icons-1.2.0/css/weather-icons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Weather Icons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-weathericon-1.2.0.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'mapicon')
+        @push('crud_fields_styles')
+            <!-- Map Icons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/map-icons-2.1.0/css/map-icons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Map Icons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-mapicon-2.1.0.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'octicon')
+        @push('crud_fields_styles')
+            <!-- Octicons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/octicons-2.1.2/css/octicons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Octicons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-octicon-2.1.2.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'typicon')
+        @push('crud_fields_styles')
+            <!-- Typicons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/typicons-2.0.6/css/typicons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Typicons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-typicon-2.0.6.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'elusiveicon')
+        @push('crud_fields_styles')
+            <!-- Elusive Icons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/elusive-icons-2.0.0/css/elusive-icons.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Elusive Icons -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-elusiveicon-2.0.0.min.js') }}"></script>
+        @endpush
+    @elseif($field['iconset'] == 'materialdesign')
+        @push('crud_fields_styles')
+            <!-- Material Icons -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/material-design-1.1.1/css/material-design-iconic-font.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Material Design -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-materialdesign-1.1.1.min.js') }}"></script>
+        @endpush
+    @else
+        @push('crud_fields_styles')
+            <!-- Font Awesome -->
+            <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/icon-fonts/font-awesome-4.2.0/css/font-awesome.min.css') }}"/>
+        @endpush
+
+        @push('crud_fields_scripts')
+            <!-- Bootstrap-Iconpicker Iconset for Font Awesome -->
+            <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/iconset/iconset-fontawesome-4.2.0.min.js') }}"></script>
+        @endpush
+    @endif
+
+    {{-- FIELD EXTRA CSS  --}}
+    @push('crud_fields_styles')
+        <!-- Bootstrap-Iconpicker -->
+        <link rel="stylesheet" href="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/css/bootstrap-iconpicker.min.css') }}"/>
+    @endpush
+
+    {{-- FIELD EXTRA JS --}}
+    @push('crud_fields_scripts')
+        <!-- Bootstrap-Iconpicker -->
+        <script type="text/javascript" src="{{ asset('vendor/backpack/bootstrap-iconpicker/bootstrap-iconpicker/js/bootstrap-iconpicker.min.js') }}"></script>
+
+        {{-- Bootstrap-Iconpicker - set hidden input value --}}
+        <script>
+            jQuery(document).ready(function($) {
+                $('button[role=iconpicker]').on('change', function(e) {
+                    $(this).siblings('input[type=hidden]').val(e.icon);
+                });
+            });
+        </script>
+    @endpush
+
+@endif
+
+
+{{-- Note: you can use @if ($crud->checkIfFieldIsFirstOfItsType($field, $fields)) to only load some CSS/JS once, even though there are multiple instances of it --}}

--- a/src/resources/views/show/fields/image.blade.php
+++ b/src/resources/views/show/fields/image.blade.php
@@ -1,0 +1,222 @@
+  <div class="form-group col-md-12 image" data-preview="#{{ $field['name'] }}" data-aspectRatio="{{ isset($field['aspect_ratio']) ? $field['aspect_ratio'] : 0 }}" data-crop="{{ isset($field['crop']) ? $field['crop'] : false }}" @include('crud::inc.field_wrapper_attributes')>
+    <div>
+        <label>{!! $field['label'] !!}</label>
+        @include('crud::inc.field_translatable_icon')
+    </div>
+    <!-- Wrap the image or canvas element with a block element (container) -->
+    <div class="row">
+        <div class="col-sm-6" style="margin-bottom: 20px;">
+            <img id="mainImage" src="{{ url(old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') )) }}">
+        </div>
+        @if(isset($field['crop']) && $field['crop'])
+        <div class="col-sm-3">
+            <div class="docs-preview clearfix">
+                <div id="{{ $field['name'] }}" class="img-preview preview-lg">
+                    <img src="" style="display: block; min-width: 0px !important; min-height: 0px !important; max-width: none !important; max-height: none !important; margin-left: -32.875px; margin-top: -18.4922px; transform: none;">
+                </div>
+            </div>
+        </div>
+        @endif
+    </div>
+    <div class="btn-group">
+        <label class="btn btn-primary btn-file">
+            {{ trans('backpack::crud.choose_file') }} <input type="file" accept="image/*" id="uploadImage"  @include('crud::inc.field_attributes', ['default_class' => 'hide'])>
+            <input type="hidden" id="hiddenImage" name="{{ $field['name'] }}">
+        </label>
+        @if(isset($field['crop']) && $field['crop'])
+        <button class="btn btn-default" id="rotateLeft" type="button" style="display: none;"><i class="fa fa-rotate-left"></i></button>
+        <button class="btn btn-default" id="rotateRight" type="button" style="display: none;"><i class="fa fa-rotate-right"></i></button>
+        <button class="btn btn-default" id="zoomIn" type="button" style="display: none;"><i class="fa fa-search-plus"></i></button>
+        <button class="btn btn-default" id="zoomOut" type="button" style="display: none;"><i class="fa fa-search-minus"></i></button>
+        <button class="btn btn-warning" id="reset" type="button" style="display: none;"><i class="fa fa-times"></i></button>
+        @endif
+        <button class="btn btn-danger" id="remove" type="button"><i class="fa fa-trash"></i></button>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+  </div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        {{-- YOUR CSS HERE --}}
+        <link href="{{ asset('vendor/backpack/cropper/dist/cropper.min.css') }}" rel="stylesheet" type="text/css" />
+        <style>
+            .hide {
+                display: none;
+            }
+            .image .btn-group {
+                margin-top: 10px;
+            }
+            img {
+                max-width: 100%; /* This rule is very important, please do not ignore this! */
+            }
+            .img-container, .img-preview {
+                width: 100%;
+                text-align: center;
+            }
+            .img-preview {
+                float: left;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                overflow: hidden;
+            }
+            .preview-lg {
+                width: 263px;
+                height: 148px;
+            }
+
+            .btn-file {
+                position: relative;
+                overflow: hidden;
+            }
+            .btn-file input[type=file] {
+                position: absolute;
+                top: 0;
+                right: 0;
+                min-width: 100%;
+                min-height: 100%;
+                font-size: 100px;
+                text-align: right;
+                filter: alpha(opacity=0);
+                opacity: 0;
+                outline: none;
+                background: white;
+                cursor: inherit;
+                display: block;
+            }
+        </style>
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        {{-- YOUR JS HERE --}}
+        <script src="{{ asset('vendor/backpack/cropper/dist/cropper.min.js') }}"></script>
+        <script>
+            jQuery(document).ready(function($) {
+                // Loop through all instances of the image field
+                $('.form-group.image').each(function(index){
+                    // Find DOM elements under this form-group element
+                    var $mainImage = $(this).find('#mainImage');
+                    var $uploadImage = $(this).find("#uploadImage");
+                    var $hiddenImage = $(this).find("#hiddenImage");
+                    var $rotateLeft = $(this).find("#rotateLeft")
+                    var $rotateRight = $(this).find("#rotateRight")
+                    var $zoomIn = $(this).find("#zoomIn")
+                    var $zoomOut = $(this).find("#zoomOut")
+                    var $reset = $(this).find("#reset")
+                    var $remove = $(this).find("#remove")
+                    // Options either global for all image type fields, or use 'data-*' elements for options passed in via the CRUD controller
+                    var options = {
+                        viewMode: 2,
+                        checkOrientation: false,
+                        autoCropArea: 1,
+                        responsive: true,
+                        preview : $(this).attr('data-preview'),
+                        aspectRatio : $(this).attr('data-aspectRatio')
+                    };
+                    var crop = $(this).attr('data-crop');
+
+                    // Hide 'Remove' button if there is no image saved
+                    if (!$mainImage.attr('src')){
+                        $remove.hide();
+                    }
+                    // Initialise hidden form input in case we submit with no change
+                    $hiddenImage.val($mainImage.attr('src'));
+
+
+                    // Only initialize cropper plugin if crop is set to true
+                    if(crop){
+
+                        $remove.click(function() {
+                            $mainImage.cropper("destroy");
+                            $mainImage.attr('src','');
+                            $hiddenImage.val('');
+                            $rotateLeft.hide();
+                            $rotateRight.hide();
+                            $zoomIn.hide();
+                            $zoomOut.hide();
+                            $reset.hide();
+                            $remove.hide();
+                        });
+                    } else {
+
+                        $(this).find("#remove").click(function() {
+                            $mainImage.attr('src','');
+                            $hiddenImage.val('');
+                            $remove.hide();
+                        });
+                    }
+
+                    $uploadImage.change(function() {
+                        var fileReader = new FileReader(),
+                                files = this.files,
+                                file;
+
+                        if (!files.length) {
+                            return;
+                        }
+                        file = files[0];
+
+                        if (/^image\/\w+$/.test(file.type)) {
+                            fileReader.readAsDataURL(file);
+                            fileReader.onload = function () {
+                                $uploadImage.val("");
+                                if(crop){
+                                    $mainImage.cropper(options).cropper("reset", true).cropper("replace", this.result);
+                                    // Override form submit to copy canvas to hidden input before submitting
+                                    $('form').submit(function() {
+                                        var imageURL = $mainImage.cropper('getCroppedCanvas').toDataURL(file.type);
+                                        $hiddenImage.val(imageURL);
+                                        return true; // return false to cancel form action
+                                    });
+                                    $rotateLeft.click(function() {
+                                        $mainImage.cropper("rotate", 90);
+                                    });
+                                    $rotateRight.click(function() {
+                                        $mainImage.cropper("rotate", -90);
+                                    });
+                                    $zoomIn.click(function() {
+                                        $mainImage.cropper("zoom", 0.1);
+                                    });
+                                    $zoomOut.click(function() {
+                                        $mainImage.cropper("zoom", -0.1);
+                                    });
+                                    $reset.click(function() {
+                                        $mainImage.cropper("reset");
+                                    });
+                                    $rotateLeft.show();
+                                    $rotateRight.show();
+                                    $zoomIn.show();
+                                    $zoomOut.show();
+                                    $reset.show();
+                                    $remove.show();
+
+                                } else {
+                                    $mainImage.attr('src',this.result);
+                                    $hiddenImage.val(this.result);
+                                    $remove.show();
+                                }
+                            };
+                        } else {
+                            alert("Please choose an image file.");
+                        }
+                    });
+
+                });
+            });
+        </script>
+
+
+    @endpush
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/matrix.blade.php
+++ b/src/resources/views/show/fields/matrix.blade.php
@@ -1,0 +1,110 @@
+<?php
+    // Check to see if an entry for this matrix exists
+    $value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : null ));
+    $labels = [];
+    foreach ($field['blocks'] as $block) {
+        $labels[$block['name']] = $block['label'];
+    }
+?>
+
+<!-- matrix input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+<label>{!! $field['label'] !!}</label>
+
+{{-- Setup an ajax wrapper --}}
+<div id="{{ $field['name'] }}" class="sortable">
+    @if($value)
+        @foreach($value as $block)
+            <?php $index = $loop->index; ?>
+            @foreach($block as $blockName => $blockField)
+                <div class="block">
+                    <label>{!! $labels[$blockName] !!}</label>
+                    @include('vendor.backpack.crud.inc.show_matrix_fields', ['block' => $field['blocks'][$blockName], 'name' => $field['name'], 'values' => $blockField, 'index' => $index])
+                </div>
+            @endforeach
+        @endforeach
+    @endif
+</div>
+
+{{-- Setup add block dropdown --}}
+<div class="btn-group">
+    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        <span class="btn-text">Add Content Block</span><span class="fa fa-plus"></span>
+    </button>
+    <ul class="dropdown-menu">
+        @foreach($field['blocks'] as $block)
+        <li><a href="#" class="block-select" data-block="{{ $block['name'] }}">{{ $block['label'] }}</a></li>
+        @endforeach
+    </ul>
+</div>
+
+{{-- HINT --}}
+@if (isset($field['hint']))
+<p class="help-block">{!! $field['hint'] !!}</p>
+@endif
+</div>
+
+{{-- BLOCK TEMPLATES --}}
+<div class="{{ $field['name'] }}_templates">
+    @foreach($field['blocks'] as $block)
+        <div class="block" data-block-template="{{ $block['name'] }}">
+            <label>{!! $block['label'] !!}</label>
+            @include('vendor.backpack.crud.inc.show_matrix_fields', ['block' => $block, 'name' => $field['name']])
+        </div>
+    @endforeach
+</div>
+
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+{{-- FIELD CSS - will be loaded in the after_styles section --}}
+@push('crud_fields_styles')
+{{-- YOUR CSS HERE --}}
+<style>
+    .{{ $field['name'] }}_templates {
+        display: none;
+    }
+    .btn-text {
+        padding-right: 10px;
+    }
+</style>
+@endpush
+@endif
+
+@section('after_scripts')
+    @if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+        <script src="{{ asset('vendor/backpack/crud/js/reorder.js') }}"></script>
+        <script src="https://code.jquery.com/ui/1.11.3/jquery-ui.min.js" type="text/javascript"></script>
+        <script src="{{ url('vendor/backpack/nestedSortable/jquery.mjs.nestedSortable2.js') }}" type="text/javascript"></script>
+    @endif
+    <script type="text/javascript">
+        jQuery(document).ready(function($) {
+            var $index = parseInt({{ $value ? count($value) : 1 }});
+
+            $('.block-select').each(function() {
+                var $this = $(this);
+                (function() {
+                    $this.click(function(e) {
+                        e.preventDefault();
+                        var $blockName = e.target.getAttribute('data-block');
+                        var $block = $('.{{ $field['name'] }}_templates').find("*[data-block-template=" + $blockName + "]")[0];
+                        var $newBlock = $($block).clone();
+                        $newBlock.find('input,textarea,select').each(function() {
+                            $(this).attr('name', "{{ $field['name'] }}[" + $index + "][" + $blockName + "][" + $(this).attr('name') + "]");
+                        });
+                        $('#{{ $field['name'] }}').append($newBlock);
+
+                        $index = $index + 1;
+                    });
+                })($this);
+            });
+
+            $.ajaxPrefilter(function(options, originalOptions, xhr) {
+                var token = $('meta[name="csrf_token"]').attr('content');
+
+                if (token) {
+                    return xhr.setRequestHeader('X-XSRF-TOKEN', token);
+                }
+            });
+
+        });
+    </script>
+@endsection

--- a/src/resources/views/show/fields/month.blade.php
+++ b/src/resources/views/show/fields/month.blade.php
@@ -1,0 +1,16 @@
+<!-- html5 month input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+        type="month"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+        >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/newsletter.blade.php
+++ b/src/resources/views/show/fields/newsletter.blade.php
@@ -1,0 +1,210 @@
+<!-- array input -->
+
+<?php
+$max = isset($field['max']) && (int) $field['max'] > 0 ? $field['max'] : -1;
+$min = isset($field['min']) && (int) $field['min'] > 0 ? $field['min'] : -1;
+$item_name = strtolower(isset($field['entity_singular']) && !empty($field['entity_singular']) ? $field['entity_singular'] : $field['label']);
+
+$items = old($field['name']) ? (old($field['name'])) : (isset($field['value']) ? ($field['value']) : (isset($field['default']) ? ($field['default']) : '' ));
+
+// make sure not matter the attribute casting
+// the $items variable contains a properly defined JSON
+if (is_array($items)) {
+    if (count($items)) {
+        $items = json_encode($items);
+    } else {
+        $items = '[]';
+    }
+} elseif (is_string($items) && !is_array(json_decode($items))) {
+    $items = '[]';
+}
+
+?>
+<div id="accordion-container" ng-app="backPackTableApp" ng-controller="tableController" @include('crud::inc.field_wrapper_attributes') >
+
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    <input class="array-json" type="hidden" id="{{ $field['name'] }}" name="{{ $field['name'] }}">
+
+    <div class="array-container form-group">
+
+        <table class="table table-bordered table-striped m-b-0" ng-init="field = '#{{ $field['name'] }}'; items = {{ $items }}; max = {{$max}}; min = {{$min}}; maxErrorTitle = '{{trans('backpack::crud.table_cant_add', ['entity' => $item_name])}}'; maxErrorMessage = '{{trans('backpack::crud.table_max_reached', ['max' => $max])}}'">
+
+            <thead>
+            <tr>
+
+                @foreach( $field['columns'] as $prop )
+                    <th style="font-weight: 600!important;">
+                        {{ $prop }}
+                    </th>
+                @endforeach
+                <th class="text-center" ng-if="max == -1 || max > 1"> {{-- <i class="fa fa-sort"></i> --}} </th>
+                <th class="text-center" ng-if="max == -1 || max > 1"> {{-- <i class="fa fa-trash"></i> --}} </th>
+            </tr>
+            </thead>
+
+            <tbody ui-sortable="sortableOptions" ng-model="items" class="table-striped">
+
+            <tr ng-repeat="item in items" class="array-row">
+
+                @foreach( $field['columns'] as $prop => $label)
+                    <td>
+                        @if($prop === 'content')
+                            <textarea
+                                    id="ckeditor-{{ $prop }}"
+                                    ng-model="item.{{ $prop }}"
+                                    @include('crud::inc.field_attributes', ['default_class' => 'form-control ckeditor'])
+                                    ckeditor
+                            ></textarea>
+                        @else
+                            <input class="form-control input-sm" type="text" ng-model="item.{{ $prop }}">
+                        @endif
+                    </td>
+                @endforeach
+                <td ng-if="max == -1 || max > 1">
+                    <span class="btn btn-sm btn-default sort-handle"><span class="sr-only">sort item</span><i class="fa fa-sort" role="presentation" aria-hidden="true"></i></span>
+                </td>
+                <td ng-if="max == -1 || max > 1">
+                    <button ng-hide="min > -1 && $index < min" class="btn btn-sm btn-default" type="button" ng-click="removeItem(item);"><span class="sr-only">delete item</span><i class="fa fa-trash" role="presentation" aria-hidden="true"></i></button>
+                </td>
+            </tr>
+
+            </tbody>
+
+        </table>
+
+        <div class="array-controls btn-group m-t-10">
+            <button ng-if="max == -1 || items.length < max" class="btn btn-sm btn-default" type="button" ng-click="addItem()"><i class="fa fa-plus"></i> {{trans('backpack::crud.add')}} {{ $item_name }}</button>
+        </div>
+
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    {{-- @push('crud_fields_styles')
+        {{-- YOUR CSS HERE --}}
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    {{-- YOUR JS HERE --}}
+    <script src="{{ asset('vendor/backpack/ckeditor/ckeditor.js') }}"></script>
+    <script src="{{ asset('vendor/backpack/ckeditor/adapters/jquery.js') }}"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-sortable/0.14.3/sortable.min.js"></script>
+    <script>
+
+        window.angularApp = window.angularApp || angular.module('backPackTableApp', ['ui.sortable'], function($interpolateProvider){
+                $interpolateProvider.startSymbol('<%');
+                $interpolateProvider.endSymbol('%>');
+            });
+
+        window.angularApp.controller('tableController', function($scope){
+
+            $scope.sortableOptions = {
+                handle: '.sort-handle'
+            };
+
+            $scope.addItem = function(){
+
+                if( $scope.max > -1 ){
+                    if( $scope.items.length < $scope.max ){
+                        var item = {};
+                        $scope.items.push(item);
+                    } else {
+                        new PNotify({
+                            title: $scope.maxErrorTitle,
+                            text: $scope.maxErrorMessage,
+                            type: 'error'
+                        });
+                    }
+                }
+                else {
+                    var item = {};
+                    $scope.items.push(item);
+                }
+            }
+
+            $scope.removeItem = function(item){
+                var index = $scope.items.indexOf(item);
+                $scope.items.splice(index, 1);
+            }
+
+            $scope.$watch('items', function(a, b){
+                if( $scope.min > -1 ){
+                    while($scope.items.length < $scope.min){
+                        $scope.addItem();
+                    }
+                }
+
+                if( typeof $scope.items != 'undefined' && $scope.items.length ){
+
+                    if( typeof $scope.field != 'undefined'){
+                        if( typeof $scope.field == 'string' ){
+                            $scope.field = $($scope.field);
+                        }
+                        $scope.field.val( angular.toJson($scope.items) );
+                    }
+                }
+            }, true);
+
+            if( $scope.min > -1 ){
+                for(var i = 0; i < $scope.min; i++){
+                    $scope.addItem();
+                }
+            }
+        });
+
+        window.angularApp.directive('ckeditor', Directive);
+
+        function Directive($rootScope) {
+            return {
+                require: 'ngModel',
+                link: function (scope, element, attr, ngModel) {
+                    // enable ckeditor
+                    var ckeditor = element.ckeditor({
+                        "filebrowserBrowseUrl": "{{ url(config('backpack.base.route_prefix').'/elfinder/ckeditor') }}",
+                        "extraPlugins" : 'wordcount',
+                        "wordcount" : {
+                            maxCharCount: '{{ isset($field['char_count']) ? $field['char_count'] : -1 }}',
+                            showParagraphs: false,
+                            showWordCount: false,
+                            showCharCount: true,
+                            countSpacesAsChars: true
+                        }
+                    });
+
+                    // update ngModel on change
+                    ckeditor.editor.on('change', function () {
+                        ngModel.$setViewValue(this.getData());
+                    });
+                }
+            };
+        }
+
+        angular.element(document).ready(function(){
+            angular.forEach(angular.element('[ng-app]'), function(ctrl){
+                var ctrlDom = angular.element(ctrl);
+                if( !ctrlDom.hasClass('ng-scope') ){
+                    angular.bootstrap(ctrl, [ctrlDom.attr('ng-app')]);
+                }
+            });
+        });
+    </script>
+    @endpush
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/number.blade.php
+++ b/src/resources/views/show/fields/number.blade.php
@@ -1,0 +1,22 @@
+<!-- number input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-addon">{!! $field['prefix'] !!}</div> @endif
+        <input
+        	type="number"
+        	name="{{ $field['name'] }}"
+            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            @include('crud::inc.field_attributes')
+        	>
+        @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/page_or_link.blade.php
+++ b/src/resources/views/show/fields/page_or_link.blade.php
@@ -1,0 +1,153 @@
+<!-- PAGE OR LINK field -->
+<!-- Used in Backpack\MenuCRUD -->
+
+<?php
+    $field['options'] = ['page_link' => trans('backpack::crud.page_link'), 'internal_link' => trans('backpack::crud.internal_link'), 'external_link' => trans('backpack::crud.external_link')];
+    $field['allows_null'] = false;
+    $page_model = $field['page_model'];
+    $active_pages = $page_model::all();
+?>
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <div class="clearfix"></div>
+
+    <div class="col-sm-3">
+        <select
+            id="page_or_link_select"
+            name="{{ $field['name'] or 'type' }}"
+            @include('crud::inc.field_attributes')
+            >
+
+            @if (isset($field['allows_null']) && $field['allows_null']==true)
+                <option value="">-</option>
+            @endif
+
+                @if (count($field['options']))
+                    @foreach ($field['options'] as $key => $value)
+                        <option value="{{ $key }}"
+                            @if (isset($field['value']) && $key==$field['value'])
+                                 selected
+                            @endif
+                        >{{ $value }}</option>
+                    @endforeach
+                @endif
+        </select>
+    </div>
+    <div class="col-sm-9">
+        <!-- external link input -->
+          <div class="page_or_link_value <?php if (!isset($entry) || $entry->type != 'external_link') {
+                echo 'hidden';
+} ?>" id="page_or_link_external_link">
+            <input
+                type="url"
+                class="form-control"
+                name="link"
+                placeholder="{{ trans('backpack::crud.page_link_placeholder') }}"
+
+                @if (!isset($entry) || $entry->type!='external_link')
+                    disabled="disabled"
+                  @endif
+
+                @if (isset($entry) && $entry->type=='external_link' && isset($entry->link) && $entry->link!='')
+                    value="{{ $entry->link }}"
+                @endif
+                >
+          </div>
+          <!-- internal link input -->
+          <div class="page_or_link_value <?php if (!isset($entry) || $entry->type != 'internal_link') {
+                echo 'hidden';
+} ?>" id="page_or_link_internal_link">
+            <input
+                type="text"
+                class="form-control"
+                name="link"
+                placeholder="{{ trans('backpack::crud.internal_link_placeholder', ['url', url(config('backpack.base.route_prefix').'/page')]) }}"
+
+                @if (!isset($entry) || $entry->type!='internal_link')
+                    disabled="disabled"
+                  @endif
+
+                @if (isset($entry) && $entry->type=='internal_link' && isset($entry->link) && $entry->link!='')
+                    value="{{ $entry->link }}"
+                @endif
+                >
+          </div>
+          <!-- page slug input -->
+          <div class="page_or_link_value <?php if (isset($entry) && $entry->type != 'page_link') {
+                echo 'hidden';
+} ?>" id="page_or_link_page">
+            <select
+                class="form-control"
+                name="page_id"
+                >
+                @if (!count($active_pages))
+                    <option value="">-</option>
+                @else
+                    @foreach ($active_pages as $key => $page)
+                        <option value="{{ $page->id }}"
+                            @if (isset($entry) && isset($entry->page_id) && $page->id==$entry->page_id)
+                                 selected
+                            @endif
+                        >{{ $page->name }}</option>
+                    @endforeach
+                @endif
+
+            </select>
+          </div>
+    </div>
+    <div class="clearfix"></div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+</div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <script>
+            jQuery(document).ready(function($) {
+
+                $("#page_or_link_select").change(function(e) {
+                    $(".page_or_link_value input").attr('disabled', 'disabled');
+                    $(".page_or_link_value select").attr('disabled', 'disabled');
+                    $(".page_or_link_value").removeClass("hidden").addClass("hidden");
+
+
+                    switch($(this).val()) {
+                        case 'external_link':
+                            $("#page_or_link_external_link input").removeAttr('disabled');
+                            $("#page_or_link_external_link").removeClass('hidden');
+                            break;
+
+                        case 'internal_link':
+                            $("#page_or_link_internal_link input").removeAttr('disabled');
+                            $("#page_or_link_internal_link").removeClass('hidden');
+                            break;
+
+                        default: // page_link
+                            $("#page_or_link_page select").removeAttr('disabled');
+                            $("#page_or_link_page").removeClass('hidden');
+                    }
+                });
+
+            });
+        </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/password.blade.php
+++ b/src/resources/views/show/fields/password.blade.php
@@ -1,0 +1,2 @@
+<!-- password -->
+<!-- DONT SHOW -->

--- a/src/resources/views/show/fields/radio.blade.php
+++ b/src/resources/views/show/fields/radio.blade.php
@@ -1,0 +1,44 @@
+<!-- radio -->
+@php
+    $optionPointer = 0;
+    $optionValue = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+@endphp
+
+<div @include('crud::inc.field_wrapper_attributes') >
+
+    <div>
+        <label>{!! $field['label'] !!}</label>
+        @include('crud::inc.field_translatable_icon')
+    </div>
+
+    @if( isset($field['options']) && $field['options'] = (array)$field['options'] )
+
+        @foreach ($field['options'] as $value => $label )
+            @php ($optionPointer++)
+
+            @if( isset($field['inline']) && $field['inline'] )
+
+            <label class="radio-inline" for="{{$field['name']}}_{{$optionPointer}}">
+                <input type="radio" id="{{$field['name']}}_{{$optionPointer}}" name="{{$field['name']}}" value="{{$value}}" {{$optionValue == $value ? ' checked': ''}}> {!! $label !!}
+            </label>
+
+            @else
+
+            <div class="radio">
+                <label for="{{$field['name']}}_{{$optionPointer}}">
+                    <input type="radio" id="{{$field['name']}}_{{$optionPointer}}" name="{{$field['name']}}" value="{{$value}}" {{$optionValue == $value ? ' checked': ''}}> {!! $label !!}
+                </label>
+            </div>
+
+            @endif
+
+        @endforeach
+
+    @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+</div>

--- a/src/resources/views/show/fields/range.blade.php
+++ b/src/resources/views/show/fields/range.blade.php
@@ -1,0 +1,16 @@
+<!-- html5 range input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+        type="range"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+        >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/select.blade.php
+++ b/src/resources/views/show/fields/select.blade.php
@@ -1,0 +1,36 @@
+<!-- select -->
+
+<div @include('crud::inc.field_wrapper_attributes') >
+
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    <?php $entity_model = $crud->model; ?>
+    <select
+        name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes')
+        >
+
+        @if ($entity_model::isColumnNullable($field['name']))
+            <option value="">-</option>
+        @endif
+
+            @if (isset($field['model']))
+                @foreach ($field['model']::all() as $connected_entity_entry)
+                    <option value="{{ $connected_entity_entry->getKey() }}"
+
+                        @if ( ( old($field['name']) && old($field['name']) == $connected_entity_entry->getKey() ) || (!old($field['name']) && isset($field['value']) && $connected_entity_entry->getKey()==$field['value']))
+
+                             selected
+                        @endif
+                    >{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                @endforeach
+            @endif
+    </select>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+</div>

--- a/src/resources/views/show/fields/select2.blade.php
+++ b/src/resources/views/show/fields/select2.blade.php
@@ -1,0 +1,13 @@
+<!-- select2 -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <?php $entity_model = $crud->model; ?>
+    @if (isset($field['model']))
+        @foreach ($field['model']::all() as $connected_entity_entry)
+            @if ( ( old($field['name']) && old($field['name']) == $connected_entity_entry->getKey() ) || (isset($field['value']) && $connected_entity_entry->getKey()==$field['value']))
+                <p>{{ $connected_entity_entry->{$field['attribute']} }}</p>
+            @endif
+        @endforeach
+    @endif
+</div>

--- a/src/resources/views/show/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/show/fields/select2_from_ajax.blade.php
@@ -1,0 +1,104 @@
+<!-- select2 from ajax -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    <?php $entity_model = $crud->model; ?>
+    <input type="hidden" name="{{ $field['name'] }}" id="select2_ajax_{{ $field['name'] }}"
+        @if(isset($field['value']))
+            value="{{ $field['value'] }}"
+        @else
+	        @if(old($field['name']))
+	            value="{{ old($field['name']) }}"
+	        @endif
+        @endif
+    @include('crud::inc.field_attributes', ['default_class' =>  'form-control'])
+    >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+@php
+    $connected_entity = new $field['model'];
+    $connected_entity_key_name = $connected_entity->getKeyName();
+@endphp
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <!-- include select2 css-->
+    <link href="{{ asset('vendor/backpack/select2/select2.css') }}" rel="stylesheet" type="text/css" />
+    <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include select2 js-->
+    <script src="{{ asset('vendor/backpack/select2/select2.js') }}"></script>
+    @endpush
+
+@endif
+
+<!-- include field specific select2 js-->
+@push('crud_fields_scripts')
+<script>
+    jQuery(document).ready(function($) {
+        // trigger select2 for each untriggered select2 box
+        $("#select2_ajax_{{ $field['name'] }}").each(function (i, obj) {
+            if (!$(obj).data("select2"))
+            {
+                $(obj).select2({
+                    placeholder: "{{ $field['placeholder'] }}",
+                    minimumInputLength: "{{ $field['minimum_input_length'] }}",
+                    ajax: {
+                        url: "{{ $field['data_source'] }}",
+                        dataType: 'json',
+                        quietMillis: 250,
+                        data: function (term, page) {
+                            return {
+                                q: term, // search term
+                                page: page
+                            };
+                        },
+                        results: function (data, params) {
+                            params.page = params.page || 1;
+
+                            var result = {
+                                results: $.map(data.data, function (item) {
+                                    textField = "{{ $field['attribute'] }}";
+                                    return {
+                                        text: item[textField],
+                                        id: item["{{ $connected_entity_key_name }}"]
+                                    }
+                                }),
+                                more: data.current_page < data.last_page
+                            };
+
+                            return result;
+                        },
+                        cache: true
+                    },
+                    initSelection: function(element, callback) {
+                        // the input tag has a value attribute preloaded that points to a preselected repository's id
+                        // this function resolves that id attribute to an object that select2 can render
+                        // using its formatResult renderer - that way the repository name is shown preselected
+                        $.ajax("{{ $field['data_source'] }}" + '/' + "{{ $field['value'] ?? ( old($field['name']) ?? 0 ) }}", {
+                            dataType: "json"
+                        }).done(function(data) {
+                            textField = "{{ $field['attribute'] }}";
+                            callback({ text: data[textField], id: data["{{ $connected_entity_key_name }}"] });
+                        });
+                    },
+                });
+            }
+        });
+    });
+</script>
+@endpush
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/show/fields/select2_from_ajax_multiple.blade.php
@@ -1,0 +1,98 @@
+<!-- select2 from ajax multiple -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    <input type="hidden" name="{{ $field['name'] }}" id="select2_ajax_multiple_{{ $field['name'] }}"
+        @if(isset($field['value']))
+            value="{{ $field['value'] }}"
+        @endif
+    @include('crud::inc.field_attributes', ['default_class' =>  'form-control'])
+    >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+@php
+    $connected_entity = new $field['model'];
+    $connected_entity_key_name = $connected_entity->getKeyName();
+@endphp
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <!-- include select2 css-->
+    <link href="{{ asset('vendor/backpack/select2/select2.css') }}" rel="stylesheet" type="text/css" />
+    <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include select2 js-->
+    <script src="{{ asset('vendor/backpack/select2/select2.js') }}"></script>
+    @endpush
+
+@endif
+
+<!-- include field specific select2 js-->
+@push('crud_fields_scripts')
+<script>
+    jQuery(document).ready(function($) {
+        // trigger select2 for each untriggered select2 box
+        $("#select2_ajax_multiple_{{ $field['name'] }}").each(function (i, obj) {
+            if (!$(obj).data("select2"))
+            {
+                $(obj).select2({
+                    multiple: true,
+                    placeholder: "{{ $field['placeholder'] }}",
+                    minimumInputLength: "{{ $field['minimum_input_length'] }}",
+                    ajax: {
+                        url: "{{ $field['data_source'] }}",
+                        dataType: 'json',
+                        quietMillis: 250,
+                        data: function (term, page) {
+                            return {
+                                q: term, // search term
+                                page: page
+                            };
+                        },
+                        results: function (data, params) {
+                            params.page = params.page || 1;
+
+                            return {
+                                results: $.map(data.data, function (item) {
+                                    textField = "{{$field['attribute']}}";
+                                    return {
+                                        text: item[textField],
+                                        id: item["{{ $connected_entity_key_name }}"]
+                                    }
+                                }),
+                                more: data.current_page < data.last_page
+                            };
+                        },
+                        cache: true
+                    },
+                    initSelection: function(element, callback) {
+                        // the input tag has a value attribute preloaded that points to a preselected repository's id
+                        // this function resolves that id attribute to an object that select2 can render
+                        // using its formatResult renderer - that way the repository name is shown preselected
+                        $.ajax("{{ $field['data_source'] }}" + '/' + "{{ $field['value'] ? $field['value'] : 0 }}", {
+                            dataType: "json"
+                        }).done(function(data) {
+                            textField = "{{$field['attribute']}}";
+                            callback({ text: data[textField], id: data["{{ $connected_entity_key_name }}"] });
+                        });
+                    },
+                });
+            }
+        });
+    });
+</script>
+@endpush
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/select2_from_array.blade.php
+++ b/src/resources/views/show/fields/select2_from_array.blade.php
@@ -1,0 +1,63 @@
+<!-- select2 from array -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    <select
+        name="{{ $field['name'] }}@if (isset($field['allows_multiple']) && $field['allows_multiple']==true)[]@endif"
+        @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2'])
+        @if (isset($field['allows_multiple']) && $field['allows_multiple']==true)multiple @endif
+        >
+
+        @if (isset($field['allows_null']) && $field['allows_null']==true)
+            <option value="">-</option>
+        @endif
+
+            @if (count($field['options']))
+                @foreach ($field['options'] as $key => $value)
+                    <option value="{{ $key }}"
+                        @if (isset($field['value']) && ($key==$field['value'] || (is_array($field['value']) && in_array($key, $field['value'])))
+                            || ( ! is_null( old($field['name']) ) && old($field['name']) == $key))
+                             selected
+                        @endif
+                    >{{ $value }}</option>
+                @endforeach
+            @endif
+    </select>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    <!-- include select2 css-->
+    <link href="{{ asset('vendor/backpack/select2/select2.css') }}" rel="stylesheet" type="text/css" />
+    <link href="{{ asset('vendor/backpack/select2/select2-bootstrap-dick.css') }}" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include select2 js-->
+    <script src="{{ asset('vendor/backpack/select2/select2.js') }}"></script>
+    <script>
+        jQuery(document).ready(function($) {
+            // trigger select2 for each untriggered select2 box
+            $('.select2').each(function (i, obj) {
+                if (!$(obj).data("select2"))
+                {
+                    $(obj).select2();
+                }
+            });
+        });
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/select2_multiple.blade.php
+++ b/src/resources/views/show/fields/select2_multiple.blade.php
@@ -1,0 +1,13 @@
+<!-- select2-multiple -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <?php $entity_model = $crud->model; ?>
+    @if (isset($field['model']))
+        @foreach ($field['model']::all() as $connected_entity_entry)
+            @if ( (isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())) || ( old( $field["name"] ) && in_array($connected_entity_entry->getKey(), old( $field["name"])) ) )
+                <p>{{ $connected_entity_entry->{$field['attribute']} }}</p>
+            @endif
+        @endforeach
+    @endif
+</div>

--- a/src/resources/views/show/fields/select_from_array.blade.php
+++ b/src/resources/views/show/fields/select_from_array.blade.php
@@ -1,0 +1,31 @@
+<!-- select from array -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <select
+        name="{{ $field['name'] }}@if (isset($field['allows_multiple']) && $field['allows_multiple']==true)[]@endif"
+        @include('crud::inc.field_attributes')
+        @if (isset($field['allows_multiple']) && $field['allows_multiple']==true)multiple @endif
+        >
+
+        @if (isset($field['allows_null']) && $field['allows_null']==true)
+            <option value="">-</option>
+        @endif
+
+            @if (count($field['options']))
+                @foreach ($field['options'] as $key => $value)
+                    <option value="{{ $key }}"
+                        @if (isset($field['value']) && ($key==$field['value'] || (is_array($field['value']) && in_array($key, $field['value'])))
+                            || ( ! is_null( old($field['name']) ) && old($field['name']) == $key))
+                             selected
+                        @endif
+                    >{{ $value }}</option>
+                @endforeach
+            @endif
+    </select>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/select_multiple.blade.php
+++ b/src/resources/views/show/fields/select_multiple.blade.php
@@ -1,0 +1,12 @@
+<!-- select multiple -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+	@if (isset($field['model']))
+		@foreach ($field['model']::all() as $connected_entity_entry)
+			@if ( (isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())) || ( old( $field["name"] ) && in_array($connected_entity_entry->getKey(), old( $field["name"])) ) )
+				<p>{{ $connected_entity_entry->{$field['attribute']} }}</p>
+			@endif
+		@endforeach
+	@endif
+</div>

--- a/src/resources/views/show/fields/send_newsletter.blade.php
+++ b/src/resources/views/show/fields/send_newsletter.blade.php
@@ -1,0 +1,7 @@
+<!-- send newsletter button -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    <div>
+        <a href="{{ url($crud->route . '/' . $entry->getKey() . '/send') }}" class="btn btn-primary ladda-button" data-style="zoom-in"><span class="ladda-label"><i class="fa fa-check"></i> Send</span></a>
+    </div>
+</div>

--- a/src/resources/views/show/fields/simplemde.blade.php
+++ b/src/resources/views/show/fields/simplemde.blade.php
@@ -1,0 +1,46 @@
+<!-- Simple MDE - Markdown Editor -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <textarea
+    	id="simplemde-{{ $field['name'] }}"
+        name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes', ['default_class' => 'form-control ckeditor'])
+    	>{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+        <style type="text/css">
+        .CodeMirror-fullscreen, .editor-toolbar.fullscreen {
+            z-index: 9999 !important;
+        }
+        </style>
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+    @endpush
+
+@endif
+
+@push('crud_fields_scripts')
+<script>
+    var simplemde = new SimpleMDE({ element: $("#simplemde-{{ $field['name'] }}")[0] });
+</script>
+@endpush
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/summernote.blade.php
+++ b/src/resources/views/show/fields/summernote.blade.php
@@ -1,0 +1,41 @@
+<!-- summernote editor -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <textarea
+        name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes', ['default_class' =>  'form-control summernote'])
+        >{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <!-- include summernote css-->
+        <link href="{{ asset('vendor/backpack/summernote/summernote.css') }}" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <!-- include summernote js-->
+        <script src="{{ asset('vendor/backpack/summernote/summernote.min.js') }}"></script>
+        <script>
+            jQuery(document).ready(function($) {
+                $('.summernote').summernote();
+            });
+        </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/table.blade.php
+++ b/src/resources/views/show/fields/table.blade.php
@@ -1,0 +1,35 @@
+<!-- array input -->
+
+<?php
+    $max = isset($field['max']) && (int) $field['max'] > 0 ? $field['max'] : -1;
+    $min = isset($field['min']) && (int) $field['min'] > 0 ? $field['min'] : -1;
+    $item_name = strtolower(isset($field['entity_singular']) && !empty($field['entity_singular']) ? $field['entity_singular'] : $field['label']);
+    $items = old($field['name']) ? (old($field['name'])) : (isset($field['value']) ? ($field['value']) : (isset($field['default']) ? ($field['default']) : '' ));
+?>
+<div @include('crud::inc.field_wrapper_attributes')>
+    <label>{!! $field['label'] !!}</label>
+    <div class="array-container form-group">
+        <table class="table table-bordered table-striped m-b-0">
+            <thead>
+                <tr>
+                    @foreach( $field['columns'] as $prop )
+                        <th style="font-weight: 600!important;">
+                            {{ $prop }}
+                        </th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody class="table-striped">
+                @foreach($items as $item)
+                    <tr class="array-row">
+                        @foreach( $field['columns'] as $prop => $label)
+                            <td>
+                                <p>{{ isset($item[$prop]) ? $item[$prop] : '' }}</p>
+                            </td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/resources/views/show/fields/text.blade.php
+++ b/src/resources/views/show/fields/text.blade.php
@@ -1,0 +1,30 @@
+<!-- text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-addon">{!! $field['prefix'] !!}</div> @endif
+        <p>{{ $field['value'] }}</p>
+        @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+</div>
+
+
+{{-- FIELD EXTRA CSS  --}}
+{{-- push things in the after_styles section --}}
+
+    {{-- @push('crud_fields_styles')
+        <!-- no styles -->
+    @endpush --}}
+
+
+{{-- FIELD EXTRA JS --}}
+{{-- push things in the after_scripts section --}}
+
+    {{-- @push('crud_fields_scripts')
+        <!-- no scripts -->
+    @endpush --}}
+
+
+{{-- Note: you can use @if ($crud->checkIfFieldIsFirstOfItsType($field, $fields)) to only load some CSS/JS once, even though there are multiple instances of it --}}

--- a/src/resources/views/show/fields/textarea.blade.php
+++ b/src/resources/views/show/fields/textarea.blade.php
@@ -1,0 +1,15 @@
+<!-- textarea -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <textarea
+    	name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes')
+
+    	>{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/time.blade.php
+++ b/src/resources/views/show/fields/time.blade.php
@@ -1,0 +1,16 @@
+<!-- html5 time input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+    	type="time"
+    	name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+    	>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/time_picker.blade.php
+++ b/src/resources/views/show/fields/time_picker.blade.php
@@ -1,0 +1,1 @@
+[//TODO: time picker]

--- a/src/resources/views/show/fields/tinymce.blade.php
+++ b/src/resources/views/show/fields/tinymce.blade.php
@@ -1,0 +1,60 @@
+<!-- Tiny MCE -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <textarea
+    	id="tinymce-{{ $field['name'] }}"
+        name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes', ['default_class' =>  'form-control tinymce'])
+        >{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+    <!-- include tinymce js-->
+    <script src="{{ asset('vendor/backpack/tinymce/tinymce.min.js') }}"></script>
+    {{-- <script src="{{ asset(config('backpack.base.route_prefix').'/js/vendor/tinymce/jquery.tinymce.min.js') }}"></script> --}}
+
+    <script type="text/javascript">
+    tinymce.init({
+        selector: "textarea.tinymce",
+        skin: "dick-light",
+        plugins: "image,link,media,anchor",
+        file_browser_callback : elFinderBrowser,
+     });
+
+    function elFinderBrowser (field_name, url, type, win) {
+      tinymce.activeEditor.windowManager.open({
+        file: '{{ url(config('backpack.base.route_prefix').'/elfinder/tinymce4') }}',// use an absolute path!
+        title: 'elFinder 2.0',
+        width: 900,
+        height: 450,
+        resizable: 'yes'
+      }, {
+        setUrl: function (url) {
+          win.document.getElementById(field_name).value = url;
+        }
+      });
+      return false;
+    }
+    </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/upload.blade.php
+++ b/src/resources/views/show/fields/upload.blade.php
@@ -1,0 +1,12 @@
+<!-- text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+	{{-- Show the file name and a "Clear" button on EDIT form. --}}
+    @if (isset($field['value']) && $field['value']!=null)
+        <div>
+            <a class="btn btn-success" target="_blank" href="{{ isset($field['disk'])?asset(\Storage::disk($field['disk'])->url($field['value'])):asset($field['value']) }}"><i class="fa fa-download"></i> Download</a>
+        </div>
+    @endif
+</div>

--- a/src/resources/views/show/fields/upload_multiple.blade.php
+++ b/src/resources/views/show/fields/upload_multiple.blade.php
@@ -1,0 +1,60 @@
+<!-- upload multiple input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+
+	{{-- Show the file name and a "Clear" button on EDIT form. --}}
+	@if (isset($field['value']) && count($field['value']))
+    <div class="well well-sm file-preview-container">
+    	@foreach($field['value'] as $key => $file_path)
+    		<div class="file-preview">
+	    		<a target="_blank" href="{{ isset($field['disk'])?asset(\Storage::disk($field['disk'])->url($file_path)):asset($file_path) }}">{{ $file_path }}</a>
+		    	<a id="{{ $field['name'] }}_{{ $key }}_clear_button" href="#" class="btn btn-default btn-xs pull-right file-clear-button" title="Clear file" data-filename="{{ $file_path }}"><i class="fa fa-remove"></i></a>
+		    	<div class="clearfix"></div>
+	    	</div>
+    	@endforeach
+    </div>
+    @endif
+	{{-- Show the file picker on CREATE form. --}}
+	<input name="{{ $field['name'] }}[]" type="hidden" value="">
+	<input
+        type="file"
+        id="{{ $field['name'] }}_file_input"
+        name="{{ $field['name'] }}[]"
+        value="@if (old($field['name'])) old($field['name']) @elseif (isset($field['default'])) $field['default'] @endif"
+        @include('crud::inc.field_attributes')
+        multiple
+    >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- FIELD EXTRA JS --}}
+{{-- push things in the after_scripts section --}}
+
+    @push('crud_fields_scripts')
+        <!-- no scripts -->
+        <script>
+	        $(".file-clear-button").click(function(e) {
+	        	e.preventDefault();
+	        	var container = $(this).parent().parent();
+	        	var parent = $(this).parent();
+	        	// remove the filename and button
+	        	parent.remove();
+	        	// if the file container is empty, remove it
+	        	if ($.trim(container.html())=='') {
+	        		container.remove();
+	        	}
+	        	$("<input type='hidden' name='clear_{{ $field['name'] }}[]' value='"+$(this).data('filename')+"'>").insertAfter("#{{ $field['name'] }}_file_input");
+	        });
+
+	        $("#{{ $field['name'] }}_file_input").change(function() {
+	        	console.log($(this).val());
+	        	// remove the hidden input, so that the setXAttribute method is no longer triggered
+	        	$(this).next("input[type=hidden]").remove();
+	        });
+        </script>
+    @endpush

--- a/src/resources/views/show/fields/url.blade.php
+++ b/src/resources/views/show/fields/url.blade.php
@@ -1,0 +1,7 @@
+<!-- html5 url input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    <p>
+        <a href="{{ $field['value'] }}" target="_blank">{{ $field['value'] }}</a>
+    </p>
+</div>

--- a/src/resources/views/show/fields/video.blade.php
+++ b/src/resources/views/show/fields/video.blade.php
@@ -1,0 +1,351 @@
+<!-- text input -->
+<?php
+
+$value = old($field['name']) ? (old($field['name'])) : (isset($field['value']) ? ($field['value']) : (isset($field['default']) ? ($field['default']) : '' ));
+
+// if attribute casting is used, convert to JSON
+if (is_array($value)) {
+    $value = json_encode((object)$value);
+} elseif (is_object($value)) {
+    $value = json_encode($value);
+} else {
+    $value = $value;
+}
+
+?>
+
+
+<div data-video @include('crud::inc.field_wrapper_attributes') >
+    <label for="{{ $field['name'] }}_link">{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input class="video-json" type="hidden" name="{{ $field['name'] }}" value="{{ $value }}">
+    <div class="input-group">
+        <input @include('crud::inc.field_attributes', ['default_class' => 'video-link form-control']) type="text" id="{{ $field['name'] }}_link">
+        <div class="input-group-addon video-previewSuffix video-noPadding">
+            <div class="video-preview">
+                <span class="video-previewImage"></span>
+                <a class="video-previewLink hidden" target="_blank" href="">
+                    <i class="fa video-previewIcon"></i>
+                </a>
+            </div>
+            <div class="video-dummy">
+                <a class="video-previewLink youtube dummy" target="_blank" href="">
+                    <i class="fa fa-youtube video-previewIcon dummy"></i>
+                </a>
+                <a class="video-previewLink vimeo dummy" target="_blank" href="">
+                    <i class="fa fa-vimeo video-previewIcon dummy"></i>
+                </a>
+            </div>
+        </div>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+    {{-- @push('crud_fields_styles')
+        {{-- YOUR CSS HERE --}}
+        <style media="screen">
+            .video-previewSuffix {
+                border: 0;
+                min-width: 68px; }
+            .video-noPadding {
+                padding: 0; }
+            .video-preview {
+                display: none; }
+            .video-previewLink {
+                 color: #fff;
+                 display: block;
+                 width: 34px; height: 34px;
+                 text-align: center;
+                 float: left; }
+            .video-previewLink.youtube {
+                background: #DA2724; }
+            .video-previewLink.vimeo {
+                background: #00ADEF; }
+            .video-previewIcon {
+                transform: translateY(10px); }
+            .video-previewImage {
+                float: left;
+                display: block;
+                width: 34px; height: 34px;
+                background-size: cover;
+                background-position: center center; }
+        </style>
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        {{-- YOUR JS HERE --}}
+        <script>
+            jQuery(document).ready(function($) {
+
+                var tryYouTube = function( link ){
+
+                    var id = null;
+
+                    // RegExps for YouTube link forms
+                    var youtubeStandardExpr = /^https?:\/\/(www\.)?youtube.com\/watch\?v=([^?&]+)/i; // Group 2 is video ID
+                    var youtubeAlternateExpr = /^https?:\/\/(www\.)?youtube.com\/v\/([^\/\?]+)/i; // Group 2 is video ID
+                    var youtubeShortExpr = /^https?:\/\/youtu.be\/([^\/]+)/i; // Group 1 is video ID
+                    var youtubeEmbedExpr = /^https?:\/\/(www\.)?youtube.com\/embed\/([^\/]+)/i; // Group 2 is video ID
+
+                    var match = link.match(youtubeStandardExpr);
+
+                    if (match != null){
+                        id = match[2];
+                    }
+                    else {
+                        match = link.match(youtubeAlternateExpr);
+
+                        if (match != null) {
+                            id = match[2];
+                        }
+                        else {
+                            match = link.match(youtubeShortExpr);
+
+                            if (match != null){
+                                id = match[1];
+                            }
+                            else {
+                                match = link.match(youtubeEmbedExpr);
+
+                                if (match != null){
+                                    id = match[2];
+                                }
+                            }
+                        }
+                    }
+
+                    return id;
+                };
+
+                var tryVimeo = function( link ){
+
+                    var id = null;
+                    var regExp = /(http|https):\/\/(www\.)?vimeo.com\/(\d+)($|\/)/;
+
+                    var match = link.match(regExp);
+
+                    if (match){
+                        id = match[3];
+                    }
+
+                    return id;
+                };
+
+                var fetchYouTube = function( videoId, callback ){
+
+                    var api = 'https://www.googleapis.com/youtube/v3/videos?id='+videoId+'&key=AIzaSyDQa76EpdNPzfeTAoZUut2AnvBA0jkx3FI&part=snippet';
+
+                    var video = {
+                        provider: 'youtube',
+                        id: null,
+                        title: null,
+                        image: null,
+                        url: null
+                    };
+
+                    $.getJSON(api, function( data ){
+
+                        if (typeof(data.items[0]) != "undefined") {
+                            var v = data.items[0].snippet;
+
+                            video.id = videoId;
+                            video.title = v.title;
+                            video.image = v.thumbnails.maxres ? v.thumbnails.maxres.url : v.thumbnails.default.url;
+                            video.url = 'https://www.youtube.com/watch?v=' + video.id;
+
+                            callback(video);
+                        }
+                    });
+                };
+
+                var fetchVimeo = function( videoId, callback ){
+
+                    var api = 'http://vimeo.com/api/v2/video/' + videoId + '.json?callback=?';
+
+                    var video = {
+                        provider: 'vimeo',
+                        id: null,
+                        title: null,
+                        image: null,
+                        url: null
+                    };
+
+                    $.getJSON(api, function( data ){
+
+                        if (typeof(data[0]) != "undefined") {
+                            var v = data[0];
+
+                            video.id = v.id;
+                            video.title = v.title;
+                            video.image = v.thumbnail_large || v.thumbnail_small;
+                            video.url = v.url;
+
+                            callback(video);
+                        }
+                    });
+                };
+
+                var parseVideoLink = function( link, callback ){
+
+                    var response = {success: false, message: 'unknown error occured, please try again', data: [] };
+
+                    try {
+                        var parser = document.createElement('a');
+                    } catch(e){
+                        response.message = 'Please post a valid youtube/vimeo url';
+                        return response;
+                    }
+
+
+                    var id = tryYouTube(link);
+
+                    if( id ){
+
+                        return fetchYouTube(id, function(video){
+
+                            if( video ){
+                                response.success = true;
+                                response.message = 'video found';
+                                response.data = video;
+                            }
+
+                            callback(response);
+                        });
+                    }
+                    else {
+
+                        id = tryVimeo(link);
+
+                        if( id ){
+
+                            return fetchVimeo(id, function(video){
+
+                                if( video ){
+                                    response.success = true;
+                                    response.message = 'video found';
+                                    response.data = video;
+                                }
+
+                                callback(response);
+                            });
+                        }
+                    }
+
+                    response.message = 'We could not detect a YouTube or Vimeo ID, please try obtain the URL again'
+                    return callback(response);
+                };
+
+                var updateVideoPreview = function(video, container){
+
+                    var pWrap = container.find('.video-preview'),
+                        pLink = container.find('.video-previewLink').not('.dummy'),
+                        pImage = container.find('.video-previewImage').not('dummy'),
+                        pIcon  = container.find('.video-previewIcon').not('.dummy'),
+                        pSuffix = container.find('.video-previewSuffix'),
+                        pDummy  = container.find('.video-dummy');
+
+                    pDummy.hide();
+
+                    pLink
+                    .attr('href', video.url)
+                    .removeClass('youtube vimeo hidden')
+                    .addClass(video.provider);
+
+                    pImage
+                    .css('backgroundImage', 'url('+video.image+')');
+
+                    pIcon
+                    .removeClass('fa-vimeo fa-youtube')
+                    .addClass('fa-' + video.provider);
+                    pWrap.fadeIn();
+                };
+
+                // Loop through all instances of the video field
+                $("[data-video]").each(function(index){
+
+                    var $this = $(this),
+                        jsonField = $this.find('.video-json'),
+                        linkField = $this.find('.video-link'),
+                        pDummy = $this.find('.video-dummy'),
+                        pWrap = $this.find('.video-preview');
+
+                        try {
+                            var videoJson = JSON.parse(jsonField.val());
+                            jsonField.val( JSON.stringify(videoJson) );
+                            linkField.val( videoJson.url );
+                            updateVideoPreview(videoJson, $this);
+                        }
+                        catch(e){
+                            pDummy.show();
+                            pWrap.hide();
+                            jsonField.val('');
+                            linkField.val('');
+                        }
+
+                    linkField.on('focus', function(){
+                        linkField.originalState = linkField.val();
+                    });
+
+                    linkField.on('change', function(){
+
+                        if( linkField.originalState != linkField.val() ){
+
+                            if( linkField.val().length ){
+
+                                videoParsing = true;
+
+                                parseVideoLink( linkField.val(), function( videoJson ){
+
+                                    if( videoJson.success ){
+                                        linkField.val( videoJson.data.url );
+                                        jsonField.val( JSON.stringify(videoJson.data) );
+                                        updateVideoPreview(videoJson.data, $this);
+                                    }
+                                    else {
+                                        pDummy.show();
+                                        pWrap.hide();
+                                        alert(videoJson.message);
+                                    }
+
+                                    videoParsing = false;
+                                });
+                            }
+                            else {
+                                videoParsing = false;
+                                jsonField.val('');
+                                $this.find('.video-preview').fadeOut();
+                                pDummy.show();
+                                pWrap.hide();
+                            }
+                        }
+                    });
+                });
+
+                var videoParsing = false;
+
+                $('form').on('submit', function(e){
+                    if( videoParsing ){
+                        alert('Video details are still loading, please wait a moment and try again');
+                        e.preventDefault();
+                        return false;
+                    }
+                })
+            });
+        </script>
+
+    @endpush
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/show/fields/view.blade.php
+++ b/src/resources/views/show/fields/view.blade.php
@@ -1,0 +1,5 @@
+<!-- view field -->
+
+<div @include('crud::inc.field_wrapper_attributes') >
+  @include($field['view'], compact('crud', 'entry', 'field'))
+</div>

--- a/src/resources/views/show/fields/week.blade.php
+++ b/src/resources/views/show/fields/week.blade.php
@@ -1,0 +1,16 @@
+<!-- html5 week input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <input
+        type="week"
+        name="{{ $field['name'] }}"
+        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        @include('crud::inc.field_attributes')
+        >
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>

--- a/src/resources/views/show/fields/wysiwyg.blade.php
+++ b/src/resources/views/show/fields/wysiwyg.blade.php
@@ -1,0 +1,1 @@
+@include('crud::fields.ckeditor')

--- a/src/resources/views/show/show_content.blade.php
+++ b/src/resources/views/show/show_content.blade.php
@@ -1,0 +1,33 @@
+@if ($crud->model->translationEnabled())
+    <input type="hidden" name="locale" value={{ $crud->request->input('locale')?$crud->request->input('locale'):App::getLocale() }}>
+@endif
+
+{{-- See if we're using tabs --}}
+@if ($crud->tabsEnabled())
+    @if(view()->exists('vendor.backpack.crud.show.show_tabbed_fields'))
+        @include('vendor.backpack.crud.show.show_tabbed_fields')
+    @else
+        @include('crud::show.show_tabbed_fields')
+    @endif
+@else
+    @if(view()->exists('vendor.backpack.crud.show.show_fields'))
+        @include('vendor.backpack.crud.show.show_fields', ['fields' => $fields])
+    @else
+        @include('crud::show.show_fields', ['fields' => $fields])
+    @endif
+@endif
+
+{{-- Define blade stacks so css and js can be pushed from the fields to these sections. --}}
+
+@section('after_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/crud.css') }}">
+    <link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/form.css') }}">
+
+    <!-- CRUD FORM CONTENT - crud_fields_styles stack -->
+    @stack('crud_fields_styles')
+@endsection
+
+@section('after_scripts')
+    <script src="{{ asset('vendor/backpack/crud/js/crud.js') }}"></script>
+    <script src="{{ asset('vendor/backpack/crud/js/form.js') }}"></script>
+@endsection

--- a/src/resources/views/show/show_fields.blade.php
+++ b/src/resources/views/show/show_fields.blade.php
@@ -1,0 +1,9 @@
+{{-- Show the inputs --}}
+@foreach ($fields as $field)
+    <!-- load the view from the application if it exists, otherwise load the one in the package -->
+    @if(view()->exists('vendor.backpack.crud.show.fields.'.$field['type']))
+        @include('vendor.backpack.crud.show.fields.'.$field['type'], array('field' => $field))
+    @else
+        @include('crud::show.fields.'.$field['type'], array('field' => $field))
+    @endif
+@endforeach

--- a/src/resources/views/show/show_tabbed_fields.blade.php
+++ b/src/resources/views/show/show_tabbed_fields.blade.php
@@ -1,0 +1,48 @@
+@php
+    $horizontalTabs = $crud->getTabsType()=='horizontal' ? true : false;
+@endphp
+
+@push('crud_fields_styles')
+<style>
+    .nav-tabs-custom {
+        box-shadow: none;
+    }
+    .nav-tabs-custom > .nav-tabs.nav-stacked > li {
+        margin-right: 0;
+    }
+
+    .tab-pane .form-group h1:first-child,
+    .tab-pane .form-group h2:first-child,
+    .tab-pane .form-group h3:first-child {
+        margin-top: 0;
+    }
+</style>
+@endpush
+
+<div class="tab-container {{ $horizontalTabs ? 'col-md-12' : 'col-md-3 m-t-10' }}">
+
+    <div class="nav-tabs-custom" id="form_tabs">
+        <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'nav-stacked nav-pills'}}" role="tablist">
+            @foreach ($crud->getTabs() as $k => $tab)
+                <li role="presentation" class="{{$k == 0 ? 'active' : ''}}">
+                    <a href="#tab_{{ str_slug($tab, "") }}" aria-controls="tab_{{ str_slug($tab, "") }}" role="tab" data-toggle="tab">{{ $tab }}</a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+
+</div>
+
+<div class="tab-content {{$horizontalTabs ? 'col-md-12' : 'col-md-9 m-t-10'}}">
+
+    @foreach ($crud->getTabs() as $k => $tab)
+        <div role="tabpanel" class="tab-pane{{$k == 0 ? ' active' : ''}}" id="tab_{{ str_slug($tab, "") }}">
+            @if(view()->exists('vendor.backpack.crud.show.show_fields'))
+                @include('vendor.backpack.crud.show.show_fields', ['fields' => $crud->getTabShowFields($tab)])
+            @else
+                @include('crud::show.show_fields', ['fields' => $crud->getTabShowFields($tab)])
+            @endif
+        </div>
+    @endforeach
+
+</div>


### PR DESCRIPTION
As mentioned in [This Issue](https://github.com/Laravel-Backpack/CRUD/issues/226), this feature adds a user friendly 'show' view.  Its not 100% complete, but in a useable and non-breaking state so thought its a good time for a PR to get some further input.

Rather than basing it off columns, i have based it off fields - i think it is much easier on the eye, and there are far more field types than columns.

Functions have been placed in `PanelTraits\Show.php`.
With no developer input, `show_fields` will be filled from `setFromDb()`.

Basically all `field` views were cloned and updated to use here.  Because of this, tabs and attributes will still work.

All field add and remove methods were carried over, renamed with `show`. ie. `$this->crud->addShowFields()`.

If `setFromDb()` is not used, but show fields need to match edit fields, simply use `$this->crud->addShowFields($this->crud->getCurrentFields());` after `addField` declarations to avoid duped code.

Still @TODO: 

- update all `crud.show.fields.x` to be show fields and not inputs. (I have done a few such as text, ckeditor, select... the rest are just dupes from `fields`).

- add 'show' translation for all languages (only english is done at the moment).