### PR TITLE
Env into Config

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -52,7 +52,7 @@ trait CrudTrait
         $instance = new static();
 
         $conn = DB::connection($instance->getConnectionName());
-        $table = Config::get('database.connections.'.env('DB_CONNECTION').'.prefix').$instance->getTable();
+        $table = Config::get('database.connections.'.Config::get('database.default').'.prefix').$instance->getTable();
 
         // register the enum, json and jsonb column type, because Doctrine doesn't support it
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');


### PR DESCRIPTION
In many productions environments env() return null (see https://github.com/laravel/framework/issues/8191).
Use Config::get() is more secure. I have lost 2h to find reason for error "There is no column with name 'column_name' on table 'table_name'." and it was no table prefix, caused by null returned from env. 

Please merge.