### PR TITLE
Fix #1076: Filter dropdown sends empty value

### DIFF
--- a/src/resources/views/filters/dropdown.blade.php
+++ b/src/resources/views/filters/dropdown.blade.php
@@ -15,7 +15,7 @@
 					<li class="{{ ($filter->isActive() && $filter->currentValue == $key)?'active':'' }}">
 						<a  parameter="{{ $filter->name }}"
 							href=""
-							key="{{ $key }}"
+							dropdownkey="{{ $key }}"
 							>{{ $value }}</a>
 					</li>
 				@endif
@@ -45,7 +45,7 @@
 			$("li.dropdown[filter-name={{ $filter->name }}] .dropdown-menu li a").click(function(e) {
 				e.preventDefault();
 
-				var value = $(this).attr('key');
+				var value = $(this).attr('dropdownkey');
 				var parameter = $(this).attr('parameter');
 
 				@if (!$crud->ajaxTable())


### PR DESCRIPTION
Fix #1076 

VueJS creates an interference with html parameters named "key". 

Renamed the parameter key to "dropdownkey" in filters/dropdown.blade.php. 

