### PR TITLE
[4.0][Fix] Video field's input should probably be URL not TEXT

### DIFF
--- a/src/resources/views/crud/fields/video.blade.php
+++ b/src/resources/views/crud/fields/video.blade.php
@@ -20,7 +20,7 @@ if (is_array($value)) {
     @include('crud::inc.field_translatable_icon')
     <input class="video-json" type="hidden" name="{{ $field['name'] }}" value="{{ $value }}">
     <div class="input-group">
-        <input @include('crud::inc.field_attributes', ['default_class' => 'video-link form-control']) type="text" id="{{ $field['name'] }}_link">
+        <input @include('crud::inc.field_attributes', ['default_class' => 'video-link form-control']) type="url" id="{{ $field['name'] }}_link">
         <div class="input-group-append video-previewSuffix video-noPadding">
             <div class="video-preview">
                 <span class="video-previewImage"></span>


### PR DESCRIPTION
This change is of little consequence, but it is probably what we should have done in the first place. It doesn't fix much, but when using [form fillers](https://chrome.google.com/webstore/detail/form-filler/bnjjngeaknajbdcgpfkgnonkmififhfo) they will fill it with an URL instead of text. Since "url" inputs fall back to "text" on browser that don't support it, it should be a non-breaking change.