### PR TITLE
[4.0][Ready] Added config for stripping the request using EXCEPT or ONLY

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -459,8 +459,8 @@ trait Fields
      */
     public function getStrippedSaveRequest()
     {
-        if ($this->getOperationSetting('stripSaveRequestUsingExcept') !== false) {
-            return $this->request->except($this->getOperationSetting('stripSaveRequestUsingExcept'));
+        if ($this->getOperationSetting('saveAllInputsExcept') !== false) {
+            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));
         } else {
             return $this->request->only($this->getAllFieldNames());
         }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -459,10 +459,10 @@ trait Fields
      */
     public function getStrippedSaveRequest()
     {
-        if (config('backpack.base.strip_save_requests', TRUE)) {
-            return $this->request->only($this->getAllFieldNames());
+        if ($this->getOperationSetting('stripSaveRequestUsingExcept') !== false) {
+            return $this->request->except($this->getOperationSetting('stripSaveRequestUsingExcept'));
         } else {
-            return $this->request->except('_token', '_method', 'http_referrer', 'current_tab', 'save_action');
+            return $this->request->only($this->getAllFieldNames());
         }
     }
 }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -251,18 +251,6 @@ return [
     // You can rename this disk here. Default: root
     'root_disk_name' => 'root',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Needs A Better Section Header ("Nitpicky Details" has my vote)
-    |--------------------------------------------------------------------------
-    */
-
-    // Enabling strip save request will allow only fields explicitly defined in your
-    // setupXxxOperation() methods to be sent with a traitStore or traitUpdate request.
-    // Disable this to allow arbitrary fields to be added to a request prior to storage.
-
-    'strip_save_requests' => false,
-
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -76,8 +76,8 @@ return [
             // Before saving the entry, how would you like the request to be stripped?
             // - false - ONLY save inputs that have fields (safest)
             // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
-            'stripSaveRequestUsingExcept' => false,
-            // 'stripSaveRequestUsingExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
+            'saveAllInputsExcept' => false,
+            // 'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
         ],
 
         /*
@@ -107,10 +107,10 @@ return [
             'showSaveActionChange' => true, //options: true, false
 
             // Before saving the entry, how would you like the request to be stripped?
-            // - false - ONLY save inputs that have fields (safest)
-            // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
-            // 'stripSaveRequestUsingExcept' => false,
-            'stripSaveRequestUsingExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
+            // - false - Save ONLY inputs that have a field (safest, default);
+            // - [x, y, z] - Save ALL inputs, EXCEPT the ones given in this array;
+            'saveAllInputsExcept' => false,
+            // 'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
         ],
 
         /*

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -72,6 +72,12 @@ return [
             // When the user chooses "save and back" or "save and new", show a bubble
             // for the fact that the default save action has been changed?
             'showSaveActionChange' => true, //options: true, false
+
+            // Before saving the entry, how would you like the request to be stripped?
+            // - false - ONLY save inputs that have fields (safest)
+            // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
+            'stripSaveRequestUsingExcept' => false,
+            // 'stripSaveRequestUsingExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
         ],
 
         /*
@@ -99,6 +105,12 @@ return [
             // When the user chooses "save and back" or "save and new", show a bubble
             // for the fact that the default save action has been changed?
             'showSaveActionChange' => true, //options: true, false
+
+            // Before saving the entry, how would you like the request to be stripped?
+            // - false - ONLY save inputs that have fields (safest)
+            // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
+            // 'stripSaveRequestUsingExcept' => false,
+            'stripSaveRequestUsingExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
         ],
 
         /*


### PR DESCRIPTION
Fixes #2104 by making it configurable if the request is stripped using EXCEPT or ONLY. 

You can:
- change it in the ```config/backpack/crud.php``` file and it would apply for all CRUDs;
- change it inside only one CRUD, for one operation, using ```$this->crud->set('update.saveAllInputsExcept', ['_token', '_method', 'http_referrer', 'current_tab', 'save_action']);```
- change it inside only one CRUD, for all operations, using:
```php
$this->crud->setOperationSetting('saveAllInputsExcept', ['_token', '_method', 'http_referrer', 'current_tab', 'save_action']);
```
- change the exceptions array to whatever you want (even add fields you'd like to ignore);