### PR TITLE
Add support for controlling display of columns in list and show

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -63,6 +63,7 @@ class CrudController extends BaseController
     public function index()
     {
         $this->crud->hasAccessOrFail('list');
+        $this->removeColumns('list');
 
         $this->data['crud'] = $this->crud;
         $this->data['title'] = ucfirst($this->crud->entity_name_plural);
@@ -198,9 +199,6 @@ class CrudController extends BaseController
     {
         $this->crud->hasAccessOrFail('show');
 
-        // set columns from db
-        $this->crud->setFromDb();
-
         // cycle through columns
         foreach ($this->crud->columns as $key => $column) {
             // remove any autoset relationship columns
@@ -208,6 +206,8 @@ class CrudController extends BaseController
                 $this->crud->removeColumn($column['name']);
             }
         }
+
+        $this->removeColumns('show');
 
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
@@ -234,5 +234,19 @@ class CrudController extends BaseController
         $this->crud->hasAccessOrFail('delete');
 
         return $this->crud->delete($id);
+    }
+
+    /**
+     * @param string $type  should be either 'list' or 'show'
+     */
+    private function removeColumns($type): void
+    {
+        // cycle through columns
+        foreach ($this->crud->columns as $key => $column) {
+            // remove columns where $type is set to false
+            if (array_key_exists($type, $column) && $column[$type] === false) {
+                $this->crud->removeColumn($key);
+            }
+        }
     }
 }

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -13,6 +13,7 @@ trait AjaxTable
     {
         $this->crud->hasAccessOrFail('list');
 
+        $this->removeColumns('list');
         $totalRows = $filteredRows = $this->crud->count();
 
         // if a search term was present


### PR DESCRIPTION
List and Show use the same 'columns' array. 
All columns are shown in both list and show by default.
This adds support for ```'list' === false``` and ```'show' === false``` attributes on that array.
These columns will be removed before display configuration in list and show views respectively, 
and removed from ajax data retrieval for list.
