### PR TITLE
Moves checklist_dependency var into @push('crud_fields_scripts')

### DIFF
--- a/src/resources/views/fields/checklist_dependency.blade.php
+++ b/src/resources/views/fields/checklist_dependency.blade.php
@@ -57,9 +57,6 @@
         //json encode of dependency matrix
         $dependencyJson = json_encode($dependencyArray);
     ?>
-    <script>
-        var  {{ $field['field_unique_name'] }} = {!! $dependencyJson !!};
-    </script>
 
     <div class="row" >
 
@@ -168,6 +165,13 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+
+@push('crud_fields_scripts')
+    <script>
+        var  {{ $field['field_unique_name'] }} = {!! $dependencyJson !!};
+    </script>
+@endpush
+
 @if ($crud->checkIfFieldIsFirstOfItsType($field))
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}


### PR DESCRIPTION
Moves the `var  {{ $field['field_unique_name'] }} = {!! $dependencyJson !!};` block into a @push block further down the file to prevent template compiling error when used with Vue.js. (possibly similar frameworks)

![Screen Shot 2019-06-04 at 5 38 06 PM](https://user-images.githubusercontent.com/1445258/58922408-8fd64200-86ef-11e9-8eac-e1b326ec6b1a.png)