### PR TITLE
[4.0][Bug] Default saveAllInputsExcept to ONLY when saveAllInputsExcept is NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 ### Fixed
 - merged #2156 - checkbox field did not pass boolean validation sometimes;
 - merged #2197, fixes #2198 - image and base64_image fields: remove button did not do anything if crop wasn't set;
+- merged #2174, fixes #2104 - ability to tell the Create and Update operations to save the request using Except instead of Only, using the new operation-level config item ```saveAllInputsExcept```;
 
 
 ## 4.0.12 - 2019-10-24

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -459,7 +459,13 @@ trait Fields
      */
     public function getStrippedSaveRequest()
     {
-        if (is_array($this->getOperationSetting('saveAllInputsExcept'))) {
+        $setting = $this->getOperationSetting('saveAllInputsExcept');
+
+        if ($setting == false || $setting == null) {
+            return $this->request->only($this->getAllFieldNames());            
+        }
+
+        if (is_array($setting)) {
             return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));            
         }
 

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -462,11 +462,11 @@ trait Fields
         $setting = $this->getOperationSetting('saveAllInputsExcept');
 
         if ($setting == false || $setting == null) {
-            return $this->request->only($this->getAllFieldNames());            
+            return $this->request->only($this->getAllFieldNames());
         }
 
         if (is_array($setting)) {
-            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));            
+            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));
         }
 
         return $this->request->only($this->getAllFieldNames());

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -459,10 +459,10 @@ trait Fields
      */
     public function getStrippedSaveRequest()
     {
-        if ($this->getOperationSetting('saveAllInputsExcept') !== false) {
-            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));
-        } else {
-            return $this->request->only($this->getAllFieldNames());
+        if (is_array($this->getOperationSetting('saveAllInputsExcept'))) {
+            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));            
         }
+
+        return $this->request->only($this->getAllFieldNames());
     }
 }


### PR DESCRIPTION
Fixes [the problem outlined here](https://github.com/Laravel-Backpack/CRUD/pull/2174#issuecomment-552865722) by @justinmoh

