### PR TITLE
[4.0][Improvement] Add max_image_size to image field type

### DIFF
--- a/src/resources/views/fields/image.blade.php
+++ b/src/resources/views/fields/image.blade.php
@@ -14,6 +14,7 @@
                 : url($prefix.$value))
         :''; // if validation failed, tha value will be base64, so no need to create a URL for it
 
+    $max_image_size_in_bytes = isset($field['max_image_size']) ? $field['max_image_size'] : -1;
 @endphp
 
   <div data-preview="#{{ $field['name'] }}"
@@ -187,7 +188,12 @@
                         }
                         file = files[0];
 
-                        if (/^image\/\w+$/.test(file.type)) {
+                        const maxImageSize = {{ $max_image_size_in_bytes }};
+                        if(maxImageSize > 0 && file.size > maxImageSize) {
+
+                            alert(`Please pick an image smaller than ${maxImageSize} bytes.`);
+                        } else if (/^image\/\w+$/.test(file.type)) {
+                            
                             fileReader.readAsDataURL(file);
                             fileReader.onload = function () {
                                 $uploadImage.val("");


### PR DESCRIPTION
This field enables validation of the max image size allowed on Javascript's end, without the need to post it to the PHP server.