### PR TITLE
[4.0][Bug fix][Ready] Only json_encode fake columns

### DIFF
--- a/src/ModelTraits/SpatieTranslatable/HasTranslations.php
+++ b/src/ModelTraits/SpatieTranslatable/HasTranslations.php
@@ -34,7 +34,7 @@ trait HasTranslations
         $translation = $this->getTranslation($key, $this->locale ?: config('app.locale'));
 
         // if it's a fake field, json_encode it
-        if (is_array($translation)) {
+        if ($this->fakeColumns && in_array($key, $this->fakeColumns)) {
             return json_encode($translation);
         }
 


### PR DESCRIPTION
Only json_encode fake columns, not all arrays. This allows you to use arrays (that are not fake columns) without letting this trait modify them.