### PR TITLE
Field Type: Divider

### DIFF
--- a/src/resources/views/fields/divider.blade.php
+++ b/src/resources/views/fields/divider.blade.php
@@ -1,0 +1,14 @@
+<!-- text input -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label @include('crud::inc.field_attributes') type="label">{!! $field['label'] !!}</label>
+</div>
+
+@push('crud_fields_styles')
+  <style type="text/css">
+    label[type="label"] {
+      border: 0;
+      padding: 10px 0;
+      border-bottom:1px solid #ccc;
+    }
+  </style>
+@endpush


### PR DESCRIPTION
Maybe its just me, but sometimes i find a need for adding an extra label "divider" similar to 'tabbed forms' which I don't really want to use for just a simple three more fields.

<img width="768" alt="screen shot 2018-04-24 at 8 46 33 am" src="https://user-images.githubusercontent.com/487798/39198561-3b78af24-479c-11e8-9b80-7eda1b4d6aeb.png">

```php
// Example Usage
[
   'name' => 'tags',
   'label' => trans('cord::clients.tags'),
   'type' => 'select2_from_array',
   'options' => $this->getAvailableTags(),
   'allows_null' => true,
],
[
   'name' => 'account_owner',
   'label' => 'Account Owner',
   'type'  => 'divider'
],
[
   'name'  => 'user_name',
   'label' => trans('backpack::permissionmanager.name'),
   'type'  => 'text',
],
```
