### PR TITLE
[3.5][Merged] List view facelift, so information takes center-stage

### DIFF
--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -73,6 +73,56 @@
 		width: auto;
 	}
 
+
+	/* backpack filters */
+
+    .backpack-filter label {
+      color: #868686;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+
+    .navbar-filters {
+      min-height: 25px;
+      border-radius: 0;
+      margin-bottom: 0px;
+      margin-top: 0px;
+      background: transparent;
+      border-color: #f4f4f4;
+      border: none;
+    }
+
+    .navbar-filters .navbar-collapse {
+    	padding: 0;
+    }
+
+    .navbar-filters .navbar-toggle {
+      padding: 10px 15px;
+      border-radius: 0;
+    }
+
+    .navbar-filters .navbar-brand {
+      height: 25px;
+      padding: 5px 15px;
+      font-size: 14px;
+      text-transform: uppercase;
+    }
+    @media (min-width: 768px) {
+      .navbar-filters .navbar-nav>li>a {
+          padding-top: 5px;
+          padding-bottom: 5px;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .navbar-filters .navbar-nav {
+        margin: 0;
+      }
+    }
+
+
+	/* pagination overwrites */
+
 	.pagination>li>a {
 	  background: transparent;
 	  border: none;

--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -14,10 +14,10 @@
 
 	#crudTable_wrapper .dataTables_processing {
 		background: rgba(255,255,255,0.9);
-		top: 21px;
-		height: 100%;
-		left: 100px;
-		width: 100%;
+		top: 26px;
+		height: 98%;
+		left: 115px;
+		width: 97%;
 		z-index: 999;
 		border: none;
 		box-shadow: none;

--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -33,6 +33,12 @@
 		/*overflow: hidden;*/
 	}
 
+	#crudTable_wrapper #crudTable {
+		margin-top: 0px!important;
+	}
+
+  /*  DataTables Loading State Visual Improvements  */
+
 	#crudTable.dataTable.dtr-inline.collapsed>tbody>tr[role="row"]>td:first-child:before,
 	#crudTable.dataTable.dtr-inline.collapsed>tbody>tr[role="row"]>th:first-child:before {
 		background-color: transparent;
@@ -65,4 +71,50 @@
 
 	div.dataTables_wrapper div.dataTables_length select {
 		width: auto;
+	}
+
+	.pagination>li>a {
+	  background: transparent;
+	  border: none;
+	  border-radius: 25px;
+	  color: #333;
+	}
+
+	.pagination>.disabled>a,
+	.pagination>.disabled>a:focus,
+	.pagination>.disabled>a:hover,
+	.pagination>.disabled>span,
+	.pagination>.disabled>span:focus,
+	.pagination>.disabled>span:hover {
+	  background: transparent;
+	}
+
+	.pagination>li>a:focus,
+	.pagination>li>a:hover,
+	.pagination>li>span:focus,
+	.pagination>li>span:hover {
+	  background: white;
+	}
+
+	.pagination>li:last-child>a, .pagination>li:last-child>span,
+	.pagination>li:first-child>a, .pagination>li:first-child>span {
+	  border-radius: 25px;
+	}
+
+	.dataTables_filter {
+		text-align: right;
+	}
+
+	.dataTables_filter label {
+		font-weight: normal;
+	    white-space: nowrap;
+	    text-align: left;
+	}
+
+	.dataTables_filter input {
+		margin-left: 0.5em;
+	    display: inline-block;
+	    width: auto;
+	    border-radius: 25px;
+	    border: none;
 	}

--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -151,6 +151,8 @@
 	  border-radius: 5px;
 	}
 
+	/* datatable search overwrites */
+
 	.dataTables_filter {
 		text-align: right;
 	}
@@ -167,4 +169,9 @@
 	    width: auto;
 	    border-radius: 25px;
 	    /*border: none;*/
+	}
+
+	/* datatable header overwrites */
+	table.dataTable {
+		margin-top: 0px!important;
 	}

