### PR TITLE
fixes #1546 fake castable translatable fields

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -80,7 +80,11 @@ trait CrudTrait
                 continue;
             }
 
-            $column_contents = $this->attributes[$column];
+            if ($this->translationEnabled() && $this->isTranslatableAttribute($column)) {
+                $column_contents = $this->{$column};
+            } else {
+                $column_contents = $this->attributes[$column];
+            }
 
             if (! is_object($column_contents)) {
                 $column_contents = json_decode($column_contents);


### PR DESCRIPTION
In my tests it completely fixes #1546 , where translatable fake fields that were also casted did not show up in the EDIT form.

I'm not super-happy about the solution. Yet another conditional in this method... But I don't see any other solution...