### PR TITLE
[Feature][3.4][Ready] Bulk action, bulk delete button

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -52,6 +52,7 @@ class CrudPanel
 
     public $details_row = false;
     public $export_buttons = false;
+    public $bulk_actions = false;
 
     public $columns = []; // Define the columns for the table view as an array;
     public $create_fields = []; // Define the fields for the "Add new entry" view as an array;

--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -24,6 +24,11 @@ class CrudRouter
             'uses' => $this->controller.'@search',
         ]);
 
+        Route::delete($this->name.'/bulk-delete', [
+            'as' => 'crud.'.$this->name.'.bulkDelete',
+            'uses' => $this->controller.'@bulkDelete',
+        ]);
+
         Route::get($this->name.'/reorder', [
             'as' => 'crud.'.$this->name.'.reorder',
             'uses' => $this->controller.'@reorder',

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -38,6 +38,7 @@ trait Delete
             'priority' => 1,
             'searchLogic' => false,
             'orderable' => false,
+            'visibleInModal' => false,
         ])->makeFirstColumn();
 
         $this->addColumn([
@@ -47,6 +48,7 @@ trait Delete
             'priority' => 1,
             'searchLogic' => false,
             'orderable' => false,
+            'visibleInModal' => false,
         ])->makeFirstColumn();
 
         $this->addButton('bottom', 'bulk_delete', 'view', 'crud::buttons.bulk_delete');

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -33,8 +33,8 @@ trait Delete
     {
         $this->addColumn([
             'type' => 'checkbox',
-            'name' => 'checkbox',
-            'label' => ' ',
+            'name' => 'bulk_actions',
+            'label' => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" />',
             'priority' => 1,
             'searchLogic' => false,
             'orderable' => false,

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -27,30 +27,10 @@ trait Delete
     }
 
     /**
-     * Add the needed columns and buttons for the bulk delete functionality.
+     * Add the button needed for the bulk delete functionality.
      */
     public function addBulkDeleteButton()
     {
-        $this->addColumn([
-            'type' => 'checkbox',
-            'name' => 'bulk_actions',
-            'label' => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" />',
-            'priority' => 1,
-            'searchLogic' => false,
-            'orderable' => false,
-            'visibleInModal' => false,
-        ])->makeFirstColumn();
-
-        $this->addColumn([
-            'type' => 'custom_html',
-            'name' => 'blank',
-            'label' => ' ',
-            'priority' => 1,
-            'searchLogic' => false,
-            'orderable' => false,
-            'visibleInModal' => false,
-        ])->makeFirstColumn();
-
         $this->addButton('bottom', 'bulk_delete', 'view', 'crud::buttons.bulk_delete');
     }
 }

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -27,10 +27,11 @@ trait Delete
     }
 
     /**
-     * Add the button needed for the bulk delete functionality.
+     * Add the bulk delete button to the bottom stack.
      */
     public function addBulkDeleteButton()
     {
+        // bottom stack
         $this->addButton('bottom', 'bulk_delete', 'view', 'crud::buttons.bulk_delete');
     }
 }

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -25,4 +25,27 @@ trait Delete
     {
         return (string) $this->model->findOrFail($id)->delete();
     }
+
+    public function addBulkDeleteButton()
+    {
+        $this->addColumn([
+            'type' => 'checkbox',
+            'name' => 'checkbox',
+            'label' => ' ',
+            'priority' => 1,
+            'searchLogic' => false,
+            'orderable' => false,
+        ])->makeFirstColumn();
+
+        $this->addColumn([
+            'type' => 'custom_html',
+            'name' => 'blank',
+            'label' => ' ',
+            'priority' => 1,
+            'searchLogic' => false,
+            'orderable' => false,
+        ])->makeFirstColumn();
+
+        $this->addButton('bottom', 'bulk_delete', 'view', 'crud::buttons.bulk_delete');
+    }
 }

--- a/src/PanelTraits/Delete.php
+++ b/src/PanelTraits/Delete.php
@@ -26,6 +26,9 @@ trait Delete
         return (string) $this->model->findOrFail($id)->delete();
     }
 