--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -76,7 +76,7 @@
 	.pagination>li>a {
 	  background: transparent;
 	  border: none;
-	  border-radius: 25px;
+	  border-radius: 5px;
 	  color: #333;
 	}
 
@@ -98,7 +98,7 @@
 
 	.pagination>li:last-child>a, .pagination>li:last-child>span,
 	.pagination>li:first-child>a, .pagination>li:first-child>span {
-	  border-radius: 25px;
+	  border-radius: 5px;
 	}
 
 	.dataTables_filter {
@@ -116,5 +116,5 @@
 	    display: inline-block;
 	    width: auto;
 	    border-radius: 25px;
-	    border: none;
+	    /*border: none;*/
 	}

--- a/src/resources/views/buttons/bulk_delete.blade.php
+++ b/src/resources/views/buttons/bulk_delete.blade.php
@@ -1,5 +1,5 @@
 @if ($crud->hasAccess('delete') && $crud->bulk_actions)
-	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default bulk-button"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
+	<a href="javascript:void(0)" onclick="bulkDeleteEntries(this)" class="btn btn-default btn-sm bulk-button"><i class="fa fa-trash"></i> {{ trans('backpack::crud.delete') }}</a>
 @endif
 
 @push('after_scripts')

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -84,8 +84,8 @@
               "paginate": {
                   "first":      "{{ trans('backpack::crud.paginate.first') }}",
                   "last":       "{{ trans('backpack::crud.paginate.last') }}",
-                  "next":       "<span class='hidden-xs hidden-sm'>{{ trans('backpack::crud.paginate.next') }}</span><span class='hidden-md hidden-lg'>></span>",
-                  "previous":   "<span class='hidden-xs hidden-sm'>{{ trans('backpack::crud.paginate.previous') }}</span><span class='hidden-md hidden-lg'><</span>"
+                  "next":       ">",
+                  "previous":   "<"
               },
               "aria": {
                   "sortAscending":  "{{ trans('backpack::crud.aria.sortAscending') }}",
@@ -107,9 +107,9 @@
               "type": "POST"
           },
           dom:
-            "<'row'<'col-sm-6 hidden-xs'l><'col-sm-6 hidden-print'f>>" +
+            "<'row hidden'<'col-sm-6 hidden-xs'i><'col-sm-6 hidden-print'f>>" +
             "<'row'<'col-sm-12'tr>>" +
-            "<'row'<'col-sm-5'i><'col-sm-2'B><'col-sm-5 hidden-print'p>>",
+            "<'row'<'col-sm-5'l><'col-sm-2'B><'col-sm-5 hidden-print'p>>",
       }
   }
   </script>
@@ -120,6 +120,12 @@
     jQuery(document).ready(function($) {
 
       crud.table = $("#crudTable").DataTable(crud.dataTableConfiguration);
+
+      // move search bar
+      $("#crudTable_filter").appendTo($('#datatable_search_stack' ));
+
+      // move "showing x out of y" info to header
+      $("#datatable_info_stack").html($('#crudTable_info'));
 
       // override ajax error message
       $.fn.dataTable.ext.errMode = 'none';

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -3,6 +3,8 @@
   <script src="https://cdn.datatables.net/1.10.16/js/dataTables.bootstrap.min.js" type="text/javascript"></script>
   <script src="https://cdn.datatables.net/responsive/2.2.1/js/dataTables.responsive.min.js"></script>
   <script src="https://cdn.datatables.net/responsive/2.2.1/js/responsive.bootstrap.min.js"></script>
+  <script src="
+https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
 
   <script>
     var crud = {
@@ -59,6 +61,7 @@
                 },
             }
         },
+        fixedHeader: true,
         @else
         responsive: false,
         scrollX: true,

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -109,7 +109,7 @@
           dom:
             "<'row hidden'<'col-sm-6 hidden-xs'i><'col-sm-6 hidden-print'f>>" +
             "<'row'<'col-sm-12'tr>>" +
