### PR TITLE
Add decimal and thousand separator params to number column

### DIFF
--- a/src/resources/views/columns/number.blade.php
+++ b/src/resources/views/columns/number.blade.php
@@ -2,4 +2,8 @@
 @php
     $value = data_get($entry, $column['name']);
 @endphp
-<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').number_format($value, array_key_exists('decimals', $column) ? $column['decimals'] : 0).(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>
+<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').number_format($value,
+    array_key_exists('decimals', $column) ? $column['decimals'] : 0,
+    array_key_exists('dec_point', $column) ? $column['dec_point'] : '.',
+    array_key_exists('thousands_sep', $column) ? $column['thousands_sep'] : ','
+ ).(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>


### PR DESCRIPTION
Add decimal point and thousand separator extra `number_format` params.
Some countries invert the decimal point and thousand separator, like this: R$ 1.464,00
The new optional params are dec_point and thousands_sep.