### PR TITLE
[Feature][3.4][Ready] Modify functionality for Fields, Columns, Filters, Buttons

### DIFF
--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -87,6 +87,30 @@ trait Buttons
     }
 
     /**
+     * Modify the attributes of a button.
+     *
+     * @param  string $name          The button name.
+     * @param  array $modifications  The attributes and their new values.
+     * @return button                The button that has suffered the changes, for daisychaining methods.
+     */
+    public function modifyButton($name, $modifications = null)
+    {
+        $button = $this->buttons()->firstWhere('name', $name);
+
+        if (! $button) {
+            abort(500, 'CRUD Button "'.$name.'" not found. Please check the button exists before you modify it.');
+        }
+
+        if (is_array($modifications)) {
+            foreach ($modifications as $key => $value) {
+                $button->{$key} = $value;
+            }
+        }
+
+        return $button;
+    }
+
+    /**
      * Remove a button from the CRUD panel.
      *
      * @param string $name Button name.

--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -272,6 +272,18 @@ trait Columns
     }
 
     /**
+     * Alias for setColumnDetails().
+     * Provides a consistent syntax with Fields, Buttons, Filters modify functionality.
+     *
+     * @param [string] Column name.
+     * @param [attributes and values array]
+     */
+    public function modifyColumn($column, $attributes)
+    {
+        $this->setColumnDetails($column, $attributes);
+    }
+
+    /**
      * Set label for a specific column.
      *
      * @param string $column

--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -155,7 +155,7 @@ trait Fields
             }
         }
     }
-    
+
     /**
      * Update value of a given key for a current field.
      *
@@ -165,8 +165,8 @@ trait Fields
      */
     public function modifyField($field, $modifications, $form = 'both')
     {
-      foreach($modifications as $key => $newValue) {
-        switch (strtolower($form)) {
+        foreach ($modifications as $key => $newValue) {
+            switch (strtolower($form)) {
           case 'create':
               $this->create_fields[$field][$key] = $newValue;
               break;
@@ -180,7 +180,7 @@ trait Fields
               $this->update_fields[$field][$key] = $newValue;
               break;
         }
-      }
+        }
     }
 
     /**

--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -155,6 +155,33 @@ trait Fields
             }
         }
     }
+    
+    /**
+     * Update value of a given key for a current field.
+     *
+     * @param string $field         The field
+     * @param array  $modifications An array of changes to be made.
+     * @param string $form          update/create/both
+     */
+    public function modifyField($field, $modifications, $form = 'both')
+    {
+      foreach($modifications as $key => $newValue) {
+        switch (strtolower($form)) {
+          case 'create':
+              $this->create_fields[$field][$key] = $newValue;
+              break;
+
+          case 'update':
+              $this->update_fields[$field][$key] = $newValue;
+              break;
+
+          default:
+              $this->create_fields[$field][$key] = $newValue;
+              $this->update_fields[$field][$key] = $newValue;
+              break;
+        }
+      }
+    }
 
     /**
      * Set label for a specific field.

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -146,7 +146,7 @@ trait Filters
     {
         $filter = $this->filters->firstWhere('name', $name);
 
-        if (!$filter) {
+        if (! $filter) {
             abort(500, 'CRUD Filter "'.$name.'" not found. Please check the filter exists before you modify it.');
         }
 

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -135,6 +135,23 @@ trait Filters
         return $this->filters;
     }
 
+    public function modifyFilter($name, $modifications)
+    {
+        $filter = $this->filters->firstWhere('name', $name);
+
+        if (!$filter) {
+            abort(500, 'CRUD Filter "'.$name.'" not found. Please check the filter exists before you modify it.');
+        }
+
+        if (is_array($modifications)) {
+            foreach ($modifications as $key => $value) {
+                $filter->{$key} = $value;
+            }
+        }
+
+        return $filter;
+    }
+
     public function removeFilter($name)
     {
         $this->filters = $this->filters->reject(function ($filter) use ($name) {

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -135,6 +135,13 @@ trait Filters
         return $this->filters;
     }
 
+    /**
+     * Modify the attributes of a filter.
+     *
+     * @param  string $name          The filter name.
+     * @param  array $modifications  An array of changes to be made.
+     * @return filter                The filter that has suffered modifications, for daisychaining methods.
+     */
     public function modifyFilter($name, $modifications)
     {
         $filter = $this->filters->firstWhere('name', $name);


### PR DESCRIPTION
- merged @AbbyJanke 's #1349 PR for adding ```modifyField()``` functionality; 
- added the ```modifyColumn()``` to the existing ```setColumnDetails()``` method;
- added ```modifyFilter()``` functionality;
- added ```modifyButton()``` functionality;

So that we now have a consistent syntax for changing stuff:

```php
$this->crud->modifyColumn($name, $modifications);
$this->crud->modifyFilter($name, $modifications);
$this->crud->modifyButton($name, $modifications);
$this->crud->modifyField($name, $modifications, $form);
```

A more _accurate_ name would probably be ```changeFieldDetails()``` / ```changeFieldProperties()``` / ```changeFieldAttributes()``` / ```changeFieldOptions()``` or something like that, but I think it's too long and it could introduce further confusion with options / attributes _inside_ the field.

What do you think? **On naming, should we use ```modifyField()``` or  ```changeField()```?** Or should we just continue the old convention from columns - ```setColumnDetails()```, ```setFieldDetails()```, ```setFilterDetails()```, ```setButtonDetails()```?