### PR TITLE
Fix #1321

### DIFF
--- a/src/ModelTraits/SpatieTranslatable/HasTranslations.php
+++ b/src/ModelTraits/SpatieTranslatable/HasTranslations.php
@@ -181,7 +181,7 @@ trait HasTranslations
                         foreach ($item as $instance) {
                             $instance->setLocale($translation_locale);
                         }
-                    } else if ($item) {
+                    } elseif ($item) {
                         $item->setLocale($translation_locale);
                     }
 

--- a/src/ModelTraits/SpatieTranslatable/HasTranslations.php
+++ b/src/ModelTraits/SpatieTranslatable/HasTranslations.php
@@ -177,7 +177,11 @@ trait HasTranslations
                 if ($translation_locale) {
                     $item = parent::__call($method, $parameters);
 
-                    if ($item) {
+                    if ($item instanceof \Traversable) {
+                        foreach ($item as $instance) {
+                            $instance->setLocale($translation_locale);
+                        }
+                    } else if ($item) {
                         $item->setLocale($translation_locale);
                     }
 


### PR DESCRIPTION
As the defined methods `find`, `findOrFail` and `findMany` are returning Collections of Instances, we need to check if setting the Locale needs to be iterated over this collection as `setLocale` is no Collection method.