### PR TITLE
Add simple json column type

### DIFF
--- a/src/resources/views/columns/json.blade.php
+++ b/src/resources/views/columns/json.blade.php
@@ -1,0 +1,5 @@
+@if(is_string($entry->{$column['name']}))
+<pre>{{ json_encode(json_decode($entry->{$column['name']}, true), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+@else
+<pre>{{ json_encode($entry->{$column['name']}, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+@endif


### PR DESCRIPTION
Another simple column type.

If the value is a string, it does json_decode to convert it to an array before running json_encode with JSON_PRETTY_PRINT and JSON_UNESCAPED_SLASHES (For preventing values like "08/08/2018" from getting displayed as "08\/08\/2018")

If it is not a string (which I then assume it is an array or object already).Apply json_encode with JSON_PRETTY_PRINT and JSON_UNESCAPED_SLASHES right away.

Like the markdown column type. This is meant more for show view. If someone wants to add colour formatting. Feel free too.

Other JSON Constants can be found here if you felt more should be applied to the formatting:

https://www.php.net/manual/en/json.constants.php