### PR TITLE
Changed the summernote field to get custom options for any field

### DIFF
--- a/src/resources/views/fields/summernote.blade.php
+++ b/src/resources/views/fields/summernote.blade.php
@@ -29,13 +29,17 @@
     @push('crud_fields_scripts')
         <!-- include summernote js-->
         <script src="{{ asset('vendor/backpack/summernote/summernote.min.js') }}"></script>
-        <script>
-            jQuery(document).ready(function($) {
-                $('.summernote').summernote(@json($field['options'] ?? []));
-            });
-        </script>
     @endpush
 
 @endif
+
+@push('crud_fields_scripts')
+    <!-- include summernote js with related options for this field -->
+    <script>
+        jQuery(document).ready(function($) {
+            $(".summernote[name='{{ $field['name'] }}']").summernote(@json($field['options'] ?? []));
+        });
+    </script>
+@endpush
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}


### PR DESCRIPTION
Currently summernote takes in account only the first summernote options applying them to all summernote fields  and discarding the others.
The aim of this PR is to correctly handle options for each field.

While I tackled this with a custom field in my view files I think this should be addressed in the default file.