### PR TITLE
[Feature][3.4][Ready] Auto-add asterisks for required fields

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\PanelTraits\Read;
 use Backpack\CRUD\PanelTraits\Tabs;
 use Backpack\CRUD\PanelTraits\Query;
 use Backpack\CRUD\PanelTraits\Views;
+use Backpack\CRUD\PanelTraits\RequiredFields;
 use Backpack\CRUD\PanelTraits\Access;
 use Backpack\CRUD\PanelTraits\Create;
 use Backpack\CRUD\PanelTraits\Delete;
@@ -26,7 +27,7 @@ use Backpack\CRUD\PanelTraits\ViewsAndRestoresRevisions;
 
 class CrudPanel
 {
-    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views;
+    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, RequiredFields;
 
     // --------------
     // CRUD variables

--- a/src/PanelTraits/RequiredFields.php
+++ b/src/PanelTraits/RequiredFields.php
@@ -11,6 +11,13 @@ trait RequiredFields
     */
     public $requiredFields = [];
 
+    /**
+     * Parse a FormRequest class, figure out what inputs are required
+     * and store this knowledge in the current object.
+     *
+     * @param [type] $class     Class that extends FormRequest
+     * @param [type] $operation create / update
+     */
     public function setRequired($class, $operation)
     {
         $formRequest = new $class;
@@ -26,6 +33,13 @@ trait RequiredFields
         }
     }
 
+    /**
+     * Check the current object to see if an input is required
+     * for the given operation.
+     * @param  [type]  $inputName Field or input name.
+     * @param  [type]  $operation create / update
+     * @return boolean
+     */
     public function isRequired($inputName, $operation)
     {
         if (!isset($this->requiredFields[$operation])) {

--- a/src/PanelTraits/RequiredFields.php
+++ b/src/PanelTraits/RequiredFields.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Backpack\CRUD\PanelTraits;
+
+trait RequiredFields
+{
+    /*
+    |--------------------------------------------------------------------------
+    |                             REQUIRED FIELDS
+    |--------------------------------------------------------------------------
+    */
+    public $requiredFields = [];
+
+    public function setRequired($class, $operation)
+    {
+        $formRequest = new $class;
+
+        $rules = $formRequest->rules();
+
+        if (count($rules)) {
+            foreach ($rules as $key => $rule) {
+                if (strpos($rule, 'required') !== false) {
+                    $this->requiredFields[$operation][] = $key;
+                }
+            }
+        }
+    }
+
+    public function isRequired($inputName, $operation)
+    {
+        if (!isset($this->requiredFields[$operation])) {
+            return false;
+        }
+
+        return in_array($inputName, $this->requiredFields[$operation]);
+    }
+}

--- a/src/PanelTraits/RequiredFields.php
+++ b/src/PanelTraits/RequiredFields.php
@@ -38,7 +38,7 @@ trait RequiredFields
      * for the given operation.
      * @param  [type]  $inputName Field or input name.
      * @param  [type]  $operation create / update
-     * @return boolean
+     * @return bool
      */
     public function isRequired($inputName, $operation)
     {

--- a/src/resources/views/inc/field_wrapper_attributes.blade.php
+++ b/src/resources/views/inc/field_wrapper_attributes.blade.php
@@ -6,8 +6,8 @@
     @endforeach
 
     @if (!isset($field['wrapperAttributes']['class']))
-		class="form-group col-xs-12{{ isset($field['attributes']['required']) ? ' required' : '' }}"
+		class="form-group col-xs-12{{ isset($field['attributes']['required'])||$crud->isRequired($field['name'], $action) ? ' required' : '' }}"
     @endif
 @else
-	class="form-group col-xs-12{{ isset($field['attributes']['required']) ? ' required' : '' }}"
+	class="form-group col-xs-12{{ isset($field['attributes']['required'])||$crud->isRequired($field['name'], $action) ? ' required' : '' }}"
 @endif


### PR DESCRIPTION
This PR fixes https://github.com/Laravel-Backpack/CRUD/issues/1493

### What it does 

Say you have a standard form request, MonsterRequest, that you use in MonsterCrudController:
```php
<?php

namespace App\Http\Requests;

class MonsterRequest extends \Backpack\CRUD\app\Http\Requests\CrudRequest
{
    /**
     * Determine if the user is authorized to make this request.
     *
     * @return bool
     */
    public function authorize()
    {
        // only allow updates if the user is logged in
        return \Auth::check();
    }

    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            'text' => 'required|min:5|max:255',
            'number' => 'required',
        ];
    }
}
```

Then in ```MonsterCrudController::setup()``` you can do:
```php
        $this->crud->setRequiredFields(StoreRequest::class, 'create');
        $this->crud->setRequiredFields(UpdateRequest::class, 'edit');
```

And the asterisks will be show automatically for the fields that are required in that FormRequest:
<img width="646" alt="screen shot 2018-07-04 at 17 02 03" src="https://user-images.githubusercontent.com/1032474/42281397-15dad27c-7fac-11e8-81cb-5204ae089708.png">


Feedback?