### PR TITLE
Additional feature:  select2 field to be used with a scope

### DIFF
--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -14,7 +14,21 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
+            @php
+                if (isset($field['scope'])) {
+                    if (isset($field['scope_params'])) {
+                        $scope_params = $field['scope_params'];
+                    } else {
+                        $scope_params = array();
+                    }
+                    $query = call_user_func_array([$field['model'], $field['scope']], $scope_params);
+                    $entities = $query->get();
+                } else {
+                    $entities = $field['model']::all();
+                }       
+            @endphp
+
+            @foreach ($entities as $connected_entity_entry)
                 @if(old($field['name']) == $connected_entity_entry->getKey() || (is_null(old($field['name'])) && isset($field['value']) && $field['value'] == $connected_entity_entry->getKey()))
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else


### PR DESCRIPTION
I've extended the existing select2 field so it can be used with a scope and optional scope parameters
It is backward compatible with the current select2 definitions in controllers.

In the controller there are 2 properties additionally available in the addField method for this field:

- **scope**: fill in the scope name (string) as defined in the model
- **scope_params**: fill the parameters (array) you can pass to the scope in the model

```
$this->crud->addField([
            'name' => 'vat_tariff_id',
            'label' => 'VAT Tariff',
            'type' => 'select2',
            'entity' => 'vat_tariff',
            'attribute' => 'nameAndPercentage',
            'model' => 'App\Models\VatTariff',
            'scope' => 'instanceCountry',
            'scope_params' => [
                '56'
            ]
        ]);
```