### PR TITLE
[Fix][3.4][Ready] Fixes issue where fields got propopulated with value on redirect back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - #1540 fixes #1539 - what happens if actions don't exist because the controller is overwritten;
 - fixes #1678 - ```textarea``` column type has default search logic;
 - fixes #1676 - pagination in ```select2_from_ajax``` and ```select2_from_ajax_multiple``` fields;
+- fixes #509 using #1689 - assets got loaded twice if using tabs;
 
 
 ## [3.4.38] - 2018-10-26

--- a/src/resources/views/fields/address.blade.php
+++ b/src/resources/views/fields/address.blade.php
@@ -12,7 +12,7 @@ if (isset($field['value']) && (is_array($field['value']) || is_object($field['va
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
-    <input type="hidden" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}" name="{{ $field['name'] }}">
+    <input type="hidden" value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}" name="{{ $field['name'] }}">
 
     @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
         @if(isset($field['prefix'])) <div class="input-group-addon">{!! $field['prefix'] !!}</div> @endif

--- a/src/resources/views/fields/browse.blade.php
+++ b/src/resources/views/fields/browse.blade.php
@@ -9,7 +9,7 @@
 		id="{{ $field['name'] }}-filemanager"
 
 		name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
 
 		@if(!isset($field['readonly']) || $field['readonly']) readonly @endif

--- a/src/resources/views/fields/browse_multiple.blade.php
+++ b/src/resources/views/fields/browse_multiple.blade.php
@@ -1,6 +1,6 @@
 @php
 $multiple = array_get($field, 'multiple', true);
-$value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : null));
+$value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
 
 if (!$multiple && is_array($value)) {
     $value = array_first($value);

--- a/src/resources/views/fields/checkbox.blade.php
+++ b/src/resources/views/fields/checkbox.blade.php
@@ -9,7 +9,7 @@
 
           name="{{ $field['name'] }}"
 
-          @if(old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : false )))
+          @if (old($field['name']) ?? $field['value'] ?? $field['default'] ?? false)
                  checked="checked"
           @endif
 

--- a/src/resources/views/fields/ckeditor.blade.php
+++ b/src/resources/views/fields/ckeditor.blade.php
@@ -6,7 +6,7 @@
     	id="ckeditor-{{ $field['name'] }}"
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
-    	>{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+    	>{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/fields/color.blade.php
+++ b/src/resources/views/fields/color.blade.php
@@ -5,7 +5,7 @@
     <input
     	type="color"
     	name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
     	>
 

--- a/src/resources/views/fields/color_picker.blade.php
+++ b/src/resources/views/fields/color_picker.blade.php
@@ -7,7 +7,7 @@
         <input
         	type="text"
         	name="{{ $field['name'] }}"
-            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
             @include('crud::inc.field_attributes')
         	>
         <div class="input-group-addon">

--- a/src/resources/views/fields/date.blade.php
+++ b/src/resources/views/fields/date.blade.php
@@ -14,7 +14,7 @@ if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $fi
     <input
         type="date"
         name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
         >
 

--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -11,7 +11,7 @@
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
-    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}">
+    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}">
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     <div class="input-group date">

--- a/src/resources/views/fields/date_range.blade.php
+++ b/src/resources/views/fields/date_range.blade.php
@@ -26,8 +26,8 @@
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
-    <input class="datepicker-range-start" type="hidden" name="{{ $field['start_name'] }}" value="{{ old($field['start_name']) ? old($field['start_name']) : (isset($start_name) ? $start_name : (isset($field['start_default']) ? $field['start_default'] : '' )) }}">
-    <input class="datepicker-range-end" type="hidden" name="{{ $field['end_name'] }}" value="{{ old($field['end_name']) ? old($field['end_name']) : (!empty($end_name) ? $end_name : (isset($field['end_default']) ? $field['end_default'] : '' )) }}">
+    <input class="datepicker-range-start" type="hidden" name="{{ $field['start_name'] }}" value="{{ old($field['start_name']) ?? $start_name ?? $field['start_default'] ?? '' }}">
+    <input class="datepicker-range-end" type="hidden" name="{{ $field['end_name'] }}" value="{{ old($field['end_name']) ?? $end_name ?? $field['end_default'] ?? '' }}">
     <label>{!! $field['label'] !!}</label>
     <div class="input-group date">
         <input

