### PR TITLE
[4.0] [FIX] select_from_array column multiple flaws

### DIFF
--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -10,7 +10,7 @@
                 $array_of_values = [];
 
                 foreach ($values as $key => $value) {
-                    if (!is_null($value)) {
+                    if (! is_null($value)) {
                         $array_of_values[] = $column['options'][$value];
                     } else {
                         echo '-';

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -10,13 +10,18 @@
                 $array_of_values = [];
 
                 foreach ($values as $key => $value) {
-                    $array_of_values[] = $column['options'][$value];
+                    if (!is_null($value)) {
+                        $array_of_values[] = $column['options'][$value];
+                    } else {
+                        echo '-';
+                        continue;
+                    }
                 }
 
                 if (count($array_of_values) > 1) {
                     echo implode(', ', $array_of_values);
                 } else {
-                    echo $array_of_values;
+                    echo array_first($array_of_values);
                 }
             } else {
                 echo $column['options'][$values];


### PR DESCRIPTION
Hello guys.

This PR is an attempt to fix the issue reported on #2219. 

The direct change to fix this issue is calling `array_first($array_of_values)` if there is only one element in the array.

After i spotted if you have `allows_null` on field, and selected the `- (null option)`, it would still break because we end with an array like
```
[
0 => null,
]
```

So we check if `!is_null($value)` if it is null we just show the **"null"** symbol (-) and continue the iteration !