### PR TITLE
[3.5] No longer convert empty strings to null

### DIFF
--- a/src/app/Http/Controllers/Operations/Create.php
+++ b/src/app/Http/Controllers/Operations/Create.php
@@ -43,13 +43,6 @@ trait Create
             $request = \Request::instance();
         }
 
-        // replace empty values with NULL, so that it will work with MySQL strict mode on
-        foreach ($request->input() as $key => $value) {
-            if (empty($value) && $value !== '0') {
-                $request->request->set($key, null);
-            }
-        }
-
         // insert item in the db
         $item = $this->crud->create($request->except(['save_action', '_token', '_method', 'current_tab']));
         $this->data['entry'] = $this->crud->entry = $item;

--- a/src/app/Http/Controllers/Operations/Update.php
+++ b/src/app/Http/Controllers/Operations/Update.php
@@ -51,13 +51,6 @@ trait Update
             $request = \Request::instance();
         }
 
-        // replace empty values with NULL, so that it will work with MySQL strict mode on
-        foreach ($request->input() as $key => $value) {
-            if (empty($value) && $value !== '0') {
-                $request->request->set($key, null);
-            }
-        }
-
         // update the row in the db
         $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
                             $request->except('save_action', '_token', '_method', 'current_tab'));


### PR DESCRIPTION
Fixes #1560 

To do:
- [ ] mention in the upgrade guide that if you're using MySQL strict mode, you need to either:

(A) add ```\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class``` in your ```$middleware``` in ```app/Http/Kernel.php```

or

(B) add ```\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class``` to your ```config/backpack/base.php``` in ```middleware_class```

otherwise you might get an error.