### PR TITLE
[4.0][Bug][Ready] Don't force the default controller namespace or set it in the config file

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -217,7 +217,7 @@ class BackpackServiceProvider extends ServiceProvider
             // get an instance of the controller
             if ($this->hasGroupStack()) {
                 $groupStack = $this->getGroupStack();
-                $groupNamespace = $groupStack && isset(end($groupStack)['namespace']) ? end($groupStack)['namespace'].'\\' : 'App\\';
+                $groupNamespace = $groupStack && isset(end($groupStack)['namespace']) ? end($groupStack)['namespace'].'\\' : '';
             } else {
                 $groupNamespace = '';
             }


### PR DESCRIPTION
In case we use CrudControllers in custom packages, we can't access to them.

In my case i have a config file with : 
```php
    // ...
        'controllers_back' => [
        'user' => '\MyPackage\app\Http\Controllers\Adminl\UserCrudController',
    // ...
```
In my serviceProvider :
```php
                // load admin routes
            Route::middleware(['web', 'admin'])
                ->group(__DIR__ . $this->routeFilePathAdmin);
```

So i don't set a namespace here but the full path in config. Developpers who use my package, can change the namespace in the config file to get custom controller.

Actually, i get error because BackPackServiceProviser add /App if i don't give a namespace

**Edit :** Put this App path in the config.