### PR TITLE
[3.5][Feature][Ready] Select_and_order field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - Nothing
 -----------
 
-## [3.4.40] - 2018-11-xx
+## [3.4.40] - 2018-11-11
 
 ### Added
 - #1587 - support for temporaryUrl to upload field type;
+- #1693 - Turkish language translations;
 
 
 ### Removed

--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -1,27 +1,13 @@
 <!-- select_and_order -->
 @php
-    $values = (array) $field['value'];
+    $values = isset($field['value']) ? (array)$field['value'] : [];
 @endphp
+
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     <div>
-        <ul id="{{ $field['name'] }}_all" class="{{ $field['name'] }}_connectedSortable select_and_order_all">
-            @if(old($field["name"]))
-                @foreach ($field['options'] as $key => $value)
-                    @if(!is_array(old($field["name"])) || !in_array($key, old($field["name"])))
-                        <li value="{{ $key}}">{{ $value }}</li>
-                    @endif
-                @endforeach
-            @elseif (isset($field['options']))
-                @foreach ($field['options'] as $key => $value)
-                    @if(is_array($values) && !in_array($key, $values))
-                        <li value="{{ $key}}">{{ $value }}</li>
-                    @endif
-                @endforeach
-            @endif
-        </ul>
-        <ul id="{{ $field['name'] }}_selected" class="{{ $field['name'] }}_connectedSortable select_and_order_selected">
+        <ul id="{{ $field['name'] }}_selected" class="{{ $field['name'] }}_connectedSortable select_and_order_selected col-xs-6 pull-left">
             @if(old($field["name"]))
                 @if(is_array(old($field["name"])))
                     @foreach (old($field["name"]) as $key)
@@ -34,6 +20,21 @@
                 @foreach ($values as $key)
                     @if(array_key_exists($key,$field['options']))
                     <li value="{{$key}}">{{ $field['options'][$key] }}</li>
+                    @endif
+                @endforeach
+            @endif
+        </ul>
+        <ul id="{{ $field['name'] }}_all" class="{{ $field['name'] }}_connectedSortable select_and_order_all col-xs-6 pull-right">
+            @if(old($field["name"]))
+                @foreach ($field['options'] as $key => $value)
+                    @if(!is_array(old($field["name"])) || !in_array($key, old($field["name"])))
+                        <li value="{{ $key}}">{{ $value }}</li>
+                    @endif
+                @endforeach
+            @elseif (isset($field['options']))
+                @foreach ($field['options'] as $key => $value)
+                    @if(is_array($values) && !in_array($key, $values))
+                        <li value="{{ $key}}">{{ $value }}</li>
                     @endif
                 @endforeach
             @endif
@@ -61,25 +62,25 @@
     @push('crud_fields_styles')
     <style>
         .select_and_order_all, .select_and_order_selected {
-            border: 1px solid #d2d6de;
-            width: 202px;
             min-height: 40px;
             list-style-type: none;
-            margin-right: 20px;
-            padding: 5px 0 0 0;
-            float: left;
-            max-height: 190px;
+            max-height: 220px;
             overflow: scroll;
             overflow-x: hidden;
+            padding: 0;
+            width: 48%;
+        }
+        .select_and_order_all li {
+            background: #fbfbfb;
+            color: grey;
         }
         .select_and_order_all li, .select_and_order_selected li{
             border: 1px solid #eee;
-            margin: 0 5px 5px 5px;
+            margin-top: 5px;
             padding: 5px;
-            font-size: 1.2em;
-            width: 175px;
-            overflow:hidden;
-            cursor:grab
+            font-size: 1em;
+            overflow: hidden;
+            cursor: grab;
         }
     </style>
     @endpush

--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -61,7 +61,8 @@
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
     <style>
