### PR TITLE
Fix no db prefix

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -57,7 +57,7 @@ trait AutoSet
     public function getDbColumnTypes()
     {
         $conn = $this->model->getConnection();
-        $table = $conn->getTablePrefix() . $this->model->getTable();
+        $table = $conn->getTablePrefix().$this->model->getTable();
         $table_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
 
         foreach ($table_columns as $key => $column) {

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -56,8 +56,8 @@ trait AutoSet
      */
     public function getDbColumnTypes()
     {
-        $table = $this->model->getTable();
         $conn = $this->model->getConnection();
+        $table = $conn->getTablePrefix() . $this->model->getTable();
         $table_columns = $conn->getDoctrineSchemaManager()->listTableColumns($table);
 
         foreach ($table_columns as $key => $column) {


### PR DESCRIPTION
If you use db prefix without this fix you will get empty columns list. Because of this intuiting a field type doesn't work.