### PR TITLE
fixes #1910 - allows keyboard use on date_picker field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 - merged #1921 - table column type can now output both arrays and objects;
 - merged #1852 - syncPivot() method now allows pivot data;
 - merged #1954 - semicolons on date_picker field js;
+- fixes #1910 - allows keyboard use on date_picker field type;
 
 
 ## [3.6.24] - 2019-07-23

--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -8,6 +8,13 @@
     }
 
     $field_language = isset($field['date_picker_options']['language'])?$field['date_picker_options']['language']:\App::getLocale();
+
+    if (!isset($field['attributes']['style'])) {
+        $field['attributes']['style'] = 'background-color: white!important;';
+    }
+    if (!isset($field['attributes']['readonly'])) {
+        $field['attributes']['readonly'] = 'readonly';
+    }
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
@@ -83,10 +90,12 @@
                     $picker.bootstrapDP('update', preparedDate);
                 }
 
-                $fake.on('keydown', function(e){
-                    e.preventDefault();
-                    return false;
-                });
+                // prevent users from typing their own date
+                // since the js plugin does not support it
+                // $fake.on('keydown', function(e){
+                //     e.preventDefault();
+                //     return false;
+                // });
 
                 $picker.on('show hide change', function(e){
                     if( e.date ){


### PR DESCRIPTION
See https://github.com/Laravel-Backpack/CRUD/issues/1910 and https://github.com/Laravel-Backpack/CRUD/issues/1878

This PR:
- makes the date_picker input ```readonly``` by default;
- removes the restriction of not typing anything inside the date_picker field; 

This:
- makes the field editable with the keyboard (by browsing the popover, NOT editing the actual value);
- makes it possible to jump out of the popover using Tab;