### PR TITLE
[BUG FIX] count() in PHP >= 7.2

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -114,8 +114,10 @@ trait CrudTrait
     public function withFakes($columns = [])
     {
         $model = '\\'.get_class($this);
-
-        if (! count($columns)) {
+        
+        $columnCount = (is_countable($columns) ? count($columns) : 0);
+        
+        if ($columnCount == 0) {
             $columns = (property_exists($model, 'fakeColumns')) ? $this->fakeColumns : ['extras'];
         }
 

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -114,9 +114,9 @@ trait CrudTrait
     public function withFakes($columns = [])
     {
         $model = '\\'.get_class($this);
-        
+
         $columnCount = (is_countable($columns) ? count($columns) : 0);
-        
+
         if ($columnCount == 0) {
             $columns = (property_exists($model, 'fakeColumns')) ? $this->fakeColumns : ['extras'];
         }


### PR DESCRIPTION
In PHP >= 7.2 the count() argument needs to NOT be null. We must ensure we are running count against a valid countable argument, otherwise bail with 0.

We must check our codebase for instances of count(), and sizeof() (alias of count()) and do the proper check for countable.

REF is_countable: [php manual](https://www.php.net/manual/en/function.is-countable.php)

This is backwards compatible.