### PR TITLE
Fix fireSluggedEvent

### DIFF
--- a/src/ModelTraits/SpatieTranslatable/SluggableObserver.php
+++ b/src/ModelTraits/SpatieTranslatable/SluggableObserver.php
@@ -75,6 +75,6 @@ class SluggableObserver extends \Cviebrock\EloquentSluggable\SluggableObserver
      */
     protected function fireSluggedEvent(Model $model, string $status)
     {
-        $this->events->fire('eloquent.slugged: '.get_class($model), [$model, $status]);
+        $this->events->dispatch('eloquent.slugged: '.get_class($model), [$model, $status]);
     }
 }


### PR DESCRIPTION
fire function is not defined in the loaded Dispatcher and throws an error. Instead call dispatch function like in the original SluggableObserver.php in SpatieTranslatable package.