### PR TITLE
Add minimumInputLength to Select2_ajax Filter

### DIFF
--- a/src/PanelTraits/Filters.php
+++ b/src/PanelTraits/Filters.php
@@ -256,6 +256,7 @@ class CrudFilter
     public $type = 'select'; // the name of the filter view that will be loaded
     public $label;
     public $placeholder;
+    public $minimumInputLength;
     public $values;
     public $options;
     public $currentValue;
@@ -272,6 +273,7 @@ class CrudFilter
         $this->viewNamespace = $options['view_namespace'] ?? $this->viewNamespace;
         $this->view = $this->viewNamespace.'.'.$this->type;
         $this->placeholder = $options['placeholder'] ?? '';
+        $this->minimumInputLength = $options['minimumInputLength'] ?? '2';
 
         $this->values = $values;
         $this->options = $options;

--- a/src/resources/views/filters/select2_ajax.blade.php
+++ b/src/resources/views/filters/select2_ajax.blade.php
@@ -49,9 +49,9 @@
         jQuery(document).ready(function($) {
             // trigger select2 for each untriggered select2 box
             $('#filter_{{ $filter->name }}').select2({
-			    minimumInputLength: 2,
             	allowClear: true,
         	    placeholder: '{{ $filter->placeholder ? $filter->placeholder : ' ' }}',
+                minimumInputLength: '{{ $filter->minimumInputLength ? $filter->minimumInputLength : '2' }}',
 				closeOnSelect: false,
 			    // tags: [],
 			    ajax: {


### PR DESCRIPTION
Hi guys, I believe this can be useful to someone. 

PS Which one is better, minimumInputLength or minimum_input_length? I don't know if you prefer CamelCase or snake_case. The 2nd option would be better to mantain the same attribute name as in CRUD fields.