### PR TITLE
Fixes #1641 - added visibleInShow attribute to columns

### DIFF
--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -192,6 +192,7 @@ trait Read
             'visibleInTable' => true,
             'visibleInModal' => false,
             'visibleInExport' => false,
+            'visibleInShow' => false,
         ])->makeFirstColumn();
 
         $this->addColumn([
@@ -204,6 +205,7 @@ trait Read
             'visibleInTabel' => true,
             'visibleInModal' => false,
             'visibleInExport' => false,
+            'visibleInShow' => false,
         ])->makeFirstColumn();
     }
 

--- a/src/app/Http/Controllers/Operations/Show.php
+++ b/src/app/Http/Controllers/Operations/Show.php
@@ -33,6 +33,11 @@ trait Show
             if ($column['type'] == 'row_number') {
                 $this->crud->removeColumn($column['name']);
             }
+
+            // remove columns that have visibleInShow set as false
+            if (isset($column['visibleInShow']) && $column['visibleInShow'] == false) {
+                $this->crud->removeColumn($column['name']);
+            }
         }
 
         // get the info for that entry


### PR DESCRIPTION
Fixes #1641 when paired with #1703.

Adds a ```visibleInShow``` attribute to columns, to prevent them from showing in the Preview screen (in the Show operation).

Todo:
- [ ] add ```visibleInShow``` attribute to columns documentation