-        .select_and_order_all, .select_and_order_selected {
+        .select_and_order_all,
+        .select_and_order_selected {
             min-height: 40px;
             list-style-type: none;
             max-height: 220px;
@@ -75,7 +76,8 @@
             background: #fbfbfb;
             color: grey;
         }
-        .select_and_order_all li, .select_and_order_selected li{
+        .select_and_order_all li,
+        .select_and_order_selected li{
             border: 1px solid #eee;
             margin-top: 5px;
             padding: 5px;
@@ -83,6 +85,17 @@
             overflow: hidden;
             cursor: grab;
             border-style: dashed;
+        }
+        .select_and_order_all li.ui-sortable-helper,
+        .select_and_order_selected li.ui-sortable-helper {
+            color: #3c8dbc;
+            border-collapse: #3c8dbc;
+            z-index: 9999;
+        }
+        .select_and_order_all .ui-sortable-placeholder,
+        .select_and_order_selected .ui-sortable-placeholder {
+            background-color: #3c8dbc;
+            visibility: visible;
         }
     </style>
     @endpush

--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -67,7 +67,8 @@
             max-height: 220px;
             overflow: scroll;
             overflow-x: hidden;
-            padding: 0;
+            padding: 0px 5px 5px 5px;
+            border: 1px solid #e6e6e6;
             width: 48%;
         }
         .select_and_order_all li {
@@ -81,6 +82,7 @@
             font-size: 1em;
             overflow: hidden;
             cursor: grab;
+            border-style: dashed;
         }
     </style>
     @endpush

--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -7,34 +7,34 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     <div>
-        <ul id="{{ $field['name'] }}_selected" class="{{ $field['name'] }}_connectedSortable select_and_order_selected col-xs-6 pull-left">
+        <ul id="{{ $field['name'] }}_selected" class="{{ $field['name'] }}_connectedSortable select_and_order_selected pull-left">
             @if(old($field["name"]))
                 @if(is_array(old($field["name"])))
                     @foreach (old($field["name"]) as $key)
                         @if(array_key_exists($key,$field['options']))
-                            <li value="{{$key}}">{{ $field['options'][$key] }}</li>
+                            <li value="{{$key}}"><i class="fa fa-arrows"></i> {{ $field['options'][$key] }}</li>
                         @endif
                     @endforeach
                 @endif
             @elseif (is_array($values))
                 @foreach ($values as $key)
                     @if(array_key_exists($key,$field['options']))
-                    <li value="{{$key}}">{{ $field['options'][$key] }}</li>
+                    <li value="{{$key}}"><i class="fa fa-arrows"></i> {{ $field['options'][$key] }}</li>
                     @endif
                 @endforeach
             @endif
         </ul>
-        <ul id="{{ $field['name'] }}_all" class="{{ $field['name'] }}_connectedSortable select_and_order_all col-xs-6 pull-right">
+        <ul id="{{ $field['name'] }}_all" class="{{ $field['name'] }}_connectedSortable select_and_order_all pull-right">
             @if(old($field["name"]))
                 @foreach ($field['options'] as $key => $value)
                     @if(!is_array(old($field["name"])) || !in_array($key, old($field["name"])))
-                        <li value="{{ $key}}">{{ $value }}</li>
+                        <li value="{{ $key}}"><i class="fa fa-arrows"></i> {{ $value }}</li>
                     @endif
                 @endforeach
             @elseif (isset($field['options']))
                 @foreach ($field['options'] as $key => $value)
                     @if(is_array($values) && !in_array($key, $values))
-                        <li value="{{ $key}}">{{ $value }}</li>
+                        <li value="{{ $key}}"><i class="fa fa-arrows"></i> {{ $value }}</li>
                     @endif
                 @endforeach
             @endif
@@ -63,7 +63,7 @@
     <style>
         .select_and_order_all,
         .select_and_order_selected {
-            min-height: 40px;
+            min-height: 120px;
             list-style-type: none;
             max-height: 220px;
             overflow: scroll;
@@ -72,9 +72,8 @@
             border: 1px solid #e6e6e6;
             width: 48%;
         }
-        .select_and_order_all li {
-            background: #fbfbfb;
-            color: grey;
+        .select_and_order_all {
+            border: none;
         }
         .select_and_order_all li,
         .select_and_order_selected li{
@@ -86,6 +85,13 @@
             cursor: grab;
             border-style: dashed;
         }
+        .select_and_order_all li {
+            background: #fbfbfb;
+            color: grey;
+        }
+        .select_and_order_selected li {
+            border-style: solid;
+        }
         .select_and_order_all li.ui-sortable-helper,
         .select_and_order_selected li.ui-sortable-helper {
             color: #3c8dbc;
@@ -94,14 +100,19 @@
         }
         .select_and_order_all .ui-sortable-placeholder,
         .select_and_order_selected .ui-sortable-placeholder {
-            background-color: #3c8dbc;
-            visibility: visible;
+            border: 1px dashed #3c8dbc;
+            visibility: visible!important;
         }
+        .ui-sortable-handle {
+            -ms-touch-action: none;
+            touch-action: none;
+        }
+
     </style>
     @endpush
 
     @push('crud_fields_scripts')
-    <script src="{{ asset('vendor/adminlte/bower_components/jquery-ui/jquery-ui.js') }}"></script>
+    <script src="{{ asset('vendor/adminlte/bower_components/jquery-ui/ui/sortable.js') }}"></script>
     @endpush
 
 @endif


### PR DESCRIPTION
Merged and polished #1626 . Adds a new field type, ```select_and_order```, which shows two columns:
- to the left are the items you have selected, and you can reorder them
- to the right are the items you can select (by dragging to the left column)

### Screenshot

![screenshot 2018-11-11 at 17 23 49](https://user-images.githubusercontent.com/1032474/48314759-a479ae00-e5d6-11e8-9b2d-6a731a3f8f79.png)


### Definition

As mentioned in the original PR, it can be used exactly like ```select_from_array```:

```php
            [
                'name' => 'featured',
                'label' => 'Featured',
                'type' => 'select_and_order',
                'options' => [
                    1 => "Option 1",
                    2 => "Option 2"
                ]
            ]
```

Or:

```php
            [
                'name' => 'featured',
                'label' => 'Featured',
                'type' => 'select_and_order',
                'options' => Product::get()->pluck('title','id')->toArray()
            ]
```

The submitted value (in this case featured) should be casted to an array in the model:
```php
            protected $casts = [
                'featured' => 'array'
            ];
```
And its value will be stored as JSON in the db: ```["3","5","7","6"]```

Thoughts, anyone? Is it clear enough from the design that you can drag items from the right to the left? Without having labels for each column? I'd hate to insert new translated lines just for this...