### PR TITLE
982 fix order columns

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -282,7 +282,7 @@ trait Columns
      *
      * @param array $columns Column order.
      *
-     * @deprecated This method was not and will not be implemented since its a duplicate of the orderColumns method.
+     * @deprecated This method was not and will not be implemented since it's a duplicate of the orderColumns method.
      * @see Columns::orderColumns() to order the CRUD columns.
      */
     public function setColumnOrder($columns)
@@ -295,7 +295,7 @@ trait Columns
      *
      * @param array $columns Column order.
      *
-     * @deprecated This method was not and will not be implemented since its a duplicate of the orderColumns method.
+     * @deprecated This method was not and will not be implemented since it's a duplicate of the orderColumns method.
      * @see Columns::orderColumns() to order the CRUD columns.
      */
     public function setColumnsOrder($columns)

--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -9,6 +9,16 @@ trait Columns
     // ------------
 
     /**
+     * Get the CRUD columns.
+     *
+     * @return array CRUD columns.
+     */
+    public function getColumns()
+    {
+        return $this->columns;
+    }
+
+    /**
      * Add a bunch of column names and their details to the CRUD object.
      *
      * @param [array or multi-dimensional array]
@@ -73,8 +83,6 @@ trait Columns
         if (isset($column_with_details['entity']) && ! isset($column_with_details['model'])) {
             $column_with_details['model'] = $this->getRelationModel($column_with_details['entity']);
         }
-
-        return $this;
     }
 
     /**
@@ -234,23 +242,6 @@ trait Columns
     }
 
     /**
-     * Order the columns in a certain way.
-     *
-     * @param [string] Column name.
-     * @param [attributes and values array]
-     */
-    public function setColumnOrder($columns)
-    {
-        // TODO
-    }
-
-    // ALIAS of setColumnOrder($columns)
-    public function setColumnsOrder($columns)
-    {
-        $this->setColumnOrder($columns);
-    }
-
-    /**
      * Get the relationships used in the CRUD columns.
      * @return [array] Relationship names
      */
@@ -263,18 +254,53 @@ trait Columns
         })->toArray();
     }
 
-    // ------------
-    // TONE FUNCTIONS - UNDOCUMENTED, UNTESTED, SOME MAY BE USED
-    // ------------
-    // TODO: check them
-
-    public function getColumns()
-    {
-        return $this->sort('columns');
-    }
-
+    /**
+     * Order the CRUD columns. If certain columns are missing from the given order array, they will be pushed to the
+     * new columns array in the original order.
+     *
+     * @param array $order An array of column names in the desired order.
+     */
     public function orderColumns($order)
     {
-        $this->setSort('columns', (array) $order);
+        $orderedColumns = [];
+        foreach ($order as $columnName) {
+            if (array_key_exists($columnName, $this->columns)) {
+                $orderedColumns[$columnName] = $this->columns[$columnName];
+            }
+        }
+
+        if(empty($orderedColumns)) {
+            return;
+        }
+
+        $remaining = array_diff_key($this->columns, $orderedColumns);
+        $this->columns = array_merge($orderedColumns, $remaining);
+    }
+
+
+    /**
+     * Set the order of the CRUD columns.
+     *
+     * @param array $columns Column order.
+     *
+     * @deprecated This method was not and will not be implemented since its a duplicate of the orderColumns method.
+     * @see Columns::orderColumns() to order the CRUD columns.
+     */
+    public function setColumnOrder($columns)
+    {
+        // not implemented
+    }
+
+    /**
+     * Set the order of the CRUD columns.
+     *
+     * @param array $columns Column order.
+     *
+     * @deprecated This method was not and will not be implemented since its a duplicate of the orderColumns method.
+     * @see Columns::orderColumns() to order the CRUD columns.
+     */
+    public function setColumnsOrder($columns)
+    {
+        $this->setColumnOrder($columns);
     }
 }

--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -269,14 +269,13 @@ trait Columns
             }
         }
 
-        if(empty($orderedColumns)) {
+        if (empty($orderedColumns)) {
             return;
         }
 
         $remaining = array_diff_key($this->columns, $orderedColumns);
         $this->columns = array_merge($orderedColumns, $remaining);
     }
-
 
     /**
      * Set the order of the CRUD columns.

--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -83,6 +83,8 @@ trait Columns
         if (isset($column_with_details['entity']) && ! isset($column_with_details['model'])) {
             $column_with_details['model'] = $this->getRelationModel($column_with_details['entity']);
         }
+
+        return $this;
     }
 
     /**

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -205,24 +205,48 @@ class CrudPanelColumnsTest extends BaseCrudPanelTest
         // TODO: refactor crud panel sync method
     }
 
-    public function testSetColumnOrder()
-    {
-        $this->markTestIncomplete('Not yet implemented');
-
-        // TODO: implement method
-    }
-
-    public function testSetColumnsOrder()
-    {
-        $this->markTestIncomplete('Not yet implemented');
-
-        // TODO: implement method
-    }
-
     public function testOrderColumns()
     {
-        $this->markTestIncomplete('Not correctly implemented');
+        $this->crudPanel->addColumns($this->threeColumnsArray);
 
-        // TODO: fix order columns method
+        $this->crudPanel->orderColumns(['column2', 'column1', 'column3']);
+
+        $this->assertEquals(['column2', 'column1', 'column3'], array_keys($this->crudPanel->columns));
+    }
+
+    public function testOrderColumnsIncompleteList()
+    {
+        $this->crudPanel->addColumns($this->threeColumnsArray);
+
+        $this->crudPanel->orderColumns(['column2', 'column3']);
+
+        $this->assertEquals(['column2', 'column3', 'column1'], array_keys($this->crudPanel->columns));
+    }
+
+    public function testOrderColumnsEmptyList()
+    {
+        $this->crudPanel->addColumns($this->threeColumnsArray);
+
+        $this->crudPanel->orderColumns([]);
+
+        $this->assertEquals($this->expectedThreeColumnsArray, $this->crudPanel->columns);
+    }
+
+    public function testOrderColumnsUnknownList()
+    {
+        $this->crudPanel->addColumns($this->threeColumnsArray);
+
+        $this->crudPanel->orderColumns(['column4', 'column5', 'column6']);
+
+        $this->assertEquals($this->expectedThreeColumnsArray, $this->crudPanel->columns);
+    }
+
+    public function testOrderColumnsMixedList()
+    {
+        $this->crudPanel->addColumns($this->threeColumnsArray);
+
+        $this->crudPanel->orderColumns(['column2', 'column5', 'column6']);
+
+        $this->assertEquals(['column2', 'column1', 'column3'], array_keys($this->crudPanel->columns));
     }
 }


### PR DESCRIPTION
Fixes #982.
Fixes #971.

@tabacitu, please notice that, as part of this PR, I've deprecated the unimplemented `setColumnOrder` and `setColumnsOrder`.

I've also noitced that the `addColumn` method ended with a `return $this` statement (the `$crudPanel`), which was odd, undocumented and different from the `addColumns` method, so I decided to remove it.

I know this is a breaking change and I can revert it if you like, but IMHO I think we should just go with it.