+    /**
+     * Add the needed columns and buttons for the bulk delete functionality.
+     */
     public function addBulkDeleteButton()
     {
         $this->addColumn([

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -159,6 +159,44 @@ trait Read
     }
 
     /**
+     * Add two more columns at the beginning of the ListEntrie table:
+     * - one shows the checkboxes needed for bulk actions
+     * - one is blank, in order for evenual details_row or expand buttons
+     * to be in a separate column
+     */
+    public function enableBulkActions()
+    {
+        $this->addColumn([
+            'type' => 'checkbox',
+            'name' => 'bulk_actions',
+            'label' => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" />',
+            'priority' => 1,
+            'searchLogic' => false,
+            'orderable' => false,
+            'visibleInModal' => false,
+        ])->makeFirstColumn();
+
+        $this->addColumn([
+            'type' => 'custom_html',
+            'name' => 'blank_first_column',
+            'label' => ' ',
+            'priority' => 1,
+            'searchLogic' => false,
+            'orderable' => false,
+            'visibleInModal' => false,
+        ])->makeFirstColumn();
+    }
+
+    /**
+     * Remove the two columns needed for bulk actions.
+     */
+    public function disableBulkActions()
+    {
+        $this->removeColumn('bulk_actions');
+        $this->removeColumn('blank_first_column');
+    }
+
+    /**
      * Set the number of rows that should be show on the list view.
      */
     public function setDefaultPageLength($value)

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -171,7 +171,7 @@ trait Read
         $this->addColumn([
             'type' => 'checkbox',
             'name' => 'bulk_actions',
-            'label' => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" />',
+            'label' => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px;" />',
             'priority' => 1,
             'searchLogic' => false,
             'orderable' => false,

--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -166,6 +166,8 @@ trait Read
      */
     public function enableBulkActions()
     {
+        $this->bulk_actions = true;
+
         $this->addColumn([
             'type' => 'checkbox',
             'name' => 'bulk_actions',
@@ -192,6 +194,8 @@ trait Read
      */
     public function disableBulkActions()
     {
+        $this->bulk_actions = false;
+
         $this->removeColumn('bulk_actions');
         $this->removeColumn('blank_first_column');
     }

--- a/src/app/Http/Controllers/Operations/Delete.php
+++ b/src/app/Http/Controllers/Operations/Delete.php
@@ -20,4 +20,25 @@ trait Delete
 
         return $this->crud->delete($id);
     }
+
+    /**
+     * Delete multiple entries in one go.
+     *
+     * @return string
+     */
+    public function bulkDelete()
+    {
+        $this->crud->hasAccessOrFail('delete');
+
+        $entries = $this->request->input('entries');
+        $deletedEntries = [];
+
+        foreach ($entries as $key => $id) {
+            if ($entry = $this->crud->model->find($id)) {
+                $deletedEntries[] = $entry->delete();
+            }
+        }
+
+        return $deletedEntries;
+    }
 }

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -67,7 +67,7 @@ return [
 
         // Bulk actions
         'bulk_no_entries_selected_title' => 'No entries selected',
-        'bulk_no_entries_selected_message' => 'Please use the checkbox next to the each element to select one or more items you would like to perform this action on.',
+        'bulk_no_entries_selected_message' => 'Please use select one or more items to perform a bulk action on them.',
 
         // Bulk delete confirmation
         'bulk_delete_are_you_sure' => 'Are you sure you want to delete these :number entries?',

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -65,6 +65,13 @@ return [
         'delete_confirmation_not_deleted_title'       => 'Not deleted',
         'delete_confirmation_not_deleted_message'     => 'Nothing happened. Your item is safe.',
 
+        // Bulk actions
+        'bulk_no_entries_selected_title' => 'No entries selected',
+        'bulk_no_entries_selected_message' => "Please use the checkbox next to the each element to select one or more items you would like to perform this action on.",
+
+        // Bulk delete confirmation
+        'bulk_delete_are_you_sure' => "Are you sure you want to delete these :number entries?",
+
         'ajax_error_title' => 'Error',
         'ajax_error_text'  => 'Error loading page. Please refresh the page.',
 

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -67,11 +67,16 @@ return [
 
         // Bulk actions
         'bulk_no_entries_selected_title' => 'No entries selected',
-        'bulk_no_entries_selected_message' => 'Please use select one or more items to perform a bulk action on them.',
+        'bulk_no_entries_selected_message' => 'Please select one or more items to perform a bulk action on them.',
 
-        // Bulk delete confirmation
+        // Bulk confirmation
         'bulk_delete_are_you_sure' => 'Are you sure you want to delete these :number entries?',
+        'bulk_delete_sucess_title' => 'Entries deleted',
+        'bulk_delete_sucess_message' => ' items have been deleted',
+        'bulk_delete_error_title' => 'Delete failed',
+        'bulk_delete_error_message' => 'One or more items could not be deleted',
 
+        // Ajax errors
         'ajax_error_title' => 'Error',
         'ajax_error_text'  => 'Error loading page. Please refresh the page.',
 

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -18,45 +18,39 @@
 	      	return;
 	      }
 
-	      var message = "{{ trans('backpack::crud.bulk_delete_are_you_sure') }}";
-	      message = message.replace(":number", crud.checkedItems.length);
+	      var message = ("{{ trans('backpack::crud.bulk_delete_are_you_sure') }}").replace(":number", crud.checkedItems.length);
+	      var button = $(this);
 
 	      // show confirm message
 	      if (confirm(message) == true) {
-	      		var ajax_calls = [];
+	      	  var ajax_calls = [];
+      		  var delete_route = "{{ url($crud->route) }}/bulk-delete";
 
-		        // for each crud.checkedItems
-		        crud.checkedItems.forEach(function(item) {
-	      		  var delete_route = "{{ url($crud->route) }}/"+item;
+	      	  // submit an AJAX delete call
+      		  $.ajax({
+	              url: delete_route,
+	              type: 'DELETE',
+				  data: { entries: crud.checkedItems },
+	              success: function(result) {
+	                  // Show an alert with the result
+	                  new PNotify({
+	                      title: ("{{ trans('backpack::crud.bulk_delete_sucess_title') }}"),
+	                      text: crud.checkedItems.length+"{{ trans('backpack::crud.bulk_delete_sucess_message') }}",
+	                      type: "success"
+	                  });
 
-		      	  // submit an AJAX delete call
-	      		  ajax_calls.push($.ajax({
-		              url: delete_route,
-		              type: 'DELETE',
-		              success: function(result) {
-		                  // Show an alert with the result
-		                  new PNotify({
-		                      title: "{{ trans('backpack::crud.delete_confirmation_title') }}",
-		                      text: "{{ trans('backpack::crud.delete_confirmation_message') }}",
-		                      type: "success"
-		                  });
-		              },
-		              error: function(result) {
-		                  // Show an alert with the result
-		                  new PNotify({
-		                      title: "{{ trans('backpack::crud.delete_confirmation_not_title') }}",
-		                      text: "{{ trans('backpack::crud.delete_confirmation_not_message') }}",
-		                      type: "warning"
-		                  });
-		              }
-		          }));
-
-		      });
-
-		      $.when.apply(this, ajax_calls).then(function ( ajax_calls ) {
-		      		crud.checkedItems = [];
-		      		crud.table.ajax.reload();
-				});
+	                  crud.checkedItems = [];
+			      	  crud.table.ajax.reload();
+	              },
+	              error: function(result) {
+	                  // Show an alert with the result
+	                  new PNotify({
+	                      title: "{{ trans('backpack::crud.bulk_delete_error_title') }}",
+	                      text: "{{ trans('backpack::crud.bulk_delete_error_message') }}",
+	                      type: "warning"
+	                  });
+	              }
+	          });
 	      }
       }
 	}

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -17,6 +17,7 @@
 
 	      	return;
 	      }
+
 	      var message = "{{ trans('backpack::crud.bulk_delete_are_you_sure') }}";
 	      message = message.replace(":number", crud.checkedItems.length);
 

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -55,7 +55,6 @@
 		      $.when.apply(this, ajax_calls).then(function ( ajax_calls ) {
 		      		crud.checkedItems = [];
 		      		crud.table.ajax.reload();
-		      		// crud.table.ajax.rebuild();
 				});
 	      }
       }

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -1,0 +1,64 @@
+@if ($crud->hasAccess('delete'))
+	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
+@endif
+
+@push('after_scripts')
+<script>
+	if (typeof bulkDeleteEntries != 'function') {
+	  function bulkDeleteEntries(button) {
+
+	      if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0)
+	      {
+	      	new PNotify({
+	              title: "No entries selected",
+	              text: "Please check items in order to perform bulk actions on multiple entries.",
+	              type: "warning"
+	          }); // TODO: move these texts to language file
+
+	      	return;
+	      }
+
+	      var message = "Are you sure you want to delete these "+crud.checkedItems.length+" entries?"; // TODO: move bulk delete message to languge file
+
+	      // show confirm message
+	      if (confirm(message) == true) {
+	      		var ajax_calls = [];
+
+		        // for each crud.checkedItems
+		        crud.checkedItems.forEach(function(item) {
+	      		  var delete_route = "{{ url($crud->route) }}/"+item;
+
+		      	  // submit an AJAX delete call
+	      		  ajax_calls.push($.ajax({
+		              url: delete_route,
+		              type: 'DELETE',
+		              success: function(result) {
+		                  // Show an alert with the result
+		                  new PNotify({
+		                      title: "{{ trans('backpack::crud.delete_confirmation_title') }}",
+		                      text: "{{ trans('backpack::crud.delete_confirmation_message') }}",
+		                      type: "success"
+		                  });
+		              },
+		              error: function(result) {
+		                  // Show an alert with the result
+		                  new PNotify({
+		                      title: "{{ trans('backpack::crud.delete_confirmation_not_title') }}",
+		                      text: "{{ trans('backpack::crud.delete_confirmation_not_message') }}",
+		                      type: "warning"
+		                  });
+		              }
+		          }));
+
+		      });
+
+		      $.when.apply(this, ajax_calls).then(function ( ajax_calls ) {
+		      		crud.checkedItems = [];
+		      		crud.table.ajax.reload();
+		      		// crud.table.ajax.rebuild();
+				});
+	      }
+      }
+	}
+</script>
+@endpush

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -1,5 +1,5 @@
 @if ($crud->hasAccess('delete') && $crud->bulk_actions)
-	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
+	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default bulk-button"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
 @endif
 
 @push('after_scripts')

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('delete'))
+@if ($crud->hasAccess('delete') && $crud->bulk_actions)
 	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
 @endif
 

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -10,15 +10,15 @@
 	      if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0)
 	      {
 	      	new PNotify({
-	              title: "No entries selected",
-	              text: "Please check items in order to perform bulk actions on multiple entries.",
+	              title: "{{ trans('backpack::crud.bulk_no_entries_selected_title') }}",
+	              text: "{{ trans('backpack::crud.bulk_no_entries_selected_message') }}",
 	              type: "warning"
-	          }); // TODO: move these texts to language file
+	          });
 
 	      	return;
 	      }
