### PR TITLE
Autogenerated Breadcrumbs

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -21,10 +21,11 @@ use Backpack\CRUD\PanelTraits\AutoFocus;
 use Backpack\CRUD\PanelTraits\FakeFields;
 use Backpack\CRUD\PanelTraits\FakeColumns;
 use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
+use Backpack\CRUD\PanelTraits\Breadcrumb;
 
 class CrudPanel
 {
-    use Create, Read, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, Breadcrumb;
 
     // --------------
     // CRUD variables

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -58,6 +58,7 @@ class CrudPanel
     public $query;
     public $entry;
     public $buttons;
+    public $breadcrumb;
     public $db_column_types = [];
     public $default_page_length = false;
 
@@ -149,6 +150,24 @@ class CrudPanel
     public function getRoute()
     {
         return $this->route;
+    }
+
+    /**
+     * Get the breadcrumb for this item
+     *
+     * @return [Eloquent Collection]
+     **/
+    public function getBreadcrumb()
+    {
+        return $this->breadcrumb;
+    }
+
+    /**
+     * Set the breadcrumb for this route.
+     */
+    public function setBreadcrumb()
+    {
+        $this->breadcrumb = $this->buildBreadcrumb();
     }
 
     /**

--- a/src/PanelTraits/Breadcrumb.php
+++ b/src/PanelTraits/Breadcrumb.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait Breadcrumb
+{
+    /*
+    |--------------------------------------------------------------------------
+    |                              BREADCRUMB
+    |--------------------------------------------------------------------------
+    */
+
+    protected $items;
+
+    /**
+     * Parse the word.
+     *
+     * @return string the parsed word.
+     **/
+    protected function parseWord($word)
+    {
+        $words = explode('_', $word);
+        $string = '';
+        foreach ($words as $key => $word) {
+            $string .= $key > 0 ? ' ' . ucfirst($word) : ucfirst($word);
+        }
+        return $string;
+    }
+
+
+    /**
+     * Generate the actual breadcrumb.
+     *
+     * @return string The actual breadcrumb to be displayed.
+     **/
+    public function buildBreadcrumb()
+    {
+        if (!$this->route) {
+          $this->setRoute(config('backpack.base.route_prefix'));
+        }
+
+        $this->items = new Collection(explode('.', $this->route));
+
+        $string = '';
+        foreach ($this->items as $key => $item) {
+            $string .= $this->getTag($key, $this->items, $item);
+        }
+        return $string;
+    }
+
+    /**
+     * Allow crumbs to be added at the beginning.
+     * @param string $item string of new item(s) to be added.
+     **/
+    public function addBreadcrumbStart($item)
+    {
+      $this->setRoute($item.'.'.$this->route);
+      $this->setBreadcrumb();
+    }
+
+    /**
+     * Allow crumbs to be added at the beginning.
+     * @param string $item string of new item(s) to be added.
+     **/
+    public function addBreadcrumbEnd($item)
+    {
+      $this->setRoute($this->route.'.'.$item);
+      $this->setBreadcrumb();
+    }
+
+    /**
+     * Determine wether this item is at the end or in the middle.
+     * @param integer $key position of the item within the array.
+     * @param Collection $items Collection of all items.
+     * @param string $item name of the item being used.
+     *
+     * @return string The string to be displayed for that item.
+     **/
+    protected function getTag(int $key, Collection $items, $item)
+    {
+        return $key === ($items->count() - 1) ? $this->getLastItemTags($item) : $this->getItemTags($item);
+    }
+
+    /**
+     * The output for an item if it is somewhere in the middle.
+     * @param string $item Name of the item to be displayed.
+     *
+     * @return string The string to be displayed
+     **/
+    private function getItemTags($item)
+    {
+        $urlPrefix = config('app.url').'/';
+
+        if($item !== ucfirst(config('backpack.base.route_prefix'))) {
+          $urlPrefix = $urlPrefix.config('backpack.base.route_prefix').'/';
+        }
+
+        $url = $urlPrefix.$item;
+        return '<li><a href="'.$url.'">'.$this->parseWord($item).'</a></li>';
+    }
+
+    /**
+     * The output for an item if it is the last item within the collection.
+     * @param string $item Name of the item to be displayed.
+     *
+     * @return string The string to be displayed
+     **/
+    private function getLastItemTags($item)
+    {
+        return '<li class="active">'.$this->parseWord($item).'</li>';
+    }
+}

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -38,6 +38,8 @@ class CrudController extends BaseController
                 $this->crud->request = $request;
                 $this->setup();
 
+                $this->crud->setBreadcrumb();
+
                 return $next($request);
             });
         }
@@ -79,6 +81,7 @@ class CrudController extends BaseController
     public function create()
     {
         $this->crud->hasAccessOrFail('create');
+        $this->crud->addBreadcrumbEnd(trans('backpack::crud.add'));
 
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
@@ -136,6 +139,7 @@ class CrudController extends BaseController
     public function edit($id)
     {
         $this->crud->hasAccessOrFail('update');
+        $this->crud->addBreadcrumbEnd(trans('backpack::crud.edit'));
 
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
@@ -197,6 +201,7 @@ class CrudController extends BaseController
     public function show($id)
     {
         $this->crud->hasAccessOrFail('show');
+        $this->crud->addBreadcrumbEnd(trans('backpack::crud.preview'));
 
         // set columns from db
         $this->crud->setFromDb();


### PR DESCRIPTION
A lot of people use Breadcrumbs within their applications and if you look at Backpack/Base there is a default one in there already. But that requires generating a lot of custom views, etc if you want it to work on everything. But this helps simplify the process by automatically generated a standard Bootstrap breadcrumb list.

`$crud->setBreadcrumb()` - Generates the full length of the breadcrumb and should be called after the setup() function which is where we define the route for an entity.

`$crud->addBreadcrumbStart('backpack')` - Adds a new item at the very beginning of the breadcrumb, useful for adding a link to dashboard if so wished.

`$crud->addBreadcrumbEnd('create')` - Adds a new item at the very end of the breadcrumb, useful for adding like "creating a new record" to the end of it.

To display a breadcrumb within a view its as simple as calling `$cord->breadcrumb`. Because sometime people might want to include custom class styling on the breadcrumb it only generates the list items. Full Example of how it should be called:

```
<ol class="breadcrumb">
     {!! $cord->breadcrumb !!}
</ol>
```