### PR TITLE
[4.0] Clean up crud config file

### DIFF
--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -29,6 +29,10 @@ trait BulkCloneOperation
     {
         $this->crud->allowAccess('bulkClone');
 
+        $this->crud->operation('bulkClone', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation('list', function () {
             $this->crud->enableBulkActions();
             $this->crud->addButton('bottom', 'bulk_clone', 'view', 'crud::buttons.bulk_clone', 'beginning');

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -29,6 +29,10 @@ trait BulkDeleteOperation
     {
         $this->crud->allowAccess('bulkDelete');
 
+        $this->crud->operation('bulkDelete', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation('list', function () {
             $this->crud->enableBulkActions();
             $this->crud->addButton('bottom', 'bulk_delete', 'view', 'crud::buttons.bulk_delete');

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -29,6 +29,10 @@ trait CloneOperation
     {
         $this->crud->allowAccess('clone');
 
+        $this->crud->operation('clone', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation(['list', 'show'], function () {
             $this->crud->addButton('line', 'clone', 'view', 'crud::buttons.clone', 'end');
         });

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -42,9 +42,7 @@ trait CreateOperation
         $this->crud->allowAccess('create');
 
         $this->crud->operation('create', function () {
-            $this->crud->set('create.groupedErrors', config('backpack.crud.show_grouped_errors', true));
-            $this->crud->set('create.inlineErrors', config('backpack.crud.show_inline_errors', true));
-            $this->crud->set('create.autoFocusOnFirstField', true);
+            $this->crud->loadDefaultOperationSettingsFromConfig();
         });
 
         $this->crud->operation('list', function () {

--- a/src/app/Http/Controllers/Operations/DeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/DeleteOperation.php
@@ -29,6 +29,10 @@ trait DeleteOperation
     {
         $this->crud->allowAccess('delete');
 
+        $this->crud->operation('delete', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation(['list', 'show'], function () {
             $this->crud->addButton('line', 'delete', 'view', 'crud::buttons.delete', 'end');
         });

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -40,6 +40,10 @@ trait ListOperation
     protected function setupListDefaults()
     {
         $this->crud->allowAccess('list');
+
+        $this->crud->operation('list', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -36,6 +36,10 @@ trait ReorderOperation
         $this->crud->set('reorder.enabled', true);
         $this->crud->allowAccess('reorder');
 
+        $this->crud->operation('reorder', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation('list', function () {
             $this->crud->addButton('top', 'reorder', 'view', 'crud::buttons.reorder');
         });

--- a/src/app/Http/Controllers/Operations/RevisionsOperation.php
+++ b/src/app/Http/Controllers/Operations/RevisionsOperation.php
@@ -36,6 +36,10 @@ trait RevisionsOperation
         // allow access to the operation
         $this->crud->allowAccess('revisions');
 
+        $this->crud->operation('revisions', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation(['list', 'show'], function () {
             // add a button in the line stack
             $this->crud->addButton('line', 'revisions', 'view', 'crud::buttons.revisions', 'end');

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -29,6 +29,10 @@ trait ShowOperation
     {
         $this->crud->allowAccess('show');
 
+        $this->crud->operation('show', function() {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
         $this->crud->operation('list', function () {
             $this->crud->addButton('line', 'show', 'view', 'crud::buttons.show', 'beginning');
         });

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -42,9 +42,7 @@ trait UpdateOperation
         $this->crud->allowAccess('update');
 
         $this->crud->operation('update', function () {
-            $this->crud->set('update.groupedErrors', config('backpack.crud.show_grouped_errors', true));
-            $this->crud->set('update.inlineErrors', config('backpack.crud.show_inline_errors', true));
-            $this->crud->set('update.autoFocusOnFirstField', true);
+            $this->crud->loadDefaultOperationSettingsFromConfig();
 
             if ($this->crud->getModel()->translationEnabled()) {
                 $this->crud->addField([

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -192,7 +192,7 @@ trait Read
      */
     public function getDefaultPageLength()
     {
-        return $this->getOperationSetting('defaultPageLength') ?? config('backpack.crud.operations.list.default_page_length') ?? 25;
+        return $this->getOperationSetting('defaultPageLength') ?? config('backpack.crud.operations.list.defaultPageLength') ?? 25;
     }
 
     /**
@@ -204,7 +204,7 @@ trait Read
         // If the default Page Length isn't in the menu's values, Add it the beginnin and resort all to show a croissant list.
         // assume both arrays are the same length.
         if (! in_array($this->getDefaultPageLength(), $this->getOperationSetting('pageLengthMenu')[0])) {
-            // Loop through 2 arrays of prop. page_length_menu
+            // Loop through 2 arrays of prop. pageLengthMenu
             foreach ($this->getOperationSetting('pageLengthMenu') as $key => &$page_length_choices) {
                 // This is a condition that should be always true.
                 if (is_array($page_length_choices)) {
@@ -233,19 +233,13 @@ trait Read
      */
     public function getPageLengthMenu()
     {
-        // if already set, use that
-        if (! $this->getOperationSetting('pageLengthMenu')) {
-            // try to get the menu settings from the config file
-            $this->setOperationSetting('pageLengthMenu', config('backpack.crud.operations.list.page_length_menu') ?? [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']]);
-
-            // if we have a 2D array, update all the values in the right hand array to their translated values
-            if (isset($this->getOperationSetting('pageLengthMenu')[1]) && is_array($this->getOperationSetting('pageLengthMenu')[1])) {
-                $aux = $this->getOperationSetting('pageLengthMenu');
-                foreach ($this->getOperationSetting('pageLengthMenu')[1] as $key => $val) {
-                    $aux[1][$key] = trans($val);
-                }
-                $this->setOperationSetting('pageLengthMenu', $aux);
+        // if we have a 2D array, update all the values in the right hand array to their translated values
+        if (isset($this->getOperationSetting('pageLengthMenu')[1]) && is_array($this->getOperationSetting('pageLengthMenu')[1])) {
+            $aux = $this->getOperationSetting('pageLengthMenu');
+            foreach ($this->getOperationSetting('pageLengthMenu')[1] as $key => $val) {
+                $aux[1][$key] = trans($val);
             }
+            $this->setOperationSetting('pageLengthMenu', $aux);
         }
 
         $this->addCustomPageLengthToPageLengthMenu();

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -192,7 +192,7 @@ trait Read
      */
     public function getDefaultPageLength()
     {
-        return $this->getOperationSetting('defaultPageLength') ?? config('backpack.crud.default_page_length') ?? 25;
+        return $this->getOperationSetting('defaultPageLength') ?? config('backpack.crud.operations.list.default_page_length') ?? 25;
     }
 
     /**
@@ -236,7 +236,7 @@ trait Read
         // if already set, use that
         if (! $this->getOperationSetting('pageLengthMenu')) {
             // try to get the menu settings from the config file
-            $this->setOperationSetting('pageLengthMenu', config('backpack.crud.page_length_menu') ?? [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']]);
+            $this->setOperationSetting('pageLengthMenu', config('backpack.crud.operations.list.page_length_menu') ?? [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']]);
 
             // if we have a 2D array, update all the values in the right hand array to their translated values
             if (isset($this->getOperationSetting('pageLengthMenu')[1]) && is_array($this->getOperationSetting('pageLengthMenu')[1])) {

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -5,13 +5,24 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 trait SaveActions
 {
     /**
+     * Get the developer's preference on what save action is the default one
+     * for the current operation.
+     * 
+     * @return string
+     */
+    public function getSaveActionDefaultForCurrentOperation()
+    {
+        return config('backpack.crud.operations.'.$this->getCurrentOperation().'.defaultSaveAction', 'save_and_back');
+    }
+
+    /**
      * Get save actions, with pre-selected action from stored session variable or config fallback.
      *
      * @return array
      */
     public function getSaveAction()
     {
-        $saveAction = session('save_action', config('backpack.crud.default_save_action', 'save_and_back'));
+        $saveAction = session($this->getCurrentOperation().'.saveAction', $this->getSaveActionDefaultForCurrentOperation());
 
         // Permissions and their related actions.
         $permissions = [
@@ -63,14 +74,16 @@ trait SaveActions
     public function setSaveAction($forceSaveAction = null)
     {
         $saveAction = $forceSaveAction ?:
-            \Request::input('save_action', config('backpack.crud.default_save_action', 'save_and_back'));
+            \Request::input('save_action', $this->getSaveActionDefaultForCurrentOperation());
 
-        if (config('backpack.crud.show_save_action_change', true) &&
-            session('save_action', 'save_and_back') !== $saveAction) {
+        $showBubble = $this->getOperationSetting('showSaveActionChange') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.showSaveActionChange') ?? true;
+
+        if ($showBubble &&
+            session($this->getCurrentOperation().'.saveAction', 'save_and_back') !== $saveAction) {
             \Alert::info(trans('backpack::crud.save_action_changed_notification'))->flash();
         }
 
-        session(['save_action' => $saveAction]);
+        session([$this->getCurrentOperation().'.saveAction' => $saveAction]);
     }
 
     /**
@@ -82,7 +95,7 @@ trait SaveActions
      */
     public function performSaveAction($itemId = null)
     {
-        $saveAction = \Request::input('save_action', config('backpack.crud.default_save_action', 'save_and_back'));
+        $saveAction = \Request::input('save_action', $this->getSaveActionDefaultForCurrentOperation());
         $itemId = $itemId ?: \Request::input('id');
 
         switch ($saveAction) {

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -119,7 +119,7 @@ trait Search
             return $this->getOperationSetting('responsiveTable');
         }
 
-        return config('backpack.crud.responsive_table');
+        return config('backpack.crud.operations.list.responsive_table');
     }
 
     /**
@@ -163,7 +163,7 @@ trait Search
             return $this->getOperationSetting('persistentTable');
         }
 
-        return config('backpack.crud.persistent_table');
+        return config('backpack.crud.operations.list.persistent_table');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -119,7 +119,7 @@ trait Search
             return $this->getOperationSetting('responsiveTable');
         }
 
-        return config('backpack.crud.operations.list.responsive_table');
+        return config('backpack.crud.operations.list.responsiveTable');
     }
 
     /**
@@ -163,7 +163,7 @@ trait Search
             return $this->getOperationSetting('persistentTable');
         }
 
-        return config('backpack.crud.operations.list.persistent_table');
+        return config('backpack.crud.operations.list.persistentTable');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -104,7 +104,7 @@ trait Settings
     {
         $operation = $operation ?? $this->getCurrentOperation();
 
-        return $this->get($operation.'.'.$key);
+        return $this->get($operation.'.'.$key) ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.'.$key) ?? null;
     }
 
     /**
@@ -134,5 +134,24 @@ trait Settings
         $operation = $operation ?? $this->getCurrentOperation();
 
         return $this->set($operation.'.'.$key, $value);
+    }
+
+    /**
+     * Automatically set values in config file (config/backpack/crud)
+     * as settings values for that operation.
+     * 
+     * @param string $configPath   Config string that leads to where the configs are stored.
+     */
+    public function loadDefaultOperationSettingsFromConfig($configPath = null)
+    {
+        $operation = $this->getCurrentOperation();
+        $configPath = $configPath ?? 'backpack.crud.operations.'.$operation;
+        $configSettings = config($configPath);
+
+        if (is_array($configSettings) && count($configSettings)) {
+            foreach ($configSettings as $key => $value) {
+                $this->setOperationSetting($key, $value);
+            }
+        }
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Tabs.php
+++ b/src/app/Library/CrudPanel/Traits/Tabs.php
@@ -7,7 +7,7 @@ trait Tabs
     public function enableTabs()
     {
         $this->setOperationSetting('tabsEnabled', true);
-        $this->setOperationSetting('tabsType', config('backpack.crud.tabs_type', 'horizontal'));
+        $this->setOperationSetting('tabsType', config('backpack.crud.'.$this->getCurrentOperation().'.tabsType', 'horizontal'));
 
         return $this->tabsEnabled();
     }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -47,7 +47,7 @@ trait Views
      */
     public function getCreateContentClass()
     {
-        return $this->get('create.contentClass') ?? config('backpack.crud.create_content_class', 'col-md-8 bold-labels');
+        return $this->get('create.contentClass') ?? config('backpack.crud.operations.create.contentClass', 'col-md-8 bold-labels');
     }
 
     // -------
@@ -93,7 +93,7 @@ trait Views
      */
     public function getListContentClass()
     {
-        return $this->get('list.contentClass') ?? config('backpack.crud.list_content_class', 'col-md-12');
+        return $this->get('list.contentClass') ?? config('backpack.crud.operations.list.contentClass', 'col-md-12');
     }
 
     /**
@@ -157,7 +157,7 @@ trait Views
      */
     public function getShowContentClass()
     {
-        return $this->get('show.contentClass') ?? config('backpack.crud.show_content_class', 'col-md-8 col-md-offset-2');
+        return $this->get('show.contentClass') ?? config('backpack.crud.operations.show.contentClass', 'col-md-8 col-md-offset-2');
     }
 
     // -------
@@ -203,7 +203,7 @@ trait Views
      */
     public function getEditContentClass()
     {
-        return $this->get('update.contentClass') ?? config('backpack.crud.edit_content_class', 'col-md-8 bold-labels');
+        return $this->get('update.contentClass') ?? config('backpack.crud.operations.update.contentClass', 'col-md-8 bold-labels');
     }
 
     /**
@@ -245,7 +245,7 @@ trait Views
      */
     public function getReorderContentClass()
     {
-        return $this->get('reorder.contentClass') ?? config('backpack.crud.reorder_content_class', 'col-md-8 col-md-offset-2');
+        return $this->get('reorder.contentClass') ?? config('backpack.crud.operations.reorder.contentClass', 'col-md-8 col-md-offset-2');
     }
 
     /**
@@ -309,7 +309,7 @@ trait Views
      */
     public function getRevisionsTimelineContentClass()
     {
-        return $this->get('revisions.timelineContentClass') ?? config('backpack.crud.revisions_timeline_content_class', 'col-md-12');
+        return $this->get('revisions.timelineContentClass') ?? config('backpack.crud.operations.revisions.timelineContentClass', 'col-md-12');
     }
 
     // -------

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -23,21 +23,21 @@ return [
 
             // enable the datatables-responsive plugin, which hides columns if they don't fit?
             // if not, a horizontal scrollbar will be shown instead
-            'responsive_table' => true,
+            'responsiveTable' => true,
 
             // stores pagination and filters in localStorage for two hours
             // whenever the user tries to see that page, backpack loads the previous pagination and filtration
-            'persistent_table' => false,
+            'persistentTable' => false,
 
             // How many items should be shown by default by the Datatable?
             // This value can be overwritten on a specific CRUD by calling
             // $this->crud->setDefaultPageLength(50);
-            'default_page_length' => 25,
+            'defaultPageLength' => 25,
 
             // A 1D array of options which will be used for both the displayed option and the value, or
             // A 2D array in which the first array is used to define the value options and the second array the displayed options
             // If a 2D array is used, strings in the right hand array will be automatically run through trans()
-            'page_length_menu' => [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']],
+            'pageLengthMenu' => [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']],
         ],
         
         /**

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -8,94 +8,121 @@ return [
     |--------------------------------------------------------------------------
     */
 
-    /*
-    |------------
-    | CREATE & UPDATE
-    |------------
-    */
-    // Where do you want to redirect the user by default, after a CRUD entry is saved in the Add or Edit forms?
-    'default_save_action' => 'save_and_back', //options: save_and_back, save_and_edit, save_and_new
+    // --------------------------
+    // Default operation settings
+    // --------------------------
+    'operations' => [
 
-    // When the user chooses "save and back" or "save and new", show a bubble
-    // for the fact that the default save action has been changed?
-    'show_save_action_change' => true, //options: true, false
+        /**
+         * List Operation
+         */
+        'list' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per view use $this->crud->setListContentClass('class-string')
+            'contentClass' => 'col-md-12',
 
-    // When using tabbed forms (create & update), what kind of tabs would you like?
-    'tabs_type' => 'horizontal', //options: horizontal, vertical
+            // enable the datatables-responsive plugin, which hides columns if they don't fit?
+            // if not, a horizontal scrollbar will be shown instead
+            'responsive_table' => true,
 
-    // How would you like the validation errors to be shown?
-    'show_grouped_errors' => true,
-    'show_inline_errors'  => true,
+            // stores pagination and filters in localStorage for two hours
+            // whenever the user tries to see that page, backpack loads the previous pagination and filtration
+            'persistent_table' => false,
 
-    // Here you may override the css-classes for the content section of the create view globally
-    // To override per view use $this->crud->setCreateContentClass('class-string')
-    'create_content_class' => 'col-md-8 bold-labels',
+            // How many items should be shown by default by the Datatable?
+            // This value can be overwritten on a specific CRUD by calling
+            // $this->crud->setDefaultPageLength(50);
+            'default_page_length' => 25,
 
-    // Here you may override the css-classes for the content section of the edit view globally
-    // To override per view use $this->crud->setEditContentClass('class-string')
-    'edit_content_class'   => 'col-md-8 bold-labels',
+            // A 1D array of options which will be used for both the displayed option and the value, or
+            // A 2D array in which the first array is used to define the value options and the second array the displayed options
+            // If a 2D array is used, strings in the right hand array will be automatically run through trans()
+            'page_length_menu' => [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']],
+        ],
+        
+        /**
+         * Create Operation
+         */
+        'create' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per view use $this->crud->setCreateContentClass('class-string')
+            'contentClass' => 'col-md-8 bold-labels',
 
-    // Here you may override the css-classes for the content section of the revisions timeline view globally
-    // To override per view use $this->crud->setRevisionsTimelineContentClass('class-string')
-    'revisions_timeline_content_class'   => 'col-md-12',
+            // When using tabbed forms (create & update), what kind of tabs would you like?
+            'tabsType' => 'horizontal', //options: horizontal, vertical
 
-    /*
-    |------------
-    | READ
-    |------------
-    */
+            // How would you like the validation errors to be shown?
+            'groupedErrors' => true,
+            'inlineErrors'  => true,
 
-    // LIST VIEW (table view)
+            // when the page loads, put the cursor on the first input?
+            'autoFocusOnFirstField' => true,
 
-    // enable the datatables-responsive plugin, which hides columns if they don't fit?
-    // if not, a horizontal scrollbar will be shown instead
-    'responsive_table' => true,
+            // Where do you want to redirect the user by default, save?
+            // options: save_and_back, save_and_edit, save_and_new
+            'defaultSaveAction' => 'save_and_back', 
 
-    // stores pagination and filters in localStorage for two hours
-    // whenever the user tries to see that page, backpack loads the previous pagination and filtration
-    'persistent_table' => false,
+            // When the user chooses "save and back" or "save and new", show a bubble
+            // for the fact that the default save action has been changed?
+            'showSaveActionChange' => true, //options: true, false
+        ],
+        
+        /**
+         * Update Operation
+         */
+        'update' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per view use $this->crud->setEditContentClass('class-string')
+            'contentClass'   => 'col-md-8 bold-labels',
 
-    // How many items should be shown by default by the Datatable?
-    // This value can be overwritten on a specific CRUD by calling
-    // $this->crud->setDefaultPageLength(50);
-    'default_page_length' => 25,
+            // When using tabbed forms (create & update), what kind of tabs would you like?
+            'tabsType' => 'horizontal', //options: horizontal, vertical
 
-    // A 1D array of options which will be used for both the displayed option and the value, or
-    // A 2D array in which the first array is used to define the value options and the second array the displayed options
-    // If a 2D array is used, strings in the right hand array will be automatically run through trans()
-    'page_length_menu' => [[10, 25, 50, 100, -1], [10, 25, 50, 100, 'backpack::crud.all']],
+            // How would you like the validation errors to be shown?
+            'groupedErrors' => true,
+            'inlineErrors'  => true,
 
-    // Here you may override the css-class for the content section of the list view globally
-    // To override per view use $this->crud->setListContentClass('class-string')
-    'list_content_class' => 'col-md-12',
+            // when the page loads, put the cursor on the first input?
+            'autoFocusOnFirstField' => true,
 
-    // SHOW (PREVIEW)
+            // Where do you want to redirect the user by default, save?
+            // options: save_and_back, save_and_edit, save_and_new
+            'defaultSaveAction' => 'save_and_back', 
 
-    // Here you may override the css-classes for the content section of the show view globally
-    // To override per view use $this->crud->setShowContentClass('class-string')
-    'show_content_class'   => 'col-md-8 col-md-offset-2',
+            // When the user chooses "save and back" or "save and new", show a bubble
+            // for the fact that the default save action has been changed?
+            'showSaveActionChange' => true, //options: true, false
+        ],
 
-    /*
-    |------------
-    | DELETE
-    |------------
-    */
+        /**
+         * Show Operation
+         */
+        'show' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per Controller use $this->crud->setShowContentClass('class-string')
+            'contentClass' => 'col-md-8',
+        ],
 
-    /*
-    |------------
-    | REORDER
-    |------------
-    */
+        /**
+         * Reorder Operation
+         */
+        'reorder' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per Controller use $this->crud->setReorderContentClass('class-string')
+            'contentClass'   => 'col-md-8 col-md-offset-2',
+        ],
 
-    // Here you may override the css-classes for the content section of the reorder view globally
-    // To override per view use $this->crud->setReorderContentClass('class-string')
-    'reorder_content_class'   => 'col-md-8 col-md-offset-2',
+        /**
+         * Revisions Operation
+         */
+        'revisions' => [
+            // Define the size/looks of the content div for all CRUDs
+            // To override per view use $this->crud->setRevisionsTimelineContentClass('class-string')
+            'timelineContentClass' => 'col-md-12',
+        ],
 
-    /*
-    |------------
-    | DETAILS ROW
-    |------------
-    */
+    ],
+
 
     /*
     |-------------------

--- a/tests/Unit/CrudPanel/CrudPanelViewsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelViewsTest.php
@@ -37,9 +37,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetCreateContentClassFromConfig()
     {
-        Config::set('backpack.crud.create_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.create.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.create_content_class'), $this->crudPanel->getCreateContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.create.contentClass'), $this->crudPanel->getCreateContentClass());
     }
 
     // UPDATE
@@ -70,9 +70,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetEditContentClassFromConfig()
     {
-        Config::set('backpack.crud.edit_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.update.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.edit_content_class'), $this->crudPanel->getEditContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.update.contentClass'), $this->crudPanel->getEditContentClass());
     }
 
     public function testSetUpdateView()
@@ -101,9 +101,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetUpdateContentClassFromConfig()
     {
-        Config::set('backpack.crud.edit_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.update.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.edit_content_class'), $this->crudPanel->getUpdateContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.update.contentClass'), $this->crudPanel->getUpdateContentClass());
     }
 
     // SHOW
@@ -134,9 +134,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetShowContentClassFromConfig()
     {
-        Config::set('backpack.crud.show_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.show.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.show_content_class'), $this->crudPanel->getShowContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.show.contentClass'), $this->crudPanel->getShowContentClass());
     }
 
     public function testSetPreviewView()
@@ -179,9 +179,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetListContentClassFromConfig()
     {
-        Config::set('backpack.crud.list_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.list.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.list_content_class'), $this->crudPanel->getListContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.list.contentClass'), $this->crudPanel->getListContentClass());
     }
 
     // DETAILS ROW
@@ -226,9 +226,9 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetReorderContentClassFromConfig()
     {
-        Config::set('backpack.crud.reorder_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.reorder.contentClass', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.reorder_content_class'), $this->crudPanel->getReorderContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.reorder.contentClass'), $this->crudPanel->getReorderContentClass());
     }
 
     // REVISIONS

--- a/tests/Unit/CrudPanel/CrudPanelViewsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelViewsTest.php
@@ -271,8 +271,8 @@ class CrudPanelViewsTest extends BaseCrudPanelTest
 
     public function testGetRevisionsTimelineContentClassFromConfig()
     {
-        Config::set('backpack.crud.revisions_timeline_content_class', $this->customContentClass);
+        Config::set('backpack.crud.operations.revisions.timelineContent', $this->customContentClass);
 
-        $this->assertEquals(Config::get('backpack.crud.revisions_timeline_content_class'), $this->crudPanel->getRevisionsTimelineContentClass());
+        $this->assertEquals(Config::get('backpack.crud.operations.revisions.timelineContent'), $this->crudPanel->getRevisionsTimelineContentClass());
     }
 }


### PR DESCRIPTION
This PR reorders all elements in the ```config/backpack/crud.php``` file by operation, and makes sure all operations load these values first, using the Settings API.

This way:
- each operation can have separate default settings (defined in the config file)
- those default settings are loaded by the operation

If the user wants to overwrite a setting for ALL cruds, they can do that in the config file.
If the user wants to overwrite a setting for ONE crud, they can do that in the controller.

Easy to understand and highly customizable, I think.