### PR TITLE
[Feature][3.4] Make Show functionality official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 
 ### Added
 - merged #1577 - French Canadian translation thanks to @khoude24;
+- merged #1579 - table column type;
 
 ### Fixed
 - text column now json_encodes value if array, so that it does not trigger error;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 ### Added
 - merged #1577 - French Canadian translation thanks to @khoude24;
 
+### Fixed
+- text column now json_encodes value if array, so that it does not trigger error;
 
 ## [3.4.27] - 2018-07-19
 

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -76,7 +76,7 @@ trait Buttons
         $this->buttons = collect();
 
         // line stack
-        $this->addButton('line', 'preview', 'view', 'crud::buttons.preview', 'end');
+        $this->addButton('line', 'show', 'view', 'crud::buttons.show', 'end');
         $this->addButton('line', 'update', 'view', 'crud::buttons.update', 'end');
         $this->addButton('line', 'revisions', 'view', 'crud::buttons.revisions', 'end');
         $this->addButton('line', 'delete', 'view', 'crud::buttons.delete', 'end');

--- a/src/app/Http/Controllers/Operations/Show.php
+++ b/src/app/Http/Controllers/Operations/Show.php
@@ -40,7 +40,7 @@ trait Show
         $this->data['title'] = trans('backpack::crud.preview').' '.$this->crud->entity_name;
 
         // remove preview button from stack:line
-        $this->crud->removeButton('preview');
+        $this->crud->removeButton('show');
         $this->crud->removeButton('delete');
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package

--- a/src/resources/views/buttons/preview.blade.php
+++ b/src/resources/views/buttons/preview.blade.php
@@ -1,3 +1,5 @@
+{{-- This button is deprecated and will be removed in CRUD 3.5 --}}
+
 @if ($crud->hasAccess('show'))
 	<a href="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-xs btn-default"><i class="fa fa-eye"></i> {{ trans('backpack::crud.preview') }}</a>
 @endif

--- a/src/resources/views/buttons/show.blade.php
+++ b/src/resources/views/buttons/show.blade.php
@@ -1,0 +1,3 @@
+@if ($crud->hasAccess('show'))
+	<a href="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-xs btn-default"><i class="fa fa-eye"></i> {{ trans('backpack::crud.preview') }}</a>
+@endif

--- a/src/resources/views/buttons/show.blade.php
+++ b/src/resources/views/buttons/show.blade.php
@@ -1,3 +1,25 @@
-@if ($crud->hasAccess('show'))
+@if ($crud->hasAccess('update'))
+	@if (!$crud->model->translationEnabled())
+
+	<!-- Single edit button -->
 	<a href="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-xs btn-default"><i class="fa fa-eye"></i> {{ trans('backpack::crud.preview') }}</a>
+
+	@else
+
+	<!-- Edit button group -->
+	<div class="btn-group">
+	  <a href="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-xs btn-default"><i class="fa fa-eye"></i> {{ trans('backpack::crud.preview') }}</a>
+	  <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	    <span class="caret"></span>
+	    <span class="sr-only">Toggle Dropdown</span>
+	  </button>
+	  <ul class="dropdown-menu dropdown-menu-right">
+  	    <li class="dropdown-header">{{ trans('backpack::crud.preview') }}:</li>
+	  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
+		  	<li><a href="{{ url($crud->route.'/'.$entry->getKey()) }}?locale={{ $key }}">{{ $locale }}</a></li>
+	  	@endforeach
+	  </ul>
+	</div>
+
+	@endif
 @endif

--- a/src/resources/views/columns/table.blade.php
+++ b/src/resources/views/columns/table.blade.php
@@ -1,0 +1,34 @@
+@php
+	$value = data_get($entry, $column['name']);
+	$columns = $column['columns'];
+
+	// if this attribute isn't using attribute casting, decode it
+	if (is_string($value)) {
+	    $value = json_decode($value);
+	}
+@endphp
+
+<span>
+	@if ($value && count($columns))
+	<table class="table table-bordered table-condensed table-striped m-b-0">
+		<thead>
+			<tr>
+				@foreach($columns as $tableColumnKey => $tableColumnLabel)
+				<th>{{ $tableColumnLabel }}</th>
+				@endforeach
+			</tr>
+		</thead>
+		<tbody>
+			@foreach ($value as $tableRow)
+			<tr>
+				@foreach($columns as $tableColumnKey => $tableColumnLabel)
+					<td>
+						{{ $tableRow->{$tableColumnKey} ?? $tableRow[$tableColumnKey] }}
+					</td>
+				@endforeach
+			</tr>
+			@endforeach
+		</tbody>
+	</table>
+	@endif
+</span>

