### PR TITLE
Fixes #509 - assets loaded twice when using tabs

### DIFF
--- a/src/PanelTraits/Fields.php
+++ b/src/PanelTraits/Fields.php
@@ -222,12 +222,12 @@ trait Fields
      * It's used in each field_type.blade.php to determine wether to push the css and js content or not (we only need to push the js and css for a field the first time it's loaded in the form, not any subsequent times).
      *
      * @param array $field        The current field being tested if it's the first of its type.
-     * @param array $fields_array All the fields in that particular form.
      *
      * @return bool true/false
      */
-    public function checkIfFieldIsFirstOfItsType($field, $fields_array)
+    public function checkIfFieldIsFirstOfItsType($field)
     {
+        $fields_array = $this->getCurrentFields();
         $first_field = $this->getFirstOfItsTypeInArray($field['type'], $fields_array);
 
         if ($field['name'] == $first_field['name']) {

--- a/src/resources/views/fields/address.blade.php
+++ b/src/resources/views/fields/address.blade.php
@@ -45,7 +45,7 @@ if (isset($field['value']) && (is_array($field['value']) || is_object($field['va
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/base64_image.blade.php
+++ b/src/resources/views/fields/base64_image.blade.php
@@ -54,7 +54,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/browse.blade.php
+++ b/src/resources/views/fields/browse.blade.php
@@ -31,7 +31,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
 	{{-- FIELD CSS - will be loaded in the after_styles section --}}
 	@push('crud_fields_styles')

--- a/src/resources/views/fields/browse_multiple.blade.php
+++ b/src/resources/views/fields/browse_multiple.blade.php
@@ -59,7 +59,7 @@ if (!$multiple && is_array($value)) {
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
         <!-- include browse server css -->

--- a/src/resources/views/fields/checklist_dependency.blade.php
+++ b/src/resources/views/fields/checklist_dependency.blade.php
@@ -168,7 +168,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/ckeditor.blade.php
+++ b/src/resources/views/fields/ckeditor.blade.php
@@ -18,7 +18,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/color_picker.blade.php
+++ b/src/resources/views/fields/color_picker.blade.php
@@ -24,7 +24,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -34,7 +34,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/date_range.blade.php
+++ b/src/resources/views/fields/date_range.blade.php
@@ -49,7 +49,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -33,7 +33,7 @@ if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $fi
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/icon_picker.blade.php
+++ b/src/resources/views/fields/icon_picker.blade.php
@@ -28,7 +28,7 @@ if (!isset($field['iconset'])) {
 </div>
 
 
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     @if($field['iconset'] == 'glyphicon')
         @push('crud_fields_scripts')

--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -64,7 +64,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/page_or_link.blade.php
+++ b/src/resources/views/fields/page_or_link.blade.php
@@ -110,7 +110,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -37,7 +37,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/fields/select2_from_ajax.blade.php
@@ -45,7 +45,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -39,7 +39,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/select2_from_array.blade.php
+++ b/src/resources/views/fields/select2_from_array.blade.php
@@ -50,7 +50,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/select2_multiple.blade.php
+++ b/src/resources/views/fields/select2_multiple.blade.php
@@ -38,7 +38,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/simplemde.blade.php
+++ b/src/resources/views/fields/simplemde.blade.php
@@ -18,7 +18,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/summernote.blade.php
+++ b/src/resources/views/fields/summernote.blade.php
@@ -17,7 +17,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/table.blade.php
+++ b/src/resources/views/fields/table.blade.php
@@ -80,7 +80,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
@@ -95,7 +95,7 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-sortable/0.14.3/sortable.min.js"></script>
         <script>
-          
+
             window.angularApp = window.angularApp || angular.module('backPackTableApp', ['ui.sortable'], function($interpolateProvider){
                 $interpolateProvider.startSymbol('<%');
                 $interpolateProvider.endSymbol('%>');

--- a/src/resources/views/fields/tinymce.blade.php
+++ b/src/resources/views/fields/tinymce.blade.php
@@ -18,7 +18,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')

--- a/src/resources/views/fields/video.blade.php
+++ b/src/resources/views/fields/video.blade.php
@@ -48,7 +48,7 @@ if (is_array($value)) {
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
-@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+@if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')


### PR DESCRIPTION
Fixes #509 in a backwards-compatible way.

Background: when ```$crud->checkIfFieldIsFirstOfItsType()``` searched if it was the first field, it only searched the fields of the current tab, because that variable got overwritten upstream.

But since this operation is done in the CrudPanel object, we don't actually need to pass the fields as a parameter. We can get them inside the ```checkIfFieldIsFirstOfItsType()``` method.

This PR removes the need for the second parameter.
Custom field types can still use the old call, with a second parameter, nothing bad is going to happen, Backpack will just ignore it.