### PR TITLE
[Feature][3.4][Ready] Allow fields to be modified.

### DIFF
--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -155,6 +155,33 @@ trait Fields
             }
         }
     }
+    
+    /**
+     * Update value of a given key for a current field.
+     *
+     * @param string $field         The field
+     * @param array  $modifications An array of changes to be made.
+     * @param string $form          update/create/both
+     */
+    public function modifyField($field, $modifications, $form = 'both')
+    {
+      foreach($modifications as $key => $newValue) {
+        switch (strtolower($form)) {
+          case 'create':
+              $this->create_fields[$field][$key] = $newValue;
+              break;
+
+          case 'update':
+              $this->update_fields[$field][$key] = $newValue;
+              break;
+
+          default:
+              $this->create_fields[$field][$key] = $newValue;
+              $this->update_fields[$field][$key] = $newValue;
+              break;
+        }
+      }
+    }
 
     /**
      * Set label for a specific field.


### PR DESCRIPTION
PR for issue #1165 allowing fields to be modified.

```php
$changes = [
   'type' => 'email'
]
$this->crud->modifyField('name', $changes, 'both']);
```

I chose to call it `modifyField()` rather then `updateField` to avoid confusion between the `$crud->update_fields`.

Can choose to update both create/update or either one.

