### PR TITLE
Customizable page length menu for list view

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -60,6 +60,7 @@ class CrudPanel
     public $buttons;
     public $db_column_types = [];
     public $default_page_length = false;
+    public $page_length_menu = false;
 
     // TONE FIELDS - TODO: find out what he did with them, replicate or delete
     public $sort = [];

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -121,7 +121,7 @@ trait Read
     }
 
     /**
-     * Set the number of rows that should be show on the table page (list view).
+     * Set the number of rows that should be show on the list view.
      */
     public function setDefaultPageLength($value)
     {
@@ -129,7 +129,7 @@ trait Read
     }
 
     /**
-     * Get the number of rows that should be show on the table page (list view).
+     * Get the number of rows that should be show on the list view.
      */
     public function getDefaultPageLength()
     {
@@ -147,25 +147,24 @@ trait Read
     }
 
     /**
-     * Specify array of available page lengths on the table page (list view).
+     * Specify array of available page lengths on the list view.
      *
-     * @param array $array 1d array of page length values,
+     * @param array $menu 1d array of page length values,
      *                     or 2d array (first array: page length values, second array: page length labels)
      *                     More at: https://datatables.net/reference/option/lengthMenu
      */
-    public function setPageLengthMenu($array)
+    public function setPageLengthMenu($menu)
     {
-        $this->page_length_menu = $array;
+        $this->page_length_menu = $menu;
     }
 
     /**
-     * Get page length menu for the table page (list view).
+     * Get page length menu for the list view.
      *
      * @return array
      */
     public function getPageLengthMenu()
     {
-        // return the custom value for this crud panel, if set using setPageLengthMenu()
         if ($this->page_length_menu) {
             return $this->page_length_menu;
         }

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -133,7 +133,7 @@ trait Read
      */
     public function getDefaultPageLength()
     {
-        // return the custom value for this crud panel, if set using setPageLength()
+        // return the custom value for this crud panel, if set using setDefaultPageLength()
         if ($this->default_page_length) {
             return $this->default_page_length;
         }
@@ -144,6 +144,34 @@ trait Read
         }
 
         return 25;
+    }
+
+    /**
+     * Specify array of available page lengths on the table page (list view).
+     *
+     * @param array $array 1d array of page length values,
+     *                     or 2d array (first array: page length values, second array: page length labels)
+     *                     More at: https://datatables.net/reference/option/lengthMenu
+     */
+    public function setPageLengthMenu($array)
+    {
+        $this->page_length_menu = $array;
+    }
+
+    /**
+     * Get page length menu for the table page (list view).
+     *
+     * @return array
+     */
+    public function getPageLengthMenu()
+    {
+        // return the custom value for this crud panel, if set using setPageLengthMenu()
+        if ($this->page_length_menu) {
+            return $this->page_length_menu;
+        }
+
+        // otherwise return default value
+        return [[10, 25, 50, 100, -1], [10, 25, 50, 100, trans('backpack::crud.all')]];
     }
 
     /*

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -144,7 +144,7 @@
 
 	  	var table = $("#crudTable").DataTable({
         "pageLength": {{ $crud->getDefaultPageLength() }},
-        "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "{{ trans('backpack::crud.all') }}"]],
+        "lengthMenu": @json($crud->getPageLengthMenu()),
         /* Disable initial sort */
         "aaSorting": [],
         "language": {


### PR DESCRIPTION
Usage (in [CrudController#setup](https://github.com/Laravel-Backpack/CRUD/blob/0be2bae4a58ce417ddd5f8865b1b6e38ee87879d/src/app/Http/Controllers/CrudController.php#L54)):
```php
$this->crud->setPageLengthMenu([100, 200, 300]);
```
or 
```php
$this->crud->setPageLengthMenu([[100, 1000, 10000, -1], ['Hundred', 'Thousand', 'Ten thousand', 'All']]);
```
Related to #1098.