### PR TITLE
Missed column type

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -92,6 +92,7 @@ trait AutoSet
 
         switch ($this->db_column_types[$field]['type']) {
             case 'int':
+            case 'integer':    
             case 'smallint':
             case 'mediumint':
             case 'longint':

--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -92,7 +92,7 @@ trait AutoSet
 
         switch ($this->db_column_types[$field]['type']) {
             case 'int':
-            case 'integer':    
+            case 'integer':
             case 'smallint':
             case 'mediumint':
             case 'longint':


### PR DESCRIPTION
In my case (10.2.13-MariaDB) int is returned as "integer".