### PR TITLE
[4.0][Feature] Nested resources with dot notation, like default Laravel

### DIFF
--- a/src/CrudRouter.php
+++ b/src/CrudRouter.php
@@ -8,6 +8,7 @@ class CrudRouter
 {
     protected $extraRoutes = [];
 
+    protected $path = null;
     protected $name = null;
     protected $options = null;
     protected $controller = null;
@@ -17,54 +18,55 @@ class CrudRouter
         $this->name = $name;
         $this->controller = $controller;
         $this->options = $options;
+        $this->path = $this->checkNameForNestedResources($name);
 
         // CRUD routes for core features
-        Route::post($this->name.'/search', [
+        Route::post($this->path.'/search', [
             'as' => 'crud.'.$this->name.'.search',
             'uses' => $this->controller.'@search',
         ]);
 
-        Route::delete($this->name.'/bulk-delete', [
+        Route::delete($this->path.'/bulk-delete', [
             'as' => 'crud.'.$this->name.'.bulkDelete',
             'uses' => $this->controller.'@bulkDelete',
         ]);
 
-        Route::get($this->name.'/reorder', [
+        Route::get($this->path.'/reorder', [
             'as' => 'crud.'.$this->name.'.reorder',
             'uses' => $this->controller.'@reorder',
         ]);
 
-        Route::post($this->name.'/reorder', [
+        Route::post($this->path.'/reorder', [
             'as' => 'crud.'.$this->name.'.save.reorder',
             'uses' => $this->controller.'@saveReorder',
         ]);
 
-        Route::get($this->name.'/{id}/details', [
+        Route::get($this->path.'/{id}/details', [
             'as' => 'crud.'.$this->name.'.showDetailsRow',
             'uses' => $this->controller.'@showDetailsRow',
         ]);
 
-        Route::get($this->name.'/{id}/translate/{lang}', [
+        Route::get($this->path.'/{id}/translate/{lang}', [
             'as' => 'crud.'.$this->name.'.translateItem',
             'uses' => $this->controller.'@translateItem',
         ]);
 
-        Route::get($this->name.'/{id}/revisions', [
+        Route::get($this->path.'/{id}/revisions', [
             'as' => 'crud.'.$this->name.'.listRevisions',
             'uses' => $this->controller.'@listRevisions',
         ]);
 
-        Route::post($this->name.'/{id}/revisions/{revisionId}/restore', [
+        Route::post($this->path.'/{id}/revisions/{revisionId}/restore', [
             'as' => 'crud.'.$this->name.'.restoreRevision',
             'uses' => $this->controller.'@restoreRevision',
         ]);
 
-        Route::post($this->name.'/{id}/clone', [
+        Route::post($this->path.'/{id}/clone', [
             'as' => 'crud.'.$this->name.'.clone',
             'uses' => $this->controller.'@clone',
         ]);
 
-        Route::post($this->name.'/bulk-clone', [
+        Route::post($this->path.'/bulk-clone', [
             'as' => 'crud.'.$this->name.'.bulkClone',
             'uses' => $this->controller.'@bulkClone',
         ]);
@@ -77,24 +79,32 @@ class CrudRouter
     {
         $options_with_default_route_names = array_merge([
             'names' => [
-                'index'     => 'crud.'.$this->name.'.index',
-                'create'    => 'crud.'.$this->name.'.create',
-                'store'     => 'crud.'.$this->name.'.store',
-                'edit'      => 'crud.'.$this->name.'.edit',
-                'update'    => 'crud.'.$this->name.'.update',
-                'show'      => 'crud.'.$this->name.'.show',
-                'destroy'   => 'crud.'.$this->name.'.destroy',
+                'index' => 'crud.'.$this->name.'.index',
+                'create' => 'crud.'.$this->name.'.create',
+                'store' => 'crud.'.$this->name.'.store',
+                'edit' => 'crud.'.$this->name.'.edit',
+                'update' => 'crud.'.$this->name.'.update',
+                'show' => 'crud.'.$this->name.'.show',
+                'destroy' => 'crud.'.$this->name.'.destroy',
             ],
         ], $this->options);
 
         Route::resource($this->name, $this->controller, $options_with_default_route_names);
     }
 
+    public function __call($method, $parameters = null)
+    {
+        if (method_exists($this, $method)) {
+            $this->{$method}($parameters);
+        }
+    }
+
     /**
      * Call other methods in this class, that register extra routes.
      *
-     * @param  [type] $injectables [description]
-     * @return [type]              [description]
+     * @param callable $injectables
+     *
+     * @return null
      */
     public function with($injectables)
     {
@@ -116,6 +126,34 @@ class CrudRouter
     }
 
     /**
+     * Check the "name" acually the path for the route
+     * if it contains . for nested resource names.
+     *
+     * @return string
+     */
+    public function checkNameForNestedResources(string $name): string
+    {
+        if (! str_contains($name, '.')) {
+            return $name;
+        }
+
+        $path = [];
+        $parts = explode('.', $this->name);
+        $except = end($parts);
+
+        foreach ($parts as $part) {
+            if ($part === $except) {
+                $path[] = $part;
+                continue;
+            }
+
+            $path[] = $part.'/{'.str_singular($part).'_id}';
+        }
+
+        return implode('/', $path);
+    }
+
+    /**
      * TODO
      * Give developers the ability to unregister a route.
      */
@@ -132,13 +170,6 @@ class CrudRouter
             } else {
                 $route();
             }
-        }
-    }
-
-    public function __call($method, $parameters = null)
-    {
-        if (method_exists($this, $method)) {
-            $this->{$method}($parameters);
         }
     }
 }


### PR DESCRIPTION
Within the Laravel application it is possible to have nested resources like: `Route::resource('parent.child', 'ExampleController');`.
In this case, Backpack will generate the exact resource name as a single URL e.g. `/admin/parent.child/12/edit`.

This will check if the name contains a dot `.` and will generate a proper URL.

**EDIT**
I've squashed some commits into a single one, cause the CS issues.