### PR TITLE
[3.5][Feature] Added Clone operation

### DIFF
--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -58,6 +58,16 @@ class CrudRouter
             'as' => 'crud.'.$this->name.'.restoreRevision',
             'uses' => $this->controller.'@restoreRevision',
         ]);
+
+        Route::get($this->name.'/{id}/clone', [
+            'as' => 'crud.'.$this->name.'.clone',
+            'uses' => $this->controller.'@clone',
+        ]);
+
+        Route::post($this->name.'/bulk-clone', [
+            'as' => 'crud.'.$this->name.'.bulkClone',
+            'uses' => $this->controller.'@bulkClone',
+        ]);
     }
 
     /**

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -85,6 +85,7 @@ trait Buttons
         $this->addButton('line', 'show', 'view', 'crud::buttons.show', 'end');
         $this->addButton('line', 'update', 'view', 'crud::buttons.update', 'end');
         $this->addButton('line', 'revisions', 'view', 'crud::buttons.revisions', 'end');
+        $this->addButton('line', 'clone', 'view', 'crud::buttons.clone', 'end');
         $this->addButton('line', 'delete', 'view', 'crud::buttons.delete', 'end');
 
         // top stack

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\CrudPanel;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
+use Backpack\CRUD\app\Http\Controllers\Operations\CloneOperation;
 use Backpack\CRUD\app\Http\Controllers\Operations\Show;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Backpack\CRUD\app\Http\Controllers\Operations\Create;
@@ -19,7 +20,7 @@ use Backpack\CRUD\app\Http\Controllers\Operations\SaveActions;
 class CrudController extends BaseController
 {
     use DispatchesJobs, ValidatesRequests;
-    use Create, Delete, ListEntries, Reorder, Revisions, SaveActions, Show, Update;
+    use Create, CloneOperation, Delete, ListEntries, Reorder, Revisions, SaveActions, Show, Update;
 
     public $data = [];
     public $request;

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+trait CloneOperation
+{
+    /**
+     * Create a duplicate of the current entry in the datatabase.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function clone($id)
+    {
+        $this->crud->hasAccessOrFail('create');
+
+        $clonedEntry = $this->crud->model->findOrFail($id)->replicate();
+
+        return (string) $clonedEntry->push();
+    }
+
+    /**
+     * Create duplicates of multiple entries in the datatabase.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function bulkClone()
+    {
+        $this->crud->hasAccessOrFail('create');
+
+        $entries = $this->request->input('entries');
+        $clonedEntries = [];
+
+        foreach ($entries as $key => $id) {
+            if ($entry = $this->crud->model->find($id)) {
+                $clonedEntries[] = $entry->replicate()->push();
+            }
+        }
+
+        return $clonedEntries;
+    }
+}

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -13,7 +13,7 @@ trait CloneOperation
      */
     public function clone($id)
     {
-        $this->crud->hasAccessOrFail('create');
+        $this->crud->hasAccessOrFail('clone');
 
         $clonedEntry = $this->crud->model->findOrFail($id)->replicate();
 
@@ -29,7 +29,7 @@ trait CloneOperation
      */
     public function bulkClone()
     {
-        $this->crud->hasAccessOrFail('create');
+        $this->crud->hasAccessOrFail('clone');
 
         $entries = $this->request->input('entries');
         $clonedEntries = [];

--- a/src/resources/views/buttons/bulk_clone.blade.php
+++ b/src/resources/views/buttons/bulk_clone.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('create') && $crud->bulk_actions)
+@if ($crud->hasAccess('clone') && $crud->bulk_actions)
 	<a href="javascript:void(0)" onclick="bulkCloneEntries(this)" class="btn btn-sm btn-default bulk-button"><i class="fa fa-clone"></i> Clone</a>
 @endif
 

--- a/src/resources/views/buttons/bulk_clone.blade.php
+++ b/src/resources/views/buttons/bulk_clone.blade.php
@@ -1,0 +1,58 @@
+@if ($crud->hasAccess('create') && $crud->bulk_actions)
+	<a href="javascript:void(0)" onclick="bulkCloneEntries(this)" class="btn btn-sm btn-default bulk-button"><i class="fa fa-clone"></i> Clone</a>
+@endif
+
+@push('after_scripts')
+<script>
+	if (typeof bulkCloneEntries != 'function') {
+	  function bulkCloneEntries(button) {
+
+	      if (typeof crud.checkedItems === 'undefined' || crud.checkedItems.length == 0)
+	      {
+	      	new PNotify({
+	              title: "{{ trans('backpack::crud.bulk_no_entries_selected_title') }}",
+	              text: "{{ trans('backpack::crud.bulk_no_entries_selected_message') }}",
+	              type: "warning"
+	          });
+
+	      	return;
+	      }
+
+	      var message = "Are you sure you want to clone these :number entries?";
+	      message = message.replace(":number", crud.checkedItems.length);
+
+	      // show confirm message
+	      if (confirm(message) == true) {
+	      		var ajax_calls = [];
+	      		var clone_route = "{{ url($crud->route) }}/bulk-clone";
+
+				// submit an AJAX delete call
+				$.ajax({
+					url: clone_route,
+					type: 'POST',
+					data: { entries: crud.checkedItems },
+					success: function(result) {
+					  // Show an alert with the result
+					  new PNotify({
+					      title: "Entries cloned",
+					      text: crud.checkedItems.length+" new entries have been added.",
+					      type: "success"
+					  });
+
+					  crud.checkedItems = [];
+					  crud.table.ajax.reload();
+					},
+					error: function(result) {
+					  // Show an alert with the result
+					  new PNotify({
+					      title: "Cloning failed",
+					      text: "One or more entries could not be created. Please try again.",
+					      type: "warning"
+					  });
+					}
+				});
+	      }
+      }
+	}
+</script>
+@endpush

--- a/src/resources/views/buttons/clone.blade.php
+++ b/src/resources/views/buttons/clone.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('create'))
+@if ($crud->hasAccess('clone'))
 	<a href="javascript:void(0)" onclick="cloneEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey().'/clone') }}" class="btn btn-xs btn-default" data-button-type="clone"><i class="fa fa-clone"></i> Clone</a>
 @endif
 

