### PR TITLE
fix column visibleInShow attribute not work with key attribute

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -36,7 +36,11 @@ trait ShowOperation
 
             // remove columns that have visibleInShow set as false
             if (isset($column['visibleInShow']) && $column['visibleInShow'] == false) {
-                $this->crud->removeColumn($column['name']);
+                if (array_key_exists('key', $column)) {
+                    $this->crud->removeColumn($column['key']);
+                } else {
+                    $this->crud->removeColumn($column['name']);
+                }
             }
         }
 


### PR DESCRIPTION
condition: When using 'key' attribute in CrudPanel::addColumn, 'visibleInShow' won't apply
solution: In CrudController::show(), check whether 'key' attribute exists, if exists remove column with 'key', otherwise remove with name like before