### PR TITLE
Allow equal height rows to prevent errors displacing fields

### DIFF
--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -27,6 +27,9 @@ return [
     'show_grouped_errors' => true,
     'show_inline_errors' => true,
 
+    // Would you like to force equal height rows?
+    'equal_height_rows' => false,
+
     /*
     |------------
     | READ

--- a/src/resources/views/create.blade.php
+++ b/src/resources/views/create.blade.php
@@ -30,7 +30,7 @@
 		    <div class="box-header with-border">
 		      <h3 class="box-title">{{ trans('backpack::crud.add_a_new') }} {{ $crud->entity_name }}</h3>
 		    </div>
-		    <div class="box-body row">
+		    <div class="box-body row" @if(config('backpack.crud.equal_height_rows'))style="display: flex;flex-wrap: wrap;"@endif>
 		      <!-- load the view from the application if it exists, otherwise load the one in the package -->
 		      @if(view()->exists('vendor.backpack.crud.form_content'))
 		      	@include('vendor.backpack.crud.form_content', [ 'fields' => $crud->getFields('create'), 'action' => 'create' ])

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -44,7 +44,7 @@
 					<h3 class="box-title">{{ trans('backpack::crud.edit') }}</h3>
 				@endif
 		    </div>
-		    <div class="box-body row">
+		    <div class="box-body row" @if(config('backpack.crud.equal_height_rows'))style="display: flex;flex-wrap: wrap;"@endif>
 		      <!-- load the view from the application if it exists, otherwise load the one in the package -->
 		      @if(view()->exists('vendor.backpack.crud.form_content'))
 		      	@include('vendor.backpack.crud.form_content', ['fields' => $fields, 'action' => 'edit'])


### PR DESCRIPTION
Solution for [#638](https://github.com/Laravel-Backpack/CRUD/issues/638)
This should do the trick.