### PR TITLE
[Feature] Custom key name for fields

### DIFF
--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -30,6 +30,11 @@ trait Fields
             $completeFieldsArray['model'] = $this->getRelationModel($completeFieldsArray['entity']);
         }
 
+        // if the key is missing, we should set it
+        if (! isset($completeFieldsArray['key'])) {
+            $completeFieldsArray['key'] = $completeFieldsArray['name'];
+        }
+
         // if the label is missing, we should set it
         if (! isset($completeFieldsArray['label'])) {
             $completeFieldsArray['label'] = ucfirst($completeFieldsArray['name']);
@@ -48,7 +53,7 @@ trait Fields
         }
 
         $this->transformFields($form, function ($fields) use ($completeFieldsArray) {
-            $fields[$completeFieldsArray['name']] = $completeFieldsArray;
+            $fields[$completeFieldsArray['key']] = $completeFieldsArray;
 
             return $fields;
         });


### PR DESCRIPTION
Allow the developer to specify a custom key name. That key will only be used when storing the field inside the $fields array. So it'll be ```$crud->fields['key']```, not ```$crud->fields['name']```.

This would allow developers to place multiple fields with the same "name" inside a create/update form.

BUT keep in mind it would still not save two different things. If two fields have the same name, only the last value will be passed as $input, so only the last value will be stored in both columns. So I'm not sure if this feature helps more than confuses...