### PR TITLE
[3.5][Feature][Ready] Add orderLogic option to columns

### DIFF
--- a/src/PanelTraits/Query.php
+++ b/src/PanelTraits/Query.php
@@ -61,7 +61,7 @@ trait Query
     /**
      * Order results of the query in a custom way.
      *
-     * @param  array $column           [description]
+     * @param  array $column           Column array with all attributes
      * @param  string $column_direction ASC or DESC
      *
      * @return \Illuminate\Database\Eloquent\Builder

--- a/src/PanelTraits/Query.php
+++ b/src/PanelTraits/Query.php
@@ -59,6 +59,31 @@ trait Query
     }
 
     /**
+     * Order results of the query in a custom way.
+     *
+     * @param  array $column           [description]
+     * @param  string $column_direction ASC or DESC
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function customOrderBy($column, $columnDirection = 'asc')
+    {
+        if (! isset($column['orderLogic'])) {
+            return $this->query;
+        }
+
+        $this->query->getQuery()->orders = null;
+
+        $orderLogic = $column['orderLogic'];
+
+        if (is_callable($orderLogic)) {
+            return $orderLogic($this->query, $column, $columnDirection);
+        }
+
+        return $this->query;
+    }
+
+    /**
      * Group the results of the query in a certain way.
      *
      * @param string $field

--- a/src/app/Http/Controllers/Operations/ListEntries.php
+++ b/src/app/Http/Controllers/Operations/ListEntries.php
@@ -59,6 +59,11 @@ trait ListEntries
                 // apply the current orderBy rules
                 $this->crud->orderBy($column['name'], $column_direction);
             }
+
+            // check for custom order logic in the column definition
+            if (isset($column['orderLogic'])) {
+                $this->crud->customOrderBy($column, $column_direction);
+            }
         }
         $entries = $this->crud->getEntries();
 


### PR DESCRIPTION
Fixed merge conflicts from https://github.com/Laravel-Backpack/CRUD/pull/1178 .

It does apply the closure, this worked well for me for Articles:
```php
            [  // Select
               'label' => "Category",
               'type' => 'select',
               'name' => 'category_id', // the db column for the foreign key
               'entity' => 'category', // the method that defines the relationship in your Model
               'attribute' => 'name', // foreign key attribute that is shown to user
               'orderable' => true,
               'orderLogic' => function ($query, $column, $columnDirection) {
                    return $query->leftJoin('categories', 'categories.id', '=', 'articles.select')
                        ->orderBy('categories.name', $columnDirection)->select('articles.*');
                }
            ],
```

For monsters:
```php
            [  // Select
               'label' => "Category",
               'type' => 'select',
               'name' => 'select', // the db column for the foreign key
               'entity' => 'category', // the method that defines the relationship in your Model
               'attribute' => 'name', // foreign key attribute that is shown to user
               'orderable' => true,
               'orderLogic' => function ($query, $column, $columnDirection) {
                    return $query->leftJoin('categories', 'categories.id', '=', 'monsters.select')
                        ->orderBy('categories.name', $columnDirection)->select('monsters.*');
                }
            ],
```

Please notice:
- ```select('original_entity_table_name.*')``` is also required in that custom query, so that the end result has a single ID (otherwise the buttons and details_row will stop working, because there are two IDs)
- ```leftJoin()``` instead of ```join()```, so that results without a category will show up;

Todo:
- [ ] add this feature to the columns docs