### PR TITLE
Fix mismatch between schema builder and connection

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -106,7 +106,7 @@ class CrudPanel
      */
     private function getSchema()
     {
-        return \Schema::setConnection($this->getModel()->getConnection());
+        return $this->getModel()->getConnection()->getSchemaBuilder();
     }
 
     /**


### PR DESCRIPTION
In `CrudPanel::getSchema()` the use of `Schema::setConnection()` would properly set the connection *but would not return the correct schema builder instance*, using the correct grammar class for the DB driver. 

This created some conflicts with SQL Server usage that uses a slightly different syntax than MySQL.

By using built in method-chaining, we are able to return the correct schema builder.

See comment https://github.com/Laravel-Backpack/CRUD/issues/1797#issuecomment-547528146 for detailed explanation .

Resolves #1797