### PR TITLE
Update table.blade.php

### DIFF
--- a/src/resources/views/columns/table.blade.php
+++ b/src/resources/views/columns/table.blade.php
@@ -23,7 +23,17 @@
 			<tr>
 				@foreach($columns as $tableColumnKey => $tableColumnLabel)
 					<td>
-						{{ $tableRow->{$tableColumnKey} ?? $tableRow[$tableColumnKey] }}
+                    
+						@if( is_array($tableRow) && isset($tableRow[$tableColumnKey]) )
+                            
+                            {{ $tableRow[$tableColumnKey] }}
+                        
+                        @elseif( property_exists($tableRow, $tableColumnKey) )
+                        
+                            {{ $tableRow->{$tableColumnKey} }}
+                        
+                        @endif
+                        
 					</td>
 				@endforeach
 			</tr>


### PR DESCRIPTION
When a property doesn't exist it will try to render it as an array element which throws: `Cannot use object of type stdClass as array`.
This can simply go away by converting the output from `{{ $tableRow->{tableColumnKey} ?? $tableRow[$tableColumnKey] }}` to `{{ $tableRow->{tableColumnKey} ?? '' }}`, but if we are expecting array as well then we need to support it.