### PR TITLE
[Feature Request] Allow setting manual value for text columns.

### DIFF
--- a/src/resources/views/columns/text.blade.php
+++ b/src/resources/views/columns/text.blade.php
@@ -1,6 +1,10 @@
 {{-- regular object attribute --}}
 @php
-	$value = data_get($entry, $column['name']);
+	if(isset($column['value'])) {
+		$value = $column['value'];
+	} else {
+		$value = data_get($entry, $column['name']);
+	}
 @endphp
 
 <span>


### PR DESCRIPTION
Small addition for the Text columns.

Current text column:
```php
[
   'name' => 'name', // The db column name
   'label' => "Tag Name", // Table column heading
   // 'prefix' => "Name: ",
   // 'suffix' => "(user)",
   // 'limit' => 120, // character limit; default is 50;
],
```

New text column option
```php
[
   'value' => 'FooBar', // Text to be displayed
   'label' => "Tag Name", // Table column heading
   // 'prefix' => "Name: ",
   // 'suffix' => "(user)",
   // 'limit' => 120, // character limit; default is 50;
],
```

Reason this is useful:
say the type of column you need is not available, don't want to create a new one for a package, so you can create a function that gets you what data you need and just overwrite using a default value.