-
-	      var message = "Are you sure you want to delete these "+crud.checkedItems.length+" entries?"; // TODO: move bulk delete message to languge file
+	      var message = "{{ trans('backpack::crud.bulk_delete_are_you_sure') }}";
+	      message = message.replace(":number", crud.checkedItems.length);
 
 	      // show confirm message
 	      if (confirm(message) == true) {

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -3,30 +3,51 @@
     <input type="checkbox"
     		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"
-    		onClick="addOrRemoveCrudCheckedItem(this)"
     		>
 </span>
 
 <script>
 	if (typeof addOrRemoveCrudCheckedItem != 'function') {
 	  function addOrRemoveCrudCheckedItem(element) {
-		var checked = element.checked;
-		var primaryKeyValue = $(element).attr('data-primary-key-value');
-		// console.log(element.checked);
-		// console.log(primaryKeyValue);
+	  	crud.lastCheckedItem = false;
 
-		if (typeof crud.checkedItems === 'undefined') {
-			crud.checkedItems = [];
-		}
+	  	$("input.crud_bulk_actions_row_checkbox").click(function (e) {
+			var checked = this.checked;
+			var primaryKeyValue = $(this).attr('data-primary-key-value');
+			// console.log(this.checked);
+			// console.log(primaryKeyValue);
 
-		if (checked) {
-			crud.checkedItems.push(primaryKeyValue);
-		} else {
-			var index = crud.checkedItems.indexOf(primaryKeyValue);
-			if (index > -1) {
-			  crud.checkedItems.splice(index, 1);
+			if (typeof crud.checkedItems === 'undefined') {
+				crud.checkedItems = [];
 			}
-		}
+
+			if (checked) {
+				// add item to crud.checkedItems variable
+				crud.checkedItems.push(primaryKeyValue);
+
+				// if shift has been pressed, also select all elements
+				// between the last checked item and this one
+				if (crud.lastCheckedItem && e.shiftKey) {
+					var start_and_end = $("#crudTable .crud_bulk_actions_row_checkbox[data-primary-key-value="+crud.lastCheckedItem+"], #crudTable .crud_bulk_actions_row_checkbox[data-primary-key-value="+primaryKeyValue+"]");
+
+					var start = start_and_end.first();
+					var end = start_and_end.last();
+
+					start.parentsUntil('tr').parent().nextUntil('tr:has([data-primary-key-value="'+end.attr('data-primary-key-value')+'"])', ).each(function(i, element) {
+						$(element).find('input.crud_bulk_actions_row_checkbox:not(:checked)').trigger('click');
+					});
+				}
+
+				// remember that this one was the last checked item
+				crud.lastCheckedItem = primaryKeyValue;
+			} else {
+				// remove item from crud.checkedItems variable
+				var index = crud.checkedItems.indexOf(primaryKeyValue);
+				if (index > -1) {
+				  crud.checkedItems.splice(index, 1);
+				}
+			}
+	  	});
 	  }
 	}
 
@@ -68,6 +89,7 @@
 
 	// activate checkbox if the page reloaded and the item is remembered as selected
 	// make it so that the function above is run after each DataTable draw event
+	crud.addFunctionToDataTablesDrawEventQueue('addOrRemoveCrudCheckedItem');
 	crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
 	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
 	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -50,6 +50,13 @@
 				  crud.checkedItems.splice(index, 1);
 				}
 			}
