### PR TITLE
Fix sortable() is not a function if include only sortable.js

### DIFF
--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -112,7 +112,7 @@
     @endpush
 
     @push('crud_fields_scripts')
-    <script src="{{ asset('vendor/adminlte/bower_components/jquery-ui/ui/sortable.js') }}"></script>
+    <script src="{{ asset('vendor/adminlte/bower_components/jquery-ui/jquery-ui.min.js') }}"></script>
     @endpush
 
 @endif


### PR DESCRIPTION
Can anyone confirm this? If yes, i have applied this fix and it's working.

If included only sortable.js i got the following error on console:

```
Uncaught TypeError: Cannot read property 'mouse' of undefined
    at sortable.js:28
    at sortable.js:24
    at sortable.js:26
jquery.min.js:2 jQuery.Deferred exception: $(...).sortable is not a function TypeError: $(...).sortable is not a function
    at HTMLDocument.<anonymous> 
jquery.min.js:2 Uncaught TypeError: $(...).sortable is not a function
    at HTMLDocument.<anonymous> (edit:977)
    at l (jquery.min.js:2)
    at c (jquery.min.js:2)
```

If i include whole jquery-ui as in the fix, the error is gone and the field it's working.

Thanks