### PR TITLE
Fix param types in docblock of Validation trait

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -10,12 +10,12 @@ trait Validation
      * Mark a FormRequest file as required for the current operation, in Settings.
      * Adds the required rules to an array for easy access.
      *
-     * @param FormRequest $formRequest
+     * @param string $class Class that extends FormRequest
      */
-    public function setValidation($formRequest)
+    public function setValidation($class)
     {
-        $this->setFormRequest($formRequest);
-        $this->setRequiredFields($formRequest);
+        $this->setFormRequest($class);
+        $this->setRequiredFields($class);
     }
 
     /**
@@ -37,18 +37,18 @@ trait Validation
     /**
      * Mark a FormRequest file as required for the current operation, in Settings.
      *
-     * @param FormRequest $formRequest
+     * @param string $class Class that extends FormRequest
      */
-    public function setFormRequest($formRequest)
+    public function setFormRequest($class)
     {
-        $this->setOperationSetting('formRequest', $formRequest);
+        $this->setOperationSetting('formRequest', $class);
     }
 
     /**
      * Get the current form request file, in any.
      * Returns null if no FormRequest is required for the current operation.
      *
-     * @return FormRequest
+     * @return string Class that extends FormRequest
      */
     public function getFormRequest()
     {


### PR DESCRIPTION
I followed the docs (https://backpackforlaravel.com/docs/4.0/getting-started-crud-operations) for setting up a custom `FormRequest`. However, my IDE warns me that the parameter of `setValidation` should be a `FormRequest` instance. As FormRequests are validated upon creation (because of `ValidatesWhenResolved`) and when reading through [the rest](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Library/CrudPanel/Traits/Validation.php#L71) of [the code](https://github.com/Laravel-Backpack/CRUD/blob/master/src/app/Library/CrudPanel/Traits/Validation.php#L87) this does not seem logical. So I changed the types to strings as that seems to be the appropriate type. I also renamed the parameter to `$class` to make it more clear and to align it with `setRequiredFields`.