### PR TITLE
[3.5][Feature][Ready] Relationship fields with callback - select options

### DIFF
--- a/src/resources/views/fields/select.blade.php
+++ b/src/resources/views/fields/select.blade.php
@@ -1,6 +1,7 @@
 <!-- select -->
 @php
 	$current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
+    $entity_model = $crud->getRelationModel($field['entity'],  - 1);
 
     if (!isset($field['options'])) {
         $options = $field['model']::all();
@@ -14,7 +15,6 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
 
-    <?php $entity_model = $crud->getRelationModel($field['entity'],  - 1); ?>
     <select
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes')

--- a/src/resources/views/fields/select.blade.php
+++ b/src/resources/views/fields/select.blade.php
@@ -1,6 +1,12 @@
 <!-- select -->
 @php
 	$current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
+
+    if (!isset($field['options'])) {
+        $options = $field['model']::all();
+    } else {
+        $options = call_user_func($field['options'], $field['model']::query());
+    }
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >
@@ -18,8 +24,8 @@
             <option value="">-</option>
         @endif
 
-        @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
+        @if (count($options))
+            @foreach ($options as $connected_entity_entry)
                 @if($current_value == $connected_entity_entry->getKey())
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select2.blade.php
+++ b/src/resources/views/fields/select2.blade.php
@@ -1,6 +1,13 @@
 <!-- select2 -->
 @php
     $current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
+    $entity_model = $crud->getRelationModel($field['entity'],  - 1);
+
+    if (!isset($field['options'])) {
+        $options = $field['model']::all();
+    } else {
+        $options = call_user_func($field['options'], $field['model']::query());
+    }
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >
@@ -8,7 +15,6 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
 
-    <?php $entity_model = $crud->getRelationModel($field['entity'],  - 1); ?>
     <select
         name="{{ $field['name'] }}"
         style="width: 100%"
@@ -19,12 +25,12 @@
             <option value="">-</option>
         @endif
 
-        @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
-                @if($current_value == $connected_entity_entry->getKey())
-                    <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+        @if (count($options))
+            @foreach ($options as $option)
+                @if($current_value == $option->getKey())
+                    <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
                 @else
-                    <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                    <option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>
                 @endif
             @endforeach
         @endif

--- a/src/resources/views/fields/select2_multiple.blade.php
+++ b/src/resources/views/fields/select2_multiple.blade.php
@@ -21,11 +21,11 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($options as $connected_entity_entry)
-                @if( (old($field["name"]) && in_array($connected_entity_entry->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())))
-                    <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+            @foreach ($options as $option)
+                @if( (old($field["name"]) && in_array($option->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($option->getKey(), $field['value']->pluck($option->getKeyName(), $option->getKeyName())->toArray())))
+                    <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
                 @else
-                    <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                    <option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>
                 @endif
             @endforeach
         @endif
@@ -70,9 +70,9 @@
                         });
 
                         var options = [];
-                        @if (isset($field['model']))
-                            @foreach ($field['model']::all() as $connected_entity_entry)
-                                options.push({{ $connected_entity_entry->getKey() }});
+                        @if (count($options))
+                            @foreach ($options as $option)
+                                options.push({{ $option->getKey() }});
                             @endforeach
                         @endif
 

--- a/src/resources/views/fields/select2_multiple.blade.php
+++ b/src/resources/views/fields/select2_multiple.blade.php
@@ -1,4 +1,12 @@
 <!-- select2 multiple -->
+@php
+    if (!isset($field['options'])) {
+        $options = $field['model']::all();
+    } else {
+        $options = call_user_func($field['options'], $field['model']::query());
+    }
+@endphp
+
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
@@ -13,7 +21,7 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($field['model']::all() as $connected_entity_entry)
+            @foreach ($options as $connected_entity_entry)
                 @if( (old($field["name"]) && in_array($connected_entity_entry->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())))
                     <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
                 @else

--- a/src/resources/views/fields/select_multiple.blade.php
+++ b/src/resources/views/fields/select_multiple.blade.php
@@ -1,7 +1,17 @@
 <!-- select multiple -->
+@php
+    if (!isset($field['options'])) {
+        $options = $field['model']::all();
+    } else {
+        $options = call_user_func($field['options'], $field['model']::query());
+    }
+@endphp
+
 <div @include('crud::inc.field_wrapper_attributes') >
+
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
+
     <select
     	class="form-control"
         name="{{ $field['name'] }}[]"
@@ -12,8 +22,8 @@
 			<option value="">-</option>
 		@endif
 
-    	@if (isset($field['model']))
-    		@foreach ($field['model']::all() as $connected_entity_entry)
+    	@if (count($options))
+    		@foreach ($options as $connected_entity_entry)
 				@if( (old($field["name"]) && in_array($connected_entity_entry->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())))
 					<option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
 				@else

--- a/src/resources/views/fields/select_multiple.blade.php
+++ b/src/resources/views/fields/select_multiple.blade.php
@@ -23,11 +23,11 @@
 		@endif
 
     	@if (count($options))
-    		@foreach ($options as $connected_entity_entry)
-				@if( (old($field["name"]) && in_array($connected_entity_entry->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($connected_entity_entry->getKey(), $field['value']->pluck($connected_entity_entry->getKeyName(), $connected_entity_entry->getKeyName())->toArray())))
-					<option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+    		@foreach ($options as $option)
+				@if( (old($field["name"]) && in_array($option->getKey(), old($field["name"]))) || (is_null(old($field["name"])) && isset($field['value']) && in_array($option->getKey(), $field['value']->pluck($option->getKeyName(), $option->getKeyName())->toArray())))
+					<option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
 				@else
-					<option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+					<option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>
 				@endif
     		@endforeach
     	@endif


### PR DESCRIPTION
Adds an ```options``` attribute to ```select```, ```select_multiple```, ```select2```, ```select2_multiple``` which can be used to customize the options shown in that particular select. Can be used to:
- order the options (fixes #1450)
- filter the options using a scope on the model (fixes #1266)
- filter the options using a custom query / callback (fixes #806 )

I think it fixes all the issues and PRs above in an inuitive way. So if you specify ```options``` on the field type, it will use the options you give it, instead of ```->all()```.

Example usage:

```php
// order the select options by name
$this->crud->addField([
    'label'     => 'Category',
    'type'      => 'select',
    'name'      => 'select',
    'entity'    => 'category',
    'attribute' => 'name',
    'tab'       => 'Selects',
    'options'   => (function ($query) {
        return $query->orderBy('name', 'ASC')->get();
    }),
]);

// apply a local scope to the Category model
$this->crud->addField([
    'label'     => 'Category',
    'type'      => 'select',
    'name'      => 'select',
    'entity'    => 'category',
    'attribute' => 'name',
    'tab'       => 'Selects',
    'options'   => (function ($query) {
        return $query->firstLevelItems()->get();
    }),
]);

// use a custom query
$this->crud->addField([
    'label'     => 'Category',
    'type'      => 'select',
    'name'      => 'select',
    'entity'    => 'category',
    'attribute' => 'name',
    'tab'       => 'Selects',
    'options'   => (function ($query) {
        return $query->where('depth', 1)->get();
    }),
]);
```