### PR TITLE
Update select2_multiple.blade.php

### DIFF
--- a/src/resources/views/fields/select2_multiple.blade.php
+++ b/src/resources/views/fields/select2_multiple.blade.php
@@ -5,6 +5,7 @@
     } else {
         $options = call_user_func($field['options'], $field['model']::query());
     }
+    $multiple = isset($field['multiple']) && $field['multiple']===false ? '': 'multiple';
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >
@@ -14,7 +15,7 @@
         name="{{ $field['name'] }}[]"
         style="width: 100%"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_multiple'])
-        multiple>
+        {{$multiple}}>
 
         @if (isset($field['allows_null']) && $field['allows_null']==true)
             <option value="">-</option>


### PR DESCRIPTION
Give users the option to disable multiple.
The simple `select` field doesn't support **polymorphic relationship** as it requires `entity`, instead the `select2_multiple` plays nice with **polymorphic relationship** with `pivot => true` as well, but I if I need polymorphic with the option to select one value I can't do it without removing `multiple` in `select2_multiple`.