### PR TITLE
On failed Edit validation, cleared fields should stay cleared

### DIFF
--- a/src/resources/views/fields/text.blade.php
+++ b/src/resources/views/fields/text.blade.php
@@ -8,7 +8,7 @@
         <input
             type="text"
             name="{{ $field['name'] }}"
-            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            value="{{ old($field['name']) !== null ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
             @include('crud::inc.field_attributes')
         >
         @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif


### PR DESCRIPTION
Change needed to allow empty values in old() to clear a field on page reload. Needs to be done in all field. Have done it only for text and number fields.