### PR TITLE
Fix docblock in CrudController

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -15,7 +15,7 @@ class CrudController extends Controller
     public $request;
 
     /**
-     * @var CrudPanel
+     * @var \Backpack\CRUD\app\Library\CrudPanel\CrudPanel
      */
     public $crud;
 


### PR DESCRIPTION
`CrudPanel` is not imported so your IDE doesn't know what it is. Fixed by specifying the FQCN.