### PR TITLE
[4.1][WIP] Allow SVG in image fields

### DIFF
--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -198,7 +198,7 @@
                         });
                     } else {
 
-                        $(this).find("#remove").click(function() {
+                        $remove.click(function() {
                             $mainImage.attr('src','');
                             $hiddenImage.val('');
                             $remove.hide();

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -220,14 +220,14 @@
                         if(maxImageSize > 0 && file.size > maxImageSize) {
 
                             alert(`Please pick an image smaller than ${maxImageSize} bytes.`);
-                        } else if (/^image\/\w+$/.test(file.type)) {
+                        } else if (/^image\/[\w\+]+$/.test(file.type)) {
                             
                             fileReader.readAsDataURL(file);
                             fileReader.onload = function () {
 
                                 $uploadImage.val("");
                                 $previews.show();
-                                if(crop){
+                                if(crop && /^image\/\w+$/.test(file.type)){
                                     $mainImage.cropper(options).cropper("reset", true).cropper("replace", this.result);
                                     // Override form submit to copy canvas to hidden input before submitting
                                     $('form').submit(function() {


### PR DESCRIPTION
Adjust the JS MIME type filter in the image field to allow image/svg+xml, but disable cropper.js if an SVG image is selected.
Fixes #766