### PR TITLE
Fix for vertical tabs can't be enabled by crud, only global

### DIFF
--- a/src/PanelTraits/Tabs.php
+++ b/src/PanelTraits/Tabs.php
@@ -9,7 +9,6 @@ trait Tabs
 
     public function enableTabs()
     {
-        $this->tabsEnabled = true;
         $this->setTabsType(config('backpack.crud.tabs_type', 'horizontal'));
 
         return $this->tabsEnabled;
@@ -40,6 +39,8 @@ trait Tabs
 
     public function setTabsType($type)
     {
+        $this->tabsEnabled = true;
+        
         $this->tabsType = $type;
 
         return $this->tabsType;


### PR DESCRIPTION
In a single crud you want to use vertical tabs, you should do `$this->crud->enableVerticalTabs()`.
But the only thing that is changed is the `$tabsType`, if you don't explicit do `$this->crud->enableTabs()` before setting the vertical option, when Fields Trait run, it will check if there are tabbed fields, and if tabs are not enabled (without the call to `enableTabs()`, even changing it to vertical keeps tabs disabled), it will initialize tabs again, and use the value from config file.

I changed the `$this->tabsEnabled = true` call to the `setTabsType()` function, so if the user calls enableVerticalTabs(), it will really enable the tabs, and set it to vertical. Removed the same instruction from `enableTabs()` because it will call the `setTabsType()` and will ofcourse mark them as enabled.