### PR TITLE
[Fix][3.5][Ready] Check that model has crudtrait

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -91,7 +91,11 @@ class CrudPanel
     public function setModel($model_namespace)
     {
         if (! class_exists($model_namespace)) {
-            throw new \Exception('This model does not exist.', 404);
+            throw new \Exception('The model does not exist.', 500);
+        }
+
+        if (!method_exists($model_namespace, 'hasCrudTrait')) {
+            throw new \Exception('Please use CrudTrait on the model.', 500);
         }
 
         $this->model = new $model_namespace();

--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -94,7 +94,7 @@ class CrudPanel
             throw new \Exception('The model does not exist.', 500);
         }
 
-        if (!method_exists($model_namespace, 'hasCrudTrait')) {
+        if (! method_exists($model_namespace, 'hasCrudTrait')) {
             throw new \Exception('Please use CrudTrait on the model.', 500);
         }
 

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -9,6 +9,11 @@ use Illuminate\Database\Eloquent\Model;
 
 trait CrudTrait
 {
+    public static function hasCrudTrait()
+    {
+        return true;
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Methods for ENUM and SELECT crud fields.


### PR DESCRIPTION
When the model does NOT have CrudTrait, the page loads, but datatable doesn't. It just shows a red alert, the console log says nothing and the AJAX response is "server error". That's it. So _so_ difficult to debug.

This fix stops the entire CRUD from rendering, if CrudTrait is NOT on the model. I've used ```method_exists()``` instead of ```class_uses()``` because people might actually overwrite the CrudTrait, so it would have a different namespace.

Theoretically this is backwards-compatible. But since people might _not_ have used CrudTrait on all the models, we should _probably_ merge this into 3.5.