### PR TITLE
Added support for dot notation to all column types

### DIFF
--- a/src/resources/views/columns/array.blade.php
+++ b/src/resources/views/columns/array.blade.php
@@ -1,16 +1,19 @@
 {{-- enumerate the values in an array  --}}
-<span>
-    <?php
-    $value = $entry->{$column['name']};
+@php
+    $value = data_get($entry, $column['name']);
 
     // the value should be an array wether or not attribute casting is used
     if (!is_array($value)) {
         $value = json_decode($value, true);
     }
+@endphp
+
+<span>
+    @php
     if ($value && count($value)) {
         echo implode(', ', $value);
     } else {
         echo '-';
     }
-    ?>
+    @endphp
 </span>

--- a/src/resources/views/columns/array_count.blade.php
+++ b/src/resources/views/columns/array_count.blade.php
@@ -1,7 +1,10 @@
 {{-- enumerate the values in an array  --}}
+@php
+    $array = data_get($entry, $column['name']);
+@endphp
+
 <span>
     <?php
-    $array = $entry->{$column['name']};
     $suffix = isset($column['suffix'])?$column['suffix']:'items';
 
     // the value should be an array wether or not attribute casting is used

--- a/src/resources/views/columns/boolean.blade.php
+++ b/src/resources/views/columns/boolean.blade.php
@@ -1,6 +1,10 @@
 {{-- converts 1/true or 0/false to yes/no/lang --}}
-<span data-order="{{ $entry->{$column['name']} }}">
-	@if ($entry->{$column['name']} === true || $entry->{$column['name']} === 1 || $entry->{$column['name']} === '1')
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
+<span data-order="{{ $value }}">
+	@if ($value === true || $value === 1 || $value === '1')
         @if ( isset( $column['options'][1] ) )
             {!! $column['options'][1] !!}
         @else

--- a/src/resources/views/columns/date.blade.php
+++ b/src/resources/views/columns/date.blade.php
@@ -1,6 +1,10 @@
 {{-- localized date using jenssegers/date --}}
-<span data-order="{{ $entry->{$column['name']} }}">
-    @if (!empty($entry->{$column['name']}))
-	{{ Date::parse($entry->{$column['name']})->format(($column['format'] ?? config('backpack.base.default_date_format'))) }}
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
+<span data-order="{{ $value }}">
+    @if (!empty($value))
+	{{ Date::parse($value)->format(($column['format'] ?? config('backpack.base.default_date_format'))) }}
     @endif
 </span>

--- a/src/resources/views/columns/datetime.blade.php
+++ b/src/resources/views/columns/datetime.blade.php
@@ -1,6 +1,10 @@
 {{-- localized datetime using jenssegers/date --}}
-<span data-order="{{ $entry->{$column['name']} }}">
-    @if (!empty($entry->{$column['name']}))
-	{{ Date::parse($entry->{$column['name']})->format(($column['format'] ?? config('backpack.base.default_datetime_format'))) }}
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
+<span data-order="{{ $value }}">
+    @if (!empty($value))
+	{{ Date::parse($value)->format(($column['format'] ?? config('backpack.base.default_datetime_format'))) }}
     @endif
 </span>

--- a/src/resources/views/columns/email.blade.php
+++ b/src/resources/views/columns/email.blade.php
@@ -1,2 +1,6 @@
 {{-- email link --}}
-<span><a href="mailto:{{ $entry->{$column['name']} }}">{{ $entry->{$column['name']} }}</a></span>
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
+<span><a href="mailto:{{ $value }}">{{ $value }}</a></span>

--- a/src/resources/views/columns/multidimensional_array.blade.php
+++ b/src/resources/views/columns/multidimensional_array.blade.php
@@ -1,6 +1,6 @@
 {{-- enumerate the values in an array  --}}
 <?php