+
+			// if no items are selected, disable all bulk buttons
+			if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0) {
+				$(".bulk-button").addClass('disabled');
+			} else {
+				$(".bulk-button").removeClass('disabled');
+			}
 	  	});
 	  }
 	}

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -1,0 +1,32 @@
+{{-- checkbox with loose false/null/0 checking --}}
+<span>
+    <input type="checkbox"
+    		class="dt_row_checkbox"
+    		data-primary-key-value="{{ $entry->getKey() }}"
+    		onClick="addOrRemoveCrudCheckedItem(this)"
+    		>
+</span>
+
+<script>
+	if (typeof addOrRemoveCrudCheckedItem != 'function') {
+	  function addOrRemoveCrudCheckedItem(element) {
+		var checked = element.checked;
+		var primaryKeyValue = $(element).attr('data-primary-key-value');
+		// console.log(element.checked);
+		// console.log(primaryKeyValue);
+
+		if (typeof crud.checkedItems === 'undefined') {
+			crud.checkedItems = [];
+		}
+
+		if (checked) {
+			crud.checkedItems.push(primaryKeyValue);
+		} else {
+			var index = crud.checkedItems.indexOf(primaryKeyValue);
+			if (index > -1) {
+			  crud.checkedItems.splice(index, 1);
+			}
+		}
+	  }
+	}
+</script>

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -3,6 +3,7 @@
     <input type="checkbox"
     		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"
