### PR TITLE
Elfinder config only yes.

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -60,7 +60,7 @@ class Install extends BaseInstall
         $this->progressBar->advance();
 
         // elFinder steps
-        if ($install_elfinder) {
+        if ($install_elfinder == 'yes') {
             $this->line(' Installing barryvdh/laravel-elfinder');
             $this->executeProcess('composer require barryvdh/laravel-elfinder');
 


### PR DESCRIPTION
When installing Crud, Elfinder config is published even when entering "no" reason for this is we are only checking if "install_elfinder" is true, well its always true with the "ask|no|yes" options. So lets make sure it only copies if it is "yes."