### PR TITLE
Update date_picker.blade.php

### DIFF
--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -74,10 +74,10 @@
                     // varying behavior across browsers. Splitting and passing in parts of the date
                     // manually gives us more defined behavior.
                     // See https://stackoverflow.com/questions/2587345/why-does-date-parse-give-incorrect-results
-                    var parts = $existingVal.split('-')
-                    var year = parts[0]
-                    var month = parts[1] - 1 // Date constructor expects a zero-indexed month
-                    var day = parts[2]
+                    var parts = $existingVal.split('-');
+                    var year = parts[0];
+                    var month = parts[1] - 1; // Date constructor expects a zero-indexed month
+                    var day = parts[2];
                     preparedDate = new Date(year, month, day).format($customConfig.format);
                     $fake.val(preparedDate);
                     $picker.bootstrapDP('update', preparedDate);


### PR DESCRIPTION
Add semicolons after variables declarations. Semicolons are optional but theirs lacks cause some errors if you are going to use Minify Response/HTML libraries.