### PR TITLE
Minimizing database accesses

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -87,7 +87,7 @@ trait Columns
         }
 
         // check if the column exists in the DB table
-        if (\Schema::hasColumn($this->model->getTable(), $column_with_details['name'])) {
+        if ($this->hasColumn($this->model->getTable(), $column_with_details['name'])) {
             $column_with_details['tableColumn'] = true;
         } else {
             $column_with_details['tableColumn'] = false;
@@ -346,4 +346,18 @@ trait Columns
 
         return reset($result);
     }
+    
+    protected function hasColumn($table, $name)
+	{
+		static $cache = [];
+		
+		if(isset($cache[$table])){
+			$columns = $cache[$table];
+		}else{
+			$columns = $cache[$table] = \Schema::getColumnListing($table);
+		}
+
+		return in_array($name, $columns);
+	}
+
 }


### PR DESCRIPTION
The following requests:
```sql
select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?
```
Otherwise, for each added column for the form, this call occurs.