### PR TITLE
Update CrudController.php

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -118,7 +118,9 @@ class CrudController extends BaseController
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message
-        \Alert::success(trans('backpack::crud.insert_success'))->flash();
+        if($this->crud->model::find($item->id))
+         \Alert::success(trans('backpack::crud.insert_success'))->flash();
+
 
         // save the redirect choice for next time
         $this->setSaveAction();


### PR DESCRIPTION
A) what you did .   
Make sure the entry really inserted before the success message flashed

B) what you expected to happen .   
No success message if the entry not inserted

C) what happened .   
success message still flashed even the entry not inserted

D) what have you already tried to fix it?    
Make it more eloquent friendly. Don't flash success message if the entry not inserted.