### PR TITLE
Allow dot notation text fields, which enables relationship information

### DIFF
--- a/src/resources/views/columns/text.blade.php
+++ b/src/resources/views/columns/text.blade.php
@@ -1,6 +1,6 @@
 {{-- regular object attribute --}}
 @php
-	$value = $entry->{$column['name']};
+	$value = data_get($entry, $column['name']);
 @endphp
 
 <span>


### PR DESCRIPTION
By using Laravels `data_get` helper, it allows the users to display relationship information by using dot notation

e.g

```php
$this->addColumn([
    'name' => 'profile.membership_number',
    'label' => 'Membership Number',
    'type' => 'text'
];
```