### PR TITLE
setFieldDetails function

### DIFF
--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -173,6 +173,22 @@ trait Fields
     }
 
     /**
+     * Set/modify details for a specific field.
+     *
+     * @param string $field
+     * @param array $attributes
+     */
+    public function setFieldDetails($field, $attributes)
+    {
+        if (isset($this->create_fields[$field])) {
+            $this->create_fields[$field] = array_merge($this->create_fields[$field], $attributes);
+        }
+        if (isset($this->update_fields[$field])) {
+            $this->update_fields[$field] = array_merge($this->update_fields[$field], $attributes);
+        }
+    }
+
+    /**
      * Check if field is the first of its type in the given fields array.
      * It's used in each field_type.blade.php to determine wether to push the css and js content or not (we only need to push the js and css for a field the first time it's loaded in the form, not any subsequent times).
      *


### PR DESCRIPTION
It might be useful to have a function like setColumnDetails for fields too.
So we can avoid repeating all the attributes only for changing one.

i.e.

```
 $this->crud->addField([  // Select2
            'label' => trans('validation.attributes.partner'),
            'type' => 'select2',
            'name' => 'user_id', // the db column for the foreign key
            'entity' => 'partner', // the method that defines the relationship in your Model
            'attribute' => 'descriptor', // foreign key attribute that is shown to user
            'model' => User::class, // foreign key model
            'wrapperAttributes' => [
                'class' => 'form-group col-xs-12 required'
            ]
        ]);

if (backpack_user()->hasRole('partner')) {
            $this->crud->setFieldDetails('user_id', ['attributes' => [
                'readonly' => 'readonly',
                'disabled' => 'disabled',
            ]]);
        }
```
