### PR TITLE
Duplicate call to function in checkbox column.

### DIFF
--- a/src/resources/views/columns/checkbox.blade.php
+++ b/src/resources/views/columns/checkbox.blade.php
@@ -108,6 +108,5 @@
 	crud.addFunctionToDataTablesDrawEventQueue('addOrRemoveCrudCheckedItem');
 	crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
 	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
-	crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
 	crud.addFunctionToDataTablesDrawEventQueue('enableOrDisableBulkButtons');
 </script>


### PR DESCRIPTION
This removes the duplicate call to `crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');`
