### PR TITLE
Fix/loss-reference

### DIFF
--- a/src/resources/views/inc/form_save_buttons.blade.php
+++ b/src/resources/views/inc/form_save_buttons.blade.php
@@ -22,5 +22,5 @@
 
     </div>
 
-    <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-default"><span class="fa fa-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
+    <a href="{{ $crud->hasAccess('list') ? (starts_with(URL::previous(), url($crud->route)) ? URL::previous() : url($crud->route)) : url()->previous() }}" class="btn btn-default"><span class="fa fa-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
 </div>


### PR DESCRIPTION
When we canceled an action on the CRUD of the Backpack, it missed the previous screen reference, I am requesting that change in that blade file to fix and implement this, it would be great to help the other dev`s