### PR TITLE
[Feature][3.5][Ready] Fix access to $crud in button from model function

### DIFF
--- a/src/resources/views/inc/button_stack.blade.php
+++ b/src/resources/views/inc/button_stack.blade.php
@@ -2,7 +2,7 @@
 	@foreach ($crud->buttons->where('stack', $stack) as $button)
 	  @if ($button->type == 'model_function')
 		@if ($stack == 'line')
-	  		  {!! $entry->{$button->content}($entry); !!}
+	  		  {!! $entry->{$button->content}($crud); !!}
 		@else
 			  {!! $crud->model->{$button->content}($crud); !!}
 		@endif


### PR DESCRIPTION
If stack is 'line' and button type is 'model_function' you don't have access to the `$crud` object.

I think it's wrong anyway because we're calling the same method with two different parameter types: 

 - `$entry->{$button->content}($entry)`  <-- here we won't have `$crud` available to the method; `$entry` is unnecessarily passed as parameter, it will be available implicitly as `$this` inside the method

and

- `$crud->model->{$button->content}($crud)`  <-- same method called with a different parameter