### PR TITLE
[Feature][3.4][Ready] Added priority attribute to columns

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -8,6 +8,8 @@ trait Columns
     // COLUMNS
     // ------------
 
+    public $actions_column_priority = 1;
+
     /**
      * Get the CRUD columns.
      *
@@ -105,6 +107,13 @@ trait Columns
         }
 
         array_filter($this->columns[$column_with_details['key']] = $column_with_details);
+
+        // make sure the column has a priority in terms of visibility
+        // if no priority has been defined, use the order in the array plus one
+        if (! array_key_exists('priority', $column_with_details)) {
+            $position_in_columns_array = (int)array_search($column_with_details['key'], array_keys($this->columns));
+            $this->columns[$column_with_details['key']]['priority'] = $position_in_columns_array+1;
+        }
 
         // if this is a relation type field and no corresponding model was specified, get it from the relation method
         // defined in the main model
@@ -380,5 +389,29 @@ trait Columns
         }
 
         return in_array($name, $columns);
+    }
+
+    /**
+     * Get the visibility priority for the actions column
+     * in the CRUD table view.
+     *
+     * @return integer The priority, from 1 to infinity. Lower is better.
+     */
+    public function getActionsColumnPriority()
+    {
+        return (int)$this->actions_column_priority;
+    }
+
+    /**
+     * Set a certain priority for the actions column
+     * in the CRUD table view. Usually set to 10000 in order to hide it.
+     *
+     * @param integer $number The priority, from 1 to infinity. Lower is better.
+     */
+    public function setActionsColumnPriority($number)
+    {
+        $this->actions_column_priority = (int)$number;
+
+        return $this;
     }
 }

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -41,7 +41,7 @@
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
                   <th
-                    data-orderable=" {{ var_export($column['orderable'], true) }}"
+                    data-orderable="{{ var_export($column['orderable'], true) }}"
                     data-priority="{{ $column['priority'] }}"
                     >
                     {{ $column['label'] }}

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -40,13 +40,16 @@
               <tr>
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th {{ isset($column['orderable']) ? 'data-orderable=' .var_export($column['orderable'], true) : '' }}>
+                  <th
+                    data-orderable=" {{ var_export($column['orderable'], true) }}"
+                    data-priority="{{ $column['priority'] }}"
+                    >
                     {{ $column['label'] }}
                   </th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )
-                  <th data-orderable="false">{{ trans('backpack::crud.actions') }}</th>
+                  <th data-orderable="false" data-priority="{{ $crud->getActionsColumnPriority() }}">{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>
             </thead>


### PR DESCRIPTION
This PR allows us to customize in which order DataTables-responsive hides the columns, when needed, and makes sure that the actions column is also visible on small screens, when possible. 

**By default, DataTables-responsive will try his best to show:** 
- **the first column** (since that usually is the most important for the user, plus it holds the modal button and the details_row button so it's crucial for usability);
- **the last column** (the actions column, where the action buttons reside);

----

### Notes

- The first and last columns above are given ```priority=1``` by default. 
- You can define a different priority for a column with the ```priority``` attribute. For example:
```php
$this->crud->addColumn([
                'name' => 'details',
                'type' => 'text',
                'label' => 'Details',
                'priority' => 2,
            ]);
```
- When giving priorities, lower is better. So a column with priority 4 will be hidden BEFORE a column with priority 2.
- You can make the last column be less important (and hide) by giving it an unreasonable priority:
```php
$this->crud->setActionsColumnPriority(10000);
```

---

### User experience on small screen

Before (user has to open the modal to click Edit):
![screen recording 2018-07-05 at 11 32 am](https://user-images.githubusercontent.com/1032474/42311713-2d7451e2-8047-11e8-81d5-19b1cfa24de9.gif)


After (user DOES NOT have to open the modal to click Edit):
![screen recording 2018-07-05 at 11 33 am](https://user-images.githubusercontent.com/1032474/42311773-50176e00-8047-11e8-99cf-a7ee397cbd99.gif)

---

### Feedback

Thoughts? Possible issues you foresee? 