### PR TITLE
Add prefix option to image column

### DIFF
--- a/src/resources/views/columns/image.blade.php
+++ b/src/resources/views/columns/image.blade.php
@@ -5,7 +5,7 @@
       target="_blank"
     >
       <img
-        src="{{ asset($entry->{$column['name']}) }}"
+        src="{{ asset( (isset($column['prefix']) ? $column['prefix'] : '') . $entry->{$column['name']}) }}"
         style="
           max-height: {{ isset($column['height']) ? $column['height'] : "25px" }};
           width: {{ isset($column['width']) ? $column['width'] : "auto" }};


### PR DESCRIPTION
Adds an optional `prefix` option to the image column, so it can work wit the `prefix` option defined in the image field. 

Fixes #1054.