### PR TITLE
count() triggers warning in PHP 7.2, check for 'null' first

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -80,7 +80,7 @@ trait CrudTrait
                 $column_contents = json_decode($this->{$column});
             }
 
-            if (count($column_contents)) {
+            if ((is_array($column_contents) || $column_contents instanceof Traversable) && count($column_contents)) {
                 foreach ($column_contents as $fake_field_name => $fake_field_value) {
                     $this->setAttribute($fake_field_name, $fake_field_value);
                 }


### PR DESCRIPTION
Starting in PHP 7.2 `count()` will [throw a warning](https://3v4l.org/hjSZr) when not passing an array or an object implementing Countable.

This causes an issue in [`CrudTrait.php:83`](https://github.com/Laravel-Backpack/CRUD/blob/master/src/CrudTrait.php#L83):

```php
if (count($column_contents)) {
```

where `$column_contents` can at times be `null`

This pull request fixes that by checking for `null` before checking the count. This issue may be present in other places as well, but I haven't encountered those yet.