### PR TITLE
[4.1][Feature][Ready] Feature select2_many and select2_one

### DIFF
--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -194,6 +194,7 @@ trait Create
                 $instance = new $model();
                 $model::whereIn($instance->getKeyName(), $removed)->update([$relation->getForeignKeyName() => $relationData['fallback_id'] ?? null]);
                 $model::whereIn($instance->getKeyName(), $added)->update([$relation->getForeignKeyName() => $item->getKey()]);
+                $item = $item->load($relationMethod);
             } else {
                 $relationModel = new $model();
                 $modelInstance = $relationModel->create($relationData['values']);

--- a/src/PanelTraits/Update.php
+++ b/src/PanelTraits/Update.php
@@ -2,7 +2,8 @@
 
 namespace Backpack\CRUD\PanelTraits;
 
-use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 trait Update
 {
@@ -92,8 +93,10 @@ trait Update
             }, $model);
 
             $relationMethod = end($relationArray);
-            if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasOneOrMany) {
+            if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasOne) {
                 return $relatedModel->{$relationMethod}->{$field['name']};
+            } else if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasMany) {
+                return $relatedModel->{$relationMethod};
             } else {
                 return $relatedModel->{$field['name']};
             }

--- a/src/PanelTraits/Update.php
+++ b/src/PanelTraits/Update.php
@@ -94,7 +94,7 @@ trait Update
 
             $relationMethod = end($relationArray);
             if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasOne) {
-                return $relatedModel->{$relationMethod}->{$field['name']};
+                return $relatedModel->{$relationMethod}->getKey();
             } elseif ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasMany) {
                 return $relatedModel->{$relationMethod};
             } else {

--- a/src/PanelTraits/Update.php
+++ b/src/PanelTraits/Update.php
@@ -95,7 +95,7 @@ trait Update
             $relationMethod = end($relationArray);
             if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasOne) {
                 return $relatedModel->{$relationMethod}->{$field['name']};
-            } else if ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasMany) {
+            } elseif ($relatedModel->{$relationMethod} && $relatedModel->{$relationMethod}() instanceof HasMany) {
                 return $relatedModel->{$relationMethod};
             } else {
                 return $relatedModel->{$field['name']};

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -53,7 +53,7 @@ class Install extends BaseInstall
                     $this->executeProcess('mkdir -p public/uploads');
                     break;
                 case '\\': // windows
-                    if(!file_exists('public\uploads')) {
+                    if (! file_exists('public\uploads')) {
                         $this->executeProcess('mkdir public\uploads');
                     }
                     break;

--- a/src/resources/views/fields/select2_many.blade.php
+++ b/src/resources/views/fields/select2_many.blade.php
@@ -1,0 +1,87 @@
+<!-- select2 many -->
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <select
+            name="{{ $field['name'] }}[]"
+            style="width: 100%"
+            @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_many'])
+            multiple>
+
+        @if (isset($field['allows_null']) && $field['allows_null']==true)
+            <option value="">-</option>
+        @endif
+
+        @if (isset($field['model']))
+            @foreach ($field['model']::all() as $connected_entity_entry)
+                @if( (old($field["name"]) && in_array($connected_entity_entry->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())))
+                    <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                @else
+                    <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                @endif
+            @endforeach
+        @endif
+    </select>
+
+    @if(isset($field['select_all']) && $field['select_all'])
+        <a class="btn btn-xs btn-default select_all" style="margin-top: 5px;"><i class="fa fa-check-square-o"></i> {{ trans('backpack::crud.select_all') }}</a>
+        <a class="btn btn-xs btn-default clear" style="margin-top: 5px;"><i class="fa fa-times"></i> {{ trans('backpack::crud.clear') }}</a>
+    @endif
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <!-- include select2 css-->
+        <link href="{{ asset('vendor/adminlte/bower_components/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <!-- include select2 js-->
+        <script src="{{ asset('vendor/adminlte/bower_components/select2/dist/js/select2.min.js') }}"></script>
+        <script>
+            jQuery(document).ready(function($) {
+                // trigger select2 for each untriggered select2_many box
+                $('.select2_many').each(function (i, obj) {
+                    if (!$(obj).hasClass("select2-hidden-accessible"))
+                    {
+                        var $obj = $(obj).select2({
+                            theme: "bootstrap"
+                        });
+
+                        var options = [];
+                        @if (isset($field['model']))
+                        @foreach ($field['model']::all() as $connected_entity_entry)
+                        options.push({{ $connected_entity_entry->getKey() }});
+                        @endforeach
+                        @endif
+
+                        @if(isset($field['select_all']) && $field['select_all'])
+                        $(obj).parent().find('.clear').on("click", function () {
+                            $obj.val([]).trigger("change");
+                        });
+                        $(obj).parent().find('.select_all').on("click", function () {
+                            $obj.val(options).trigger("change");
+                        });
+                        @endif
+                    }
+                });
+            });
+        </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/fields/select2_one.blade.php
+++ b/src/resources/views/fields/select2_one.blade.php
@@ -10,7 +10,7 @@
     <select
             name="{{ $field['name'] }}"
             style="width: 100%"
-            @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_field'])
+            @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_one'])
     >
 
         @if (isset($field['allows_null']) && $field['allows_null']==true)
@@ -53,7 +53,7 @@
         <script>
             jQuery(document).ready(function($) {
                 // trigger select2 for each untriggered select2 box
-                $('.select2_field').each(function (i, obj) {
+                $('.select2_one').each(function (i, obj) {
                     if (!$(obj).hasClass("select2-hidden-accessible"))
                     {
                         $(obj).select2({

--- a/src/resources/views/fields/select2_one.blade.php
+++ b/src/resources/views/fields/select2_one.blade.php
@@ -1,0 +1,70 @@
+<!-- select2_one -->
+@php
+    $current_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+@endphp
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::inc.field_translatable_icon')
+    <?php $entity_model = $crud->getRelationModel($field['entity'],  - 1); ?>
+    <select
+            name="{{ $field['name'] }}"
+            style="width: 100%"
+            @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_field'])
+    >
+
+        @if (isset($field['allows_null']) && $field['allows_null']==true)
+            <option value="">-</option>
+        @endif
+
+        @if (isset($field['model']))
+            @foreach ($field['model']::all() as $connected_entity_entry)
+                @if($current_value == $connected_entity_entry->getKey())
+                    <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                @else
+                    <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                @endif
+            @endforeach
+        @endif
+    </select>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+
+    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+    @push('crud_fields_styles')
+        <!-- include select2 css-->
+        <link href="{{ asset('vendor/adminlte/bower_components/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" rel="stylesheet" type="text/css" />
+    @endpush
+
+    {{-- FIELD JS - will be loaded in the after_scripts section --}}
+    @push('crud_fields_scripts')
+        <!-- include select2 js-->
+        <script src="{{ asset('vendor/adminlte/bower_components/select2/dist/js/select2.min.js') }}"></script>
+        <script>
+            jQuery(document).ready(function($) {
+                // trigger select2 for each untriggered select2 box
+                $('.select2_field').each(function (i, obj) {
+                    if (!$(obj).hasClass("select2-hidden-accessible"))
+                    {
+                        $(obj).select2({
+                            theme: "bootstrap"
+                        });
+                    }
+                });
+            });
+        </script>
+    @endpush
+
+@endif
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -94,6 +94,26 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         ],
     ];
 
+    private $userInputFieldsManyToOne = [
+        [
+            'name' => 'id',
+            'type' => 'hidden',
+        ], [
+            'name' => 'name',
+        ], [
+            'name' => 'email',
+            'type' => 'email',
+        ], [
+            'name' => 'password',
+            'type' => 'password',
+        ], [
+            'name' => 'articles',
+            'type' => 'select2_many',
+            'entity' => 'articles',
+            'attribute' => 'content',
+        ]
+    ];
+
     public function testCreate()
     {
         $this->crudPanel->setModel(User::class);
@@ -139,6 +159,26 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $this->assertEntryEquals($inputData, $entry);
         $this->assertEquals($article->toArray(), $entry->toArray());
+    }
+
+    public function tesateWithManyToOneRelationship()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addFields($this->userInputFieldsManyToOne);
+        $faker = Factory::create();
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => bcrypt($faker->password()),
+            'remember_token' => null,
+            'roles' => [1, 2],
+            'articles' => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertInstanceOf(User::class, $entry);
+        $this->assertEntryEquals($inputData, $entry);
     }
 
     public function testCreateWithManyToManyRelationship()

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -106,10 +106,18 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         ], [
             'name' => 'password',
             'type' => 'password',
+        ],[
+            'label' => 'Roles',
+            'type' => 'select_multiple',
+            'name' => 'roles',
+            'entity' => 'roles',
+            'attribute' => 'name',
+            'pivot' => true,
         ], [
             'name' => 'articles',
             'type' => 'select2_many',
             'entity' => 'articles',
+            'model' => Article::class,
             'attribute' => 'content',
         ],
     ];

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -111,7 +111,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
             'type' => 'select2_many',
             'entity' => 'articles',
             'attribute' => 'content',
-        ]
+        ],
     ];
 
     public function testCreate()

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -106,7 +106,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         ], [
             'name' => 'password',
             'type' => 'password',
-        ],[
+        ], [
             'label' => 'Roles',
             'type' => 'select_multiple',
             'name' => 'roles',

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -161,7 +161,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals($article->toArray(), $entry->toArray());
     }
 
-    public function tesateWithManyToOneRelationship()
+    public function testeWithManyToOneRelationship()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsManyToOne);

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -161,7 +161,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals($article->toArray(), $entry->toArray());
     }
 
