### PR TITLE
[4.0][Improvement] Refine autoset

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -108,14 +108,16 @@ class CrudPanel
         return $this->model;
     }
 
-    /**
-     * Get the database connection, as specified in the .env file or overwritten by the property on the model.
-     */
-    private function getSchema()
+    protected function getDbColumns()
     {
-        return \Schema::setConnection($this->getModel()->getConnection());
+        if (empty($this->db_columns)) {
+            $table         = $this->model->getTable();
+            $conn          = $this->model->getConnection();
+            $this->db_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
         }
 
+        return $this->db_columns;
+    }
     /**
      * Set the route for this CRUD.
      * Ex: admin/article.

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -58,7 +58,10 @@ class CrudPanel
     public $query;
     public $entry;
     public $buttons;
-    public $db_column_types = [];
+
+    protected $db_columns = [];
+    protected $db_column_types = [];
+    protected $db_column_names = [];
     public $default_page_length = false;
 
     // TONE FIELDS - TODO: find out what he did with them, replicate or delete
@@ -111,7 +114,7 @@ class CrudPanel
     private function getSchema()
     {
         return \Schema::setConnection($this->getModel()->getConnection());
-    }
+        }
 
     /**
      * Set the route for this CRUD.

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -61,11 +61,11 @@ trait AutoSet
         $conn = $this->model->getConnection();
         $table_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
 
-        foreach ($table_columns as $key => $column) {
-            $column_type = $column->getType()->getName();
-            $this->db_column_types[$column->getName()]['type'] = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
-            $this->db_column_types[$column->getName()]['default'] = $column->getDefault();
-        }
+            foreach ($table_columns as $key => $column) {
+                $column_type = $column->getType()->getName();
+                $this->db_column_types[ $column->getName() ]['type']    = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
+                $this->db_column_types[ $column->getName() ]['default'] = $column->getDefault();
+            }
 
         return $this->db_column_types;
     }
@@ -167,19 +167,37 @@ trait AutoSet
     /**
      * Get the database column names, in order to figure out what fields/columns to show in the auto-fields-and-columns functionality.
      *
-     * @return [array] Database column names as an array.
+     * @param bool $filtered
+     *
+     * @return array Database column names as an array.
      */
-    public function getDbColumnsNames()
+    public function getDbColumnsNames($filtered = true)
     {
-        // Automatically-set columns should be both in the database, and in the $fillable variable on the Eloquent Model
-        $columns = $this->model->getConnection()->getSchemaBuilder()->getColumnListing($this->model->getTable());
-        $fillable = $this->model->getFillable();
-
-        if (! empty($fillable)) {
-            $columns = array_intersect($columns, $fillable);
+        if (empty($this->db_column_types)) {
+            $this->getDbColumnTypes();
         }
 
-        // but not updated_at, deleted_at
-        return array_values(array_diff($columns, [$this->model->getKeyName(), $this->model->getCreatedAtColumn(), $this->model->getUpdatedAtColumn(), 'deleted_at']));
+        //build the db_column_names array only once
+        if (empty($this->db_column_names)) {
+            // Automatically-set columns should be both in the database, and in the $fillable variable on the Eloquent Model
+            $this->db_column_names = array_keys($this->db_column_types);
+
+            if ( $filtered) {
+                $columns  = $this->db_column_names;
+                $fillable = $this->model->getFillable();
+                if ( ! empty($fillable)) {
+                    $columns = array_intersect($columns, $fillable);
+                }// but not updated_at, deleted_at
+                $this->db_column_names = array_values(array_diff($columns,
+                    [
+                        $this->model->getKeyName(),
+                        $this->model->getCreatedAtColumn(),
+                        $this->model->getUpdatedAtColumn(),
+                        'deleted_at',
+                    ]));
+            }
+        }
+
+        return $this->db_column_names;
     }
 }

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -53,19 +53,20 @@ trait AutoSet
     /**
      * Get all columns from the database for that table.
      *
-     * @return [array]
+     * @return array
      */
     public function getDbColumnTypes()
     {
-        $table = $this->model->getTable();
-        $conn = $this->model->getConnection();
-        $table_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
+        if (empty($this->db_column_types)) {
+            $table_columns = $this->getDbColumns();
 
             foreach ($table_columns as $key => $column) {
                 $column_type = $column->getType()->getName();
+
                 $this->db_column_types[ $column->getName() ]['type']    = trim(preg_replace('/\(\d+\)(.*)/i', '', $column_type));
                 $this->db_column_types[ $column->getName() ]['default'] = $column->getDefault();
             }
+        }
 
         return $this->db_column_types;
     }
@@ -75,7 +76,7 @@ trait AutoSet
      *
      * @param  [string] Field name.
      *
-     * @return [string] Fielt type.
+     * @return string Field type.
      */
     public function getFieldTypeFromDbColumnType($field)
     {
@@ -157,7 +158,7 @@ trait AutoSet
      *
      * @param  [string]
      *
-     * @return [string]
+     * @return string
      */
     public function makeLabel($value)
     {

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -11,8 +11,10 @@ trait AutoSet
     /**
      * For a simple CRUD Panel, there should be no need to add/define the fields.
      * The public columns in the database will be converted to be fields.
+     *
+     * @param bool $filtered
      */
-    public function setFromDb()
+    public function setFromDb($filtered = true)
     {
         $this->setDoctrineTypesMapping();
         $this->getDbColumnTypes();
@@ -45,7 +47,7 @@ trait AutoSet
                     'autoset' => true,
                 ]);
             }
-        }, $this->getDbColumnsNames());
+        }, $this->getDbColumnsNames($filtered));
     }
 
     /**

--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -60,6 +60,8 @@ trait Columns
      * Add a column at the end of to the CRUD object's "columns" array.
      *
      * @param [string or array]
+     *
+     * @return Columns
      */
     public function addColumn($column)
     {
@@ -358,14 +360,6 @@ trait Columns
 
     protected function hasColumn($table, $name)
     {
-        static $cache = [];
-
-        if (isset($cache[$table])) {
-            $columns = $cache[$table];
-        } else {
-            $columns = $cache[$table] = $this->getSchema()->getColumnListing($table);
-        }
-
-        return in_array($name, $columns);
+        return \in_array($name, $this->getDbColumnsNames(), true);
     }
 }


### PR DESCRIPTION
Reduces the number of database requests to get column metadata to just a single request for the life of the CRUDpanel in the session.

Allows optionally retrieving all of the database columns, not just fillable, including timestamps by adding a ```filtered = true``` attribute to ```setFromDb``` (I often need to display ```created_at``` and ```updated_at``` metadata in entity lists).

No breaking changes

All current tests pass 