### PR TITLE
[Bug fix] datatables trigger responsive when colvis toggled

### DIFF
--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -27,15 +27,12 @@
         fn.apply(window, args);
       },
       dataTableConfiguration: {
-        // initComplete: function () {
-        //     crud.responsiveToggle(
-        //         jQuery('#crudTable').DataTable()
-        //     );
-        // },
         responsive: {
             details: {
                 display: $.fn.dataTable.Responsive.display.modal( {
                     header: function ( row ) {
+                        // show the content of the first column
+                        // as the modal header
                         var data = row.data();
                         return data[0];
                     }
@@ -134,9 +131,14 @@
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
-            // console.log(functionName);
             crud.executeFunctionByName(functionName);
          });
+      } ).dataTable();
+
+      // when datatables-colvis (column visibility) is toggled
+      // rebuild the datatable using the datatable-responsive plugin
+      $('#crudTable').on( 'column-visibility.dt',   function (event) {
+         crud.table.responsive.rebuild();
       } ).dataTable();
 
       // when columns are hidden by reponsive plugin,


### PR DESCRIPTION
When column visibility is toggled (datatables-colvis plugin), the datatables-responsive plugin is used again, so that visible columns are recalculated.

In my opinion, it's a more proper fix for #1489 and #1416 .

@OwenMelbz what do you think? Works as expected for you? It fixes the problem you raised, right? 