### PR TITLE
[Feature][3.4][Ready] Check license code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 ## Added
 - notification bubble if BACKPACK_LICENSE env variable is missing;
 
-## Fixed
-- HTML is now allowed in Alert messages;
-
 
 ## [3.3.11] - 2018-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - Nothing
 -----------
 
+## Added
+- notification bubble if BACKPACK_LICENSE env variable is missing;
+
+## Fixed
+- HTML is now allowed in Alert messages;
+
 
 ## [3.3.11] - 2018-02-23
 

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD;
 
 use Route;
 use Illuminate\Support\ServiceProvider;
+use Prologue\Alerts\Facades\Alert;
 
 class CrudServiceProvider extends ServiceProvider
 {
@@ -56,7 +57,11 @@ class CrudServiceProvider extends ServiceProvider
                     '--tag' => 'public',
                 ]);
             }
+        } else {
+            $this->checkLicenseCodeExists();
         }
+
+        $this->checkLicenseCodeExists();
 
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(
@@ -111,5 +116,18 @@ class CrudServiceProvider extends ServiceProvider
         }
 
         return false;
+    }
+
+    /**
+     * Check to to see if a license code exists.
+     * If it does not, throw a notification bubble.
+     *
+     * @return void
+     */
+    private function checkLicenseCodeExists()
+    {
+        if (!env('BACKPACK_LICENSE')) {
+            Alert::add("warning", "<strong>You're using unlicensed software.</strong> Please <a target='_blank' href='http://backpackforlaravel.com'>purchase a license code</a> to hide this message.");
+        }
     }
 }

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -61,8 +61,6 @@ class CrudServiceProvider extends ServiceProvider
             $this->checkLicenseCodeExists();
         }
 
-        $this->checkLicenseCodeExists();
-
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(
             __DIR__.'/config/backpack/crud.php',


### PR DESCRIPTION
Simply checks that a backpack license code exists, in staging/production/etc (not local). If not, it throws a notification bubble asking the user to purchase a license. 

![screen shot 2018-02-28 at 07 48 49](https://user-images.githubusercontent.com/1032474/36772716-07061c30-1c5f-11e8-9346-2d2061ae6506.png)

As you can see, the check is laughably simple. But in the future, this method _can_ and _will_ be modified to make it more difficult for users to bypass it. But for now, it should do its primary job - let people know a license is always required. And it gives us a place to improve this license check, in future patches. So people that do _crack_ it for ```v3.4.0``` might find their crack is no longer working in the next patch, ```v3.4.1.```. I believe this should be uncomfortable enough to make a lot of people be fair and purchase the license code, or ask for a free license code. But hey - we'll see.

### Background on my reasoning:

In my opinion, people who use Backpack in production, but have not purchased/requested a license code, can be split into 3 groups, by their reason:
(1) because they didn't know one is required;
(2) because they tried it without a license and saw we didn't check;
(3) because they don't really intend to pay for it, if they can get it for free;
(4) contributors, who know a license isn't enforced and even if it were, they're entitled to free licenses;

Group (4) will be solved easily, in time. Contributors will be nudged to [register on backpackforlaravel.com](https://backpackforlaravel.com/), then click a "_request contributor license_" button (doesn't exist yet). I trust contributors to trust us with this - we're honest people and really _really_ appreciate their help, so free licenses is the least we can do.

I don't think there's much we can do about group (3). Sure, we can make it increasingly annoying and difficult for them to crack it. And we will. But after all, our source code is public. And even if it was not, people find ways to crack stuff. Even multi-billion-dollar closed-source software gets cracked. We will too. I think the only thing we _can_ do is to let them know it's not ok. It's a start. I'm working on a bulletproof way to enforce licenses in Composer projects, and I think I have it, but this will require massive effort to implement. Effort that we cannot spend right now.

But this patch _should_ do something to nudge group (1) and (2) to purchase or request a license. And I say - that should do.

Thoughts, anyone?