### PR TITLE
Add missing td for preview page.

### DIFF
--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -35,6 +35,7 @@
 		                <td>
 		                    <strong>{{ $column['label'] }}</strong>
 		                </td>
+                        <td>
 							@if (!isset($column['type']))
 		                      @include('crud::columns.text')
 		                    @else
@@ -48,6 +49,7 @@
 		                        @endif
 		                      @endif
 		                    @endif
+                        </td>
 		            </tr>
 		        @endforeach
 				@if ($crud->buttons->where('stack', 'line')->count())


### PR DESCRIPTION
Minor cosmetic fix for the `preview` page as it is missing `<td></td>` tags around the database content.

<img width="605" alt="screen shot 2018-04-22 at 1 52 13 pm" src="https://user-images.githubusercontent.com/487798/39099772-8b1d3144-4634-11e8-930f-0dd16e4babc3.png">