### PR TITLE
Removed dependency of error_views

### DIFF
--- a/src/Exception/AccessDeniedException.php
+++ b/src/Exception/AccessDeniedException.php
@@ -14,6 +14,6 @@ class AccessDeniedException extends Exception
      */
     public function render($request)
     {
-        return response(view('errors.403', ['exception' => $this]), 403);
+        return abort(403);
     }
 }


### PR DESCRIPTION
This allows one to use the default laravel error messages.

Since I deleted the error views from `\resources\views\errors\***.blade.php` I was getting an error because of the render by `AccessDeniedException.php`.

@tabacitu I also think **backpack/base** should not publish the views for error messages, or at least they should be updated. This is the new design, which can be easily modified.

![image](https://user-images.githubusercontent.com/1838187/47608463-1a521700-da26-11e8-94e3-3a9ef1771763.png)

Tell me what you think about **backpack/base** and I may help with a PR.
