### PR TITLE
Fix Auth guard check in CrudRequest

### DIFF
--- a/src/app/Http/Requests/CrudRequest.php
+++ b/src/app/Http/Requests/CrudRequest.php
@@ -17,7 +17,7 @@ class CrudRequest extends FormRequest
     public function authorize()
     {
         // only allow creates if the user is logged in
-        return \Auth::check();
+        return backpack_auth()->check();
     }
 
     /**


### PR DESCRIPTION
When "_The guard that protects the Backpack admin panel._" is changed **CrudRequests** won't work because they check auth against the default _config.auth.defaults.guard_.

This uses the **backpack_auth()** helper to check for the proper auth.