--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -11,7 +11,7 @@ if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $fi
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
-    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}">
+    <input type="hidden" name="{{ $field['name'] }}" value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}">
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     <div class="input-group date" data-bs-datetimepicker="{{ isset($field['datetime_picker_options']) ? json_encode($field['datetime_picker_options']) : '{}'}}">

--- a/src/resources/views/fields/email.blade.php
+++ b/src/resources/views/fields/email.blade.php
@@ -5,7 +5,7 @@
     <input
     	type="email"
     	name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
     	>
 

--- a/src/resources/views/fields/hidden.blade.php
+++ b/src/resources/views/fields/hidden.blade.php
@@ -11,7 +11,7 @@
   <input
   	type="hidden"
     name="{{ $field['name'] }}"
-    value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+    value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
     @include('crud::inc.field_attributes')
   	>
 </div>

--- a/src/resources/views/fields/icon_picker.blade.php
+++ b/src/resources/views/fields/icon_picker.blade.php
@@ -12,7 +12,7 @@ if (!isset($field['iconset'])) {
     @include('crud::inc.field_translatable_icon')
 
     <div>
-        <button class="btn btn-default " role="iconpicker" data-icon="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}" data-iconset="{{ $field['iconset'] }}"></button>
+        <button class="btn btn-default " role="iconpicker" data-icon="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}" data-iconset="{{ $field['iconset'] }}"></button>
         <input
             type="hidden"
             name="{{ $field['name'] }}"

--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -5,7 +5,7 @@
     }
 
     $prefix = isset($field['prefix']) ? $field['prefix'] : '';
-    $value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '') );
+    $value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
     $image_url = $value
         ? preg_match('/^data\:image\//', $value)
             ? $value

--- a/src/resources/views/fields/month.blade.php
+++ b/src/resources/views/fields/month.blade.php
@@ -5,7 +5,7 @@
     <input
         type="month"
         name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
         >
 

--- a/src/resources/views/fields/number.blade.php
+++ b/src/resources/views/fields/number.blade.php
@@ -9,7 +9,7 @@
         	type="number"
         	name="{{ $field['name'] }}"
             id="{{ $field['name'] }}"
-            value="{{ old($field['name']) !== null ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
             @include('crud::inc.field_attributes')
         	>
         @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif

--- a/src/resources/views/fields/radio.blade.php
+++ b/src/resources/views/fields/radio.blade.php
@@ -1,7 +1,7 @@
 <!-- radio -->
 @php
     $optionPointer = 0;
-    $optionValue = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+    $optionValue = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
 
     // if the class isn't overwritten, use 'radio'
     if (!isset($field['attributes']['class'])) {

--- a/src/resources/views/fields/range.blade.php
+++ b/src/resources/views/fields/range.blade.php
@@ -5,7 +5,7 @@
     <input
         type="range"
         name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
         >
 

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -1,11 +1,13 @@
 <!-- select2 -->
 @php
-    $current_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+    $current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >
+
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
+
     <?php $entity_model = $crud->getRelationModel($field['entity'],  - 1); ?>
     <select
         name="{{ $field['name'] }}"

--- a/src/resources/views/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/fields/select2_from_ajax.blade.php
@@ -2,7 +2,7 @@
 @php
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
-    $old_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : false ));
+    $old_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? false;
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >

--- a/src/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -2,7 +2,7 @@
 @php
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
-    $old_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : false ));
+    $old_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? false;
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >

