### PR TITLE
Don't fail when a collection is loaded

### DIFF
--- a/src/PanelTraits/Read.php
+++ b/src/PanelTraits/Read.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\PanelTraits;
 
+use Illuminate\Support\Collection;
+
 trait Read
 {
     /*
@@ -59,6 +61,9 @@ trait Read
     {
         if (! $this->entry) {
             $this->entry = $this->model->findOrFail($id);
+            if ($this->entry instanceof Collection) {
+                $this->entry = $this->entry->first();
+            }
             $this->entry = $this->entry->withFakes();
         }
 


### PR DESCRIPTION
In the project we're working on, with a custom route that is added on to the crud controller, we've had the issue that the object is not upcasted in the right way, this ends up being a collection containing only one item.

Not sure why or how this is happening. 
It bails out with: `Method Illuminate\\Database\\Eloquent\\Collection::withFakes does not exist.`.

This is really unhelpful, the change here allows for that to happen without breaking anything else. It's an edge case and I'm not sure if this fix is right. But the application doesn't break anymore :)