### PR TITLE
[FEATURE] - Add the ability to remove ALL fields

### DIFF
--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -143,7 +143,7 @@ trait Fields
 
     /**
      * Remove many fields from the create/update/both forms by their name.
-     *
+     * 
      * @param array  $array_of_names A simple array of the names of the fields to be removed.
      * @param string $form           update/create/both
      */
@@ -152,6 +152,21 @@ trait Fields
         if (! empty($array_of_names)) {
             foreach ($array_of_names as $name) {
                 $this->removeField($name, $form);
+            }
+        }
+    }
+    
+    /**
+     * Remove all fields from the create/update/both forms.
+     * 
+     * @param string $form           update/create/both
+     */
+    public function removeAllFields($form = 'both')
+    {
+        $current_fields = $this->getCurrentFields();
+        if (! empty($current_fields)) {
+            foreach ($current_fields as $field) {
+                $this->removeField($field['name'], $form);
             }
         }
     }


### PR DESCRIPTION
Added a function to remove all fields from a CRUD on create/update or both forms. It helps if you have a form with 10+ fields.

I'v named it removeAllFields($form), as the others are removeField and removeFields.

now you can call $this->crud->removeAllFields() and have an empty crud to add the one or two fields you need on that form.

Nothing much to validate here, we call getCurrentFields() iterate over them, and delete.

Hope it helps someone too !

**_Haaaaaaa, before you ask, i'm using this because some fields are not yet initialized in crud so removing the ones defined i'm not going to write the code to add the same field again._** 