### PR TITLE
checkbox fix: incorrect behavior of the value field during editing

### DIFF
--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -17,7 +17,7 @@
         	  @endforeach
           @endif
           @if (!isset($field['attributes']['id']))
-              id="{{  $field['name'] }}_checkbox"
+              id="{{ $field['name'] }}_checkbox"
           @endif
           >
     	<label class="form-check-label font-weight-normal" for="{{ $field['attributes']['id'] ?? $field['name'] . '_checkbox' }}">{!! $field['label'] !!}</label>
@@ -42,6 +42,7 @@
             function bpFieldInitCheckbox(element) {
                 var hidden_element = element.siblings('input[type=hidden]');
 
+                if (hidden_element.val() === '') hidden_element.val(0);
                 // set the default checked/unchecked state
                 // if the field has been loaded with javascript
                 if (hidden_element.val() != 0) {


### PR DESCRIPTION
Hello Cristian. Thank you for your work. Sorry for my English.  
If you open the entity editing page with not active checkbox ($field['value'] = false, because field has a boolean value in $casts) and try to save the entity (do not click on checkbox), you will receive a validation error. Why? Look at "value" in the picture when page is loaded (it's empty). Validator waiting '0' or '1'  
  
![chkbx](https://user-images.githubusercontent.com/35972279/66725795-49dc7800-ee5f-11e9-828c-63d442d4bb18.png)  
  
Look at row below from changed file. When page is loading $field['value'] isset and not null - it's false (boolean) and Blade print emptiness, because {{ false }} => "" and {{ true }} => "1"  
```
6 |    <input type="hidden" name="{{ $field['name'] }}" value="{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? 0 }}">
```
At first I wanted to fix this problem with php, but I have to create a few lines of code. The second way is to use js. Only one row of code. Now it is impossible to create an empty attribute "value". Do you like this solution? I can do this using php.