### PR TITLE
[Bug Fix] enables responsive mode on the table

### DIFF
--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -27,6 +27,11 @@
         fn.apply(window, args);
       },
       dataTableConfiguration: {
+        initComplete: function () {
+            crud.responsiveToggle(
+                jQuery('#crudTable').DataTable()
+            );
+        },
         responsive: {
             details: {
                 display: $.fn.dataTable.Responsive.display.modal( {


### PR DESCRIPTION
By default, the tables responsive nature does not kick in - so when you have more items that fit on the screen they cannot be viewed via the column visibility.

Scenario:

if you have 10 columns, 5 are on screen, 5 are off screen

You turn off the visibility of the first 5 - expecting to see the next 5.

They never appear.

If you trigger the responsive rebuild and recalculations, then they appear.

This fix enables the calculations by default to fix the issue before it happens

@tabacitu i've sent you a video by email of it happening as it has confidential information within