### PR TITLE
Adds the entry object to the query options function

### DIFF
--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -6,7 +6,7 @@
     if (!isset($field['options'])) {
         $options = $field['model']::all();
     } else {
-        $options = call_user_func($field['options'], $field['model']::query());
+        $options = call_user_func($field['options'], $field['model']::query(), $entry ?? null);
     }
 @endphp
 


### PR DESCRIPTION
This pull request adds the possibility to use the entry model in the options function.

**Why?**
Because right now you can only filter on data that is not dynamic. But for example in my case I have a model that has 2 relationships with the same object. I want to make a select field which fills the "introductionTool" field, but it has to be choosen from one of the tools in the hasMany relationship. For this to work I need to have the Id of the entry, so I can change the options method.

```php
    public function introductionTool()
    {
        return $this->belongsTo(Tool::class, 'introduction_tool_id');
    }

    public function tools()
    {
        return $this->hasMany(Tool::class)->orderBy('sort');
    }
```

```php
        $this->crud->addField([
            'type' => 'select',
            'name' => 'introduction_tool_id',
            'entity' => 'tool',
            'attribute' => 'title',
            'model' => "App\Core\Models\Tool",
            'options' => function($query, $entry){
                if($entry !== null){
                    return $query->where('map_id', $entry->id)->get();
                } else {
                    return $query->where('map_id', 0)->get();
                }
            },

        ]);
```

Is it possible to add this change, or if not is there a way to make it work without this change?
