### PR TITLE
Added 'Collection' as return type to 'filters()' method

### DIFF
--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -141,7 +141,7 @@ trait Filters
     }
 
     /**
-     * @return array
+     * @return array|\Illuminate\Support\Collection
      */
     public function filters()
     {


### PR DESCRIPTION
`collect(filters())` is wrong doh!

Because of the default on the property `$filters = []` , autocomplete suggests `filters()` returns an array, which is wrong. 
After adding any filter to the CRUD panel, `$filters` becomes a Collection.
 
PS: Or, is there a reason for setting default as empty array and not as `null`? I find it less confusing, since in use it gets converted to a collection. 
PPS:  Could we type hint `$filters` as Collection? I couldn't find a way to do it on a trait though.