### PR TITLE
Issue 643 reoccurred

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -4,7 +4,7 @@
 	<section class="content-header">
 	  <h1>
 	    <span class="text-capitalize">{{ $crud->entity_name_plural }}</span>
-	    <small>{{ trans('backpack::crud.all') }} <span class="text-lowercase">{{ $crud->entity_name_plural }}</span> {{ trans('backpack::crud.in_the_database') }}.</small>
+	    <small>{{ trans('backpack::crud.all') }} <span>{{ $crud->entity_name_plural }}</span> {{ trans('backpack::crud.in_the_database') }}.</small>
 	  </h1>
 	  <ol class="breadcrumb">
 	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -16,7 +16,7 @@
 
 @section('content')
 	@if ($crud->hasAccess('list'))
-		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span class="text-lowercase">{{ $crud->entity_name_plural }}</span></a><br><br>
+		<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
 	@endif
 
 	<!-- Default box -->
@@ -24,7 +24,7 @@
 	    <div class="box-header with-border">
 	      <h3 class="box-title">
             {{ trans('backpack::crud.preview') }}
-            <span class="text-lowercase">{{ $crud->entity_name }}</span>
+            <span>{{ $crud->entity_name }}</span>
           </h3>
 	    </div>
 	    <div class="box-body">

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -52,7 +52,7 @@
 		        @endforeach
 				@if ($crud->buttons->where('stack', 'line')->count())
 					<tr>
-						<td><strong>{{ trans('backpack::crud.actions') }}</td>
+						<td><strong>{{ trans('backpack::crud.actions') }}</strong></td>
 						<td>
 							@include('crud::inc.button_stack', ['stack' => 'line'])
 						</td>


### PR DESCRIPTION
As already fixed some time ago in #667 issue #643 reoccured again with some other PR.

This PR removes all occurrences of text-lowercase as it completely messes up german translations in CRUD views (yeah we Germans like odd capitalisation 😅).

As already discussed in #643 this won't mess up anything else.