### PR TITLE
[Ready] Get the correct current ID for nested resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - Nothing
 -----------
 
+## [3.4.5] - 2018-04-xx
+
+## Fixed
+- getting the correct current id for nested resources; fixes #1323; fixes #252; merges #1339;
+
+
 ## [3.4.4] - 2018-03-29
 
 ## Fixed

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -10,6 +10,44 @@ trait Read
     |--------------------------------------------------------------------------
     */
 
+   /**
+     * Find and retrieve the id of the current entry.
+     *
+     * @return [Number] The id in the db or false.
+     */
+    public function getCurrentEntryId()
+    {
+        if ($this->entry) {
+            return $this->entry->getKey();
+        }
+
+        $params = \Route::current()->parameters();
+
+        return  // use the entity name to get the current entry
+                // this makes sure the ID is corrent even for nested resources
+                $this->request->{$this->entity_name} ??
+                // otherwise use the next to last parameter
+                array_values($params)[count($params)-1] ??
+                // otherwise return false
+                false;
+    }
+
+    /**
+     * Find and retrieve the current entry.
+     *
+     * @return [Eloquent Collection] The row in the db or false.
+     */
+    public function getCurrentEntry()
+    {
+        $id = $this->getCurrentEntryId();
+
+        if (!$id) {
+            return false;
+        }
+
+        return $this->getEntry($id);
+    }
+
     /**
      * Find and retrieve an entry in the database or fail.
      *

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -136,6 +136,9 @@ class CrudController extends BaseController
     {
         $this->crud->hasAccessOrFail('update');
 
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
@@ -197,6 +200,9 @@ class CrudController extends BaseController
     {
         $this->crud->hasAccessOrFail('show');
 
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+
         // set columns from db
         $this->crud->setFromDb();
 
@@ -231,6 +237,9 @@ class CrudController extends BaseController
     public function destroy($id)
     {
         $this->crud->hasAccessOrFail('delete');
+
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
 
         return $this->crud->delete($id);
     }

--- a/src/app/Http/Controllers/CrudFeatures/Revisions.php
+++ b/src/app/Http/Controllers/CrudFeatures/Revisions.php
@@ -15,6 +15,9 @@ trait Revisions
     {
         $this->crud->hasAccessOrFail('revisions');
 
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
@@ -39,6 +42,9 @@ trait Revisions
     public function restoreRevision($id)
     {
         $this->crud->hasAccessOrFail('revisions');
+
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
 
         $revisionId = \Request::input('revision_id', false);
         if (! $revisionId) {

--- a/src/app/Http/Controllers/CrudFeatures/ShowDetailsRow.php
+++ b/src/app/Http/Controllers/CrudFeatures/ShowDetailsRow.php
@@ -17,6 +17,9 @@ trait ShowDetailsRow
     {
         $this->crud->hasAccessOrFail('details_row');
 
+        // get entry ID from Request (makes sure its the last ID for nested resources)
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
 


### PR DESCRIPTION
Fixes #1323 and #252 

The current entry ID is taken using one of the following methods:
- if a route resource has been used, the ID will be present in the request; so we'll get it that way;
- if the route has been manually entered, the ID will be present as the next to last parameter; so @jrpub's [method here](https://github.com/Laravel-Backpack/CRUD/issues/252#issuecomment-304232919) will be used; 

Let me know if you think of any way this would fail.

//TODO:
- what happens if the route has a complex name for the current entity ex: (```admin-panel```, ```car-requirement``` etc)?