### PR TITLE
Add JSON Editor Field :fire:

### DIFF
--- a/src/resources/views/fields/json_editor.blade.php
+++ b/src/resources/views/fields/json_editor.blade.php
@@ -1,0 +1,70 @@
+{{-- json field based on: https://github.com/josdejong/jsoneditor --}}
+@php
+
+$value = new stdClass();
+
+if (old($field['name'])) {
+    $value = old($field['name']);
+} elseif (isset($field['value']) && isset($field['default'])) {
+    $value = array_merge_recursive($field['default'], $field['value']);
+} elseif (isset($field['value'])) {
+    $value = $field['value'];
+} elseif (isset($field['default'])) {
+    $value = $field['default'];
+}
+
+// if attribute casting is used, convert to JSON
+if (is_array($value) || is_object($value) ) {
+    $value = json_encode($value);
+} elseif ($value instanceof \Spatie\SchemalessAttributes\SchemalessAttributes) {
+    $value = json_encode($value->all());
+}
+@endphp
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+
+    <div id="jsoneditor" style="height: 400px;"></div>
+
+    <input type="hidden" id="{{ $field['name'] }}"
+           name="{{ $field['name'] }}"
+           value=""
+            @include('crud::inc.field_attributes') />
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+    {{-- FIELD EXTRA CSS  --}}
+    {{-- push things in the after_styles section --}}
+
+    @push('crud_fields_styles')
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/5.24.6/jsoneditor.min.css" />
+    @endpush
+
+
+    {{-- FIELD EXTRA JS --}}
+    {{-- push things in the after_scripts section --}}
+
+    @push('crud_fields_scripts')
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/5.24.6/jsoneditor.min.js"></script>
+        @javascript('jsonString', $value)
+        <script>
+            const container = document.getElementById('jsoneditor');
+
+            const options = {
+                onChange: function() {
+                    const hiddenField = document.getElementById('{{ $field['name'] }}');
+                    hiddenField.value = editor.getText();
+                },
+                modes: ['form', 'tree', 'code']
+            };
+
+            const editor = new JSONEditor(container, options, JSON.parse(jsonString));
+            document.getElementById('{{ $field['name'] }}').value = editor.getText();
+        </script>
+    @endpush
+@endif
+{{-- Note: most of the times you'll want to use @if ($crud->checkIfFieldIsFirstOfItsType($field, $fields)) to only load CSS/JS once, even though there are multiple instances of it. --}}


### PR DESCRIPTION
A json editor field

It is basically this but for use in backpack as a custom field type:

https://github.com/josdejong/jsoneditor

I think there are many places where it could still be improved. Feel free to take it from here and improve it

Some important points:
- The field value when fetched from the eloquent model can be an array, object or Spatie SchemalessAttribute

- I used spatie javascript blade tag to inject the json string. You guys likely would want to do it a different way

```
@javascript('jsonString', $value)
```

- When the form is submitted, a json string value is submitted for thi value.

```
document.getElementById('{{ $field['name'] }}').value = editor.getText();
```

Instead of an array or object. You guys may want to change this as well

- Specifying the default value will result in an array_recursive_merge with the actual value of the json field. With the array of the JSON value from the record taking priority as it is on the right.

Feel free to ask me any questions about this. Thank you