### PR TITLE
Make declarations compatible with cviebrock/eloquent-sluggable

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -20,22 +20,6 @@ trait CrudTrait
         $table_prefix = Config::get('database.connections.'.$default_connection.'.prefix');
 
         $instance = new static(); // create an instance of the model to be able to get the table name
-
-        if(DB::connection()->getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME) == 'pgsql'){
-            $types = DB::select(DB::raw("
-                SELECT MATCHES[1]
-                FROM pg_constraint,REGEXP_MATCHES(consrc, '''(.+?)''', 'g') MATCHES
-                WHERE contype = 'c'
-                AND conname = '".$table_prefix.$instance->getTable()."_".$field_name."_check'
-                AND conrelid = '".$table_prefix.$instance->getTable()."'::regclass;
-            "));
-            $enum = [];
-            foreach($types as $type){
-                $enum[] = $type->matches;
-            }
-            return $enum;
-        }
-
         $type = DB::select(DB::raw('SHOW COLUMNS FROM `'.$table_prefix.$instance->getTable().'` WHERE Field = "'.$field_name.'"'))[0]->Type;
         preg_match('/^enum\((.*)\)$/', $type, $matches);
         $enum = [];

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -20,6 +20,22 @@ trait CrudTrait
         $table_prefix = Config::get('database.connections.'.$default_connection.'.prefix');
 
         $instance = new static(); // create an instance of the model to be able to get the table name
+
+        if(DB::connection()->getPdo()->getAttribute(\PDO::ATTR_DRIVER_NAME) == 'pgsql'){
+            $types = DB::select(DB::raw("
+                SELECT MATCHES[1]
+                FROM pg_constraint,REGEXP_MATCHES(consrc, '''(.+?)''', 'g') MATCHES
+                WHERE contype = 'c'
+                AND conname = '".$table_prefix.$instance->getTable()."_".$field_name."_check'
+                AND conrelid = '".$table_prefix.$instance->getTable()."'::regclass;
+            "));
+            $enum = [];
+            foreach($types as $type){
+                $enum[] = $type->matches;
+            }
+            return $enum;
+        }
+
         $type = DB::select(DB::raw('SHOW COLUMNS FROM `'.$table_prefix.$instance->getTable().'` WHERE Field = "'.$field_name.'"'))[0]->Type;
         preg_match('/^enum\((.*)\)$/', $type, $matches);
         $enum = [];

--- a/src/ModelTraits/SpatieTranslatable/SlugService.php
+++ b/src/ModelTraits/SpatieTranslatable/SlugService.php
@@ -13,7 +13,7 @@ class SlugService extends \Cviebrock\EloquentSluggable\Services\SlugService
      * @param bool $force
      * @return bool
      */
-    public function slug(Model $model, $force = false)
+    public function slug(Model $model, bool $force = false): bool
     {
         $this->setModel($model);
 
@@ -47,7 +47,7 @@ class SlugService extends \Cviebrock\EloquentSluggable\Services\SlugService
      * @param string $attribute
      * @return string
      */
-    protected function makeSlugUnique($slug, array $config, $attribute)
+    protected function makeSlugUnique(string $slug, array $config, string $attribute): string
     {
         if (! $config['unique']) {
             return $slug;

--- a/src/ModelTraits/SpatieTranslatable/Sluggable.php
+++ b/src/ModelTraits/SpatieTranslatable/Sluggable.php
@@ -25,7 +25,7 @@ trait Sluggable
      * @param  array|null $except
      * @return Model
      */
-    public function replicate(array $except = null)
+    public function replicate(array $except = null): Model
     {
         $instance = parent::replicate($except);
         (new SlugService())->slug($instance, true);
@@ -43,7 +43,7 @@ trait Sluggable
      * @param string $slug
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeFindSimilarSlugs(Builder $query, Model $model, $attribute, $config, $slug)
+    public function scopeFindSimilarSlugs(Builder $query, string $attribute, array $config, string $slug): Builder
     {
         $separator = $config['separator'];
         $attribute = $attribute.'->'.$this->getLocale();

--- a/src/ModelTraits/SpatieTranslatable/SluggableObserver.php
+++ b/src/ModelTraits/SpatieTranslatable/SluggableObserver.php
@@ -43,7 +43,7 @@ class SluggableObserver extends \Cviebrock\EloquentSluggable\SluggableObserver
      * @param string $event
      * @return bool|null
      */
-    protected function generateSlug(Model $model, $event)
+    protected function generateSlug(Model $model, string $event)
     {
         // If the "slugging" event returns a value, abort
         if ($this->fireSluggingEvent($model, $event) !== null) {
@@ -61,7 +61,7 @@ class SluggableObserver extends \Cviebrock\EloquentSluggable\SluggableObserver
      * @param  string $event
      * @return mixed
      */
-    protected function fireSluggingEvent(Model $model, $event)
+    protected function fireSluggingEvent(Model $model, string $event)
     {
         return $this->events->until('eloquent.slugging: '.get_class($model), [$model, $event]);
     }
@@ -73,7 +73,7 @@ class SluggableObserver extends \Cviebrock\EloquentSluggable\SluggableObserver
      * @param  string $status
      * @return void
      */
-    protected function fireSluggedEvent(Model $model, $status)
+    protected function fireSluggedEvent(Model $model, string $status)
     {
         $this->events->fire('eloquent.slugged: '.get_class($model), [$model, $status]);
     }

--- a/src/ModelTraits/SpatieTranslatable/SluggableScopeHelpers.php
+++ b/src/ModelTraits/SpatieTranslatable/SluggableScopeHelpers.php
@@ -16,7 +16,7 @@ trait SluggableScopeHelpers
      * @param string $slug
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWhereSlug(Builder $scope, $slug)
+    public function scopeWhereSlug(Builder $scope, string $slug): Builder
     {
         return $scope->where($this->getSlugKeyName().'->'.$this->getLocale(), $slug);
     }
@@ -28,7 +28,7 @@ trait SluggableScopeHelpers
      * @param array $columns
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null
      */
-    public static function findBySlug($slug, array $columns = ['*'])
+    public static function findBySlug(string $slug, array $columns = ['*'])
     {
         return static::whereSlug($slug)->first($columns);
     }
@@ -42,7 +42,7 @@ trait SluggableScopeHelpers
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public static function findBySlugOrFail($slug, array $columns = ['*'])
+    public static function findBySlugOrFail(string $slug, array $columns = ['*'])
     {
         return static::whereSlug($slug)->firstOrFail($columns);
     }


### PR DESCRIPTION
It will prevent this kind of warnings:
Symfony \ Component \ Debug \ Exception \ FatalErrorException (E_UNKNOWN)
Declaration of Backpack\CRUD\ModelTraits\SpatieTranslatable\Sluggable::replicate(?array $except = NULL) must be compatible with Backpack\PageManager\app\Models\Page::replicate(?array $except = NULL): Illuminate\Database\Eloquent\Model