### PR TITLE
Update Create.php [bugfix][improvement]

### DIFF
--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -122,17 +122,22 @@ trait Create
         foreach ($fields_with_relationships as $key => $field) {
             if (isset($field['pivot']) && $field['pivot']) {
                 $values = isset($data[$field['name']]) ? $data[$field['name']] : [];
-                $model->{$field['name']}()->sync($values);
 
-                if (isset($field['pivotFields'])) {
-                    foreach ($field['pivotFields'] as $pivotField) {
-                        foreach ($data[$pivotField] as $pivot_id => $pivot_field) {
-                            $model->{$field['name']}()->updateExistingPivot($pivot_id, [$pivotField => $pivot_field]);
+                $relation_data = [];
+                foreach ($values as $pivot_id) {
+                    $pivot_data = [];
+
+                    if (isset($field['pivotFields'])) {
+                        foreach ($field['pivotFields'] as $pivot_field_name) {
+                            $pivot_data[$pivot_field_name] = $data[$pivot_field_name][$pivot_id];
                         }
                     }
+                    $relation_data[$pivot_id] = $pivot_data;
                 }
-            }
 
+                $model->{$field['name']}()->sync($relation_data);
+            }
+            
             if (isset($field['morph']) && $field['morph'] && isset($data[$field['name']])) {
                 $values = $data[$field['name']];
                 $model->{$field['name']}()->sync($values);

--- a/src/PanelTraits/Create.php
+++ b/src/PanelTraits/Create.php
@@ -137,7 +137,7 @@ trait Create
 
                 $model->{$field['name']}()->sync($relation_data);
             }
-            
+
             if (isset($field['morph']) && $field['morph'] && isset($data[$field['name']])) {
                 $values = $data[$field['name']];
                 $model->{$field['name']}()->sync($values);


### PR DESCRIPTION
The idea is to:
- allow the creation/update of rows for schemas where the pivot columns are mandatory (not Nullables). With the current implementation, the initial **sync** doesn't include the pivots, so if they are mandatory the database operation fails.
- as a side effect, reduce the number of db calls when saving pivot rows (from M*N + 1 to just M where M is the number of relations)