### PR TITLE
[4.0][Feature][Ready] Added CRUD facade; Bound CrudPanel to service container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,10 @@
         "laravel": {
             "providers": [
                 "Backpack\\CRUD\\CrudServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "CRUD": "Backpack\\CRUD\\CrudPanelFacade"
+            }
         }
     }
 }

--- a/src/CrudPanelFacade.php
+++ b/src/CrudPanelFacade.php
@@ -4,6 +4,11 @@ namespace Backpack\CRUD;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * This object allows developers to use CRUD::addField() instead of $this->crud->addField(),
+ * by providing a Facade that leads to the CrudPanel object. That object is stored in Laravel's
+ * service container as 'crud'. 
+ */
 class CrudPanelFacade extends Facade
 {
     /**

--- a/src/CrudPanelFacade.php
+++ b/src/CrudPanelFacade.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Backpack\CRUD;
+
+use Illuminate\Support\Facades\Facade;
+
+class CrudPanelFacade extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'crud';
+    }
+}

--- a/src/CrudPanelFacade.php
+++ b/src/CrudPanelFacade.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * This object allows developers to use CRUD::addField() instead of $this->crud->addField(),
  * by providing a Facade that leads to the CrudPanel object. That object is stored in Laravel's
- * service container as 'crud'. 
+ * service container as 'crud'.
  */
 class CrudPanelFacade extends Facade
 {

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Backpack\CRUD\CrudPanel;
 
 class CrudServiceProvider extends ServiceProvider
 {
@@ -85,8 +86,9 @@ class CrudServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('CRUD', function ($app) {
-            return new CRUD($app);
+        // Bind the CrudPanel object to Laravel's service container
+        $this->app->singleton('crud', function ($app) {
+            return new CrudPanel($app);
         });
 
         // load a macro for Route,

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
-use Backpack\CRUD\CrudPanel;
 use Illuminate\Http\Request;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
@@ -23,7 +22,8 @@ class CrudController extends BaseController
     public function __construct()
     {
         if (! $this->crud) {
-            $this->crud = app()->make(CrudPanel::class);
+            // make a new CrudPanel object, from the one stored in Laravel's service container
+            $this->crud = app()->make('crud');
 
             // call the setup function inside this closure to also have the request there
             // this way, developers can use things stored in session (auth variables, etc)


### PR DESCRIPTION
Fixes #1988 

# CrudPanel is bound to Laravel's service container

Allows developers to use a different CrudPanel object, instead of the one in the package. 

For example, if you want to prevent Updating in all your CRUDs (including the ones in packages like Settings, PermissionManager, etc), you could do:
```php
$this->app->extend('crud', function () {
    return new \App\Services\CustomCrudPanel();
});
```

which points to

```php
<?php

namespace App\Services;

use Backpack\CRUD\CrudPanel;

class CustomCrudPanel extends CrudPanel
{
    /**
     * Prevent users from updating entries.
     */
    public function update($id, $data)
    {
        $data = $this->decodeJsonCastedAttributes($data, 'update', $id);
        $data = $this->compactFakeFields($data, 'update', $id);
        $item = $this->model->findOrFail($id);

        \Alert::warning("<strong>Disabled in Demo</strong><br>For security reasons, the db entries aren't updated in the demo.");

        return $item;
    }
}
```

Then all CrudControllers will actually be using the ```CustomCrudPanel``` object, instead of the stock ```CrudPanel```.

# Added a CRUD Facade

Additionally, this PR introduces a new ```CRUD``` Facade, for the CrudPanel object that's bound to Laravel's service container. This allows developers to use ```CRUD::addField()``` and ```$this->crud->addField()``` interchangeably. Might have to do ```use CRUD;``` at the top of the controller for this to work.

So instead of this:
```php
        $this->crud->setModel('App\Models\Monster');
        $this->crud->setRoute(config('backpack.base.route_prefix').'/monster');
        $this->crud->setEntityNameStrings('monster', 'monsters');
```

You can now do this:
```php
        CRUD::setModel('App\Models\Monster');
        CRUD::setRoute(config('backpack.base.route_prefix').'/monster');
        CRUD::setEntityNameStrings('monster', 'monsters');
```

I'm not sure if we should make the Facade the default, when generating new files, or that we should encourage people to use it. Facades are another layer of abstraction, so they might be confusing for some people.... Food for thought...