### PR TITLE
[Bug Fix] Fixes an issue with "autoFocus" on iterable fields

### DIFF
--- a/src/resources/views/form_content.blade.php
+++ b/src/resources/views/form_content.blade.php
@@ -68,7 +68,10 @@
         @endphp
 
         @if ($focusField)
-          window.focusField = $('[name="{{ $focusField['name'] }}"]').eq(0),
+        @php
+        $focusFieldName = !is_iterable($focusField['value']) ? $focusField['name'] : ($focusField['name'] . '[]');
+        @endphp
+          window.focusField = $('[name="{{ $focusFieldName }}"]').eq(0),
         @else
           var focusField = $('form').find('input, textarea, select').not('[type="hidden"]').eq(0),
         @endif


### PR DESCRIPTION
If you try autofocus onto a field which is considered iterable, such as an array, tagging, relationships etc, it throws an error.

![console error](https://user-images.githubusercontent.com/1094740/40242042-6dddfffc-5ab4-11e8-9ac6-6018c32162dc.jpg)

This is because the field name is something like `fieldName[]` rather than `fieldName`

![the code it produces](https://user-images.githubusercontent.com/1094740/40242048-7357049c-5ab4-11e8-8fa4-f3e82877f3a8.jpg)

This PR checks if the field is iterable and adjusts the name accordingly

![what it should produce](https://user-images.githubusercontent.com/1094740/40242057-7c6f0516-5ab4-11e8-80cf-417d4ce114e1.jpg)