### PR TITLE
Fix for PHP 7.2 count() function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -25,7 +25,7 @@ if (! function_exists('is_countable')) {
      *
      * @param $obj
      *
-     * @return boolean
+     * @return bool
      */
     function is_countable($obj)
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -16,3 +16,19 @@ if (! function_exists('square_brackets_to_dots')) {
         return $string;
     }
 }
+
+if (! function_exists('is_countable')) {
+    /**
+     * We need this because is_countable was only introduced in PHP 7.3,
+     * and in PHP 7.2 you should check if count() argument is really countable.
+     * This function may be removed in future if PHP >= 7.3 becomes a requirement.
+     *
+     * @param $obj
+     *
+     * @return boolean
+     */
+    function is_countable($obj)
+    {
+        return is_array($obj) || $obj instanceof Countable;
+    }
+}


### PR DESCRIPTION
This PR MUST be commited along with #1882 .

The reason is that is_countable is not defined in PHP < 7.3, so we should "replicate" it's functionality for backwards compatibility.