### PR TITLE
fix typo in setSubheading

### DIFF
--- a/src/app/Library/CrudPanel/Traits/HeadingsAndTitles.php
+++ b/src/app/Library/CrudPanel/Traits/HeadingsAndTitles.php
@@ -115,6 +115,6 @@ trait HeadingsAndTitles
             $action = $this->getActionMethod();
         }
 
-        return $this->set($action.'subheading', $string);
+        return $this->set($action.'.subheading', $string);
     }
 }


### PR DESCRIPTION
There's a typo in function parameter in `setSubheading()`, which render the method couldn't work properly.

This is a no-brainer fix which amend the concatenation dot in the parameter string.

---

#2161 