### PR TITLE
Allow custom sorting for crud columns

### DIFF
--- a/src/PanelTraits/Query.php
+++ b/src/PanelTraits/Query.php
@@ -54,6 +54,23 @@ trait Query
     }
 
     /**
+     * Order the results of the query in a custom way.
+     */
+    public function customOrderBy($column, $column_direction)
+    {
+        if (isset($column['orderLogic'])) {
+            $this->query->getQuery()->orders = null;
+        
+            $orderLogic = $column['orderLogic'];
+
+            if (is_callable($orderLogic)) {
+                return $orderLogic($this->query, $column, $column_direction);
+            }
+        }
+        return $this->query;
+    }
+
+    /**
      * Group the results of the query in a certain way.
      *
      * @param  [type]

--- a/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
+++ b/src/app/Http/Controllers/CrudFeatures/AjaxTable.php
@@ -45,6 +45,11 @@ trait AjaxTable
             if ($column['tableColumn']) {
                 $this->crud->orderBy($column['name'], $column_direction);
             }
+
+            // check for custom order logic in the column definition
+            if (isset($column['orderLogic'])) {
+                $this->crud->customOrderBy($column, $column_direction);
+            }
         }
 
         $entries = $this->crud->getEntries();


### PR DESCRIPTION
After having the same problem as in #1112 this is my first take on it.
Basically, in a similar way to the ```searchLogic``` option for a crud column this PR should add the ability to do:
```
$this->crud->addColumn([
    'name' => "country_id",
    'label' => "Nationality",
    'type' => "...",
    'function_name' => '...',
    'orderLogic' => function ($query, $column, $column_direction) {
        return $query->join('countries', 'countries.id', '=', 'customers.country_id')
            ->orderBy('countries.name', $column_direction);
    }
]);
```

This will allow for sorting the column by a fields other than id.