### PR TITLE
Optional other fields in select2 ajax request

### DIFF
--- a/src/resources/views/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/fields/select2_from_ajax.blade.php
@@ -99,7 +99,9 @@
                             return {
                                 q: params.term, // search term
                                 page: params.page, // pagination
-                                form: form.serializeArray()  // all other form inputs
+                                @if($field['add_other_fields_in_ajax_request)'] ?? true)
+                                    form: form.serializeArray() // all other form inputs
+                                @endif
                             };
                         },
                         processResults: function (data, params) {

--- a/src/resources/views/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/fields/select2_from_ajax.blade.php
@@ -99,7 +99,7 @@
                             return {
                                 q: params.term, // search term
                                 page: params.page, // pagination
-                                @if($field['add_other_fields_in_ajax_request)'] ?? true)
+                                @if($field['include_all_form_fields)'] ?? true)
                                     form: form.serializeArray() // all other form inputs
                                 @endif
                             };

--- a/src/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -80,7 +80,9 @@
                             return {
                                 q: params.term, // search term
                                 page: params.page, // pagination
-                                form: form.serializeArray() // all other form inputs
+                                @if($field['add_other_fields_in_ajax_request)'] ?? true)
+                                    form: form.serializeArray() // all other form inputs
+                                @endif
                             };
                         },
                         processResults: function (data, params) {

--- a/src/resources/views/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/fields/select2_from_ajax_multiple.blade.php
@@ -80,7 +80,7 @@
                             return {
                                 q: params.term, // search term
                                 page: params.page, // pagination
-                                @if($field['add_other_fields_in_ajax_request)'] ?? true)
+                                @if($field['include_all_form_fields)'] ?? true)
                                     form: form.serializeArray() // all other form inputs
                                 @endif
                             };


### PR DESCRIPTION
The current _**select2_from_ajax**_ and _**select2_from_ajax_multiple**_ fields add all other fields to the ajax request by means of a **_form: form.serializeArray()_.** option. This could break if the number of fields increases, ie when there are other pivoted multiple option fields. This is due to server and client side restrictions on URL length.

Using POST is an option, but it's not preferred, as GET is the default option and easier to build and test IMO.

This option allows us to disable the feature but _defaults to not do so_.