### PR TITLE
[Feature][3.4][Ready] fixes #1575; added table column type

### DIFF
--- a/src/resources/views/columns/table.blade.php
+++ b/src/resources/views/columns/table.blade.php
@@ -1,0 +1,34 @@
+@php
+	$value = data_get($entry, $column['name']);
+	$columns = $column['columns'];
+
+	// if this attribute isn't using attribute casting, decode it
+	if (is_string($value)) {
+	    $value = json_decode($value);
+	}
+@endphp
+
+<span>
+	@if ($value && count($columns))
+	<table class="table table-bordered table-condensed table-striped m-b-0">
+		<thead>
+			<tr>
+				@foreach($columns as $tableColumnKey => $tableColumnLabel)
+				<th>{{ $tableColumnLabel }}</th>
+				@endforeach
+			</tr>
+		</thead>
+		<tbody>
+			@foreach ($value as $tableRow)
+			<tr>
+				@foreach($columns as $tableColumnKey => $tableColumnLabel)
+					<td>
+						{{ $tableRow->{$tableColumnKey} ?? $tableRow[$tableColumnKey] }}
+					</td>
+				@endforeach
+			</tr>
+			@endforeach
+		</tbody>
+	</table>
+	@endif
+</span>


### PR DESCRIPTION
Adds a "table" column type, to match the "table" field type. Should only be used inside the Preview functionality. Details [here](https://github.com/Laravel-Backpack/CRUD/issues/1575#issuecomment-410631234).

Syntax:
```php
$this->crud->addColumn([
            'name' => 'fields', 
            'label' => 'Terenuri', 
            'type' => 'table', 
            'columns' => [
                'suprafata' => 'Suprafata',
                'tarla' => 'Tarla',
                'parcela' => 'Parcela',
                'bloc_fizic' => 'Bloc fizic'
            ]
        ]);
```