-    public function testeWithManyToOneRelationship()
+    public function testCreateWithManyToOneRelationship()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsManyToOne);

--- a/tests/Unit/CrudPanel/CrudPanelReadTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReadTest.php
@@ -186,7 +186,7 @@ class CrudPanelReadTest extends BaseDBCrudPanelTest
         $entries = $this->crudPanel->getEntries();
 
         $this->assertInstanceOf(Collection::class, $entries);
-        $this->assertEquals(1, $entries->count());
+        $this->assertEquals(2, $entries->count());
         $this->assertEquals(User::find(1), $entries->first());
     }
 

--- a/tests/config/database/seeds/ArticlesTableSeeder.php
+++ b/tests/config/database/seeds/ArticlesTableSeeder.php
@@ -23,5 +23,17 @@ class ArticlesTableSeeder extends Seeder
             'cast_tags' => '{"cast_tags":["tag1","tag2","tag3"]}',
             'cast_extras' => '{"cast_extra_details":["detail1","detail2","detail3"]}',
         ]]);
+
+        DB::table('articles')->insert([[
+            'id' => 2,
+            'user_id' => 2,
+            'content' => 'Some Content',
+            'metas' => '{"meta_title":"Meta Title Value","meta_description":"Meta Description Value"}',
+            'tags' => '{"tags":["tag1","tag2","tag3"]}',
+            'extras' => '{"extra_details":["detail1","detail2","detail3"]}',
+            'cast_metas' => '{"cast_meta_title":"Meta Title Value","cast_meta_description":"Meta Description Value"}',
+            'cast_tags' => '{"cast_tags":["tag1","tag2","tag3"]}',
+            'cast_extras' => '{"cast_extra_details":["detail1","detail2","detail3"]}',
+        ]]);
     }
 }

--- a/tests/config/database/seeds/UsersTableSeeder.php
+++ b/tests/config/database/seeds/UsersTableSeeder.php
@@ -25,6 +25,16 @@ class UsersTableSeeder extends Seeder
             'updated_at' => $now,
         ]]);
 
+        DB::table('users')->insert([[
+            'id' => 2,
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => bcrypt('secret'),
+            'remember_token' => str_random(10),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]]);
+
         DB::table('user_role')->insert([
             'user_id' => 1,
             'role_id' => 1,


### PR DESCRIPTION
This PR references #1442 and implements fields for the following "inverse" relation types as these are currently not present.

- hasMany: select2_many
- hasOne: select2_one

As this affects only private functions in the `PanelTrait\Create` this should be non-breaking as people being affected with this changes have excessively overwritten the CrudPanel and PanelTraits, I think.