+    		style="width: 16px; height: 16px;"
     		>
 </span>
 
@@ -12,6 +13,8 @@
 	  	crud.lastCheckedItem = false;
 
 	  	$("input.crud_bulk_actions_row_checkbox").click(function (e) {
+	  		e.stopPropagation();
+
 			var checked = this.checked;
 			var primaryKeyValue = $(this).attr('data-primary-key-value');
 			// console.log(this.checked);

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -52,11 +52,7 @@
 			}
 
 			// if no items are selected, disable all bulk buttons
-			if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0) {
-				$(".bulk-button").addClass('disabled');
-			} else {
-				$(".bulk-button").removeClass('disabled');
-			}
+			enableOrDisableBulkButtons();
 	  	});
 	  }
 	}
@@ -97,10 +93,21 @@
       }
     }
 
+    if (typeof enableOrDisableBulkButtons != 'function') {
+      function enableOrDisableBulkButtons() {
+		if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0) {
+			$(".bulk-button").addClass('disabled');
+		} else {
+			$(".bulk-button").removeClass('disabled');
+		}
+      }
+    }
+
 	// activate checkbox if the page reloaded and the item is remembered as selected
 	// make it so that the function above is run after each DataTable draw event
 	crud.addFunctionToDataTablesDrawEventQueue('addOrRemoveCrudCheckedItem');
 	crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
 	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
 	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
