### PR TITLE
[4.0][Feature][Needs testing] Allow overwriting Name for CRUD Resources.

### DIFF
--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -24,6 +24,8 @@ class CrudRouter
             unset($this->options['name']);
         }
 
+        $this->name = str_replace('/', '.', $this->name);
+
         // CRUD routes for core features
         Route::post($this->name.'/search', [
             'as' => 'crud.'.$this->name.'.search',

--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -18,6 +18,12 @@ class CrudRouter
         $this->controller = $controller;
         $this->options = $options;
 
+        // if a name is defined in options, overwrite default name.
+        if(isset($this->options['name'])) {
+          $this->name = $this->options['name'];
+          unset($this->options['name']);
+        }
+
         // CRUD routes for core features
         Route::post($this->name.'/search', [
             'as' => 'crud.'.$this->name.'.search',

--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -19,9 +19,9 @@ class CrudRouter
         $this->options = $options;
 
         // if a name is defined in options, overwrite default name.
-        if(isset($this->options['name'])) {
-          $this->name = $this->options['name'];
-          unset($this->options['name']);
+        if (isset($this->options['name'])) {
+            $this->name = $this->options['name'];
+            unset($this->options['name']);
         }
 
         // CRUD routes for core features


### PR DESCRIPTION
A check to see if `name` was passed to `CRUD::Resource()` function to use that as a name rather then the predefined.

Example:
```php
CRUD::resource('client/{client_id}/users', 'ClientUserCrudController', ['name' => 'client.users']);
```

```php
// Default Naming
crud.client/{client_id}/users.index

// Custom Naming
crud.client.users.index
```