### PR TITLE
Third slug is same as second

### DIFF
--- a/src/ModelTraits/SpatieTranslatable/Sluggable.php
+++ b/src/ModelTraits/SpatieTranslatable/Sluggable.php
@@ -52,7 +52,7 @@ trait Sluggable
             $q->where($attribute, '=', $slug)
                 ->orWhere($attribute, 'LIKE', $slug.$separator.'%')
                 // Fixes issues with Json data types in MySQL where data is sourrounded by "
-                ->orWhere($attribute, 'LIKE', '"'.$slug.$separator.'%'); 
+                ->orWhere($attribute, 'LIKE', '"'.$slug.$separator.'%');
         });
     }
 }

--- a/src/ModelTraits/SpatieTranslatable/Sluggable.php
+++ b/src/ModelTraits/SpatieTranslatable/Sluggable.php
@@ -51,7 +51,8 @@ trait Sluggable
         return $query->where(function (Builder $q) use ($attribute, $slug, $separator) {
             $q->where($attribute, '=', $slug)
                 ->orWhere($attribute, 'LIKE', $slug.$separator.'%')
-                ->orWhere($attribute, 'LIKE', '"'.$slug.$separator.'%');
+                // Fixes issues with Json data types in MySQL where data is sourrounded by "
+                ->orWhere($attribute, 'LIKE', '"'.$slug.$separator.'%'); 
         });
     }
 }

--- a/src/ModelTraits/SpatieTranslatable/Sluggable.php
+++ b/src/ModelTraits/SpatieTranslatable/Sluggable.php
@@ -50,7 +50,8 @@ trait Sluggable
 
         return $query->where(function (Builder $q) use ($attribute, $slug, $separator) {
             $q->where($attribute, '=', $slug)
-                ->orWhere($attribute, 'LIKE', $slug.$separator.'%');
+                ->orWhere($attribute, 'LIKE', $slug.$separator.'%')
+                ->orWhere($attribute, 'LIKE', '"'.$slug.$separator.'%');
         });
     }
 }


### PR DESCRIPTION
It seems the MySql `LIKE` operator won't properly handle input.
After some troubleshooting I encountered, that with the JSON operator `->` it will select the value *with* `"`-marks surrounded.

So having the column `slug` with content `{"en":"a-slug-1"}` the line `->orWhere($attribute, 'LIKE', $slug.$separator.'%')` won't match as mysql selects `slug->en` as `"a-slug-1"` and not as `a-slug-1`.

As I suppose this has been working some time (or with other Databases) I just added one additional line which resolves this issue but won't break anything for everyone not having this (strange) issue.