### PR TITLE
Include 'show' in default access granted.

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -42,7 +42,7 @@ class CrudPanel
     public $entity_name_plural = 'entries'; // what name will show up on the buttons, in plural (ex: Delete 5 entities)
     public $request;
 
-    public $access = ['list', 'create', 'update', 'delete'/* 'revisions', reorder', 'show', 'details_row' */];
+    public $access = ['list', 'create', 'update', 'delete', 'show'/* 'revisions', reorder', 'details_row' */];
 
     public $reorder = false;
     public $reorder_label = false;


### PR DESCRIPTION
With the new 3.3 Move to always using AJAX Tables which requires the 'show' access permission we also need to include it within the default access otherwise you receive a permission denied error automatically on creating new applications.