### PR TITLE
[3.5][Feature] model_function_attribute column - allow developers to pass parameters

### DIFF
--- a/src/resources/views/columns/model_function_attribute.blade.php
+++ b/src/resources/views/columns/model_function_attribute.blade.php
@@ -1,6 +1,6 @@
 {{-- custom return value via attribute --}}
 @php
-    $value = @$entry->{$column['function_name']}(...($column['function_parameters']?:[]))
+    $value = @$entry->{$column['function_name']}(...($column['function_parameters']?:[]))->{$column['attribute']}
 @endphp
 <span>
 	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit($value, array_key_exists('limit', $column) ? $column['limit'] : 50, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}

--- a/src/resources/views/columns/model_function_attribute.blade.php
+++ b/src/resources/views/columns/model_function_attribute.blade.php
@@ -1,6 +1,6 @@
 {{-- custom return value via attribute --}}
 @php
-    $value = $entry->{$column['function_name']}()->{$column['attribute']};
+    $value = @$entry->{$column['function_name']}(...($column['function_parameters']?:[]))
 @endphp
 <span>
 	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit($value, array_key_exists('limit', $column) ? $column['limit'] : 50, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}


### PR DESCRIPTION
Added a new option "function_parameters" for addColumn used for passing parameters (that aren't row fields) to the model function. Example:

 $this->crud->addColumn([
                   'name' => "district_id",
                   'label' => "District", 
                   'type' => "model_function_attribute",
                   'function_name' => 'getDistrictsByAreaId', // the method in your Model
                   'function_parameters' => [2], // used by model function getDistrictsByAreaId($area_id)
                ]);