### PR TITLE
Hide 'Actions' Column On Export

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -46,7 +46,7 @@
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
-                  <th data-orderable="false">{{ trans('backpack::crud.actions') }}</th>
+                  <th data-orderable="false" class="not-export-col">{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>
             </thead>


### PR DESCRIPTION
There is no need to have the `Actions` Column when exporting data since it does not create a link on PDF's, Excel etc, and on copy or if we printed it not like we could anyways. Since we already filter out any columns with the class of `not-export-col` i simply added that to the header for actions.