### PR TITLE
Fixes for Select2_from_array

### DIFF
--- a/src/resources/views/fields/select2_from_array.blade.php
+++ b/src/resources/views/fields/select2_from_array.blade.php
@@ -1,7 +1,4 @@
 <!-- select2 from array -->
-@php
-    echo '<pre>'; var_dump($field); echo '</pre>';
-@endphp
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     <select


### PR DESCRIPTION
Currently on the latest tag, we've got a var_dump on select2_from_array

Merging this + tagging as `3.6.29` will be a quick resolve