### PR TITLE
Hide "Remove Filters" when not selected

### DIFF
--- a/src/resources/views/inc/filters_navbar.blade.php
+++ b/src/resources/views/inc/filters_navbar.blade.php
@@ -18,7 +18,7 @@
 			@foreach ($crud->filters as $filter)
 				@include($filter->view)
 			@endforeach
-          <li><a href="#" id="remove_filters_button"><i class="fa fa-eraser"></i> {{ trans('backpack::crud.remove_filters') }}</a></li>
+          <li ><a href="#" id="remove_filters_button" class="hidden"><i class="fa fa-eraser"></i> {{ trans('backpack::crud.remove_filters') }}</a></li>
         </ul>
       </div><!-- /.navbar-collapse -->
     </div><!-- /.container-fluid -->
@@ -90,7 +90,10 @@
               new_url = new_url.addQuery(parameter, value);
             }
 
+            $('#remove_filters_button').removeClass('hidden');
+
         return new_url.toString();
+
       }
 
       function normalizeAmpersand(string) {
@@ -111,6 +114,7 @@
 
   				// clear all filters
   				$(".navbar-filters li[filter-name]").trigger('filter:clear');
+          $('#remove_filters_button').addClass('hidden');
       	})
       });
     </script>


### PR DESCRIPTION
There is no point in showing the "Remove Filters" button when no filters are selected, simply adds a single bootstrap class and jquery remove/add commands to display/hide when selecting new filters or removing all filters.