### PR TITLE
Changed CrudTrait::addFakes to support objects

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -80,7 +80,7 @@ trait CrudTrait
                 $column_contents = json_decode($this->{$column});
             }
 
-            if ((is_array($column_contents) || $column_contents instanceof Traversable) && count($column_contents)) {
+            if ((is_array($column_contents) || is_object($column_contents) || $column_contents instanceof Traversable) && count($column_contents)) {
                 foreach ($column_contents as $fake_field_name => $fake_field_value) {
                     $this->setAttribute($fake_field_name, $fake_field_value);
                 }


### PR DESCRIPTION
Since the modified version of CrudTrait fake fields stopped working for me, so I propose the following change.

```
if ((is_array($column_contents) || $column_contents instanceof Traversable) 
    && count($column_contents))
```

results in always FALSE, since `json_decode($this->{$column})` returns an object (for more information [in the traversable docs](http://php.net/manual/en/class.traversable.php#118575)).

In order to make it works I added `is_object($column_contents)`.
Alternatively we can use `json_decode($this->{$column}, true)` so it will return an associative array.

Example not working:
> $contents = '{"text_1":"sadfasdfasdf<\/p>"}';
> $column_contents = json_decode($contents);
> is_array($column_contents) 
=> false
> $column_contents instanceof Traversable
=> false

Example working:
> $contents = '{"text_1":"sadfasdfasdf<\/p>"}';
> $column_contents = json_decode($contents);
> is_object($column_contents) 
=> true