### PR TITLE
[Feature][3.4][Merged] One-line installation command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     ],
     "require": {
         "backpack/base": "^0.8.0",
-        "barryvdh/laravel-elfinder": "^0.3.10",
         "doctrine/dbal": "^2.5",
         "venturecraft/revisionable": "1.*",
         "intervention/image": "^2.3"

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -7,6 +7,10 @@ use Illuminate\Support\ServiceProvider;
 
 class CrudServiceProvider extends ServiceProvider
 {
+    protected $commands = [
+        \Backpack\CRUD\app\Console\Commands\Install::class,
+    ];
+
     /**
      * Indicates if loading of the provider is deferred.
      *
@@ -78,12 +82,13 @@ class CrudServiceProvider extends ServiceProvider
 
         // register its dependencies
         $this->app->register(\Backpack\Base\BaseServiceProvider::class);
-        $this->app->register(\Barryvdh\Elfinder\ElfinderServiceProvider::class);
-        $this->app->register(\Intervention\Image\ImageServiceProvider::class);
 
         // register their aliases
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('Image', \Intervention\Image\Facades\Image::class);
+
+        // register the artisan commands
+        $this->commands($this->commands);
 
         // map the elfinder prefix
         if (! \Config::get('elfinder.route.prefix')) {

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -35,7 +35,7 @@ class Install extends BaseInstall
     {
         $install_elfinder = $this->confirm("Install & set up the File Manager (elFinder)? The admin will be able to browse the 'uploads' folder and create/read/modify files and folders there.", 'yes');
 
-        $steps = $install_elfinder?9:4;
+        $steps = $install_elfinder ? 9 : 4;
 
         $this->progressBar = $this->output->createProgressBar($steps);
         $this->progressBar->start();

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Backpack\Base\app\Console\Commands\Install as BaseInstall;
+
+class Install extends BaseInstall
+{
+    protected $progressBar;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:crud:install
+                                {--timeout=300} : How many seconds to allow each process to run.
+                                {--debug} : Show process output or not. Useful for debugging.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make uploads directory and publish assets for Backpack\CRUD dependencies';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->progressBar = $this->output->createProgressBar(8);
+        $this->progressBar->start();
+        $this->info(" Backpack\CRUD installation started. Please wait...");
+        $this->progressBar->advance();
+
+        $this->line(' Creating uploads directory');
+        $this->executeProcess('mkdir -p public/uploads');
+
+        $this->line(' Publishing elFinder assets');
+        $this->executeProcess('php artisan elfinder:publish');
+
+        $this->line(' Publishing CRUD assets');
+        $this->executeProcess('php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="public"');
+
+        $this->line(' Publishing CRUD language files');
+        $this->executeProcess('php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="lang"');
+
+        $this->line(' Publishing CRUD config file and custom elFinder config file');
+        $this->executeProcess('php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="config"');
+
+        $this->line(' Publishing custom elfinder views');
+        $this->executeProcess('php artisan vendor:publish --provider="Backpack\CRUD\CrudServiceProvider" --tag="elfinder"');
+
+        $this->line(' Adding sidebar menu item');
+        $this->executeProcess("php artisan backpack:base:add-sidebar-content '<li><a href=\"{{  backpack_url(\"elfinder\") }}\"><i class=\"fa fa-files-o\"></i> <span>File manager</span></a></li>'");
+
+        $this->progressBar->finish();
+        $this->info(" Backpack\CRUD installation finished.");
+    }
+}

--- a/src/config/elfinder.php
+++ b/src/config/elfinder.php
@@ -7,7 +7,7 @@ return [
     | Upload dir
     |--------------------------------------------------------------------------
     |
-    | The dir where to store the images (relative from public)
+    | The dir where to store the images (relative from public).
     |
     */
     'dir' => ['uploads'],
@@ -40,7 +40,7 @@ return [
 
     'route' => [
         'prefix'     => config('backpack.base.route_prefix', 'admin').'/elfinder',
-        'middleware' => ['web', 'admin'], //Set to null to disable middleware filter
+        'middleware' => ['web', config('backpack.base.middleware_key', 'admin')], //Set to null to disable middleware filter
     ],
 
     /*


### PR DESCRIPTION
This makes it possible to install Backpack\CRUD with ```php artisan backpack:crud:install```

IMPORTANT:
- it now ASKS the user if he wants to install elFinder;
- this is a BREAKING CHANGE, because I've removed elfinder from ```composer.json```; if the user doesn't want elFinder, it should not be installed with composer, at all; not only disabled; otherwise the elfinder routes would still be loaded, and that would open a door for hacking attempts;

Also:
- I just discovered that the elFinder config file uses ```config('backpack.base.route_prefix', 'admin')```, which WILL NOT WORK; we can't use configs inside other configs; this doesn't trigger an error because the ```admin``` fallback is specified; but it always falls back to it;