+	crud.addFunctionToDataTablesDrawEventQueue('enableOrDisableBulkButtons');
 </script>

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -1,7 +1,7 @@
 {{-- checkbox with loose false/null/0 checking --}}
 <span>
     <input type="checkbox"
-    		class="dt_row_checkbox"
+    		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"
     		onClick="addOrRemoveCrudCheckedItem(this)"
     		>
@@ -47,7 +47,28 @@
 	  }
 	}
 
+	if (typeof addBulkActionMainCheckboxesFunctionality != 'function') {
+      function addBulkActionMainCheckboxesFunctionality() {
+      	$(".crud_bulk_actions_main_checkbox").prop('checked', false);
+
+        // when the crud_bulk_actions_main_checkbox is selected, toggle all visible checkboxes
+        $("input.crud_bulk_actions_main_checkbox").click(function(event) {
+          if (this.checked) { // if checked, check all visible checkboxes
+              $("input.crud_bulk_actions_row_checkbox:not(:checked)").trigger('click');
+              // make sure the other checkbox has the same checked status
+              $("input.crud_bulk_actions_main_checkbox").prop('checked', true);
+          } else { // if not checked, uncheck all visible checkboxes
+              $("input.crud_bulk_actions_row_checkbox:checked").trigger('click');
+              // make sure the other checkbox has the same checked status
+              $("input.crud_bulk_actions_main_checkbox").prop('checked', false);
+          }
+        });
+      }
+    }
+
 	// activate checkbox if the page reloaded and the item is remembered as selected
 	// make it so that the function above is run after each DataTable draw event
 	crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
+	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
+	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
 </script>

--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -29,4 +29,25 @@
 		}
 	  }
 	}
+
+	if (typeof markCheckboxAsCheckedIfPreviouslySelected != 'function') {
+	  function markCheckboxAsCheckedIfPreviouslySelected() {
+	  	$('#crudTable input[type=checkbox][data-primary-key-value]').each(function(i, element) {
+			var checked = element.checked;
+			var primaryKeyValue = $(element).attr('data-primary-key-value');
+
+	  		if (typeof crud.checkedItems !== 'undefined' && crud.checkedItems.length > 0)
+	  		{
+	  			var index = crud.checkedItems.indexOf(primaryKeyValue);
+				if (index > -1) {
+					element.checked = true;
+				}
+			}
+	  	});
+	  }
+	}
+
+	// activate checkbox if the page reloaded and the item is remembered as selected
+	// make it so that the function above is run after each DataTable draw event
+	crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
 </script>

--- a/src/resources/views/columns/custom_html.blade.php
+++ b/src/resources/views/columns/custom_html.blade.php
@@ -1,0 +1,3 @@
+<span>
+	{!! $column['value']?? ' ' !!}
+</span>

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -140,6 +140,11 @@
           }
       });
 