-            "<'row'<'col-sm-5'l><'col-sm-2'B><'col-sm-5 hidden-print'p>>",
+            "<'row m-t-10'<'col-sm-5'l><'col-sm-2'B><'col-sm-5 hidden-print'p>>",
       }
   }
   </script>

--- a/src/resources/views/inc/datatables_logic.blade.php
+++ b/src/resources/views/inc/datatables_logic.blade.php
@@ -127,6 +127,9 @@
       // move "showing x out of y" info to header
       $("#datatable_info_stack").html($('#crudTable_info'));
 
+      // move the bottom buttons before pagination
+      $("#bottom_buttons").insertBefore($('#crudTable_wrapper .row:last-child' ));
+
       // override ajax error message
       $.fn.dataTable.ext.errMode = 'none';
       $('#crudTable').on('error.dt', function(e, settings, techNote, message) {

--- a/src/resources/views/inc/export_buttons.blade.php
+++ b/src/resources/views/inc/export_buttons.blade.php
@@ -9,6 +9,7 @@
   <script src="//cdn.datatables.net/buttons/1.5.1/js/buttons.colVis.min.js" type="text/javascript"></script>
   <script>
     crud.dataTableConfiguration.buttons = [
+        'colvis',
         {
             name: 'copyHtml5',
             extend: 'copyHtml5',
@@ -69,18 +70,17 @@
                 $.fn.DataTable.ext.buttons.print.action.call(this, e, dt, button, config);
                 crud.responsiveToggle(dt);
             }
-        },
-        'colvis'
+        }
     ];
 
     // move the datatable buttons in the top-right corner and make them smaller
     function moveExportButtonsToTopRight() {
-      crud.table.buttons().each(function(button) {
-        if (button.node.className.indexOf('buttons-columnVisibility') == -1)
-        {
-          button.node.className = button.node.className + " btn-sm";
-        }
-      })
+      // crud.table.buttons().each(function(button) {
+      //   if (button.node.className.indexOf('buttons-columnVisibility') == -1)
+      //   {
+      //     button.node.className = button.node.className + " btn-sm";
+      //   }
+      // })
       $(".dt-buttons").appendTo($('#datatable_button_stack' )).css('display', 'block');
     }
 

--- a/src/resources/views/inc/export_buttons.blade.php
+++ b/src/resources/views/inc/export_buttons.blade.php
@@ -75,12 +75,12 @@
 
     // move the datatable buttons in the top-right corner and make them smaller
     function moveExportButtonsToTopRight() {
-      // crud.table.buttons().each(function(button) {
-      //   if (button.node.className.indexOf('buttons-columnVisibility') == -1)
-      //   {
-      //     button.node.className = button.node.className + " btn-sm";
-      //   }
-      // })
+      crud.table.buttons().each(function(button) {
+        if (button.node.className.indexOf('buttons-columnVisibility') == -1)
+        {
+          button.node.className = button.node.className + " btn-sm";
+        }
+      })
       $(".dt-buttons").appendTo($('#datatable_button_stack' )).css('display', 'block');
     }
 

--- a/src/resources/views/inc/filters_navbar.blade.php
+++ b/src/resources/views/inc/filters_navbar.blade.php
@@ -24,57 +24,6 @@
     </div><!-- /.container-fluid -->
   </nav>
 
-
-@push('crud_list_styles')
-	<style>
-    .backpack-filter label {
-      color: #868686;
-      font-weight: 600;
-      text-transform: uppercase;
-    }
-
-    .navbar-filters {
-      min-height: 25px;
-      border-radius: 0;
-      margin-bottom: 0px;
-      /*margin-left: -10px;*/
-      /*margin-right: -10px;*/
-      margin-top: 10px;
-      background: transparent;
-      border-color: #f4f4f4;
-      border: none;
-    }
-
-    .navbar-filters .navbar-collapse {
-    	padding: 0;
-    }
-
-    .navbar-filters .navbar-toggle {
-      padding: 10px 15px;
-      border-radius: 0;
-    }
-
-    .navbar-filters .navbar-brand {
-      height: 25px;
-      padding: 5px 15px;
-      font-size: 14px;
-      text-transform: uppercase;
-    }
-    @media (min-width: 768px) {
-      .navbar-filters .navbar-nav>li>a {
-          padding-top: 5px;
-          padding-bottom: 5px;
-      }
-    }
-
-    @media (max-width: 768px) {
-      .navbar-filters .navbar-nav {
-        margin: 0;
-      }
-    }
-    </style>
-@endpush
-
 @push('crud_list_scripts')
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.18.2/URI.min.js" type="text/javascript"></script>
     <script>

