### PR TITLE
Typehint CrudPanel class

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -23,7 +23,12 @@ class CrudController extends BaseController
     use AjaxTable, Reorder, Revisions, ShowDetailsRow, SaveActions;
 
     public $data = [];
+
+    /**
+     * @var CrudPanel
+     */
     public $crud;
+
     public $request;
 
     public function __construct()


### PR DESCRIPTION
This little change allows IDEs to autocomplete all `$this->crud` calls in CrudControllers. I think it greatly improves UX when working with Backpack, epsecially given it's just one line of actual change.

I see that `CrudController` allows to override the `crud` property but I think this should not be a problem since anyone overriding its value can also provide own typehint in phpdoc.

What do you think @tabacitu?