### PR TITLE
Fix image field when form is re-displayed

### DIFF
--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -6,7 +6,14 @@
 
     $prefix = isset($field['prefix']) ? $field['prefix'] : '';
     $value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') );
-    $image_url = $value?(isset($field['disk']) ? Storage::disk($field['disk'])->url($prefix.$value) : url($prefix.$value)):'';
+    $image_url = $value
+        ? preg_match('/^data\:image\//', $value)
+            ? $value
+            : (isset($field['disk'])
+                ? Storage::disk($field['disk'])->url($prefix.$value)
+                : url($prefix.$value))
+        :'';
+
 @endphp
 
   <div data-preview="#{{ $field['name'] }}"


### PR DESCRIPTION
When trying to create a new record and validation fails, the form is displayed
again with the submitted values for the user to fix the issues. The images
however are handled a bit differently: they're displayed inline as
`data:image/sometype;...` so that the user doesn't need to select them again
from disk.

The issue here is that the base URL gets added in front of
`data:image/sometype`, which causes the display of the image to fail since
`http://somedomain/data:image/sometype;...` isn't valid.