### PR TITLE
Update checked attribute logic for checkbox field

### DIFF
--- a/src/resources/views/fields/checkbox.blade.php
+++ b/src/resources/views/fields/checkbox.blade.php
@@ -9,7 +9,7 @@
 
           name="{{ $field['name'] }}"
 
-          @if(old($field['name']) == 1 || (old($field['name']) == null && ((isset($field['value']) && (int) $field['value'] == 1) || (isset($field['default']) && $field['default']))))
+          @if(old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : false )))
                  checked="checked"
           @endif
 


### PR DESCRIPTION
On edit view, if model value == 0, and default value == 1, the checkbox will be checked.

The actual checked attribute is set by : old, than value  OR default value.
The logic process should be to set the checked attribute by old , than value, than default value.

I fix it by using the same logic of `fields/text.blade.php`.