--- a/src/resources/views/fields/simplemde.blade.php
+++ b/src/resources/views/fields/simplemde.blade.php
@@ -6,7 +6,7 @@
     	id="simplemde_{{ $field['name'] }}"
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes', ['default_class' => 'form-control'])
-    	>{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+    	>{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/fields/summernote.blade.php
+++ b/src/resources/views/fields/summernote.blade.php
@@ -5,7 +5,7 @@
     <textarea
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control summernote'])
-        >{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+        >{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/fields/table.blade.php
+++ b/src/resources/views/fields/table.blade.php
@@ -5,7 +5,7 @@
     $min = isset($field['min']) && (int) $field['min'] > 0 ? $field['min'] : -1;
     $item_name = strtolower(isset($field['entity_singular']) && !empty($field['entity_singular']) ? $field['entity_singular'] : $field['label']);
 
-    $items = old($field['name']) ? (old($field['name'])) : (isset($field['value']) ? ($field['value']) : (isset($field['default']) ? ($field['default']) : '' ));
+    $items = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
 
     // make sure not matter the attribute casting
     // the $items variable contains a properly defined JSON

--- a/src/resources/views/fields/text.blade.php
+++ b/src/resources/views/fields/text.blade.php
@@ -8,7 +8,7 @@
         <input
             type="text"
             name="{{ $field['name'] }}"
-            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
             @include('crud::inc.field_attributes')
         >
         @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif

--- a/src/resources/views/fields/textarea.blade.php
+++ b/src/resources/views/fields/textarea.blade.php
@@ -6,7 +6,7 @@
     	name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes')
 
-    	>{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+    	>{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/fields/time.blade.php
+++ b/src/resources/views/fields/time.blade.php
@@ -5,7 +5,7 @@
     <input
     	type="time"
     	name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
     	>
 

--- a/src/resources/views/fields/tinymce.blade.php
+++ b/src/resources/views/fields/tinymce.blade.php
@@ -6,7 +6,7 @@
     	id="tinymce-{{ $field['name'] }}"
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control tinymce'])
-        >{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}</textarea>
+        >{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -23,7 +23,7 @@
         type="file"
         id="{{ $field['name'] }}_file_input"
         name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'form-control hidden':'form-control'])
     >
 

--- a/src/resources/views/fields/upload_multiple.blade.php
+++ b/src/resources/views/fields/upload_multiple.blade.php
@@ -21,7 +21,7 @@
         type="file"
         id="{{ $field['name'] }}_file_input"
         name="{{ $field['name'] }}[]"
-        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
+        value="@if (old($field['name'])) old($field['name']) @elseif (isset($field['default'])) $field['default'] @endif"
         @include('crud::inc.field_attributes')
         multiple
     >

--- a/src/resources/views/fields/upload_multiple.blade.php
+++ b/src/resources/views/fields/upload_multiple.blade.php
@@ -21,7 +21,7 @@
         type="file"
         id="{{ $field['name'] }}_file_input"
         name="{{ $field['name'] }}[]"
-        value="@if (old($field['name'])) old($field['name']) @elseif (isset($field['default'])) $field['default'] @endif"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
         multiple
     >

--- a/src/resources/views/fields/url.blade.php
+++ b/src/resources/views/fields/url.blade.php
@@ -5,7 +5,7 @@
     <input
     	type="url"
     	name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
     	>
 

--- a/src/resources/views/fields/video.blade.php
+++ b/src/resources/views/fields/video.blade.php
@@ -1,7 +1,7 @@
 <!-- text input -->
 <?php
 
-$value = old($field['name']) ? (old($field['name'])) : (isset($field['value']) ? ($field['value']) : (isset($field['default']) ? ($field['default']) : '' ));
+$value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
 
 // if attribute casting is used, convert to JSON
 if (is_array($value)) {

--- a/src/resources/views/fields/week.blade.php
+++ b/src/resources/views/fields/week.blade.php
@@ -5,7 +5,7 @@
     <input
         type="week"
         name="{{ $field['name'] }}"
-        value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+        value="{{ old($field['name']) ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::inc.field_attributes')
         >
 


### PR DESCRIPTION
If you cleared an input, then got redirected back to the same form (because of validation errors that had NOTHING to do with this field), you field got prepopulated with the value from the database, instead of staying cleared.

First mentioned and fixed by @abarta here: https://github.com/Laravel-Backpack/CRUD/pull/1421

This implements the fix for all field types.