### PR TITLE
Fix adding button from view

### DIFF
--- a/src/PanelTraits/Buttons.php
+++ b/src/PanelTraits/Buttons.php
@@ -64,7 +64,7 @@ trait Buttons
 
     public function addButtonFromView($stack, $name, $view, $position = false)
     {
-        $view = 'vendor.backpack.crud.buttons.'.$view;
+        $view = 'crud::buttons.'.$view;
 
         $this->addButton($stack, $name, 'view', $view, $position);
     }

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -140,7 +140,7 @@ class CrudPanelButtonsTest extends BaseCrudPanelTest
 
         $this->crudPanel->addButtonFromView($expectedButton->stack, $expectedButton->name, $viewName, $expectedButton->content);
 
-        $backpackButtonViewPackage = 'vendor.backpack.crud.buttons.';
+        $backpackButtonViewPackage = 'crud::buttons.';
         $actualButton = $this->crudPanel->buttons->last();
 
         $this->assertEquals($expectedButton->stack, $actualButton->stack);


### PR DESCRIPTION
Is there any reason Backpack checks only `resources\views\vendor\backpack\crud\buttons` directory when adding a button ?

```php
public function addButtonFromView($stack, $name, $view, $position = false)
{
    $view = 'vendor.backpack.crud.buttons.'.$view;

    $this->addButton($stack, $name, 'view', $view, $position);
}
```

I am developing a package which is using Backpack and then, I prefer to be added buttons from `crud::buttons` namespace.

I am doing following way so far.

```php
// in CrudController
$this->crud->addButton('line', 'my_button', 'view', 'crud::buttons.my_button', 'last');
```