### PR TITLE
[3.6][Improvement] In datetime_picker field change parents to closest

### DIFF
--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -57,7 +57,7 @@ if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $fi
             $('[data-bs-datetimepicker]').each(function(){
 
                 var $fake = $(this),
-                $field = $fake.parents('.form-group').find('input[type="hidden"]'),
+                $field = $fake.closest('.form-group').find('input[type="hidden"]'),
                 $customConfig = $.extend({
                     format: 'DD/MM/YYYY HH:mm',
                     defaultDate: $field.val(),

--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -68,7 +68,7 @@ if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $fi
 
                 $customConfig.locale = $customConfig['language'];
                 delete($customConfig['language']);
-                $picker = $fake.datetimepicker($customConfig);
+                var $picker = $fake.datetimepicker($customConfig);
 
                 $fake.on('keydown', function(e){
                     e.preventDefault();


### PR DESCRIPTION
Change jQuery `parents` to `closest` for nested `.form-group` use.