### PR TITLE
[4.0] Fixed route macro for nested route group

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -215,8 +215,9 @@ class BackpackServiceProvider extends ServiceProvider
             $routeName .= $name;
 
             // get an instance of the controller
-            $groupStack = $this->hasGroupStack() && isset($this->getGroupStack()[0]['namespace']) ? $this->getGroupStack()[0]['namespace'].'\\' : 'App\\';
-            $namespacedController = $groupStack.$controller;
+            $groupStack = $this->getGroupStack();
+            $groupNamespace = $groupStack && isset(end($groupStack)['namespace']) ? end($groupStack)['namespace'].'\\' : 'App\\';
+            $namespacedController = $groupNamespace.$controller;
             $controllerInstance = new $namespacedController();
 
             return $controllerInstance->setupRoutes($name, $routeName, $controller);


### PR DESCRIPTION
I think sometimes people want to use nested route group.
Therefor, the namespace should be used from last element in a group stack.

Thanks,