### PR TITLE
Fix select_grouped field

### DIFF
--- a/src/resources/views/fields/select_grouped.blade.php
+++ b/src/resources/views/fields/select_grouped.blade.php
@@ -7,12 +7,12 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
     @php
-        $entity_model = $crud->getRelationModel($field['entity'],  - 1);
-        $group_by_model = (new $entity_model)->{$field['group_by']}()->getRelated();
-        $categories = $group_by_model::has($field['group_by_relationship_back'])->get();
-
+        $entity_model = $crud->model;
+        $related_model = $crud->getRelationModel($field['entity']);
+        $group_by_model = (new $related_model)->{$field['group_by']}()->getRelated();
+        $categories = $group_by_model::with($field['group_by_relationship_back'])->get();
         if (isset($field['model'])) {
-            $categorylessEntries = $field['model']::has($field['group_by'], '=', 0)->get();
+            $categorylessEntries = $related_model::doesnthave($field['group_by'])->get();
         }
     @endphp
     <select


### PR DESCRIPTION
I have not been able to get this field working properly on my admin panel. The `$entity_model` does not have the `group_by` field, as this field is only available on the related model, which was not adjustable.

I think this implementation is more straightforward and should work as expected.