### PR TITLE
Make compatible with MongoDB

### DIFF
--- a/src/PanelTraits/Columns.php
+++ b/src/PanelTraits/Columns.php
@@ -409,6 +409,10 @@ trait Columns
     {
         static $cache = [];
 
+        if ($this->getSchema()->getConnection()->getConfig()['driver'] === 'mongodb') {
+            return true;
+        }
+
         if (isset($cache[$table])) {
             $columns = $cache[$table];
         } else {

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -47,7 +47,7 @@ trait ListOperation
         }
         // limit the number of results according to the datatables pagination
         if ($this->request->input('length')) {
-            $this->crud->take($this->request->input('length'));
+            $this->crud->take((int)$this->request->input('length'));
         }
         // overwrite any order set in the setup() method with the datatables order
         if ($this->request->input('order')) {


### PR DESCRIPTION
All that is needed to use this awesome package with MongoDB collections is these two minor edits. MongoDB does not have an hasColumn method (since it doesn't have columns), and it is strict about the limit parameter being cast as an integer (currently it is cast as a string)

These changes should not at all affect existing users but will allow MongoDB users to make use of Backpack in their hybrid applications that make use of both MySQL and MongoDB