### PR TITLE
Allows custom column templates to be searchable

### DIFF
--- a/src/PanelTraits/Search.php
+++ b/src/PanelTraits/Search.php
@@ -51,7 +51,7 @@ trait Search
         // sensible fallback search logic, if none was explicitly given
         if ($column['tableColumn']) {
             $columnType = isset($column['search_as']) ? $column['search_as'] : $column['type'];
-            
+
             switch ($columnType) {
                 case 'email':
                 case 'date':

--- a/src/PanelTraits/Search.php
+++ b/src/PanelTraits/Search.php
@@ -50,7 +50,9 @@ trait Search
 
         // sensible fallback search logic, if none was explicitly given
         if ($column['tableColumn']) {
-            switch ($column['type']) {
+            $columnType = isset($column['search_as']) ? $column['search_as'] : $column['type'];
+            
+            switch ($columnType) {
                 case 'email':
                 case 'date':
                 case 'datetime':


### PR DESCRIPTION
Currently, there is a hardcoded list of column types which can be searched.

```php
case 'email':
case 'date':
case 'datetime':
case 'text':
case 'select':
case 'select_multiple':
```

The problem is that this renders completely legit custom columns to be unsearchable.

This commit allows users to tell the Search trait how it should treat the column regarding searching by introducing a `search_as` property.

This lets you tell the search to act a certain way, e.g `text`, `email`, `select_multiple` etc.

--

The actual problem we have is that we use a custom blade template e.g `text_link.blade.php` which simply wraps a link around the column text. So the searchable value is still just `text`.

```
<span>
    <a href="{{ url($crud->route.'/'.$entry->getKey()) }}/edit" title="Open {{ $value }}">
        {{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 50, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}
    </a>
</span>
```