### PR TITLE
Add default priority for responsive columns

### DIFF
--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -40,13 +40,14 @@
               <tr>
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th {{ isset($column['orderable']) ? 'data-orderable=' .var_export($column['orderable'], true) : '' }}>
+                  <th @if($loop->first) data-priority @endif
+                    {{ isset($column['orderable']) ? 'data-orderable=' .var_export($column['orderable'], true) : '' }}>
                     {{ $column['label'] }}
                   </th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
-                  <th data-orderable="false">{{ trans('backpack::crud.actions') }}</th>
+                  <th data-priority data-orderable="false">{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>
             </thead>


### PR DESCRIPTION
When using responsive columns and space is not enough for all of them, the _actions_ column is hidden and can only be used in the modal, which is not what an user expects when using an admin panel (they expect for the actions to be always available, even if a bit of data is hidden).

Adding a `data-priority` attribute in the table header tells data tables responsive extension which columns should be shown. This attribute can or can not have a parameter telling the column priority. [Here is the documentation for that feature.](https://www.datatables.net/extensions/responsive/priority).

So adding a `data-priority` attribute to the actions column header makes it always visible despite other columns being hidden. However, this causes a second issue. When space is so low than only one column can be shown, only the actions column will be visible. To solve this, the `data-priority` attribute is also added to the first column.

This is a simple solution for having expected defaults for which columns are shown. This could be extended so each column has a `responsive-priority` property that is passed to the list view, but it may be out of scope for now.

Looking forward to hear your opinions.