+      // Bulk actions: if no items are selected, disable all bulk buttons
+      if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0) {
+        $(".bulk-button").addClass('disabled');
+      }
+
       // on DataTable draw event run all functions in the queue
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -41,6 +41,12 @@
                 } ),
                 renderer: function ( api, rowIdx, columns ) {
                   var data = $.map( columns, function ( col, i ) {
+                      var allColumnHeaders = $("#crudTable thead>tr>th");
+
+                      if ($(allColumnHeaders[col.columnIndex]).attr('data-visible-in-modal') == 'false') {
+                        return '';
+                      }
+
                       return '<tr data-dt-row="'+col.rowIndex+'" data-dt-column="'+col.columnIndex+'">'+
                                 '<td style="vertical-align:top;"><strong>'+col.title.trim()+':'+'<strong></td> '+
                                 '<td style="padding-left:10px;padding-bottom:10px;">'+col.data+'</td>'+

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -140,11 +140,6 @@
           }
       });
 
-      // Bulk actions: if no items are selected, disable all bulk buttons
-      if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0) {
-        $(".bulk-button").addClass('disabled');
-      }
-
       // on DataTable draw event run all functions in the queue
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -21,12 +21,14 @@
     <!-- THE ACTUAL CONTENT -->
     <div class="col-md-12">
       <div class="box">
+        @if ( $crud->buttons->where('stack', 'top')->count() ||  $crud->exportButtons())
         <div class="box-header hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
 
           @include('crud::inc.button_stack', ['stack' => 'top'])
 
           <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>
         </div>
+        @endif
 
         <div class="box-body overflow-hidden">
 
@@ -71,8 +73,11 @@
 
         </div><!-- /.box-body -->
 
-        @include('crud::inc.button_stack', ['stack' => 'bottom'])
-
+        @if ( $crud->buttons->where('stack', 'bottom')->count() )
+        <div class="box-footer hidden-print">
+          @include('crud::inc.button_stack', ['stack' => 'bottom'])
+        </div>
+        @endif
       </div><!-- /.box -->
     </div>
 

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -46,7 +46,7 @@
                     data-orderable="{{ var_export($column['orderable'], true) }}"
                     data-priority="{{ $column['priority'] }}"
                     >
-                    {{ $column['label'] }}
+                    {!! $column['label'] !!}
                   </th>
                 @endforeach
 
@@ -61,7 +61,7 @@
               <tr>
                 {{-- Table columns --}}
                 @foreach ($crud->columns as $column)
-                  <th>{{ $column['label'] }}</th>
+                  <th>{!! $column['label'] !!}</th>
                 @endforeach
 
                 @if ( $crud->buttons->where('stack', 'line')->count() )

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -45,6 +45,7 @@
                   <th
                     data-orderable="{{ var_export($column['orderable'], true) }}"
                     data-priority="{{ $column['priority'] }}"
+                    data-visible-in-modal="{{ (isset($column['visibleInModal']) && $column['visibleInModal'] == false) ? 'false' : 'true' }}"
                     >
                     {!! $column['label'] !!}
                   </th>


### PR DESCRIPTION
Status: **100% working, needs feedback.**
Video: https://cl.ly/5f02ac5502b7

![screen shot 2018-08-26 at 10 44 42](https://user-images.githubusercontent.com/1032474/44625982-1538f480-a91d-11e8-948c-1b4edc55a4f6.png)


In order to enable this, you need to do:
```php
$this->crud->enableBulkActions();
$this->crud->addBulkDeleteButton();
```

This _particular button_ makes a separate AJAX call for each item you want to delete, so you don't need an additional method inside the Controller. But having a button that calls a method with "items to delete" as arguments is totally possible. Don't know whether to keep it this way or not - I personally like the fact that, if an entry fails, I get 4 success messages and one warning. But I'm not sure about this one. **Thoughts?**

To do:
- [x] refresh the DataTable after all AJAX calls have been made;
- [x] make checkboxes reappear checked when using pagination and filtering;
- [x] move texts to language file;
- [x] hide the ```custom_html``` and ```checkbox``` columns from the preview modal (on small viewports);
- [x] (probably) ```addBulkDeleteButton()``` that does the above;
- [x] (probably) checkbox on table headers that selects or deselects all visible checkboxes - but what happens with what's not visible / on other pagination pages???;
- [x] (maybe) allow users to select multiple items using SHIFT;
- [x] (maybe) one AJAX call instead of one for each entry;