### PR TITLE
Fix for url generation after save_and_edit

### DIFF
--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD;
 
-use Route;
 use Illuminate\Support\ServiceProvider;
 
 class CrudServiceProvider extends ServiceProvider

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Process\Process;
 use Backpack\Base\app\Console\Commands\Install as BaseInstall;
 
 class Install extends BaseInstall

--- a/src/app/Http/Controllers/Operations/SaveActions.php
+++ b/src/app/Http/Controllers/Operations/SaveActions.php
@@ -91,13 +91,12 @@ trait SaveActions
                 break;
             case 'save_and_edit':
                 $redirectUrl = $this->crud->route.'/'.$itemId.'/edit';
-                if (\Request::has('current_tab')) {
-                    $redirectUrl = $redirectUrl.'#'.\Request::get('current_tab');
-                }
                 if (\Request::has('locale')) {
                     $redirectUrl .= '?locale='.\Request::input('locale');
                 }
-
+                if (\Request::has('current_tab')) {
+                    $redirectUrl = $redirectUrl.'#'.\Request::get('current_tab');
+                }
                 break;
             case 'save_and_back':
             default:


### PR DESCRIPTION
Like stated in #1902 , the url generated is broken. The fragment should be the last part of the url.

GOOD: url.com?parm=1&parm2=2#hash

Ref: (http://tools.ietf.org/html/rfc3986#section-4.1) [ rfc about url fragment ]