### PR TITLE
Remove outdated and unused import.

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -5,7 +5,6 @@ namespace Backpack\CRUD\app\Http\Controllers;
 use Backpack\CRUD\CrudPanel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Request as StoreRequest;
-use Illuminate\Support\Facades\Form as Form;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Http\Request as UpdateRequest;
 use Illuminate\Routing\Controller as BaseController;


### PR DESCRIPTION
Illuminate/Support/Facades/Form no longer exists and is not referenced elsewhere in the class.