### PR TITLE
Ignoring the hidden 'current_tab' field on store/update

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -113,7 +113,7 @@ class CrudController extends BaseController
         }
 
         // insert item in the db
-        $item = $this->crud->create($request->except(['save_action', '_token', '_method']));
+        $item = $this->crud->create($request->except(['save_action', '_token', '_method', 'current_tab']));
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message
@@ -177,7 +177,7 @@ class CrudController extends BaseController
 
         // update the row in the db
         $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $request->except('save_action', '_token', '_method'));
+                            $request->except('save_action', '_token', '_method', 'current_tab'));
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message


### PR DESCRIPTION
Fixes breaking issue in `return_current_tab` commit. Basically just adding "current_tab" to the exception list when storing and updating records.

https://github.com/Laravel-Backpack/CRUD/commit/4c8a338f36412ae99a9cb76e5a8bc97086d158d4#commitcomment-29499637