### PR TITLE
[4.0][Bug] Added missing row class to tabbed fields view

### DIFF
--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -26,7 +26,7 @@
 
 @if ($crud->getFieldsWithoutATab()->filter(function ($value, $key) { return $value['type'] != 'hidden'; })->count())
 <div class="card">
-    <div class="card-body">
+    <div class="card-body row">
     @include('crud::inc.show_fields', ['fields' => $crud->getFieldsWithoutATab()])
     </div>
 </div>


### PR DESCRIPTION
Fixes: #2145 
Basically when the crud has tabs it loads the _show_tabbed_fields_ which was missing a row class and for that reason the _wrapperAttributes_ wouldn't work.