### PR TITLE
Fix select_and_order dropping existing values.

### DIFF
--- a/src/resources/views/fields/select_and_order.blade.php
+++ b/src/resources/views/fields/select_and_order.blade.php
@@ -41,10 +41,12 @@
         </ul>
 
         {{-- The results will be stored here --}}
-        <div id="{{ $field['name'] }}_results"></div>
+        <div id="{{ $field['name'] }}_results">
+            @foreach ($values as $key)
+                <input type="hidden" name="{{ $field['name'] }}[]" value="{{ $key }}">
+            @endforeach
+        </div>
     </div>
-
-
 
     {{-- HINT --}}
     @if (isset($field['hint']))


### PR DESCRIPTION
Saving an entity again after saving an order removes all values when using the field as "fake"

This change hard codes the existing values as inputs.