### PR TITLE
[4.0][Bug] Fixed the language switch float

### DIFF
--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -41,9 +41,9 @@
 		  {!! method_field('PUT') !!}
 
 		  	@if ($crud->model->translationEnabled())
-		    <div class="mb-2">
+		    <div class="mb-2 text-right">
 		    	<!-- Single button -->
-				<div class="btn-group float-right">
+				<div class="btn-group">
 				  <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[$crud->request->input('locale')?$crud->request->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
 				  </button>


### PR DESCRIPTION
The issue here was that the language switch would interfere with the fields card as shown below:

![language_float](https://user-images.githubusercontent.com/24225940/67760259-a8057f80-fa49-11e9-99c4-6b9cb63c278d.png)

Replacing the `float-right` with `text-right` on the parent element will produce the following result:

![language_align](https://user-images.githubusercontent.com/24225940/67760327-c9666b80-fa49-11e9-92b1-54eb509f376f.png)
