### PR TITLE
Add missing URL update in the example filter

### DIFF
--- a/src/resources/views/filters/example.blade.php
+++ b/src/resources/views/filters/example.blade.php
@@ -59,6 +59,9 @@ END OF FILTER JAVSCRIPT CHECKLIST --}}
 				new_url = normalizeAmpersand(new_url.toString());
 				ajax_table.ajax.url(new_url).load();
 
+                // add filter to URL
+                crud.updateUrl(new_url);
+
 				// mark this filter as active in the navbar-filters
 				if (URI(new_url).hasQuery('{{ $filter->name }}', true)) {
 					$("li[filter-name={{ $filter->name }}]").removeClass('active').addClass('active');


### PR DESCRIPTION
The URL string, used for the DataTables is updated,
but the one for the browser's URL address bar was not.
Similarly to other filters, the URL must also be updated,
so that when the user refreshes the page, it would still
show the same data.