### PR TITLE
Crud add enum enable option

### DIFF
--- a/src/CrudPanel.php
+++ b/src/CrudPanel.php
@@ -83,6 +83,7 @@ class CrudPanel
 
     // TONE FIELDS - TODO: find out what he did with them, replicate or delete
     public $sort = [];
+    public $enum_type_auto_set = false;
 
     // The following methods are used in CrudController or your EntityCrudController to manipulate the variables above.
 
@@ -90,6 +91,7 @@ class CrudPanel
     {
         $this->setErrorDefaults();
         $this->initButtons();
+        $this->enum_type_auto_set = config('backpack.crud.enable_enum_auto_set', false);
     }
 
     // ------------------------------------------------------

--- a/src/DBAL/Type/EnumType.php
+++ b/src/DBAL/Type/EnumType.php
@@ -1,0 +1,32 @@
+<?php
+namespace Backpack\CRUD\DBAL\Type;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class EnumType extends Type
+{
+    /**
+     * Gets the SQL declaration snippet for a field of this type.
+     *
+     * @param mixed[] $fieldDeclaration The field declaration.
+     * @param AbstractPlatform $platform The currently used database platform.
+     *
+     * @return string
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'ENUM()';
+
+    }
+
+    /**
+     * Gets the name of this type.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'enum';
+    }
+}

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -39,6 +39,10 @@ return [
     // To override per view use $this->crud->setRevisionsTimelineContentClass('class-string')
     'revisions_timeline_content_class'   => 'col-md-10 col-md-offset-1',
 
+    // Here you may set whether to enable enum-auto-set
+    // Notice that not every database support enum type, that may cause some problem
+    'enable_enum_auto_set' => false,
+
     /*
     |------------
     | READ

--- a/src/resources/views/columns/enum.blade.php
+++ b/src/resources/views/columns/enum.blade.php
@@ -1,0 +1,10 @@
+{{-- regular object attribute --}}
+@php
+	$value = data_get($entry, $column['name']);
+
+	if (is_array($value)) {
+		$value = json_encode($value);
+	}
+@endphp
+
+<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 50, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>


### PR DESCRIPTION
issue #2059
I add an EnumType class just for autoset(reference from [here](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/cookbook/mysql-enums.html))
And add a config option letting developer design whether to enable enum-autoset

Unfortunately, it's quite annoying to write a testing for it because sqlite doesn't support enum type.

I didn't do a fully quality assertion. I only testing with my MySQL project.
Maybe someone can try it on other DB.

Just an simple hack, any ideas?