### PR TITLE
Fix 'pivotFields' on Create Trait

### DIFF
--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -103,8 +103,8 @@ trait Create
 
                 if (isset($field['pivotFields'])) {
                     foreach ($field['pivotFields'] as $pivotField) {
-                        foreach ($data[$pivotField] as $pivot_id => $field) {
-                            $model->{$field['name']}()->updateExistingPivot($pivot_id, [$pivotField => $field]);
+                        foreach ($data[$pivotField] as $pivot_id => $pivot_field) {
+                            $model->{$field['name']}()->updateExistingPivot($pivot_id, [$pivotField => $pivot_field]);
                         }
                     }
                 }


### PR DESCRIPTION
The problem is the variable $field (now, on master branch) on line 99 will be overwritten by for loop on line 106.
When try to save the page, where I've used the addField functionally, I received the error: <Illegal string offset 'name'> because $field['name'] (on line 107) is not the correct field name.

Fix issue #393