### PR TITLE
[4.0][Refactor][Ready] Rename CRUD::resource() to Route::crudResource()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,10 +61,7 @@
         "laravel": {
             "providers": [
                 "Backpack\\CRUD\\CrudServiceProvider"
-            ],
-            "aliases": {
-                "CRUD": "Backpack\\CRUD\\CrudServiceProvider"
-            }
+            ]
         }
     }
 }

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -78,7 +78,6 @@ class CrudServiceProvider extends ServiceProvider
             'backpack.crud'
         );
 
-
         $this->sendUsageStats();
     }
 

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD;
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class CrudServiceProvider extends ServiceProvider
@@ -77,6 +78,7 @@ class CrudServiceProvider extends ServiceProvider
             'backpack.crud'
         );
 
+
         $this->sendUsageStats();
     }
 
@@ -91,6 +93,13 @@ class CrudServiceProvider extends ServiceProvider
             return new CRUD($app);
         });
 
+        // add the Route::crudResource() macro for developers to set all CRUD routes in one line
+        if (! Route::hasMacro('crudResource')) {
+            Route::macro('crudResource', function ($name, $controller, array $options = []) {
+                return new CrudRouter($name, $controller, $options);
+            });
+        }
+
         // register the helper functions
         $this->loadHelpers();
 
@@ -101,11 +110,6 @@ class CrudServiceProvider extends ServiceProvider
         if (! \Config::get('elfinder.route.prefix')) {
             \Config::set('elfinder.route.prefix', \Config::get('backpack.base.route_prefix').'/elfinder');
         }
-    }
-
-    public static function resource($name, $controller, array $options = [])
-    {
-        return new CrudRouter($name, $controller, $options);
     }
 
     /**


### PR DESCRIPTION
In 3.0 we have a ```CRUD``` alias (pointing to CrudServiceProvider) that was registered for just one method - ```CRUD::resource()```, which registers all the routes needed for a CRUD.

This PR:
- makes ```CRUD::resource()``` stop working;
- makes ```Route::crudResource()``` start working (doing the exact same thing);
- eliminates the CRUD alias;

Why:
- I don't think it makes sense to load this alias for just one method;
- There is a more intuitive and reasonable way to achieve the same thing, since the ```Route``` class in macroable;
- This opens up the possibility for us to use the ```CRUD``` alias for something else (not that we _should_, but we _could_);

Things we can do with the ```CRUD``` alias, since it would now be free to use:
(A) A services class (or helpers class), ex: ```CRUD::isCountable()```.
(B) A facade to the CrudPanel class (or currently running CrudPanel class). So that we can do:

```php
// inside the ProductCrudController
CRUD::addField();
CRUD::addColumn();

// inside the views
CRUD::getEntry();
```

Instead of:
```php
// inside the ProductCrudController
$this->crud->addField();
$this->crud->addColumn();

// inside the views
$crud->getEntry();
```

Obviously I think option B would be a better idea :-)

Thoughts? Feedback?