### PR TITLE
[3.6][Fix][WIP] Carbon Immutable dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file
 
 ## [3.6.25] - 2019-08-17
 
+### Fixed
+- merged #1964, fixes #1836 - allows carbon immutable dates;
+
+
+## [3.6.25] - 2019-08-17
+
 ### Added
 - merged #1952 - ```json``` column type;
 

--- a/src/resources/views/fields/date.blade.php
+++ b/src/resources/views/fields/date.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface )) {
     $field['value'] = $field['value']->toDateString();
 }
 ?>

--- a/src/resources/views/fields/date.blade.php
+++ b/src/resources/views/fields/date.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
     $field['value'] = $field['value']->toDateString();
 }
 ?>

--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -3,7 +3,7 @@
 <?php
     // if the column has been cast to Carbon or Date (using attribute casting)
     // get the value as a date string
-    if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface )) {
         $field['value'] = $field['value']->format('Y-m-d');
     }
 

--- a/src/resources/views/fields/date_picker.blade.php
+++ b/src/resources/views/fields/date_picker.blade.php
@@ -3,7 +3,7 @@
 <?php
     // if the column has been cast to Carbon or Date (using attribute casting)
     // get the value as a date string
-    if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+    if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
         $field['value'] = $field['value']->format('Y-m-d');
     }
 

--- a/src/resources/views/fields/date_range.blade.php
+++ b/src/resources/views/fields/date_range.blade.php
@@ -9,7 +9,7 @@
             $formattedDate = null;
             if (isset($entry) && !empty($entry->{$dateFieldName})) {
                 $dateField = $entry->{$dateFieldName};
-                if ($dateField instanceof \Carbon\Carbon || $dateField instanceof \Jenssegers\Date\Date) {
+                if ($dateField instanceof \Carbon\CarbonInterface || $dateField instanceof \Jenssegers\Date\Date) {
                     $formattedDate = $dateField->format('Y-m-d H:i:s');
                 } else {
                     $formattedDate = date('Y-m-d H:i:s', strtotime($entry->{$dateFieldName}));

--- a/src/resources/views/fields/date_range.blade.php
+++ b/src/resources/views/fields/date_range.blade.php
@@ -9,7 +9,7 @@
             $formattedDate = null;
             if (isset($entry) && !empty($entry->{$dateFieldName})) {
                 $dateField = $entry->{$dateFieldName};
-                if ($dateField instanceof \Carbon\CarbonInterface || $dateField instanceof \Jenssegers\Date\Date) {
+                if ($dateField instanceof \Carbon\CarbonInterface) {
                     $formattedDate = $dateField->format('Y-m-d H:i:s');
                 } else {
                     $formattedDate = date('Y-m-d H:i:s', strtotime($entry->{$dateFieldName}));

--- a/src/resources/views/fields/datetime.blade.php
+++ b/src/resources/views/fields/datetime.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface )) {
     $field['value'] = $field['value']->toDateTimeString();
 }
 ?>

--- a/src/resources/views/fields/datetime.blade.php
+++ b/src/resources/views/fields/datetime.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
     $field['value'] = $field['value']->toDateTimeString();
 }
 ?>

--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface )) {
     $field['value'] = $field['value']->format('Y-m-d H:i:s');
 }
 

--- a/src/resources/views/fields/datetime_picker.blade.php
+++ b/src/resources/views/fields/datetime_picker.blade.php
@@ -3,7 +3,7 @@
 <?php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
-if (isset($field['value']) && ( $field['value'] instanceof \Carbon\Carbon || $field['value'] instanceof \Jenssegers\Date\Date )) {
+if (isset($field['value']) && ( $field['value'] instanceof \Carbon\CarbonInterface || $field['value'] instanceof \Jenssegers\Date\Date )) {
     $field['value'] = $field['value']->format('Y-m-d H:i:s');
 }
 

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -8,7 +8,7 @@
     <div class="well well-sm">
         @if (isset($field['disk']))
         @if (isset($field['temporary']))
-            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
+            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\CarbonInterface::now()->addMinutes($field['temporary'])))) }}">
         @else
             <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(array_get($field, 'prefix', '').$field['value']))) }}">
         @endif

--- a/src/resources/views/fields/upload.blade.php
+++ b/src/resources/views/fields/upload.blade.php
@@ -8,7 +8,7 @@
     <div class="well well-sm">
         @if (isset($field['disk']))
         @if (isset($field['temporary']))
-            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\CarbonInterface::now()->addMinutes($field['temporary'])))) }}">
+            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
         @else
             <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(array_get($field, 'prefix', '').$field['value']))) }}">
         @endif


### PR DESCRIPTION
Fixes #1836 . Allows you to use ```CarbonImmutable::class``` in your app. Previously when doing ```Date::use(CarbonImmutable::class)``` in your ```AppServiceProvider::register()```, your date & datetime fields stopped working.