### PR TITLE
A proof of concept for making strippedSaveRequests optional

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -459,6 +459,10 @@ trait Fields
      */
     public function getStrippedSaveRequest()
     {
-        return $this->request->only($this->getAllFieldNames());
+        if (config('backpack.base.strip_save_requests', TRUE)) {
+            return $this->request->only($this->getAllFieldNames());
+        } else {
+            return $this->request->except('_token', '_method', 'http_referrer', 'current_tab', 'save_action');
+        }
     }
 }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -253,6 +253,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Needs A Better Section Header ("Nitpicky Details" has my vote)
+    |--------------------------------------------------------------------------
+    */
+
+    // Enabling strip save request will allow only fields explicitly defined in your
+    // setupXxxOperation() methods to be sent with a traitStore or traitUpdate request.
+    // Disable this to allow arbitrary fields to be added to a request prior to storage.
+
+    'strip_save_requests' => false,
+
+
+    /*
+    |--------------------------------------------------------------------------
     | License Code
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
A quick PR regarding https://github.com/Laravel-Backpack/CRUD/issues/2104. 
More proof of concept than a ready to go PR. 

The copy in the config probably isn't in tone with what you've already got, and I'm not sure if it's necessary to exclude() anything from the request if we're working under the assumption that getStrippedSaveRequest() exists (in part) to obviate $fillable. 
