### PR TITLE
[4.0][Security improvement] Only store explicitly defined fields in Create and Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 - Laravel-Backpack/Base#387 - Easily remove the bundled js and css and use CDNs if you want to;
 - Laravel-Backpack/Base#380 - New design - Backstrap, based on CoreUI;
 - [Webfactor/Laravel-Generators](https://github.com/webfactor/laravel-generatorssu) to the installation command;
+- the Create and Update operations only save the values of the fields (determined using the name attribute); anything else it ignores; this is for security reasons - to prevent saving fields that have been inserted in the front-end maliciously; 
+- field types can now have arrays for names, instead of strings; when a field type wants to save multiple attributes, it should have all of them as array in the "name" field attribute; this makes sure that they will get saved in the database;
+
 
 ### Fixed
 - merged #1984 fixes #1952 and #1981 - ```table``` fied type has been rewritten using JQuery instead of Angular, for consistency;
@@ -40,6 +43,8 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 - delete button now shows up (and works) in the Show operation view;
 - for the List operation, the default order is now by primary key DESC (instead of ASC); backwards-compatible, in that if a different order has been set for the primary key, that one will be used instead;
 - we've reduced the default character limit for a all columns that had it - previously if ```text```, ```email```, ```model_function```, ```model_function_attribute```, ```phone```, ```row_number```, ```select``` column had its contents bigger than 50 characters, it got shortened (_Something some[...]_); we've reduced this limit to 40 characters, so that more columns can fit into one screen by default; you can overwrite this default with ```'limit' => 50``` in your column;
+- checklist_dependency field now uses array for name;
+- date_range field now uses array for names;
 
 
 ### Removed

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -85,7 +85,7 @@ trait CreateOperation
         $request = $this->crud->validateRequest();
 
         // insert item in the db
-        $item = $this->crud->create($request->except(['save_action', '_token', '_method', 'current_tab', 'http_referrer']));
+        $item = $this->crud->create($this->crud->getStrippedSaveRequest());
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -95,7 +95,7 @@ trait UpdateOperation
 
         // update the row in the db
         $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $request->except('save_action', '_token', '_method', 'current_tab', 'http_referrer'));
+                            $this->crud->getStrippedSaveRequest());
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -25,14 +25,19 @@ trait FakeFields
         $compactedFakeFields = [];
         foreach ($fields as $field) {
             // compact fake fields
-            if (isset($field['fake']) && $field['fake'] == true && array_key_exists($field['name'], $requestInput)) {
-                $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
-                $this->addCompactedField($requestInput, $field['name'], $fakeFieldKey);
+            // cast the field name to array first, to account for array field names
+            // in fields that send multiple inputs and want them all saved to the database 
+            foreach ((array)$field['name'] as $fieldName) {
+                if (isset($field['fake']) && $field['fake'] == true && array_key_exists($fieldName, $requestInput)) {
+                    $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
+                    $this->addCompactedField($requestInput, $fieldName, $fakeFieldKey);
 
-                if (! in_array($fakeFieldKey, $compactedFakeFields)) {
-                    $compactedFakeFields[] = $fakeFieldKey;
+                    if (! in_array($fakeFieldKey, $compactedFakeFields)) {
+                        $compactedFakeFields[] = $fakeFieldKey;
+                    }
                 }
             }
+            
         }
 
         // json_encode all fake_value columns if applicable in the database, so they can be properly stored and interpreted

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -60,7 +60,8 @@ trait Fields
         }
 
         $fields = $this->getOperationSetting('fields');
-        $fields = \Arr::add($this->fields(), $newField['name'], $newField);
+        $fieldKey = is_array($newField['name']) ? implode("_", $newField['name']) : $newField['name'];
+        $fields = \Arr::add($this->fields(), $fieldKey, $newField);
         $this->setOperationSetting('fields', $fields);
 
         return $this;
@@ -240,7 +241,7 @@ trait Fields
         foreach ($fields as $field) {
 
             // Test the field is castable
-            if (isset($field['name']) && array_key_exists($field['name'], $casted_attributes)) {
+            if (isset($field['name']) && is_string($field['name']) && array_key_exists($field['name'], $casted_attributes)) {
 
                 // Handle JSON field types
                 $jsonCastables = ['array', 'object', 'json'];
@@ -440,5 +441,24 @@ trait Fields
     public function fieldTypeNotLoaded($field)
     {
         return ! in_array($this->getFieldTypeWithNamespace($field), $this->getLoadedFieldTypes());
+    }
+
+    /**
+     * Get a list of all field names for the current operation.
+     * 
+     * @return array
+     */
+    public function getAllFieldNames()
+    {
+        return \Arr::flatten(\Arr::pluck($this->getCurrentFields(), 'name'));
+    }
+
+    /**
+     * Returns the request without anything that might have been maliciously inserted.
+     * Only specific field names that have been introduced with addField() are kept in the request. 
+     */
+    public function getStrippedSaveRequest()
+    {
+        return $this->request->only($this->getAllFieldNames());
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -98,6 +98,17 @@ trait Update
             }
         }
 
-        return $model->{$field['name']};
+        if (is_string($field['name'])) {
+            return $model->{$field['name']};
+        }
+
+        if (is_array($field['name'])) {
+            $result = [];
+            foreach ($field['name'] as $key => $value) {
+                $result = $model->{$value};
+            }
+
+            return $result;
+        }
     }
 }

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -24,11 +24,16 @@
         $start_name = formatDate($entry, $field['name'][0]);
         $end_name = formatDate($entry, $field['name'][1]);
     }
