### PR TITLE
Fixed URL generation for the AJAX call in reorder

### DIFF
--- a/src/resources/views/reorder.blade.php
+++ b/src/resources/views/reorder.blade.php
@@ -137,7 +137,7 @@ function tree_element($entry, $key, $all_entries, $crud)
 
         // send it with POST
         $.ajax({
-            url: '{{ Request::url() }}',
+            url: '{{ URL::current() }}',
             type: 'POST',
             data: { tree: arraied },
         })


### PR DESCRIPTION
This fixes the problem where forceScheme is set to HTTPS, but the URL would still come out as HTTP.

Fixes #1618.