### PR TITLE
Changed the summernote options to be related to that field only

### DIFF
--- a/src/resources/views/columns/closure_function.blade.php
+++ b/src/resources/views/columns/closure_function.blade.php
@@ -1,0 +1,4 @@
+{{-- closure function --}}
+<span>
+	{!! $column['function']($entry) !!}
+</span>

--- a/src/resources/views/fields/summernote.blade.php
+++ b/src/resources/views/fields/summernote.blade.php
@@ -29,13 +29,17 @@
     @push('crud_fields_scripts')
         <!-- include summernote js-->
         <script src="{{ asset('vendor/backpack/summernote/summernote.min.js') }}"></script>
-        <script>
-            jQuery(document).ready(function($) {
-                $('.summernote').summernote(@json($field['options'] ?? []));
-            });
-        </script>
     @endpush
 
 @endif
+
+@push('crud_fields_scripts')
+    <!-- include summernote js with related options for this field -->
+    <script>
+        jQuery(document).ready(function($) {
+            $(".summernote[name='{{ $field['name'] }}']").summernote(@json($field['options'] ?? []));
+        });
+    </script>
+@endpush
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}


### PR DESCRIPTION
Currently summernote takes in account only the first summernote field options and discard the others.
The aim of this PR is to add options for each each field. 

While I tackled this with a custom field in my view files I think this should be addressed in the default file.
