### PR TITLE
Fixes mobile sidebar background/overlay

### DIFF
--- a/src/resources/views/base/layouts/top_left.blade.php
+++ b/src/resources/views/base/layouts/top_left.blade.php
@@ -15,7 +15,7 @@
 
     @include(backpack_view('inc.sidebar'))
 
-    <main class="main mt-2">
+    <main class="main pt-2">
 
        @includeWhen(isset($breadcrumbs), backpack_view('inc.breadcrumbs'))
 


### PR DESCRIPTION
On mobile devices there is a dark overlay when the sidebar is expanded, with the margin replaced by padding, the gap between the header and page content is fixed.