### PR TITLE
Add Responsive Table Modal Padding

### DIFF
--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -43,7 +43,7 @@
                   var data = $.map( columns, function ( col, i ) {
                       return '<tr data-dt-row="'+col.rowIndex+'" data-dt-column="'+col.columnIndex+'">'+
                                 '<td><strong>'+col.title.trim()+':'+'<strong></td> '+
-                                '<td>'+col.data+'</td>'+
+                                '<td style="padding-left:10px;padding-bottom:10px;">'+col.data+'</td>'+
                               '</tr>';
                   } ).join('');
 


### PR DESCRIPTION
Helps make the modal pop for responsive tables a little prettier. Instead of no padding, just adds a little bit extra.

Before:
<img width="645" alt="screen shot 2018-07-30 at 3 25 25 pm" src="https://user-images.githubusercontent.com/487798/43427058-d4b10ada-940c-11e8-98cf-281a94c6f271.png">

After:
<img width="629" alt="screen shot 2018-07-30 at 3 22 49 pm" src="https://user-images.githubusercontent.com/487798/43427011-afd9ff8c-940c-11e8-84cd-ace778636641.png">
