### PR TITLE
[4.0][Improvement][Needs feedback] Optimize reorder for speed (use DB instead of Eloquent)

### DIFF
--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -30,7 +30,7 @@ trait Reorder
                         'parent_id' => empty($entry['parent_id']) ? null : $entry['parent_id'],
                         'depth' => empty($entry['depth']) ? null : $entry['depth'],
                         'lft' => empty($entry['left']) ? null : $entry['left'],
-                        'rgt' => empty($entry['right']) ? null : $entry['right']
+                        'rgt' => empty($entry['right']) ? null : $entry['right'],
                     ]);
 
                 $count++;

--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -22,20 +22,20 @@ trait Reorder
         $count = 0;
 
         \DB::beginTransaction();
-            foreach ($request as $key => $entry) {
-                if ($entry['item_id'] != '' && $entry['item_id'] != null) {
-                    \DB::table($this->model->getTable())
-                        ->where('id', '=', $entry['item_id'])
-                        ->update([
-                            'parent_id' => empty($entry['parent_id']) ? null : $entry['parent_id'],
-                            'depth' => empty($entry['depth']) ? null : $entry['depth'],
-                            'lft' => empty($entry['left']) ? null : $entry['left'],
-                            'rgt' => empty($entry['right']) ? null : $entry['right']
-                        ]);
+        foreach ($request as $key => $entry) {
+            if ($entry['item_id'] != '' && $entry['item_id'] != null) {
+                \DB::table($this->model->getTable())
+                    ->where('id', '=', $entry['item_id'])
+                    ->update([
+                        'parent_id' => empty($entry['parent_id']) ? null : $entry['parent_id'],
+                        'depth' => empty($entry['depth']) ? null : $entry['depth'],
+                        'lft' => empty($entry['left']) ? null : $entry['left'],
+                        'rgt' => empty($entry['right']) ? null : $entry['right']
+                    ]);
 
-                    $count++;
-                }
+                $count++;
             }
+        }
         \DB::commit();
 
         return $count;

--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -24,7 +24,7 @@ trait Reorder
         \DB::beginTransaction();
             foreach ($request as $key => $entry) {
                 if ($entry['item_id'] != '' && $entry['item_id'] != null) {
-                    \DB::table('topics')
+                    \DB::table($this->model->getTable())
                         ->where('id', '=', $entry['item_id'])
                         ->update([
                             'parent_id' => empty($entry['parent_id']) ? null : $entry['parent_id'],

--- a/src/PanelTraits/Reorder.php
+++ b/src/PanelTraits/Reorder.php
@@ -21,18 +21,22 @@ trait Reorder
     {
         $count = 0;
 
-        foreach ($request as $key => $entry) {
-            if ($entry['item_id'] != '' && $entry['item_id'] != null) {
-                $item = $this->model->find($entry['item_id']);
-                $item->parent_id = empty($entry['parent_id']) ? null : $entry['parent_id'];
-                $item->depth = empty($entry['depth']) ? null : $entry['depth'];
-                $item->lft = empty($entry['left']) ? null : $entry['left'];
-                $item->rgt = empty($entry['right']) ? null : $entry['right'];
-                $item->save();
+        \DB::beginTransaction();
+            foreach ($request as $key => $entry) {
+                if ($entry['item_id'] != '' && $entry['item_id'] != null) {
+                    \DB::table('topics')
+                        ->where('id', '=', $entry['item_id'])
+                        ->update([
+                            'parent_id' => empty($entry['parent_id']) ? null : $entry['parent_id'],
+                            'depth' => empty($entry['depth']) ? null : $entry['depth'],
+                            'lft' => empty($entry['left']) ? null : $entry['left'],
+                            'rgt' => empty($entry['right']) ? null : $entry['right']
+                        ]);
 
-                $count++;
+                    $count++;
+                }
             }
-        }
+        \DB::commit();
 
         return $count;
     }


### PR DESCRIPTION
reorder was extremely slow (~15s) with big datasets (~200 entries) because it created a lot of db queries. this brings it down to <100ms with just one db query.