--- a/src/resources/views/inc/filters_navbar.blade.php
+++ b/src/resources/views/inc/filters_navbar.blade.php
@@ -8,7 +8,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#">{{ trans('backpack::crud.filters') }}</a>
+        <a class="navbar-brand" href="#"><i class="fa fa-filter"></i> <span class="hidden-md hidden-lg">{{ trans('backpack::crud.filters') }}</span></a>
       </div>
 
       <!-- Collect the nav links, forms, and other content for toggling -->

--- a/src/resources/views/inc/filters_navbar.blade.php
+++ b/src/resources/views/inc/filters_navbar.blade.php
@@ -36,12 +36,13 @@
     .navbar-filters {
       min-height: 25px;
       border-radius: 0;
-      margin-bottom: 10px;
-      margin-left: -10px;
-      margin-right: -10px;
-      margin-top: -11px;
-      background: #f9f9f9;
+      margin-bottom: 0px;
+      /*margin-left: -10px;*/
+      /*margin-right: -10px;*/
+      margin-top: 10px;
+      background: transparent;
       border-color: #f4f4f4;
+      border: none;
     }
 
     .navbar-filters .navbar-collapse {

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -79,15 +79,16 @@
             </tfoot>
           </table>
 
+          @if ( $crud->buttons->where('stack', 'bottom')->count() )
+          <div id="bottom_buttons" class="hidden-print m-b-20">
+            @include('crud::inc.button_stack', ['stack' => 'bottom'])
+
+            <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>
+          </div>
+          @endif
+
         </div><!-- /.box-body -->
 
-        @if ( $crud->buttons->where('stack', 'bottom')->count() )
-        <div class="hidden-print">
-          @include('crud::inc.button_stack', ['stack' => 'bottom'])
-
-          <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>
-        </div>
-        @endif
       </div><!-- /.box -->
     </div>
 

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -6,11 +6,11 @@
 	    <span class="text-capitalize">{{ $crud->entity_name_plural }}</span>
 	    <small id="datatable_info_stack"></small>
 	  </h1>
-	  {{-- <ol class="breadcrumb">
+	  <ol class="breadcrumb">
 	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
 	    <li><a href="{{ url($crud->route) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
 	    <li class="active">{{ trans('backpack::crud.list') }}</li>
-	  </ol> --}}
+	  </ol>
 	</section>
 @endsection
 

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -23,7 +23,7 @@
       <div class="">
 
         <div class="row">
-          <div class="col-md-6">
+          <div class="col-xs-6">
             @if ( $crud->buttons->where('stack', 'top')->count() ||  $crud->exportButtons())
             <div class="hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
 
@@ -32,7 +32,7 @@
             </div>
             @endif
           </div>
-          <div class="col-md-6">
+          <div class="col-xs-6">
               <div id="datatable_search_stack" class="pull-right"></div>
           </div>
         </div>

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -99,6 +99,7 @@
 @section('after_styles')
   <!-- DATA TABLES -->
   <link href="https://cdn.datatables.net/1.10.16/css/dataTables.bootstrap.min.css" rel="stylesheet" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.2.1/css/responsive.bootstrap.min.css">
 
   <link rel="stylesheet" href="{{ asset('vendor/backpack/crud/css/crud.css') }}">

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -22,7 +22,7 @@
     <div class="col-md-12">
       <div class="">
 
-        <div class="row">
+        <div class="row m-b-10">
           <div class="col-xs-6">
             @if ( $crud->buttons->where('stack', 'top')->count() ||  $crud->exportButtons())
             <div class="hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
@@ -80,7 +80,7 @@
           </table>
 
           @if ( $crud->buttons->where('stack', 'bottom')->count() )
-          <div id="bottom_buttons" class="hidden-print m-b-20">
+          <div id="bottom_buttons" class="hidden-print">
             @include('crud::inc.button_stack', ['stack' => 'bottom'])
 
             <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>

--- a/src/resources/views/list.blade.php
+++ b/src/resources/views/list.blade.php
@@ -4,13 +4,13 @@
 	<section class="content-header">
 	  <h1>
 	    <span class="text-capitalize">{{ $crud->entity_name_plural }}</span>
-	    <small>{{ trans('backpack::crud.all') }} <span>{{ $crud->entity_name_plural }}</span> {{ trans('backpack::crud.in_the_database') }}.</small>
+	    <small id="datatable_info_stack"></small>
 	  </h1>
-	  <ol class="breadcrumb">
+	  {{-- <ol class="breadcrumb">
 	    <li><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
 	    <li><a href="{{ url($crud->route) }}" class="text-capitalize">{{ $crud->entity_name_plural }}</a></li>
 	    <li class="active">{{ trans('backpack::crud.list') }}</li>
-	  </ol>
+	  </ol> --}}
 	</section>
 @endsection
 
@@ -20,24 +20,31 @@
 
     <!-- THE ACTUAL CONTENT -->
     <div class="col-md-12">
-      <div class="box">
-        @if ( $crud->buttons->where('stack', 'top')->count() ||  $crud->exportButtons())
-        <div class="box-header hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
+      <div class="">
 
-          @include('crud::inc.button_stack', ['stack' => 'top'])
+        <div class="row">
+          <div class="col-md-6">
+            @if ( $crud->buttons->where('stack', 'top')->count() ||  $crud->exportButtons())
+            <div class="hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
 
-          <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>
+              @include('crud::inc.button_stack', ['stack' => 'top'])
+
+            </div>
+            @endif
+          </div>
+          <div class="col-md-6">
+              <div id="datatable_search_stack" class="pull-right"></div>
+          </div>
         </div>
-        @endif
-
-        <div class="box-body overflow-hidden">
 
         {{-- Backpack List Filters --}}
         @if ($crud->filtersEnabled())
           @include('crud::inc.filters_navbar')
         @endif
 
-        <table id="crudTable" class="table table-striped table-hover display responsive nowrap" cellspacing="0">
+        <div class="overflow-hidden">
+
+        <table id="crudTable" class="box table table-striped table-hover display responsive nowrap m-t-0" cellspacing="0">
             <thead>
               <tr>
                 {{-- Table columns --}}
@@ -75,8 +82,10 @@
         </div><!-- /.box-body -->
 
         @if ( $crud->buttons->where('stack', 'bottom')->count() )
-        <div class="box-footer hidden-print">
+        <div class="hidden-print">
           @include('crud::inc.button_stack', ['stack' => 'bottom'])
+
+          <div id="datatable_button_stack" class="pull-right text-right hidden-xs"></div>
         </div>
         @endif
       </div><!-- /.box -->


### PR DESCRIPTION
- moved "showing x items" right after the entity name, since "all items in the db" wasn't exactly true once it's filtered;
- moved the export buttons to the bottom-right corner, in line with bulk buttons
- made filters not stand out as much (when activated they pretty much work like tabs now)
- made pagination stand out less
- moved record per page to bottom
- rounded corners for pagination and search to make them less bulky
- added FixedHeader to DataTables, so that tables bigger than the viewport have better UX (usually tables with 25+ rows)

Before/after shot:
![screenshot 2018-10-31 at 15 39 13](https://user-images.githubusercontent.com/1032474/47791888-63a2af00-dd23-11e8-8a42-9325992ffb8f.png)

Thoughts, anyone?