### PR TITLE
[Ready] Order in select and select2

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -23,10 +23,11 @@ use Backpack\CRUD\PanelTraits\FakeFields;
 use Backpack\CRUD\PanelTraits\FakeColumns;
 use Illuminate\Database\Eloquent\Collection;
 use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
+use Backpack\CRUD\PanelTraits\CustomFormView;
 
 class CrudPanel
 {
-    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, CustomFormView;
 
     // --------------
     // CRUD variables
@@ -65,6 +66,10 @@ class CrudPanel
 
     // TONE FIELDS - TODO: find out what he did with them, replicate or delete
     public $sort = [];
+
+    public $custom_form_view='';
+    public $wide_form=false;
+
 
     // The following methods are used in CrudController or your EntityCrudController to manipulate the variables above.
 

--- a/src/PanelTraits/CustomFormView.php
+++ b/src/PanelTraits/CustomFormView.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait CustomFormView
+{
+    //when set as wide, removes the from wrapper that makes it look narrow
+    public function setFormView($custom_form_view, $is_wide = false)
+    {
+        $this->custom_form_view = $custom_form_view;
+        $this->wide_form        = $is_wide;
+    }
+
+    public function extractFields($fields)
+    {
+        $f = [];
+        foreach ($fields as $field) {
+            $f[$field['name']] = $field;
+        }
+        return $f;
+    }
+    public function extractTemplates($fields)
+    {
+        $t = [];
+        foreach ($fields as $field) {
+            if (isset($field['view_namespace'])) {
+                $t[$field['name']] = $field['view_namespace'] . '.' . $field['type'];
+            } else {
+                $t[$field['name']] = 'crud::fields.' . $field['type'];
+            }
+        }
+        return $t;
+    }
+
+}

--- a/src/resources/views/create.blade.php
+++ b/src/resources/views/create.blade.php
@@ -15,8 +15,12 @@
 @endsection
 
 @section('content')
+
+{{-- this is the form wrapper, we can set it off to let the programmer use the hole screen --}}
+@if(!$crud->wide_form)
 <div class="row">
 	<div class="col-md-8 col-md-offset-2">
+@endif
 		<!-- Default box -->
 		@if ($crud->hasAccess('list'))
 			<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
@@ -52,7 +56,10 @@
 
 		  </div><!-- /.box -->
 		  </form>
+		  
+@if(!$crud->wide_form)
 	</div>
 </div>
+@endif
 
 @endsection

--- a/src/resources/views/edit.blade.php
+++ b/src/resources/views/edit.blade.php
@@ -15,8 +15,12 @@
 @endsection
 
 @section('content')
+
+{{-- this is the form wrapper, we can set it off to let the programmer use the hole screen --}}
+@if(!$crud->wide_form)
 <div class="row">
 	<div class="col-md-8 col-md-offset-2">
+@endif
 		<!-- Default box -->
 		@if ($crud->hasAccess('list'))
 			<a href="{{ url($crud->route) }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a><br><br>
@@ -67,6 +71,9 @@
 		    </div><!-- /.box-footer-->
 		  </div><!-- /.box -->
 		  </form>
+
+@if(!$crud->wide_form)
 	</div>
 </div>
+@endif
 @endsection

--- a/src/resources/views/fields/select.blade.php
+++ b/src/resources/views/fields/select.blade.php
@@ -16,7 +16,7 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
+            @foreach ($field['model']::orderBy($field['attribute'])->get() as $connected_entity_entry)
                 @if(old($field['name']) == $connected_entity_entry->getKey() || (is_null(old($field['name'])) && isset($field['value']) && $field['value'] == $connected_entity_entry->getKey()))
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select.blade.php
+++ b/src/resources/views/fields/select.blade.php
@@ -16,7 +16,13 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::orderBy($field['attribute'])->get() as $connected_entity_entry)
+            @php        
+                if(isset($field['sorted']) && $field['sorted'] == false)
+                    $models=$field['model']::all();
+                else
+                    $models=$field['model']::orderBy($field['attribute'])->get();
+            @endphp
+            @foreach ($models as $connected_entity_entry)
                 @if(old($field['name']) == $connected_entity_entry->getKey() || (is_null(old($field['name'])) && isset($field['value']) && $field['value'] == $connected_entity_entry->getKey()))
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select.blade.php
+++ b/src/resources/views/fields/select.blade.php
@@ -17,10 +17,10 @@
 
         @if (isset($field['model']))
             @php        
-                if(isset($field['sorted']) && $field['sorted'] == false)
-                    $models=$field['model']::all();
-                else
+                if(isset($field['sorted']) && $field['sorted'] == true)
                     $models=$field['model']::orderBy($field['attribute'])->get();
+                else
+                    $models=$field['model']::all();
             @endphp
             @foreach ($models as $connected_entity_entry)
                 @if(old($field['name']) == $connected_entity_entry->getKey() || (is_null(old($field['name'])) && isset($field['value']) && $field['value'] == $connected_entity_entry->getKey()))

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -18,7 +18,13 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::orderBy($field['attribute'])->get() as $connected_entity_entry)
+            @php        
+                if(isset($field['sorted']) && $field['sorted'] == false)
+                    $models=$field['model']::all();
+                else
+                    $models=$field['model']::orderBy($field['attribute'])->get();
+            @endphp
+            @foreach ($models as $connected_entity_entry)
                 @if($current_value == $connected_entity_entry->getKey())
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -18,7 +18,7 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
+            @foreach ($field['model']::orderBy($field['attribute'])->get() as $connected_entity_entry)
                 @if($current_value == $connected_entity_entry->getKey())
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -19,10 +19,10 @@
 
         @if (isset($field['model']))
             @php        
-                if(isset($field['sorted']) && $field['sorted'] == false)
-                    $models=$field['model']::all();
-                else
+                if(isset($field['sorted']) && $field['sorted'] == true)
                     $models=$field['model']::orderBy($field['attribute'])->get();
+                else
+                    $models=$field['model']::all();
             @endphp
             @foreach ($models as $connected_entity_entry)
                 @if($current_value == $connected_entity_entry->getKey())

--- a/src/resources/views/form_content.blade.php
+++ b/src/resources/views/form_content.blade.php
@@ -2,8 +2,13 @@
 <input type="hidden" name="locale" value={{ $crud->request->input('locale')?$crud->request->input('locale'):App::getLocale() }}>
 @endif
 
-{{-- See if we're using tabs --}}
-@if ($crud->tabsEnabled())
+@if($crud->custom_form_view)
+{{-- if we are using a custom form view extract template name and field for the programmer --}}
+    @include($crud->custom_form_view,[
+      't'=>$crud->extractTemplates($fields),
+      'f'=>$crud->extractFields($fields)
+      ])
+@elseif ($crud->tabsEnabled()){{-- See if we're using tabs --}}
     @include('crud::inc.show_tabbed_fields')
 @else
     @include('crud::inc.show_fields', ['fields' => $fields])


### PR DESCRIPTION
Select and Select2 controls don't have order, which is annoying. 
This commit fixes it

## before
![imagen](https://user-images.githubusercontent.com/4065733/41171765-5507df66-6b17-11e8-96c5-903111e7eb8c.png)

## after
![imagen](https://user-images.githubusercontent.com/4065733/41171777-5bc3c702-6b17-11e8-9204-bc776e38cc46.png)
