### PR TITLE
[4.1][Package / Custom Field] Support for uploading image to amazon s3 when adding image(s) from summernote

### DIFF
--- a/src/resources/views/fields/summernote.blade.php
+++ b/src/resources/views/fields/summernote.blade.php
@@ -3,9 +3,9 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     <textarea
-        name="{{ $field['name'] }}"
-        @include('crud::inc.field_attributes', ['default_class' =>  'form-control summernote'])
-        >{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
+            name="{{ $field['name'] }}"
+            @include('crud::inc.field_attributes', ['default_class' =>  'form-control summernote'])
+    >{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
     {{-- HINT --}}
     @if (isset($field['hint']))
@@ -22,7 +22,7 @@
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
         <!-- include summernote css-->
-        <link href="{{ asset('vendor/backpack/summernote/summernote.css') }}" rel="stylesheet" type="text/css" />
+        <link href="{{ asset('vendor/backpack/summernote/summernote.css') }}" rel="stylesheet" type="text/css"/>
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
@@ -36,9 +36,61 @@
 @push('crud_fields_scripts')
     <!-- include summernote js with related options for this field -->
     <script>
-        jQuery(document).ready(function($) {
-            $(".summernote[name='{{ $field['name'] }}']").summernote(@json($field['options'] ?? []));
-        });
+      jQuery(document).ready(function ($) {
+        // get the alert options if set from the crud controller
+        let $alert = @json($field['s3_alert'] ?? null);
+        // get the options set on the crud controller
+        let $options = @json($field['options'] ?? (object)[]);
+        // if s3 is true (default false), we loop through all the files uploaded
+        if ('{{ $field['s3'] ?? false }}') {
+          $options.onImageUpload = function (files) {
+            for (let i = 0; i < files.length; i++) {
+              $.upload(files[i]);
+            }
+          }
+        }
+        // display a notification
+        // https://laravel-backpack.readme.io/v3.0/docs/base#section-triggering-notification-bubbles-in-javascript
+        $.showNotification = function (alertType, filename, type) {
+          new PNotify({
+            title: $alert[type].title,
+            text: $alert.show_file_name ? filename +' '+ $alert[type].text : $alert[type].text,
+            type: alertType
+          });
+        }
+
+        // ajax request to the controller set in the crud controller
+        // the controller should handle the file and return the url
+        $.upload = function (file) {
+          let formData = new FormData();
+          formData.append('file', file);
+
+          $.ajax({
+            method: 'POST',
+            url: '{{ $field['s3_upload'] ?? '#' }}',
+            //check laravel document: https://laravel.com/docs/5.6/csrf#csrf-x-csrf-token
+            headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
+            processData: false,
+            contentType: false,
+            dataType: 'json',
+            data: formData,
+            success: function (data) {
+              if ($alert) {
+                $.showNotification($alert.success.type, file.name, 'success')
+              }
+              $(".summernote[name='{{ $field['name'] }}']").summernote('insertImage', data.url);
+            },
+            error: function () {
+              // here we just display a simple notification to let the user know what happened
+              if ($alert) {
+                $.showNotification($alert.error.type, file.name, 'error')
+              }
+            }
+          });
+        };
+
+        $(".summernote[name='{{ $field['name'] }}']").summernote($options);
+      });
     </script>
 @endpush
 {{-- End of Extra CSS and JS --}}


### PR DESCRIPTION
Add support for uploading image to amazon s3 from summernote.

### How it works
In your CrudController if the type of the field is summernote 3 more options will be possible
` 's3' => true, // default false`

` 's3_upload' => route('upload.to.s3')`
The route to the controller used to upload the image to s3
```
Route::post('/upload/image', [
        'uses' => 'ImageController@uploadToS3',
        'as' => 'upload.to.s3'
    ]);
```
The controller needs to return 
`response()->json(['url' => 'https://your-image.png'])`

> s3_upload is only needed if s3 is true

An alert can be shown to the user whether an upload has been successful or has failed.
Alerts are documented here
https://laravel-backpack.readme.io/v3.0/docs/base#section-triggering-notification-bubbles-in-javascript

```
 's3_alert' => [
      'error' => [
                 'title' => '',
                 'type' => 'error', // default error
                 'text' => ''
       ],
       'success' => [
                 'title' => '',
                 'type' => 'success', // default success
                 'text' => ''
       ],
        'show_file_name' => true, // to display the name of the file on the alert (default: false)
 ]
```

**I don't want to see any alert?**
If you don't need any alert just don't add _s3_alert_, if the key is not present no alert will be shown.
**I don't want to use amazon s3?**
If you don't need to upload the image to S3 you don't have to do anything just use it as usual

You need to implement you own function to upload the image to s3

> This is just an example of how it can be done, implement your own function

```
public function uploadToS3(Request $request)
    {
        try {
            $image = $request->file('file');
            $image_size = getimagesize($image);
            $imageName = 'folder/' . sha1(time()) . $image->getClientOriginalExtension();
            //resize if width is greater than 1024
            if ($image_size[0] > 1080) {
                $ratio = $image_size[0] / $image_size[1];
                $height = 1080 / $ratio;
                $imageScaled = Image::make($image)
                    ->resize(1080, $height)
                    ->stream('jpg', '100');
                Storage::disk('s3')->put($imageName, $imageScaled->__toString(), 'public');
            } else {
                $imageScaled = Image::make($image)->stream('jpg', '100');
                Storage::disk('s3')->put($imageName, $imageScaled->__toString(), 'public');
            }
            // return s3 link
            return response()->json(['url' => Storage::disk('s3')->url($imageName)], 200);
        } catch (\Exception $e) {
           Log::critical($e->getMessage());
        }
    }
```

### Screenshot
<a href="https://ibb.co/FxFyPY9"><img src="https://i.ibb.co/5MPS7jd/success-without-filename.png" alt="success-without-filename" border="0"></a>
<a href="https://ibb.co/vwH3NrJ"><img src="https://i.ibb.co/Wx6krdc/success-with-file-name.png" alt="success-with-file-name" border="0"></a>
<a href="https://ibb.co/JqR98nj"><img src="https://i.ibb.co/vhxSf14/error-upload.png" alt="error-upload" border="0"></a>
<a href="https://ibb.co/f0zSSf3"><img src="https://i.ibb.co/kcsyyjL/code-view.png" alt="code-view" border="0"></a>

### Thanks
@laeng that provided a way to deal with s3 upload on summernote
https://github.com/summernote/summernote/issues/72#issuecomment-392415872