-$array = $entry->{$column['name']};
+$array = data_get($entry, $column['name']);
 
 // if the isn't using attribute casting, decode it
 if (is_string($array)) {

--- a/src/resources/views/columns/number.blade.php
+++ b/src/resources/views/columns/number.blade.php
@@ -1,2 +1,5 @@
 {{-- regular object attribute --}}
-<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').number_format($entry->{$column['name']}, array_key_exists('decimals', $column) ? $column['decimals'] : 0).(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').number_format($value, array_key_exists('decimals', $column) ? $column['decimals'] : 0).(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>

--- a/src/resources/views/columns/radio.blade.php
+++ b/src/resources/views/columns/radio.blade.php
@@ -1,6 +1,6 @@
 @php
 	$keyName = isset($column['key']) ? $column['key'] : $column['name'];
-	$entryValue=$entry->{$keyName};
+	$entryValue = data_get($entry, $keyName);
 	$displayValue = isset($column['options'][$entryValue]) ? $column['options'][$entryValue] : '';
 @endphp
 

--- a/src/resources/views/columns/select_from_array.blade.php
+++ b/src/resources/views/columns/select_from_array.blade.php
@@ -1,11 +1,15 @@
 {{-- select_from_array column --}}
+@php
+    $values = data_get($entry, $column['name']);
+@endphp
+
 <span>
 	<?php
-		if ($entry->{$column['name']} !== null) {
-			if (is_array($entry->{$column['name']})) {
+		if ($values !== null) {
+			if (is_array($values)) {
 				$array_of_values = [];
 
-				foreach ($entry->{$column['name']} as $key => $value) {
+				foreach ($values as $key => $value) {
 					$array_of_values[] = $column['options'][$value];
 				}
 
@@ -15,7 +19,7 @@
 					echo $array_of_values;
 				}
 			} else {
-				echo $column['options'][$entry->{$column['name']}];
+				echo $column['options'][$values];
 			}
 	    } else {
 	    	echo "-";

--- a/src/resources/views/columns/select_multiple.blade.php
+++ b/src/resources/views/columns/select_multiple.blade.php
@@ -1,8 +1,10 @@
 {{-- relationships with pivot table (n-n) --}}
+@php
+    $results = data_get($entry, $column['name']);
+@endphp
+
 <span>
     <?php
-        $results = $entry->{$column['entity']};
-
         if ($results && $results->count()) {
             $results_array = $results->pluck($column['attribute']);
             echo implode(', ', $results_array->toArray());

--- a/src/resources/views/columns/textarea.blade.php
+++ b/src/resources/views/columns/textarea.blade.php
@@ -1,2 +1,6 @@
 {{-- regular object attribute --}}
-<span>{!! $entry->{$column['name']} !!}</span>
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
+<span>{!! $value !!}</span>

--- a/src/resources/views/columns/upload_multiple.blade.php
+++ b/src/resources/views/columns/upload_multiple.blade.php
@@ -1,6 +1,10 @@
+@php
+    $value = data_get($entry, $column['name']);
+@endphp
+
 <span>
-    @if ($entry->{$column['name']} && count($entry->{$column['name']}))
-        @foreach ($entry->{$column['name']} as $file_path)
+    @if ($value && count($value))
+        @foreach ($value as $file_path)
             - <a target="_blank" href="{{ isset($column['disk'])?asset(\Storage::disk($column['disk'])->url($file_path)):asset($file_path) }}">{{ $file_path }}</a><br>
         @endforeach
     @else

--- a/src/resources/views/columns/video.blade.php
+++ b/src/resources/views/columns/video.blade.php
@@ -1,14 +1,16 @@
 {{-- regular object attribute --}}
 @php
-    if( !empty($entry->{$column['name']}) ) {
+    $value = data_get($entry, $column['name']);
+
+    if( !empty($value) ) {
 
         // if attribute casting is used, convert to object
-        if (is_array($entry->{$column['name']})) {
-            $video = (object)$entry->{$column['name']};
-        } elseif (is_string($entry->{$column['name']})) {
-            $video = json_decode($entry->{$column['name']});
+        if (is_array($value)) {
+            $video = (object)$value;
+        } elseif (is_string($value)) {
+            $video = json_decode($value);
         } else {
-            $video = $entry->{$column['name']};
+            $video = $value;
         }
         $bgColor = $video->provider == 'vimeo' ? '#00ADEF' : '#DA2724';
     }


### PR DESCRIPTION
Takes #1758 a little bit further and allows the developer to use ```product.attribute_name``` for all column types where it makes sense (excluded: model_function, view and such).