### PR TITLE
auto-set from current model instead of default connection

### DIFF
--- a/src/PanelTraits/AutoSet.php
+++ b/src/PanelTraits/AutoSet.php
@@ -160,7 +160,7 @@ trait AutoSet
     public function setDoctrineTypesMapping()
     {
         $types = ['enum' => 'string'];
-        $platform = \DB::getDoctrineConnection()->getDatabasePlatform();
+        $platform = $this->getSchema()->getConnection()->getDoctrineConnection()->getDatabasePlatform();
         foreach ($types as $type_key => $type_value) {
             if (! $platform->hasDoctrineTypeMappingFor($type_key)) {
                 $platform->registerDoctrineTypeMapping($type_key, $type_value);

--- a/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
@@ -3,6 +3,10 @@
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\ColumnType;
+use Doctrine\DBAL\DBALException;
+use Illuminate\Support\Facades\DB;
+
+class MyColumnTypeWithOtherConnection extends ColumnType { protected $connection = 'testing_2'; }
 
 class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
 {
@@ -804,5 +808,30 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
         $columnNames = $this->crudPanel->getDbColumnsNames();
 
         $this->assertEquals(array_keys($this->expectedColumnTypes), $columnNames);
+    }
+
+    public function testSetDoctrineTypesMapping()
+    {
+        $original_db_config = $this->app['config']->get('database.connections.testing');
+        $new_model_db_config = array_merge($original_db_config, ['prefix' => 'testing2']);
+
+        $this->app['config']->set('database.connections.testing_2', $new_model_db_config);
+
+        $original_db_platform = $this->crudPanel->getModel()->getConnection()->getDoctrineConnection()->getDatabasePlatform();
+        $this->crudPanel->setDoctrineTypesMapping();
+        $type = $original_db_platform->getDoctrineTypeMapping('enum');
+
+        $this->crudPanel->setModel(MyColumnTypeWithOtherConnection::class);
+        $new_model_db_platform = $this->crudPanel->getModel()->getConnection()->getDoctrineConnection()->getDatabasePlatform();
+
+        try {
+            $new_model_db_platform->getDoctrineTypeMapping('enum');
+        } catch (DBALException $e) {
+            $this->assertInstanceOf(DBALException::class, $e);
+        }
+        $this->crudPanel->setDoctrineTypesMapping();
+
+        $type = $new_model_db_platform->getDoctrineTypeMapping('enum');
+        $this->assertEquals('string', $type);
     }
 }


### PR DESCRIPTION
a bug-fix for my issue #1982 

Edit "AutoSet" method "setDoctrineTypesMapping"
Instead of getting connection from default db connection,
Set connection with current $model

-- commit log--
edit setDoctrineTypesMapping
get doctrine connection from class property $model, instead of \DB::getDoctrineConnection()