### PR TITLE
ckeditor field does not work with options

### DIFF
--- a/src/resources/views/crud/fields/ckeditor.blade.php
+++ b/src/resources/views/crud/fields/ckeditor.blade.php
@@ -41,7 +41,7 @@
                 element.ckeditor({
                     "filebrowserBrowseUrl": "{{ url(config('backpack.base.route_prefix').'/elfinder/ckeditor') }}",
                     "extraPlugins" : '{{ isset($field['extra_plugins']) ? implode(',', $field['extra_plugins']) : 'embed,widget' }}',
-            "embed_provider": '//ckeditor.iframe.ly/api/oembed?url={url}&callback={callback}',
+                    "embed_provider": '//ckeditor.iframe.ly/api/oembed?url={url}&callback={callback}'
                     @if (isset($field['options']) && count($field['options']))
                         {!! ', '.trim(json_encode($field['options']), "{}") !!}
                     @endif


### PR DESCRIPTION
Since ab465ad9b7ec4cd89a87333ae4089940fe85fffa, ckeditor field does not work with options.

``` php
[   // CKEditor
    'name' => 'description',
    'label' => 'Description',
    'type' => 'ckeditor',
    // optional:
    'options' => [
        'autoGrow_minHeight' => 200,
        'autoGrow_bottomSpace' => 50,
        'removePlugins' => 'resize,maximize',
    ]
],
```

This field generates following javascript.

``` javascript
    // trigger a new CKEditor
    element.ckeditor({
        "filebrowserBrowseUrl": "http://app.buildcms2.test/elfinder/ckeditor",
        "extraPlugins" : 'embed,widget',
"embed_provider": '//ckeditor.iframe.ly/api/oembed?url={url}&callback={callback}',
                                , "autoGrow_minHeight":200,"autoGrow_bottomSpace":50,"removePlugins":"resize,maximize"
                        });
```

The problem is containing double colons between `embed_provider` and `autoGrow_minHeight`.
So, I have removed it.

``` javascript
    // trigger a new CKEditor
    element.ckeditor({
        "filebrowserBrowseUrl": "http://app.buildcms2.test/elfinder/ckeditor",
        "extraPlugins" : 'embed,widget',
        "embed_provider": '//ckeditor.iframe.ly/api/oembed?url={url}&callback={callback}'
                                , "autoGrow_minHeight":200,"autoGrow_bottomSpace":50,"removePlugins":"resize,maximize"
                        });
```

Thanks,