### PR TITLE
Use Setters/Getters for page titles

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -21,12 +21,13 @@ use Backpack\CRUD\PanelTraits\Reorder;
 use Backpack\CRUD\PanelTraits\AutoFocus;
 use Backpack\CRUD\PanelTraits\FakeFields;
 use Backpack\CRUD\PanelTraits\FakeColumns;
+use Backpack\CRUD\PanelTraits\PageTitles;
 use Illuminate\Database\Eloquent\Collection;
 use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {
-    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, PageTitles;
 
     // --------------
     // CRUD variables

--- a/src/PanelTraits/PageTitles.php
+++ b/src/PanelTraits/PageTitles.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait PageTitles
+{
+    public function initTitles() {
+      $this->setCreateTitle(trans('backpack::crud.add').' '.$this->entity_name);
+      $this->setEditTitle(trans('backpack::crud.edit').' '.$this->entity_name);
+      $this->setShowTitle(trans('backpack::crud.preview').' '.$this->entity_name);
+      $this->setRevisionsTitle(ucfirst($this->entity_name).' '.trans('backpack::crud.revisions'));
+      $this->setReorderTitle(trans('backpack::crud.reorder').' '.$this->entity_name);
+      $this->setListTitle(ucfirst($this->entity_name_plural));
+    }
+
+    // -------
+    // CREATE
+    // -------
+
+    /**
+     * Sets the list title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setCreateTitle($title)
+    {
+        $this->createTitle = $title;
+
+        return $this->createTitle;
+    }
+
+    /**
+     * Gets the create title.
+     * @return string name of the page
+     */
+    public function getCreateTitle()
+    {
+        return $this->createTitle;
+    }
+
+    // -------
+    // READ
+    // -------
+
+    /**
+     * Sets the list title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setListTitle($title)
+    {
+        $this->listTitle = $title;
+
+        return $this->listTitle;
+    }
+
+    /**
+     * Gets the list title.
+     * @return string name of the page
+     */
+    public function getListTitle()
+    {
+        return $this->listTitle;
+    }
+
+    /**
+     * Sets the details row title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setDetailsRowTitle($title)
+    {
+        $this->detailsRowTitle = $title;
+
+        return $this->detailsRowTitle;
+    }
+
+    /**
+     * Gets the details row title.
+     * @return string name of the page
+     */
+    public function getDetailsRowTitle()
+    {
+        return $this->detailsRowTitle;
+    }
+
+    /**
+     * Sets the show title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setShowTitle($title)
+    {
+        $this->showTitle = $title;
+
+        return $this->showTitle;
+    }
+
+    /**
+     * Gets the show title.
+     * @return string name of the page
+     */
+    public function getShowTitle()
+    {
+        return $this->showTitle;
+    }
+
+    // -------
+    // UPDATE
+    // -------
+
+    /**
+     * Sets the edit title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setEditTitle($title)
+    {
+        $this->editTitle = $title;
+
+        return $this->editTitle;
+    }
+
+    /**
+     * Gets the edit title.
+     * @return string name of the page
+     */
+    public function getEditTitle()
+    {
+        return $this->editTitle;
+    }
+
+    /**
+     * Sets the reorder title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setReorderTitle($title)
+    {
+        $this->reorderTitle = $title;
+
+        return $this->reorderTitle;
+    }
+
+    /**
+     * Gets the reorder title.
+     * @return string name of the page
+     */
+    public function getReorderTitle()
+    {
+        return $this->reorderTitle;
+    }
+
+    /**
+     * Sets the revision title.
+     * @param string $title name of the page
+     * @return string $title name of the page
+     */
+    public function setRevisionsTitle($title)
+    {
+        $this->revisionsTitle = $title;
+
+        return $this->revisionsTitle;
+    }
+
+    /**
+     * Gets the revisions title.
+     * @return string name of the page
+     */
+    public function getRevisionsTitle()
+    {
+        return $this->revisionsTitle;
+    }
+
+    // -------
+    // ALIASES
+    // -------
+
+    public function getPreviewTitle()
+    {
+        return $this->getShowTitle();
+    }
+
+    public function setPreviewitle($title)
+    {
+        return $this->setShowTitle($title);
+    }
+
+    public function getUpdateTitle()
+    {
+        return $this->getEditTitle();
+    }
+
+    public function setUpdateTitle($title)
+    {
+        return $this->setEditTitle($title);
+    }
+}

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -42,6 +42,8 @@ class CrudController extends BaseController
                 $this->crud->request = $request;
                 $this->setup();
 
+                $this->crud->initTitles();
+
                 return $next($request);
             });
         }
@@ -64,7 +66,7 @@ class CrudController extends BaseController
         $this->crud->hasAccessOrFail('list');
 
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = ucfirst($this->crud->entity_name_plural);
+        $this->data['title'] = $this->crud->getListTitle();
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getListView(), $this->data);
@@ -83,7 +85,7 @@ class CrudController extends BaseController
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getCreateFields();
-        $this->data['title'] = trans('backpack::crud.add').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getCreateTitle();
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getCreateView(), $this->data);
@@ -144,7 +146,7 @@ class CrudController extends BaseController
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->getSaveAction();
         $this->data['fields'] = $this->crud->getUpdateFields($id);
-        $this->data['title'] = trans('backpack::crud.edit').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getEditTitle();
 
         $this->data['id'] = $id;
 
@@ -217,7 +219,7 @@ class CrudController extends BaseController
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = trans('backpack::crud.preview').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getShowTitle();
 
         // remove preview button from stack:line
         $this->crud->removeButton('preview');

--- a/src/app/Http/Controllers/CrudFeatures/Reorder.php
+++ b/src/app/Http/Controllers/CrudFeatures/Reorder.php
@@ -22,7 +22,7 @@ trait Reorder
         // get all results for that entity
         $this->data['entries'] = $this->crud->getEntries();
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = trans('backpack::crud.reorder').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getReorderTitle();
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getReorderView(), $this->data);

--- a/src/app/Http/Controllers/CrudFeatures/Revisions.php
+++ b/src/app/Http/Controllers/CrudFeatures/Revisions.php
@@ -21,7 +21,7 @@ trait Revisions
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = ucfirst($this->crud->entity_name).' '.trans('backpack::crud.revisions');
+        $this->data['title'] = $this->crud->getRevisionsTitle();
         $this->data['id'] = $id;
         $this->data['revisions'] = $this->crud->listRevisions($id);
 


### PR DESCRIPTION
Rather then setting the titles within the controller, we changing it to use Setters/Getters opens up more flexibility. Example, you want the same data from the `preview` page but with different views with different content. Example of how my controller looks currently without setting a title:

```php
    /**
     * Display the specified resource comments
     *
     * @param int $id
     *
     * @return Response
     */
    public function show($id)
    {
      $this->crud->setShowView('cord::clients.comments');
      return parent::show($id);
    }

    /**
     * Display the specified resource details.
     *
     * @param int $id
     *
     * @return Response
     */
    public function details($id)
    {
      $this->crud->setShowView('cord::clients.details');
      return parent::show($id);
    }
```

Two pages completely different, but I am displaying content for that client on both so to avoid copy/pasting the same code over and over from the parent `show()` function just to change the title i can add a single line to avoid extra duplicate code.
```php
$this->crud->setShowTitle('My New Title');
```