### PR TITLE
[4.0] [FIX/Feature] Datatables inconsistent behaviour. Persistent table duration implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 ### Fixed
 - merged #2156 - checkbox field did not pass boolean validation sometimes;
 - merged #2197, fixes #2198 - image and base64_image fields: remove button did not do anything if crop wasn't set;
+- merged #2174, fixes #2104 - ability to tell the Create and Update operations to save the request using Except instead of Only, using the new operation-level config item ```saveAllInputsExcept```;
 
 
 ## 4.0.12 - 2019-10-24

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -167,6 +167,20 @@ trait Search
     }
 
     /**
+     * Get duration for persistent table
+     *
+     * @return bool
+     */
+    public function getPersistentTableDuration()
+    {
+        if ($this->getOperationSetting('persistentTableDuration') !== null) {
+            return $this->getOperationSetting('persistentTableDuration');
+        }
+
+        return config('backpack.crud.operations.list.persistentTableDuration', false);
+    }
+
+    /**
      * Remember to show a persistent table.
      */
     public function enablePersistentTable()

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -29,6 +29,13 @@ return [
             // whenever the user tries to see that page, backpack loads the previous pagination and filtration
             'persistentTable' => true,
 
+            // the time the table will be persisted in minutes
+            // after this the table info is cleared from localStorage.
+            // use false to never force localStorage clear. (default)
+            // keep in mind: User can clear his localStorage whenever he wants.
+
+            'persistentTableDuration' => false,
+
             // How many items should be shown by default by the Datatable?
             // This value can be overwritten on a specific CRUD by calling
             // $this->crud->setDefaultPageLength(50);

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -8,11 +8,23 @@
 
   <script>
     @if ($crud->getPersistentTable())
+
     // if there's a filtered URL saved for this list view, redirect to that one
     var saved_list_url = localStorage.getItem('{{ str_slug($crud->getRoute()) }}_list_url');
 
+    var arr =  window.location.href.split('?');
+        //check if url has parameters.
+        if (arr.length > 1 && arr[1] !== '') {
+                // IT HAS! Check if it is our own persistence redirect.
+                if (window.location.search.indexOf('persistent-table=true') < 1) {
+                    // IF NOT: we don't want to redirect the user.
+                    saved_list_url = false;
+                }
+        }
+
     @if($crud->getPersistentTableDuration())
-        var saved_list_url_time = localStorage.getItem('{{ str_slug($crud->getRoute()) }}_list_url_time')
+        var saved_list_url_time = localStorage.getItem('{{ str_slug($crud->getRoute()) }}_list_url_time');
+        var persistentUrl = saved_list_url+'&persistent-table=true';
 
         if (saved_list_url_time) {
             var $current_date = new Date();
@@ -21,8 +33,8 @@
 
             //if the save time is not expired we force the filter redirection.
             if($saved_time > $current_date) {
-                if (saved_list_url && saved_list_url!=window.location.href) {
-                    window.location.href = saved_list_url;
+                if (saved_list_url && persistentUrl!=window.location.href) {
+                    window.location.href = persistentUrl;
                 }
             } else {
             //persistent table expired, let's not redirect the user
@@ -31,8 +43,8 @@
         }
 
     @endif
-        if (saved_list_url && saved_list_url!=window.location.href) {
-            window.location.href = saved_list_url;
+        if (saved_list_url && persistentUrl!=window.location.href) {
+            window.location.href = persistentUrl;
         }
     @endif
 

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -85,6 +85,20 @@
 
         @if ($crud->getPersistentTable())
         stateSave: true,
+        /*
+            if developer forced field into table 'visibleInTable => true' we make sure when saving datatables state
+            that it reflects the developer decision.
+        */
+
+        stateSaveParams: function(settings, data) {
+            data.columns.forEach(function(item, index) {
+                var columnHeading = crud.table.columns().header()[index];
+                      if ($(columnHeading).attr('data-visible-in-table') == 'true') {
+                       return item.visible = true;
+                      }
+
+            });
+        },
         @endif
         autoWidth: false,
         pageLength: {{ $crud->getDefaultPageLength() }},

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -18,7 +18,10 @@
                     name: 'copyHtml5',
                     extend: 'copyHtml5',
                     exportOptions: {
-                       columns: [':visible:not(.not-export-col):not(.hidden):not([data-visible-in-export=false])'],
+                        columns: function ( idx, data, node ) {
+                            var $column = crud.table.column( idx );
+                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                        }
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -30,7 +33,10 @@
                     name: 'excelHtml5',
                     extend: 'excelHtml5',
                     exportOptions: {
-                       columns: [':visible:not(.not-export-col):not(.hidden):not([data-visible-in-export=false])'],
+                        columns: function ( idx, data, node ) {
+                            var $column = crud.table.column( idx );
+                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                        }
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -42,7 +48,10 @@
                     name: 'csvHtml5',
                     extend: 'csvHtml5',
                     exportOptions: {
-                       columns: [':visible:not(.not-export-col):not(.hidden):not([data-visible-in-export=false])'],
+                        columns: function ( idx, data, node ) {
+                            var $column = crud.table.column( idx );
+                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                        }
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -54,7 +63,10 @@
                     name: 'pdfHtml5',
                     extend: 'pdfHtml5',
                     exportOptions: {
-                       columns: [':visible:not(.not-export-col):not(.hidden):not([data-visible-in-export=false])'],
+                        columns: function ( idx, data, node ) {
+                            var $column = crud.table.column( idx );
+                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                        }
                     },
                     orientation: 'landscape',
                     action: function(e, dt, button, config) {
@@ -67,7 +79,10 @@
                     name: 'print',
                     extend: 'print',
                     exportOptions: {
-                       columns: [':visible:not(.not-export-col):not(.hidden):not([data-visible-in-export=false])'],
+                        columns: function ( idx, data, node ) {
+                            var $column = crud.table.column( idx );
+                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                        }
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -80,7 +95,9 @@
         {
             extend: 'colvis',
             text: '<i class="fa fa-eye-slash"></i> {{ trans('backpack::crud.export.column_visibility') }}',
-            columns: ':not(.not-export-col):not([data-visible-in-export=false])',
+            columns: function ( idx, data, node ) {
+                return  $(node).attr('data-visible-in-table') == 'false';
+            },
             dropup: true
         }
     ];

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -25,6 +25,12 @@
 
             new_url = URI(new_url).normalizeQuery();
 
+            // this param is only needed in datatables persistent url redirector
+            // not when applying filters so we remove it.
+            if (new_url.hasQuery('persistent-table')) {
+                new_url.removeQuery('persistent-table');
+            }
+
             if (new_url.hasQuery(parameter)) {
               new_url.removeQuery(parameter);
             }

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -58,9 +58,45 @@
                   <th
                     data-orderable="{{ var_export($column['orderable'], true) }}"
                     data-priority="{{ $column['priority'] }}"
-                    data-visible="{{ var_export($column['visibleInTable'] ?? true) }}"
-                    data-visible-in-modal="{{ var_export($column['visibleInModal'] ?? true) }}"
-                    data-visible-in-export="{{ var_export($column['visibleInExport'] ?? true) }}"
+                     {{--
+
+                        data-visible-in-table => if developer forced field in table with 'visibleInTable => true'
+                        data-visible => regular visibility of the field
+                        data-can-be-visible-in-table => prevents the column to be loaded into the table (export-only)
+                        data-visible-in-modal => if column apears on responsive modal
+                        data-visible-in-export => if this field is exportable
+                        data-force-export => force export even if field are hidden
+
+                    --}}
+
+                    {{-- If it is an export field only, we are done. --}}
+                    @if(isset($column['exportOnlyField']) && $column['exportOnlyField'] === true)
+                        data-visible="false"
+                        data-visible-in-table="false"
+                        data-can-be-visible-in-table="false"
+                        data-visible-in-modal="false"
+                        data-visible-in-export="true"
+                        data-force-export="true"
+
+                    @else
+
+                        data-visible-in-table="{{var_export($column['visibleInTable'] ?? false)}}"
+                        data-visible="{{var_export($column['visibleInTable'] ?? true)}}"
+                        data-can-be-visible-in-table="true"
+                        data-visible-in-modal="{{var_export($column['visibleInModal'] ?? true)}}"
+                        @if(isset($column['visibleInExport']))
+                            @if($column['visibleInExport'] === false)
+                            data-visible-in-export="false"
+                            data-force-export="false"
+                            @else
+                            data-visible-in-export="true"
+                            data-force-export="true"
+                            @endif
+                        @else
+                            data-visible-in-export="true"
+                            data-force-export="false"
+                        @endif
+                    @endif
                     >
                     {!! $column['label'] !!}
                   </th>


### PR DESCRIPTION
So ... here we are again around Datatables. I hope this one is for good :D

As recently reported in #2193 by @axelzuze and mentioned again some time ago by other users, I have made an attempt to fix Datatables export and visibility. 

I will try to describe all the behavior on this thread. Here we go.

If you add a regular column, for sake of example lets just use:

```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text
]

// Will appear on table, can be hidden by user, can be exported if not hidden in table.

```
 
```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'visibleInTable' => false
]
// Will start hidden in table, can be shown by user, can be exported if not hidden in table.
```

```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'visibleInTable' => false,
    'visibleInExport' => true
]
// Will start hidden in table, can be shown by user, WILL ALLWAYS BE EXPORTED  EVEN IF HIDDEN.
```
```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'visibleInTable' => false,
    'visibleInExport' => false
]
// Will start hidden in table, can be shown by user, WILL NEVER BE EXPORTED EVEN IF SHOWN.
```

```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'visibleInTable' => true,
    'visibleInExport' => true/false
]
// Will ALLWAYS start in table, user can't hide it, if visibleInExport is not set/true this column will ALLWAYS be exported (because is allways visible) if you don't want this column to be exported use the visibleInExport => false
```

```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'visibleInExport' => false
]
// Will start in table, can be hidden by user, WILL NEVER BE EXPORTED EVEN IF SHOWN
```

```
 [
    'name' => 'text',
    'label' => 'Text label,
    'type' => 'text,
    'exportOnlyField' => true
]
// Will start hidden in table, user cannot show it, will allways be exported. Also don't show in modal.
```

I think i got to cover all use cases, but please guys, give it a look and tell me what you think. 

Best,
Pedro
