### PR TITLE
[Feature][3.4][Ready] Actions (way to get the controller method being called) 

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -178,6 +178,31 @@ class CrudPanel
     // ACTIONS - the current operation being processed
     // -----------------------------------------------
 
+
+    /**
+     * Get the action being performed by the controller,
+     * including middleware names, route name, method name,
+     * namespace, prefix, etc.
+     *
+     * @return string The EntityCrudController method name.
+     */
+    public function getAction()
+    {
+        return $this->request->route()->getAction();
+    }
+
+
+    /**
+     * Get the full name of the controller method
+     * currently being called (including namespace).
+     *
+     * @return string The EntityCrudController method name.
+     */
+    public function getActionName()
+    {
+        return $this->request->route()->getActionName();
+    }
+
     /**
      * Get the name of the controller method
      * currently being called.
@@ -193,12 +218,12 @@ class CrudPanel
      * Check if the controller method being called
      * matches a given string.
      *
-     * @param  string $name Name of the method (ex: index, create, update)
-     * @return bool         Whether the condition is met or not.
+     * @param  string $methodName   Name of the method (ex: index, create, update)
+     * @return bool                 Whether the condition is met or not.
      */
-    public function actionIs($name)
+    public function actionIs($methodName)
     {
-        return $name === $this->getActionMethod();
+        return $methodName === $this->getActionMethod();
     }
 
     // ----------------------------------

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -174,6 +174,33 @@ class CrudPanel
         $this->entity_name_plural = $plural;
     }
 
+    // -----------------------------------------------
+    // ACTIONS - the current operation being processed
+    // -----------------------------------------------
+
+    /**
+     * Get the name of the controller method
+     * currently being called.
+     *
+     * @return string The EntityCrudController method name.
+     */
+    public function getActionMethod()
+    {
+        return $this->request->route()->getActionMethod();
+    }
+
+    /**
+     * Check if the controller method being called
+     * matches a given string.
+     *
+     * @param  string $name Name of the method (ex: index, create, update)
+     * @return bool         Whether the condition is met or not.
+     */
+    public function actionIs($name)
+    {
+        return $name === $this->getActionMethod();
+    }
+
     // ----------------------------------
     // Miscellaneous functions or methods
     // ----------------------------------

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -184,7 +184,7 @@ class CrudPanel
      * including middleware names, route name, method name,
      * namespace, prefix, etc.
      *
-     * @return string The EntityCrudController method name.
+     * @return string The EntityCrudController route action array.
      */
     public function getAction()
     {
@@ -196,7 +196,7 @@ class CrudPanel
      * Get the full name of the controller method
      * currently being called (including namespace).
      *
-     * @return string The EntityCrudController method name.
+     * @return string The EntityCrudController full method name with namespace.
      */
     public function getActionName()
     {


### PR DESCRIPTION
What is the current action being performed? This PR gives us a way to see that. It returns the name of the method on the controller. So for ```MonsterCrudController::index()```:
- ```$this->crud->actionIs('index')``` returns ```true```;
- ```$this->crud->actionIs('create')``` returns ```false```;
- ```$this->crud->getActionMethod()``` returns ```index```;
- ```$this->crud->getActionName()``` returns ```App\Http\Controllers\Admin\MonsterCrudController@index```;
- ```$this->crud->getAction()``` returns:
```php
array:7 [▼
  "middleware" => array:2 [▼
    0 => "web"
    1 => "admin"
  ]
  "as" => "crud.monster.index"
  "uses" => "App\Http\Controllers\Admin\MonsterCrudController@index"
  "controller" => "App\Http\Controllers\Admin\MonsterCrudController@index"
  "namespace" => "App\Http\Controllers\Admin"
  "prefix" => "admin"
  "where" => []
]
```

Note:
- this will take the method being run BY THE REQUEST; that means if you have other methods in your controller (say... ```MonsterCrudController::extraMethodYouCallSometimes()```, if you run ```$this->crud->getActionMethod()``` in that method, it will NOT return ```extraMethodYouCallSometimes```, but the FIRST method being run by the request - ```index```, ```create```, etc;

This provides a way to easily figure out what CRUD OPERATION is being performed (create / list / update / delete / etc). I like the term "operation" much better, but:
- Laravel already has the term [Controller Action](https://laravel.com/docs/5.6/controllers#basic-controllers), which refers to the controller method being called by the route;
- we _could_ come up with better names for operations, and map them to existing CrudController methods, to make them more intuitive ("list" operation calls ```index()```, "preview" operation calls ```show()```), but I think this extra layer would only make the library more difficult to understand and customize/overwrite;
- so I think it's easier to **think of actions as controller methods**; what's the current action being performed? create; ok, so then the ```create()``` method must have been called;

This should allow us:
- (with a breaking change) to FINALLY rename ```Access``` variables to something that makes sense, not some semi-intuitive strings we came up with two years ago when creating that functionality;
- to have views that are used by multiple operations (because we can then have conditionals inside the views);
- to easily load different views depending on the current operation; ACTION! (damn it); the current _action_ being performed;

Small change, this PR. **The only doubt I have is about the naming of ```$this->crud->actionIs()```, whether we can figure out a better name, or more consistent with other conditionals we have. Thoughts?**