### PR TITLE
Eliminating unneccessary query from enum field.

### DIFF
--- a/src/resources/views/fields/enum.blade.php
+++ b/src/resources/views/fields/enum.blade.php
@@ -2,7 +2,10 @@
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
-    <?php $entity_model = $crud->model; ?>
+    @php
+        $entity_model = $crud->model;
+        $possible_values = $entity_model::getPossibleEnumValues($field['name']);
+    @endphp
     <select
         name="{{ $field['name'] }}"
         @include('crud::inc.field_attributes')
@@ -12,8 +15,8 @@
             <option value="">-</option>
         @endif
 
-            @if (count($entity_model::getPossibleEnumValues($field['name'])))
-                @foreach ($entity_model::getPossibleEnumValues($field['name']) as $possible_value)
+            @if (count($possible_values))
+                @foreach ($possible_values as $possible_value)
                     <option value="{{ $possible_value }}"
                         @if (( old(square_brackets_to_dots($field['name'])) &&  old(square_brackets_to_dots($field['name'])) == $possible_value) || (isset($field['value']) && $field['value']==$possible_value))
                             selected


### PR DESCRIPTION
The current enum field requires 2 queries to load, while actually only 1 is needed. 
This will cause a small performance boost.