### PR TITLE
Update CrudTrait.php

### DIFF
--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -99,7 +99,7 @@ trait CrudTrait
             if ((is_array($column_contents) || is_object($column_contents) || $column_contents instanceof Traversable)) {
                 foreach ($column_contents as $fake_field_name => $fake_field_value) {
                     //TODO: handle mutlidimensional arrays.
-                    if (!is_array($fake_field_value) && !is_object($fake_field_value)) {
+                    if (! is_array($fake_field_value) && ! is_object($fake_field_value)) {
                         $this->setAttribute($fake_field_name, $fake_field_value);
                     }
                 }

--- a/src/CrudTrait.php
+++ b/src/CrudTrait.php
@@ -98,7 +98,10 @@ trait CrudTrait
 
             if ((is_array($column_contents) || is_object($column_contents) || $column_contents instanceof Traversable)) {
                 foreach ($column_contents as $fake_field_name => $fake_field_value) {
-                    $this->setAttribute($fake_field_name, $fake_field_value);
+                    //TODO: handle mutlidimensional arrays.
+                    if (!is_array($fake_field_value) && !is_object($fake_field_value)) {
+                        $this->setAttribute($fake_field_name, $fake_field_value);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When using table column/field type and casting its value to object or array it fails with "preg_match() expects parameter 2 to be string, array given". `$this->setAttribute()` calls `$this->isStandardDateFormat()` on `HasAttributes` trait which expects its value to be string instead in the case when you cast table data to array the value sent is array.