+
+    if (isset($field['default'])) {
+        $start_default = $field['default'][0];
+        $end_default = $field['default'][1];
+    }
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
-    <input class="datepicker-range-start" type="hidden" name="{{ $field['name'][0] }}" value="{{ old(square_brackets_to_dots($field['name'][0])) ?? $start_name ?? $field['start_default'] ?? '' }}">
-    <input class="datepicker-range-end" type="hidden" name="{{ $field['name'][1] }}" value="{{ old(square_brackets_to_dots($field['name'][1])) ?? $end_name ?? $field['end_default'] ?? '' }}">
+    <input class="datepicker-range-start" type="hidden" name="{{ $field['name'][0] }}" value="{{ old(square_brackets_to_dots($field['name'][0])) ?? $start_name ?? $start_default ?? '' }}">
+    <input class="datepicker-range-end" type="hidden" name="{{ $field['name'][1] }}" value="{{ old(square_brackets_to_dots($field['name'][1])) ?? $end_name ?? $end_default ?? '' }}">
     <label>{!! $field['label'] !!}</label>
     <div class="input-group date">
         <input

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -21,14 +21,14 @@
     }
 
     if (isset($entry)) {
-        $start_name = formatDate($entry, $field['start_name']);
-        $end_name = formatDate($entry, $field['end_name']);
+        $start_name = formatDate($entry, $field['name'][0]);
+        $end_name = formatDate($entry, $field['name'][1]);
     }
 ?>
 
 <div @include('crud::inc.field_wrapper_attributes') >
-    <input class="datepicker-range-start" type="hidden" name="{{ $field['start_name'] }}" value="{{ old(square_brackets_to_dots($field['start_name'])) ?? $start_name ?? $field['start_default'] ?? '' }}">
-    <input class="datepicker-range-end" type="hidden" name="{{ $field['end_name'] }}" value="{{ old(square_brackets_to_dots($field['end_name'])) ?? $end_name ?? $field['end_default'] ?? '' }}">
+    <input class="datepicker-range-start" type="hidden" name="{{ $field['name'][0] }}" value="{{ old(square_brackets_to_dots($field['name'][0])) ?? $start_name ?? $field['start_default'] ?? '' }}">
+    <input class="datepicker-range-end" type="hidden" name="{{ $field['name'][1] }}" value="{{ old(square_brackets_to_dots($field['name'][1])) ?? $end_name ?? $field['end_default'] ?? '' }}">
     <label>{!! $field['label'] !!}</label>
     <div class="input-group date">
         <input


### PR DESCRIPTION
This PR fixes #1231 :
- Create and Update operations now strip the request of anything that hasn't been defined as a field; this way, the visitor can't insert his own inputs in the page and have them saved in the db; even if we usually trust the admin not to be malicious, and we had $fillable in place, this extra layer of security is probably a good idea;
- allows for field names to be ```string``` (like before), but also ```array```;
- ```checklist_dependency``` and ```date_range```, the two fields who have multiple inputs inside one field, have a different definition now, requiring an array for the field name;