### PR TITLE
[4.1][Feature] Added simple reordering using a 'seq' field

### DIFF
--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -13,24 +13,32 @@ trait Reorder
     /**
      * Change the order and parents of the given elements, according to the NestedSortable AJAX call.
      *
-     * @param  [Request] The entire request from the NestedSortable AJAX Call.
+     * If using simple reordering, the field 'seq' is required,
+     * otherwise the reordering required the fields 'parent_id', 'depth', 'lft' and 'rgt'.
      *
-     * @return [integer] The number of items whose position in the tree has been changed.
+     * @param  array  $entries  The entire request from the NestedSortable AJAX Call.
+     * @return int  The number of items whose position in the tree has been changed.
      */
-    public function updateTreeOrder($request)
+    public function updateTreeOrder(array $entries)
     {
         $count = 0;
 
-        foreach ($request as $key => $entry) {
-            if ($entry['item_id'] != '' && $entry['item_id'] != null) {
-                $item = $this->model->find($entry['item_id']);
-                $item->parent_id = empty($entry['parent_id']) ? null : $entry['parent_id'];
-                $item->depth = empty($entry['depth']) ? null : $entry['depth'];
-                $item->lft = empty($entry['left']) ? null : $entry['left'];
-                $item->rgt = empty($entry['right']) ? null : $entry['right'];
-                $item->save();
-
+        foreach ($entries as $entry) {
+            if (! empty($entry['item_id'])) {
                 $count++;
+                $fields = $this->reorder_simple ?
+                    [
+                        'seq' => $count,
+                    ] :
+                    [
+                        'parent_id' => $entry['parent_id'] ?: null,
+                        'depth'     => $entry['depth'] ?: null,
+                        'lft'       => $entry['lft'] ?: null,
+                        'rgt'       => $entry['rgt'] ?: null,
+                    ];
+                optional($this->model->find($entry['item_id']))
+                    ->fill($fields)
+                    ->save();
             }
         }
 
@@ -41,18 +49,26 @@ trait Reorder
      * Enable the Reorder functionality in the CRUD Panel for users that have the been given access to 'reorder' using:
      * $this->crud->allowAccess('reorder');.
      *
-     * @param  [string] Column name that will be shown on the labels.
-     * @param  [integer] Maximum hierarchy level to which the elements can be nested (1 = no nesting, just reordering).
+     * If using simple reordering, the field 'seq' is required,
+     * otherwise the reordering required the fields 'parent_id', 'depth', 'lft' and 'rgt'.
+     *
+     * @param  string  $label      Column name that will be shown on the labels.
+     * @param  int     $max_level  Maximum hierarchy level for nesting of entities (1 = no nesting, just reordering).
+     * @param  bool    $simple     Whether reordering should be simple. Will set max level to 1.
+     * @return void
      */
-    public function enableReorder($label = 'name', $max_level = 1)
+    public function enableReorder($label = 'name', $max_level = 1, $simple = false)
     {
         $this->reorder = true;
         $this->reorder_label = $label;
-        $this->reorder_max_level = $max_level;
+        $this->reorder_max_level = $simple ? 1 : $max_level;
+        $this->reorder_simple = $simple;
     }
 
     /**
      * Disable the Reorder functionality in the CRUD Panel for all users.
+     *
+     * @return void
      */
     public function disableReorder()
     {

--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -14,8 +14,8 @@ trait Reorder
      * Change the order and parents of the given elements, according to the NestedSortable AJAX call.
      *
      * Required database fields - all being 'integer' INT(10) - optionally unsigned:
-     *   normal: parent_id, depth, lft, rgt
-     *   simple: seq
+     *   - normal: parent_id, depth, lft, rgt
+     *   - simple: seq
      *
      * @param  array  $entries  The entire request from the NestedSortable AJAX Call.
      *                          List of items with following keys: parent_id, depth, lft, rgt.
@@ -55,8 +55,8 @@ trait Reorder
      * $this->crud->allowAccess('reorder');.
      *
      * Required database fields - all being 'integer' INT(10) - optionally unsigned:
-     *   normal: parent_id, depth, lft, rgt
-     *   simple: seq
+     *   - normal: parent_id, depth, lft, rgt
+     *   - simple: seq
      *
      * @param  string  $label      Column name that will be shown on the labels.
      * @param  int     $max_level  Maximum hierarchy level for nesting of entities (1 = no nesting, just reordering).

--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -2,14 +2,14 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\CrudFeatures;
 
+use Illuminate\Http\Request;
+
 trait Reorder
 {
     /**
      *  Reorder the items in the database using the Nested Set pattern.
      *
-     *  Database columns needed: id, parent_id, lft, rgt, depth, name/title
-     *
-     *  @return Response
+     *  @return \Illuminate\Http\Response
      */
     public function reorder()
     {
@@ -31,21 +31,19 @@ trait Reorder
     /**
      * Save the new order, using the Nested Set pattern.
      *
-     * Database columns needed: id, parent_id, lft, rgt, depth, name/title
-     *
-     * @return
+     * @param  \Illuminate\Http\Request  $request
+     * @return string|false
      */
-    public function saveReorder()
+    public function saveReorder(Request $request)
     {
         $this->crud->hasAccessOrFail('reorder');
 
-        $all_entries = \Request::input('tree');
-
-        if (count($all_entries)) {
-            $count = $this->crud->updateTreeOrder($all_entries);
-        } else {
+        $entries = $request->tree;
+        if (empty($entries)) {
             return false;
         }
+
+        $count = $this->crud->updateTreeOrder($entries);
 
         return 'success for '.$count.' items';
     }


### PR DESCRIPTION
Basically I thought the current reordering was too complex, when you just needed a simple ordering of entities, so I cleaned up the code a bit and added a simple option.

Docs will need to be updated if this is added.

Let me know what you guys think :)

Note: the reorder view template could use a serious cleanup as well.