### PR TITLE
Always ensure $_SERVER['REMOTE_ATTR'] is set.

### DIFF
--- a/src/LicenseCheck.php
+++ b/src/LicenseCheck.php
@@ -19,7 +19,7 @@ trait LicenseCheck
         }
 
         // don't show notice bubble on localhost
-        if (in_array($_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'])) {
+        if (in_array($_SERVER['REMOTE_ADDR'] ?? [], ['127.0.0.1', '::1'])) {
             return;
         }
 


### PR DESCRIPTION
When deploying backpack to Laravel Vapor... The application never ends up booting successfully because of the license check. 

Please see problem 2: https://github.com/Laravel-Backpack/CRUD/issues/2118
