### PR TITLE
[Feature] Range Filter (FROM/TO) allow single

### DIFF
--- a/src/resources/views/filters/range.blade.php
+++ b/src/resources/views/filters/range.blade.php
@@ -78,7 +78,7 @@ END OF FILTER JAVSCRIPT CHECKLIST --}}
 				e.preventDefault();
 				var from = $("li[filter-name={{ $filter->name }}] .from").val();
 				var to = $("li[filter-name={{ $filter->name }}] .to").val();
-				if (from && to) {
+				if (from || to) {
 					var range = {
 						'from': from,
 						'to': to


### PR DESCRIPTION
This allows the range filter to filter only FROM or TO independant of beeing both filled.

The issued was raised in #1458 

We need to change the docs to reflect this change properly, is there a repo with docs? 

I leave here the solution for creating the filter:

```
$this->crud->addFilter([
            'name' => 'number',
            'type' => 'range',
            'label'=> 'Range',
            'label_from' => 'min value',
            'label_to' => 'max value'
          ],
          false,
          function($value) { // if the filter is active
            $range = json_decode($value);
            empty($range->from) ?:  $this->crud->addClause('where', 'number', '>=', $range->from);
            empty($range->to) ?:  $this->crud->addClause('where', 'number', '<=', $range->to);
          });
```