### PR TITLE
[Bug Fix][3.5][Ready] Adds crud->orderBy only when no other order has been specified

### DIFF
--- a/src/PanelTraits/Query.php
+++ b/src/PanelTraits/Query.php
@@ -50,6 +50,11 @@ trait Query
      */
     public function orderBy($field, $order = 'asc')
     {
+        if ($this->request->has('order'))
+        {
+            return $this->query;
+        }
+
         return $this->query->orderBy($field, $order);
     }
 

--- a/src/PanelTraits/Query.php
+++ b/src/PanelTraits/Query.php
@@ -50,8 +50,7 @@ trait Query
      */
     public function orderBy($field, $order = 'asc')
     {
-        if ($this->request->has('order'))
-        {
+        if ($this->request->has('order')) {
             return $this->query;
         }
 


### PR DESCRIPTION
Fixes #1415 (not 1416 as the commit says). Only applies crud->orderBy when the user hasn't clicked a table column heading.

_Might_ be a breaking change for some niche use cases. See #1415 for more details.