### PR TITLE
[4.0][BUG] Emulate hidden class from 3.6

### DIFF
--- a/src/resources/views/crud/columns/check.blade.php
+++ b/src/resources/views/crud/columns/check.blade.php
@@ -16,4 +16,4 @@ $text = $checkValue == false ? $exportUncheckedText : $exportCheckedText;
     <i class="fa {{ $icon }}"></i>
 </span>
 
-<span class="hidden">{{ $text }}</span>
+<span class="sr-only">{{ $text }}</span>


### PR DESCRIPTION
We now don't have available `.hidden` class, so using check column in crud always shows the label.

Has pointed in #2142 by @johnpuddephatt `.sr-only` it's the way to go on this scenarios (also available in boostrap 3.x). This hides the element but keep it for screen-readers.