### PR TITLE
Dont escape labels in Show view

### DIFF
--- a/src/resources/views/show.blade.php
+++ b/src/resources/views/show.blade.php
@@ -49,7 +49,7 @@
 		        @foreach ($crud->columns as $column)
 		            <tr>
 		                <td>
-		                    <strong>{{ $column['label'] }}</strong>
+		                    <strong>{!! $column['label'] !!}</strong>
 		                </td>
                         <td>
 							@if (!isset($column['type']))


### PR DESCRIPTION
The "Edit" view does not escape <label> fields, but the "Show" view does.

I feel like they should be consistent - and following on from this item:

https://github.com/Laravel-Backpack/CRUD/issues/97

I think that "Don't escape" is the way to go.