### PR TITLE
Add a view column type

### DIFF
--- a/src/PanelTraits/Search.php
+++ b/src/PanelTraits/Search.php
@@ -140,8 +140,16 @@ trait Search
                             ->with('entry', $entry)
                             ->render();
         } else {
+            // show the custom column view
+            if ($column['type'] === 'view') {
+                return \View::make(array_get($column, 'view'))
+                    ->with('crud', $this)
+                    ->with('column', $column)
+                    ->with('entry', $entry)
+                    ->render();
+            }
             // if the column has been overwritten show that one
-            if (view()->exists('vendor.backpack.crud.columns.'.$column['type'])) {
+            elseif (view()->exists('vendor.backpack.crud.columns.'.$column['type'])) {
                 return \View::make('vendor.backpack.crud.columns.'.$column['type'])
                                 ->with('crud', $this)
                                 ->with('column', $column)

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -35,10 +35,12 @@
 		                <td>
 		                    <strong>{{ $column['label'] }}</strong>
 		                </td>
-							@if (!isset($column['type']))
+		                    @if (!isset($column['type']))
 		                      @include('crud::columns.text')
 		                    @else
-		                      @if(view()->exists('vendor.backpack.crud.columns.'.$column['type']))
+		                      @if ($column['type'] === 'view')
+		                        @include($column['view'])
+		                      @elseif(view()->exists('vendor.backpack.crud.columns.'.$column['type']))
 		                        @include('vendor.backpack.crud.columns.'.$column['type'])
 		                      @else
 		                        @if(view()->exists('crud::columns.'.$column['type']))


### PR DESCRIPTION
Hello !

Currently the only way I found to implement custom column types from a package is to publish views from this package to the `resources/views/vendor/backpack/crud/columns/` folder. But it is not very convenient.

What would you think of a `view` column type, like for the fields ?

```php
$this->crud->addColumn([
    [
        'label'     => 'My custom column',
        'type'      => 'view',
        'view'      => 'my-package::path.to.my.custom.view',
    ],
]);
```