### PR TITLE
Retrieve table columns as array of Column objects in Autoset trait (revised)

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -61,8 +61,8 @@ trait AutoSet
 
         foreach ($table_columns as $key => $column) {
             $column_type = $column->getType()->getName();
-            $this->db_column_types[ $column->getName()]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
-            $this->db_column_types[ $column->getName()]['default'] = $column->getDefault();
+            $this->db_column_types[$column->getName()]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
+            $this->db_column_types[$column->getName()]['default'] = $column->getDefault();
         }
 
         return $this->db_column_types;

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -57,12 +57,12 @@ trait AutoSet
     {
         $table = $this->model->getTable();
         $conn = $this->model->getConnection();
-        $table_columns = $conn->getSchemaBuilder()->getColumnListing($table);
+        $table_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
 
         foreach ($table_columns as $key => $column) {
-            $column_type = $conn->getSchemaBuilder()->getColumnType($table, $column);
-            $this->db_column_types[$column]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
-            $this->db_column_types[$column]['default'] = $conn->getDoctrineSchemaManager()->listTableDetails($table)->getColumn($column)->getDefault();
+            $column_type = $column->getType()->getName();
+            $this->db_column_types[ $column->getName()]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
+            $this->db_column_types[ $column->getName()]['default'] = $column->getDefault();
         }
 
         return $this->db_column_types;


### PR DESCRIPTION
Updated version of https://github.com/Laravel-Backpack/CRUD/pull/1137

_This version does not require any changes to existing tests._

When using the Autoset trait, the getDbColumnTypes() method uses many separate queries to get the column type and column default.

This change retrieves the table columns just once as an array of \Doctrine\DBAL\Schema\Column and iterates through that array to retrieve the column type and default. This results in a fairly dramatic performance improvement.