--- a/src/resources/views/buttons/clone.blade.php
+++ b/src/resources/views/buttons/clone.blade.php
@@ -1,0 +1,45 @@
+@if ($crud->hasAccess('create'))
+	<a href="javascript:void(0)" onclick="cloneEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey().'/clone') }}" class="btn btn-xs btn-default" data-button-type="clone"><i class="fa fa-clone"></i> Clone</a>
+@endif
+
+<script>
+	if (typeof cloneEntry != 'function') {
+	  $("[data-button-type=clone]").unbind('click');
+
+	  function cloneEntry(button) {
+	      // ask for confirmation before deleting an item
+	      // e.preventDefault();
+	      var button = $(button);
+	      var route = button.attr('data-route');
+
+          $.ajax({
+              url: route,
+              type: 'POST',
+              success: function(result) {
+                  // Show an alert with the result
+                  new PNotify({
+                      title: "Entry cloned",
+                      text: "A new entry has been added, with the same information as this one.",
+                      type: "success"
+                  });
+
+                  // Hide the modal, if any
+                  $('.modal').modal('hide');
+
+                  crud.table.ajax.reload();
+              },
+              error: function(result) {
+                  // Show an alert with the result
+                  new PNotify({
+                      title: "Cloning failed",
+                      text: "The new entry could not be created. Please try again.",
+                      type: "warning"
+                  });
+              }
+          });
+      }
+	}
+
+	// make it so that the function above is run after each DataTable draw event
+	// crud.addFunctionToDataTablesDrawEventQueue('cloneEntry');
+</script>


### PR DESCRIPTION
Fixes #28 

Adds Clone operation with two actions: ```clone()``` and ```bulkClone()```. To enable it, one only needs to:
```php
$this->crud->allowAccess('clone');

// and maybe, if you have bulk actions:
$this->crud->addButton('bottom', 'bulk_clone', 'view', 'crud::buttons.bulk_clone', 'beginning');
```

**IMPORTANT**: The clone operation does NOT duplicate related entries. So n-n relationships will be unaffected. However, this also means that n-n relationships are ignored. So when you clone an entry, the new entry:
- will NOT have the same 1-1 relationships
- will have the same 1-n relationships
- will NOT have the same n-1 relationships
- will NOT have the same n-n relationships

This might be somewhat counterintuitive for end users - though it should make perfect sense for us developers. Hence, the ```Clone``` operation is NOT enabled by default. 

Todo:
- [ ] add Clone operation to the documentation