### PR TITLE
Fixed odd "bump" on closing sidebar menu

### DIFF
--- a/src/public/packages/@digitallyhappy/backstrap/css/overlay.css
+++ b/src/public/packages/@digitallyhappy/backstrap/css/overlay.css
@@ -57,7 +57,7 @@ body {
   }
 }
 
-.sidebar-lg-show .sidebar-pills {
+.sidebar-pills {
   padding: 15px;
   width: 230px;
 }

--- a/src/resources/views/base/inc/menu_user_dropdown.blade.php
+++ b/src/resources/views/base/inc/menu_user_dropdown.blade.php
@@ -6,4 +6,5 @@
     <a class="dropdown-item" href="{{ route('backpack.account.info') }}"><i class="fa fa-user"></i> {{ trans('backpack::base.my_account') }}</a>
     <div class="dropdown-divider"></div>
     <a class="dropdown-item" href="{{ backpack_url('logout') }}"><i class="fa fa-lock"></i> {{ trans('backpack::base.logout') }}</a>
+  </div>
 </li>


### PR DESCRIPTION
Fixed odd "bump" on closing sidebar menu

Example slowed down to 10%:
![Sample GIF](https://media.giphy.com/media/hVCgwiMMK3gTyQgYF3/giphy.gif)