### PR TITLE
IE11 Compatibility

### DIFF
--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -13,7 +13,7 @@
           this.functionsToRunOnDataTablesDrawEvent.push(functionName);
         }
       },
-      responsiveToggle(dt) {
+      responsiveToggle: function(dt) {
           $(dt.table().header()).find('th').toggleClass('all');
           dt.responsive.rebuild();
           dt.responsive.recalc();


### PR DESCRIPTION
The new responsiveToggle function uses new Javascript shorthand which isn't supported by IE11. This corrects that