### PR TITLE
Added methods to get a filter and check if it's active, by name

### DIFF
--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -147,6 +147,30 @@ trait Filters
     {
         return $this->filters;
     }
+    
+    /**
+     * @param string $name
+     *
+     * @return null|CrudFilter
+     */
+    public function getFilter($name)
+    {
+        if(filtersEnabled())
+            return $this->filters()->firstWhere('name', $name);
+    }
+     
+    /**
+     * @param string $name
+     *                          
+     * @return bool
+     */
+    public function hasActiveFilter($name)
+    {
+        $crudFilter = $this->getFilterByName($name);
+        
+        return $crudFilter instanceof CrudFilter
+            && $crudFilter->isActive();
+    }
 
     /**
      * Modify the attributes of a filter.

--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -147,7 +147,7 @@ trait Filters
     {
         return $this->filters;
     }
-    
+
     /**
      * @param string $name
      *
@@ -155,19 +155,20 @@ trait Filters
      */
     public function getFilter($name)
     {
-        if(filtersEnabled())
+        if(filtersEnabled()){
             return $this->filters()->firstWhere('name', $name);
+        }
     }
-     
+
     /**
      * @param string $name
-     *                          
+     * 
      * @return bool
      */
     public function hasActiveFilter($name)
     {
         $crudFilter = $this->getFilterByName($name);
-        
+
         return $crudFilter instanceof CrudFilter
             && $crudFilter->isActive();
     }


### PR DESCRIPTION
Useful for example in a CrudController with columns generated by model methods:
```
$this->crud->setColumns([
    [
    'name'                => 'post_comments',
    'label'               => 'Comments',
    'type'                => 'model_function',
    'function_name'       => 'getFormattedCommentsColumn',
    'function_parameters' => [$this->crud->hasActiveFilter('future_posts')],
    ]
]);
```
  
and in the `Post` model
```
    public function getFormattedCommentsColumn($onlyFuture = false)
    {
        $commentsRel = $this->comments();

        if($onlyFuture ) {
            $commentsRel->someScope();
        }

        return view(
            'post_list.dates_column',
            $this,
            ['comments' => $commentsRel->get()]
        );
    }
```