### PR TITLE
Removed laravelcollective html dependency. Provides Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     ],
     "require": {
         "backpack/base": "^0.8.0",
-        "laravelcollective/html": "~5.0",
         "barryvdh/laravel-elfinder": "^0.3.10",
         "doctrine/dbal": "^2.5",
         "venturecraft/revisionable": "1.*",

--- a/src/resources/views/create.blade.php
+++ b/src/resources/views/create.blade.php
@@ -24,7 +24,13 @@
 
 		@include('crud::inc.grouped_errors')
 
-		  {!! Form::open(array('url' => $crud->route, 'method' => 'post', 'files'=>$crud->hasUploadFields('create'))) !!}
+		  <form method="post"
+		  		action="{{ url($crud->route) }}"
+				@if ($crud->hasUploadFields('create'))
+				enctype="multipart/form-data"
+				@endif
+		  		>
+		  {!! csrf_field() !!}
 		  <div class="box">
 
 		    <div class="box-header with-border">
@@ -45,7 +51,7 @@
 		    </div><!-- /.box-footer-->
 
 		  </div><!-- /.box -->
-		  {!! Form::close() !!}
+		  </form>
 	</div>
 </div>
 

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -24,7 +24,14 @@
 
 		@include('crud::inc.grouped_errors')
 
-		  {!! Form::open(array('url' => $crud->route.'/'.$entry->getKey(), 'method' => 'put', 'files'=>$crud->hasUploadFields('update', $entry->getKey()))) !!}
+		  <form method="post"
+		  		action="{{ url($crud->route.'/'.$entry->getKey()) }}"
+				@if ($crud->hasUploadFields('update', $entry->getKey()))
+				enctype="multipart/form-data"
+				@endif
+		  		>
+		  {!! csrf_field() !!}
+		  {!! method_field('PUT') !!}
 		  <div class="box">
 		    <div class="box-header with-border">
 		    	@if ($crud->model->translationEnabled())
@@ -59,7 +66,7 @@
 
 		    </div><!-- /.box-footer-->
 		  </div><!-- /.box -->
-		  {!! Form::close() !!}
+		  </form>
 	</div>
 </div>
 @endsection

--- a/src/resources/views/inc/revision_timeline.blade.php
+++ b/src/resources/views/inc/revision_timeline.blade.php
@@ -26,10 +26,11 @@
           </div>
         </div>
         <div class="timeline-footer p-t-0">
-          {!! Form::open(array('url' => \Request::url().'/'.$history->id.'/restore', 'method' => 'post')) !!}
+          <form method="post" action="{{ url(\Request::url().'/'.$history->id.'/restore') }}">
+          {!! csrf_field() !!}
           <button type="submit" class="btn btn-primary btn-sm restore-btn" data-entry-id="{{ $entry->id }}" data-revision-id="{{ $history->id }}" onclick="onRestoreClick(event)">
             <i class="fa fa-undo"></i> {{ trans('backpack::crud.undo') }}</button>
-          {!! Form::close() !!}
+          </form>
         </div>
       @endif
     </div>


### PR DESCRIPTION
Fixes #910 for Backpack/CRUD and allows us to add L5.6 support.

Notes:
- this might be considered a breaking change, since people _might_ have customized the involved blade files (```create```, ```edit``` and ```revision_timeline```)
- for this to be successfully merged, we need to also remove the dependency in Backpack\LangFileManager (blade files: ```language_inputs``` and ```translations```)