### PR TITLE
Made the check column type exportable

### DIFF
--- a/src/resources/views/columns/check.blade.php
+++ b/src/resources/views/columns/check.blade.php
@@ -1,12 +1,19 @@
 {{-- checkbox with loose false/null/0 checking --}}
-<?php
-$icon = "fa-check-square-o";
+@php
+$checkValue = data_get($entry, $column['name']);
 
-if (strip_tags($entry->{$column['name']}) == false) {
-    $icon = "fa-square-o";
-}
-?>
+$checkedIcon = data_get($column, 'icons.checked', 'fa-check-square-o');
+$uncheckedIcon = data_get($column, 'icons.unchecked', 'fa-square-o');
+
+$exportCheckedText = data_get($column, 'labels.checked', 'Yes');
+$exportUncheckedText = data_get($column, 'labels.unchecked', 'No');
+
+$icon = $checkValue == false ? $uncheckedIcon : $checkedIcon;
+$text = $checkValue == false ? $exportUncheckedText : $exportCheckedText;
+@endphp
 
 <span>
     <i class="fa {{ $icon }}"></i>
 </span>
+
+<span class="hidden">{{ $text }}</span>


### PR DESCRIPTION
Currently, when you try to export the columns, as this simply shows a font it shows blank in the export.

This adds the ability to apply labels to the checked states, which can then be exported, which might also be better for accessibility.

There is also some refactoring for more flexible configuration

Should be completely backwards compatible