### PR TITLE
Add ability to remove multiple buttons via names in an array

### DIFF
--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -136,7 +136,7 @@ trait Buttons
 
     /**
      * @param array $names Button names
-     * @param string $stack Optional stack name.
+     * @param string|null $stack Optional stack name.
      */
     public function removeButtons($names, $stack = null)
     {

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -140,11 +140,11 @@ trait Buttons
      */
     public function removeButtons($names, $stack = null)
     {
-        $this->buttons = $this->buttons->reject(function ($button) use ($names, $stack) {
-            return $stack == null ?
-                in_array($button->name, $names) :
-                ($button->stack == $stack) && (in_array($button->name, $names));
-        });
+        if (! empty($names)) {
+            foreach ($names as $name) {
+                $this->removeButton($name, $stack);
+            }
+        }
     }
 
     public function removeAllButtons()

--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -134,6 +134,19 @@ trait Buttons
         });
     }
 
+    /**
+     * @param array $names Button names
+     * @param string $stack Optional stack name.
+     */
+    public function removeButtons($names, $stack = null)
+    {
+        $this->buttons = $this->buttons->reject(function ($button) use ($names, $stack) {
+            return $stack == null ?
+                in_array($button->name, $names) :
+                ($button->stack == $stack) && (in_array($button->name, $names));
+        });
+    }
+
     public function removeAllButtons()
     {
         $this->buttons = collect([]);

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -159,6 +159,32 @@ class CrudPanelButtonsTest extends BaseCrudPanelTest
         $this->assertNull($this->getButtonByName($buttonName));
     }
 
+    public function testRemoveButtons()
+    {
+        $buttons = [
+            $this->defaultButtonNames[0],
+            $this->defaultButtonNames[1]
+        ];
+
+        $this->crudPanel->removeButtons($buttons);
+
+        $this->assertEquals(count($this->defaultButtonNames) -2, count($this->crudPanel->buttons));
+        $this->assertNull($this->getButtonByName($buttons[0]));
+        $this->assertNull($this->getButtonByName($buttons[1]));
+    }
+
+    public function testRemoveUnknownButtons()
+    {
+        $buttonNames = [
+            'someButtonName',
+            'someOtherButtonName'
+        ];
+
+        $this->crudPanel->removeButtons($buttonNames);
+
+        $this->assertEquals(count($this->defaultButtonNames), count($this->crudPanel->buttons));
+    }
+
     public function testRemoveUnknownButton()
     {
         $buttonName = 'someButtonName';

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -163,12 +163,12 @@ class CrudPanelButtonsTest extends BaseCrudPanelTest
     {
         $buttons = [
             $this->defaultButtonNames[0],
-            $this->defaultButtonNames[1]
+            $this->defaultButtonNames[1],
         ];
 
         $this->crudPanel->removeButtons($buttons);
 
-        $this->assertEquals(count($this->defaultButtonNames) -2, count($this->crudPanel->buttons));
+        $this->assertEquals(count($this->defaultButtonNames) - 2, count($this->crudPanel->buttons));
         $this->assertNull($this->getButtonByName($buttons[0]));
         $this->assertNull($this->getButtonByName($buttons[1]));
     }
@@ -177,7 +177,7 @@ class CrudPanelButtonsTest extends BaseCrudPanelTest
     {
         $buttonNames = [
             'someButtonName',
-            'someOtherButtonName'
+            'someOtherButtonName',
         ];
 
         $this->crudPanel->removeButtons($buttonNames);


### PR DESCRIPTION
Adds the ability to remove multiple buttons via the removeButtons function by passing in an array of button names for example instead of this:

$this->crud->removeButton('update');
$this->crud->removeButton('delete');
$this->crud->removeButton('create');

You can do this:
$this->crud->removeButtons(['update', 'delete', 'create']);