### PR TITLE
Fixes Laravel-Backpack/CRUD#1425 Broken Undo revision

### DIFF
--- a/src/app/Http/Controllers/CrudFeatures/Revisions.php
+++ b/src/app/Http/Controllers/CrudFeatures/Revisions.php
@@ -43,9 +43,6 @@ trait Revisions
     {
         $this->crud->hasAccessOrFail('revisions');
 
-        // get entry ID from Request (makes sure its the last ID for nested resources)
-        $id = $this->crud->getCurrentEntryId() ?? $id;
-
         $revisionId = \Request::input('revision_id', false);
         if (! $revisionId) {
             abort(500, 'Can\'t restore revision without revision_id');


### PR DESCRIPTION
While `getCurrentEntryId()` does have a use case in nested resources, this call obviously does not belong in the Revisions trait, as it will set `$id` to the last id in the route, which in the case of Revisions, means the `$revisionId`.

The currently released version of the code, when used in production, will cause harm to existing data, because hitting undo will potentially update the wrong records. Therefore, this call needs to be removed from the Revisions trait, to restore the proper functionality and prevent from further data damage.

More background can be found in #1425 and #1341, specifically https://github.com/Laravel-Backpack/CRUD/issues/1341#issuecomment-395113544

But this will at least fix #1425.