--- a/src/resources/views/columns/text.blade.php
+++ b/src/resources/views/columns/text.blade.php
@@ -1,6 +1,10 @@
 {{-- regular object attribute --}}
 @php
 	$value = data_get($entry, $column['name']);
+
+	if (is_array($value)) {
+		$value = json_encode($value);
+	}
 @endphp
 
 <span>

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -22,11 +22,24 @@
 	<!-- Default box -->
 	  <div class="box">
 	    <div class="box-header with-border">
-	    	<span class="pull-right"><a href="javascript: window.print();"><i class="fa fa-print"></i></a></span>
-	      <h3 class="box-title">
-            {{ trans('backpack::crud.preview') }}
-            <span>{{ $crud->entity_name }}</span>
-          </h3>
+	    	<span class="pull-right m-l-20 m-r-20 m-t-5"><a href="javascript: window.print();"><i class="fa fa-print"></i></a></span>
+
+          @if ($crud->model->translationEnabled())
+			    	<!-- Single button -->
+					<div class="btn-group pull-right">
+					  <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[$crud->request->input('locale')?$crud->request->input('locale'):App::getLocale()] }} <span class="caret"></span>
+					  </button>
+					  <ul class="dropdown-menu">
+					  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
+						  	<li><a href="{{ url($crud->route.'/'.$entry->getKey()) }}?locale={{ $key }}">{{ $locale }}</a></li>
+					  	@endforeach
+					  </ul>
+					</div>
+					<h3 class="box-title" style="line-height: 30px;">{{ trans('backpack::crud.preview') .' '. $crud->entity_name }}</h3>
+				@else
+					<h3 class="box-title">{{ trans('backpack::crud.preview') .' '. $crud->entity_name }}</h3>
+				@endif
 	    </div>
 	    <div class="box-body">
 			<table class="table table-striped table-bordered">

--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -41,7 +41,7 @@
 					<h3 class="box-title">{{ trans('backpack::crud.preview') .' '. $crud->entity_name }}</h3>
 				@endif
 	    </div>
-	    <div class="box-body">
+	    <div class="box-body no-padding">
 			<table class="table table-striped table-bordered">
 		        <tbody>
 		        @foreach ($crud->columns as $column)


### PR DESCRIPTION
So far, our "Show" functionality has not been documented & recommended because of a few implementation inconsistencies, and its use of ```setFromDb()```, which will be deprecated. These changes here make it so we can document the feature and allow everybody to use it:
- some cosmetic changes to ```show.blade.php```;
- added a button called ```show.blade.php```;
- did NOT remove the ```preview.blade.php``` button, for backwards-compatibility purposes; just added a deprecation comment to it;
- added multi-language functionality to the show button and show page (similar to Edit - a dropdown to pick the language);
- added a ```table``` column type, to match the ```table``` field type;
- we have no way of removing its use of ```setFromDb()``` since it would be a breaking change, so we embraced it - please see the Show usage syntax we'd be recommending in the docs, below;


### How to use the Show functionality (officially)

1. In your ```EntityCrudController::setup()``` method specify ```$this->crud->allowAccess('show');``` - this will make a Preview button appear in the table view, and allow access to the show view.
2. By default, the "show" functionality uses the same column types you've defined in setup() and adds all other fillable attributes. In case you need to add/change/remove any columns, create a ```show()``` method in the controller. Using the ```addColumn()``` you're already familiar with you'll be replacing any columns automagically added (since they'll have the same name):
```php
public function show($id)
    {
        $content = parent::show($id);

        $this->crud->addColumn([
            'name' => 'table',
            'label' => 'Table',
            'type' => 'table',
            'columns' => [
                'name'  => 'Name',
                'desc'  => 'Description',
                'price' => 'Price',
            ]
        ]);
        $this->crud->addColumn([
            'name' => 'fake_table',
            'label' => 'Fake Table',
            'type' => 'table',
            'columns' => [
                'name'  => 'Name',
                'desc'  => 'Description',
                'price' => 'Price',
            ],
        ]);
        $this->crud->addColumn('text');
        $this->crud->removeColumn('date');
        $this->crud->removeColumn('extras');

        return $content;
    }
```