### PR TITLE
Return to current tab on save and edit

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/SaveActions.php
+++ b/src/app/Http/Controllers/CrudFeatures/SaveActions.php
@@ -89,8 +89,8 @@ trait SaveActions
                 break;
             case 'save_and_edit':
                 $redirectUrl = $this->crud->route.'/'.$itemId.'/edit';
-                if(\Request::has('current_tab')) {
-                  $redirectUrl = $redirectUrl.'#'.\Request::get('current_tab');
+                if (\Request::has('current_tab')) {
+                    $redirectUrl = $redirectUrl.'#'.\Request::get('current_tab');
                 }
                 if (\Request::has('locale')) {
                     $redirectUrl .= '?locale='.\Request::input('locale');

--- a/src/app/Http/Controllers/CrudFeatures/SaveActions.php
+++ b/src/app/Http/Controllers/CrudFeatures/SaveActions.php
@@ -89,9 +89,13 @@ trait SaveActions
                 break;
             case 'save_and_edit':
                 $redirectUrl = $this->crud->route.'/'.$itemId.'/edit';
+                if(\Request::has('current_tab')) {
+                  $redirectUrl = $redirectUrl.'#'.\Request::get('current_tab');
+                }
                 if (\Request::has('locale')) {
                     $redirectUrl .= '?locale='.\Request::input('locale');
                 }
+
                 break;
             case 'save_and_back':
             default:

--- a/src/resources/views/form_content.blade.php
+++ b/src/resources/views/form_content.blade.php
@@ -5,6 +5,7 @@
 {{-- See if we're using tabs --}}
 @if ($crud->tabsEnabled())
     @include('crud::inc.show_tabbed_fields')
+    <input type="hidden" name="current_tab" value="{{ str_slug($crud->getTabs()[0], "") }}" />
 @else
     @include('crud::inc.show_fields', ['fields' => $fields])
 @endif
@@ -116,6 +117,11 @@
         });
 
       @endif
+
+      $("a[data-toggle='tab']").click(function(){
+          currentTabName = $(this).attr('tab_name');
+          $("input[name='current_tab']").val(currentTabName);
+      });
 
       });
     </script>

--- a/src/resources/views/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/inc/show_tabbed_fields.blade.php
@@ -27,7 +27,7 @@
         <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'nav-stacked nav-pills'}}" role="tablist">
             @foreach ($crud->getTabs() as $k => $tab)
                 <li role="presentation" class="{{$k == 0 ? 'active' : ''}}">
-                    <a href="#tab_{{ str_slug($tab, "") }}" aria-controls="tab_{{ str_slug($tab, "") }}" role="tab" data-toggle="tab">{{ $tab }}</a>
+                    <a href="#tab_{{ str_slug($tab, "") }}" aria-controls="tab_{{ str_slug($tab, "") }}" role="tab" tab_name="{{ str_slug($tab, "") }}" data-toggle="tab" class="tab_toggler">{{ $tab }}</a>
                 </li>
             @endforeach
         </ul>


### PR DESCRIPTION
When clicking "Save and Edit" this will automatically return you to the tab that you were last on. For issue #1430