### PR TITLE
Allow for temporary URL for upload files

### DIFF
--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -7,10 +7,11 @@
     @if (!empty($field['value']))
     <div class="well well-sm">
         @if (isset($field['disk']))
-        @if (isset($field['temporary'])
+        @if (isset($field['temporary']))
             <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
         @else
             <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(array_get($field, 'prefix', '').$field['value']))) }}">
+        @endif
         @else
             <a target="_blank" href="{{ (asset(array_get($field, 'prefix', '').$field['value'])) }}">
         @endif

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -7,6 +7,9 @@
     @if (!empty($field['value']))
     <div class="well well-sm">
         @if (isset($field['disk']))
+        @if (isset($field['temporary'])
+            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
+        @else
             <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(array_get($field, 'prefix', '').$field['value']))) }}">
         @else
             <a target="_blank" href="{{ (asset(array_get($field, 'prefix', '').$field['value'])) }}">


### PR DESCRIPTION
I added a parameter to allow a temporary URL. When uploading my files to Amazon S3 they default to private and the URL generated is a broken link. Allowing for temporary URL's should fix that