### PR TITLE
[4.1][Feature] Instant fields 

### DIFF
--- a/src/app/Http/Controllers/Operations/InstantFieldsOperation.php
+++ b/src/app/Http/Controllers/Operations/InstantFieldsOperation.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Http\Controllers\CrudController;
-use Exception;
 use Illuminate\Support\Facades\Route;
 
 trait InstantFieldsOperation
@@ -38,62 +37,67 @@ trait InstantFieldsOperation
             'uses'      => $controller.'@getInstantUpdateModal',
             'operation' => 'InstantFieldsOperation',
         ]);
-
-
-
     }
 
-    public function setupInstantFieldsDefaults() {
+    public function setupInstantFieldsDefaults()
+    {
         $this->crud->setOperationSetting('on_the_fly', true);
     }
 
-    public function getInstantCreateModal() {
+    public function getInstantCreateModal()
+    {
         if (request()->has('entity')) {
             $this->setupCreateOperation();
+
             return $this->getInstantModal(request()->get('entity'), 'create', $this->crud->getCreateFields());
         }
     }
 
-    public function getInstantUpdateModal() {
+    public function getInstantUpdateModal()
+    {
         if (request()->has('entity')) {
             $this->setupUpdateOperation();
-            return $this->getInstantModal(request()->get('entity'),'update', $this->crud->getUpdateFields());
+
+            return $this->getInstantModal(request()->get('entity'), 'update', $this->crud->getUpdateFields());
         }
     }
 
     public function getInstantModal($entity, $action, $fields)
     {
-            return view(
+        return view(
                 'crud::inc.on-the-fly',
                 [
                     'fields' => $fields,
                     'action' => $action,
                     'crud' => $this->crud,
-                    'entity' => $entity
+                    'entity' => $entity,
                 ]
                 );
     }
 
-    public function refreshOptions() {
+    public function refreshOptions()
+    {
         $this->setupCreateOperation();
 
         if (request()->has('field')) {
             $field = $this->crud->fields()[request()->get('field')];
             $relatedModelInstance = new $field['model']();
-            if($field) {
-                if (!isset($field['options'])) {
-                    $options = $field['model']::all()->pluck($field['attribute'],$relatedModelInstance->getKeyName());
+            if ($field) {
+                if (! isset($field['options'])) {
+                    $options = $field['model']::all()->pluck($field['attribute'], $relatedModelInstance->getKeyName());
                 } else {
-                    $options = call_user_func($field['options'], $field['model']::query()->pluck($field['attribute'],$relatedModelInstance->getKeyName()));
+                    $options = call_user_func($field['options'], $field['model']::query()->pluck($field['attribute'], $relatedModelInstance->getKeyName()));
                 }
             }
+
             return response()->json($options);
         }
     }
 
-    public function storeOnTheFly() {
+    public function storeOnTheFly()
+    {
         $this->setupCreateOperation();
+
         return $this->store();
     }
-
 }

--- a/src/app/Http/Controllers/Operations/InstantFieldsOperation.php
+++ b/src/app/Http/Controllers/Operations/InstantFieldsOperation.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Exception;
+use Illuminate\Support\Facades\Route;
+
+trait InstantFieldsOperation
+{
+    /**
+     * Define which routes are needed for this operation.
+     *
+     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
+     * @param string $routeName  Prefix of the route name.
+     * @param string $controller Name of the current CrudController.
+     */
+    protected function setupInstantFieldsRoutes($segment, $routeName, $controller)
+    {
+        Route::get($segment.'/instant-fields/create', [
+            'as'        => $segment.'-on-the-fly-create',
+            'uses'      => $controller.'@getInstantCreateModal',
+            'operation' => 'InstantFieldsOperation',
+        ]);
+        Route::post($segment.'/instant-fields/create', [
+            'as'        => $segment.'-on-the-fly-create',
+            'uses'      => $controller.'@storeOnTheFly',
+            'operation' => 'InstantFieldsOperation',
+        ]);
+        Route::get($segment.'/instant-fields/refresh', [
+            'as'        => $segment.'-on-the-fly-refresh-options',
+            'uses'      => $controller.'@refreshOptions',
+            'operation' => 'InstantFieldsOperation',
+        ]);
+
+        Route::get($segment.'/instant-fields/update', [
+            'as'        => $segment.'-on-the-fly-update',
+            'uses'      => $controller.'@getInstantUpdateModal',
+            'operation' => 'InstantFieldsOperation',
+        ]);
+
+
+
+    }
+
+    public function setupInstantFieldsDefaults() {
+        $this->crud->setOperationSetting('on_the_fly', true);
+    }
+
+    public function getInstantCreateModal() {
+        if (request()->has('entity')) {
+            $this->setupCreateOperation();
+            return $this->getInstantModal(request()->get('entity'), 'create', $this->crud->getCreateFields());
+        }
+    }
+
+    public function getInstantUpdateModal() {
+        if (request()->has('entity')) {
+            $this->setupUpdateOperation();
+            return $this->getInstantModal(request()->get('entity'),'update', $this->crud->getUpdateFields());
+        }
+    }
+
+    public function getInstantModal($entity, $action, $fields)
+    {
+            return view(
+                'crud::inc.on-the-fly',
+                [
+                    'fields' => $fields,
+                    'action' => $action,
+                    'crud' => $this->crud,
+                    'entity' => $entity
+                ]
+                );
+    }
+
+    public function refreshOptions() {
+        $this->setupCreateOperation();
+
+        if (request()->has('field')) {
+            $field = $this->crud->fields()[request()->get('field')];
+            $relatedModelInstance = new $field['model']();
+            if($field) {
+                if (!isset($field['options'])) {
+                    $options = $field['model']::all()->pluck($field['attribute'],$relatedModelInstance->getKeyName());
+                } else {
+                    $options = call_user_func($field['options'], $field['model']::query()->pluck($field['attribute'],$relatedModelInstance->getKeyName()));
+                }
+            }
+            return response()->json($options);
+        }
+    }
+
+    public function storeOnTheFly() {
+        $this->setupCreateOperation();
+        return $this->store();
+    }
+
+}

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -384,7 +384,7 @@ trait Fields
             if (isset($field['view_namespace'])) {
                 $fieldType = implode('.', [$field['view_namespace'], $field['type']]);
             }
-        }else{
+        } else {
             $fieldType = $field;
         }
 
@@ -413,12 +413,14 @@ trait Fields
         return false;
     }
 
-    public function isAnyTypeLoaded($fieldTypes) {
-        foreach($fieldTypes as $fieldType) {
-            if($this->fieldTypeLoaded($fieldType)) {
+    public function isAnyTypeLoaded($fieldTypes)
+    {
+        foreach ($fieldTypes as $fieldType) {
+            if ($this->fieldTypeLoaded($fieldType)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -379,10 +379,13 @@ trait Fields
      */
     public function getFieldTypeWithNamespace($field)
     {
-        $fieldType = $field['type'];
-
-        if (isset($field['view_namespace'])) {
-            $fieldType = implode('.', [$field['view_namespace'], $field['type']]);
+        if (is_array($field)) {
+            $fieldType = $field['type'];
+            if (isset($field['view_namespace'])) {
+                $fieldType = implode('.', [$field['view_namespace'], $field['type']]);
+            }
+        }else{
+            $fieldType = $field;
         }
 
         return $fieldType;
@@ -397,6 +400,7 @@ trait Fields
     public function addLoadedFieldType($field)
     {
         $alreadyLoaded = $this->getLoadedFieldTypes();
+
         $type = $this->getFieldTypeWithNamespace($field);
 
         if (! in_array($type, $this->getLoadedFieldTypes(), true)) {
@@ -406,6 +410,15 @@ trait Fields
             return true;
         }
 
+        return false;
+    }
+
+    public function isAnyTypeLoaded($fieldTypes) {
+        foreach($fieldTypes as $fieldType) {
+            if($this->fieldTypeLoaded($fieldType)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -71,11 +71,11 @@ trait CrudTrait
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
         try {
             $conn->getDoctrineColumn($table, $column_name);
+
             return ! $conn->getDoctrineColumn($table, $column_name)->getNotnull();
         } catch (Exception $e) {
             return true;
         }
-
     }
 
     /*

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Models\Traits;
 
 use DB;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Traversable;
@@ -68,8 +69,13 @@ trait CrudTrait
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
+        try {
+            $conn->getDoctrineColumn($table, $column_name);
+            return ! $conn->getDoctrineColumn($table, $column_name)->getNotnull();
+        } catch (Exception $e) {
+            return true;
+        }
 
-        return ! $conn->getDoctrineColumn($table, $column_name)->getNotnull();
     }
 
     /*

--- a/src/public/packages/backpack/crud/js/selects.js
+++ b/src/public/packages/backpack/crud/js/selects.js
@@ -1,0 +1,223 @@
+let refreshOptionList = function (element, $field, $refreshUrl) {
+    return new Promise(function (resolve, reject) {
+        $.ajax({
+            url: $refreshUrl,
+            data: {
+                'field': $field
+            },
+            type: 'GET',
+            // async: false,
+            success: function (result) {
+                //console.log(result);
+                $(element).attr('data-options-for-select', JSON.stringify(result));
+                resolve(result);
+            },
+            error: function (result) {
+                // Show an alert with the result
+
+                reject(result);
+            }
+        });
+    });
+};
+
+
+function fillSelectOptions(element, $created = false, $multiple = false) {
+
+    var $options = JSON.parse(element.attr('data-options-for-select'));
+
+    var $allows_null = element.attr('data-allows-null');
+
+    var $relatedKey = element.attr('data-on-the-fly-related-key');
+
+    //used to check if after a related creation the created entity is still available in options
+    var $createdIsOnOptions = false;
+
+    //if this field is a select multiple we json parse the current value
+    if ($multiple == true) {
+
+        var $currentValue = JSON.parse(element.attr('data-current-value'));
+
+        var selectedOptions = [];
+
+        //if there are any selected options we re-select them
+        for (const [key, value] of Object.entries($currentValue)) {
+        selectedOptions.push(key);
+    }
+
+    //we add the options to the select and check if we have some created, if yes we append to selected options
+    for (const [key, value] of Object.entries($options)) {
+        var $option = new Option(value, key);
+
+        if ($created) {
+            if(key == $created[$relatedKey]) {
+                $createdIsOnOptions = true;
+                selectedOptions.push(key);
+            }
+        }
+
+        $(element).append($option);
+    }
+
+    $(element).val(selectedOptions);
+
+    }else{
+        //it's a single select
+        var $currentValue = element.attr('data-current-value');
+
+        for (const [key, value] of Object.entries($options)) {
+
+            var $option = new Option(value, key);
+            $(element).append($option);
+            if (key == $currentValue) {
+                $(element).val(key);
+            }
+            if ($created) {
+                //we check if created is presented in the available options, might not be based on some model constrain (like active() scope)
+                if(key == $created[$relatedKey]) {
+                    $createdIsOnOptions = true;
+                    $(element).val(key);
+                }
+
+         }
+    }
+    }
+    if ($allows_null == 'true' && $multiple == false && ($currentValue == '' || (Array.isArray($currentValue) && $currentValue.length)) && $createdIsOnOptions == false) {
+        var $option = new Option('-', '');
+        $(element).prepend($option);
+        if (($currentValue == '' || (Array.isArray($currentValue) && $currentValue.length))) {
+            $(element).val('');
+        }
+    }
+    if($allows_null == 'false' && ($currentValue == '' || (Array.isArray($currentValue) && $currentValue.length)) && $createdIsOnOptions == false) {
+        $(element).val(Object.keys($options)[0]);
+
+    }
+
+    $(element).trigger('change')
+}
+
+function triggerSelectOptions(element, $refreshUrl, $created = false, $multiple = false) {
+    $fieldName = element.attr('data-original-name');
+    $(element).empty();
+
+    if ($created) {
+        refreshOptionList(element, $fieldName, $refreshUrl).then(result => {
+
+            fillSelectOptions(element, $created, $multiple);
+        }, result => {
+
+        });
+    } else {
+        fillSelectOptions(element, $created, $multiple);
+    }
+}
+
+function setupOnTheFlyButtons(element, urls) {
+    var $onTheFlyCreateButton = element.attr('data-on-the-fly-create-button');
+    var $fieldEntity = element.attr('data-field-related-name');
+    var $onTheFlyCreateButtonElement = $(document.getElementById($onTheFlyCreateButton));
+
+    $onTheFlyCreateButtonElement.on('click', function () {
+        $(".loading_modal_dialog").show();
+        $.ajax({
+            url: urls.createUrl,
+            data: {
+                'entity': $fieldEntity
+            },
+            type: 'GET',
+            success: function (result) {
+                $('body').append(result);
+                triggerModal(element, urls);
+
+            },
+            error: function (result) {
+                // Show an alert with the result
+                swal({
+                    title: "error",
+                    text: "error",
+                    icon: "error",
+                    timer: 4000,
+                    buttons: false,
+                });
+            }
+        });
+    });
+
+}
+
+function triggerModal(element, $urls) {
+    var $fieldName = element.attr('data-field-related-name');
+    var $multiple = (element.attr('data-field-multiple') === 'true');
+    var modalName = '#'+$fieldName+'-on-the-fly-create-dialog';
+    var $modal = $(modalName);
+
+    $modal.modal({ backdrop: 'static', keyboard: false });
+    var $modalSaveButton = $modal.find('#saveButton');
+    var $form = $(document.getElementById($fieldName+"-on-the-fly-create-form"));
+
+
+    initializeFieldsWithJavascript($form);
+
+    $modalSaveButton.on('click', function () {
+        var $formData = new FormData(document.getElementById($fieldName+"-on-the-fly-create-form"));
+
+        var loadingText = '<i class="fa fa-circle-o-notch fa-spin"></i> loading...';
+        if ($modalSaveButton.html() !== loadingText) {
+            $modalSaveButton.data('original-text', $(this).html());
+            $modalSaveButton.html(loadingText);
+            $modalSaveButton.prop('disabled', true);
+        }
+
+
+        $.ajax({
+            url: $urls['createUrl'],
+            data: $formData,
+            processData: false,
+            contentType: false,
+            type: 'POST',
+            success: function (result) {
+
+                $createdEntity = result.data;
+                triggerSelectOptions(element, $urls['refreshUrl'], $createdEntity,$multiple);
+
+                $modal.modal('hide');
+                swal({
+                    title: "Related entity creation",
+                    text: "Related entity created with success.",
+                    icon: "success",
+                    timer: 4000,
+                    buttons: false,
+                });
+            },
+            error: function (result) {
+                // Show an alert with the result
+
+                var $errors = result.responseJSON.errors;
+
+                let message = '';
+                for (var i in $errors) {
+                    message += $errors[i] + ' \n';
+                }
+
+                swal({
+                    title: "Creating related entity error",
+                    text: message,
+                    icon: "error",
+                    timer: 4000,
+                    buttons: false,
+                });
+                $modalSaveButton.prop('disabled', false);
+                $modalSaveButton.html($modalSaveButton.data('original-text'));
+            }
+        });
+    });
+
+    $modal.on('hidden.bs.modal', function (e) {
+        $modal.remove();
+    });
+
+    $modal.on('shown.bs.modal', function (e) {
+        $(".loading_modal_dialog").hide();
+    });
+}

--- a/src/resources/views/crud/buttons/on_the_fly/create.blade.php
+++ b/src/resources/views/crud/buttons/on_the_fly/create.blade.php
@@ -1,0 +1,11 @@
+<span class="browse btn btn-sm btn-light move" id="{{ $onTheFlyEntity }}-on-the-fly-create-{{$name}}" type="button"><span class="fa fa-plus"></span> New</span>
+
+@include('crud::buttons.on_the_fly.loader')
+
+@push('on_the_fly_styles')
+@stack('loading_styles')
+@endpush
+
+@push('on_the_fly_scripts')
+@stack('loading_scripts')
+@endpush

--- a/src/resources/views/crud/buttons/on_the_fly/loader.blade.php
+++ b/src/resources/views/crud/buttons/on_the_fly/loader.blade.php
@@ -1,0 +1,138 @@
+@push('loading_styles')
+<style>
+    .loading_modal_dialog {
+        position: fixed;
+  z-index: 999;
+  height: 2em;
+  width: 2em;
+  overflow: visible;
+  margin: auto;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display:none;
+  -webkit-user-select: none;  /* Chrome all / Safari all */
+  -moz-user-select: none;     /* Firefox all */
+  -ms-user-select: none;      /* IE 10+ */
+  user-select: none;          /* Likely future */
+}
+.loading_modal_dialog:before {
+  content: '';
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.3);
+}
+.loading_modal_dialog:after {
+  content: 'teste';
+
+}
+
+
+/* :not(:required) hides these rules from IE9 and below */
+.loading_modal_dialog:not(:required) {
+  /* hide "loading..." text */
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+
+.loading_modal_dialog:not(:required):after {
+  content: '';
+  display: block;
+  font-size: 10px;
+  width: 1em;
+  height: 1em;
+  margin-top: -0.5em;
+  -webkit-animation: spinner 1500ms infinite linear;
+  -moz-animation: spinner 1500ms infinite linear;
+  -ms-animation: spinner 1500ms infinite linear;
+  -o-animation: spinner 1500ms infinite linear;
+  animation: spinner 1500ms infinite linear;
+  border-radius: 0.5em;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.75) 1.5em 0 0 0, rgba(0, 0, 0, 0.75) 1.1em 1.1em 0 0, rgba(0, 0, 0, 0.75) 0 1.5em 0 0, rgba(0, 0, 0, 0.75) -1.1em 1.1em 0 0, rgba(0, 0, 0, 0.5) -1.5em 0 0 0, rgba(0, 0, 0, 0.5) -1.1em -1.1em 0 0, rgba(0, 0, 0, 0.75) 0 -1.5em 0 0, rgba(0, 0, 0, 0.75) 1.1em -1.1em 0 0;
+  box-shadow: rgba(0, 0, 0, 0.75) 1.5em 0 0 0, rgba(0, 0, 0, 0.75) 1.1em 1.1em 0 0, rgba(0, 0, 0, 0.75) 0 1.5em 0 0, rgba(0, 0, 0, 0.75) -1.1em 1.1em 0 0, rgba(0, 0, 0, 0.75) -1.5em 0 0 0, rgba(0, 0, 0, 0.75) -1.1em -1.1em 0 0, rgba(0, 0, 0, 0.75) 0 -1.5em 0 0, rgba(0, 0, 0, 0.75) 1.1em -1.1em 0 0;
+}
+
+/* Animation */
+
+@-webkit-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-moz-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@-o-keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    -o-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+    </style>
+@endpush
+
+@push('loading_scripts')
+<script>
+            jQuery(document).ready(function($) {
+                $( "body" ).prepend('<div class="loading_modal_dialog">Loading related entity form ...</div>');
+            });
+</script>
+@endpush

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -53,3 +53,7 @@
 </div>
 
 @endsection
+
+@section('after_scripts')
+  @stack('crud_create_scripts')
+@endsection

--- a/src/resources/views/crud/fields/select2.blade.php
+++ b/src/resources/views/crud/fields/select2.blade.php
@@ -1,51 +1,101 @@
 <!-- select2 -->
 @php
+
     $current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
     $entity_model = $crud->getRelationModel($field['entity'],  - 1);
 
+    $entity_model_instance = new $field['model']();
+
     if (!isset($field['options'])) {
-        $options = $field['model']::all();
+        $options = $field['model']::all()->pluck($field['attribute'],$entity_model_instance->getKeyName());
     } else {
-        $options = call_user_func($field['options'], $field['model']::query());
+        $options = call_user_func($field['options'], $field['model']::query()->pluck($field['attribute'],$entity_model_instance->getKeyName()));
     }
+    //dd($options);
+    $fieldOnTheFlyConfiguration = $field['on_the_fly'] ?? [];
+
+    //if user don't specify 'entity_route' we assume it's the same from $field['entity']
+    $onTheFlyEntity = isset($field['on_the_fly']['entity_route']) ? $field['on_the_fly']['entity_route'] : $field['entity'];
+
+    //we make sure on_the_fly operation is setup and that user wants to allow field creation
+    $activeOnTheFlyCreate = $crud->has($crud->getOperation().'.on_the_fly') ?
+    isset($field['on_the_fly']['create']) ? $field['on_the_fly']['create'] : false : false;
+
+    $activeOnTheFlyUpdate = $crud->has($crud->getOperation().'.on_the_fly') ?
+    isset($field['on_the_fly']['update']) ? $field['on_the_fly']['update'] : false : false;
+
+    if($activeOnTheFlyCreate || $activeOnTheFlyUpdate) {
+
+    if(!isset($onTheFly)) {
+        $createRoute = route($onTheFlyEntity."-on-the-fly-create");
+
+        $updateRoute = route($onTheFlyEntity."-on-the-fly-update");
+        $createRouteEntity = explode('/',$crud->route)[1];
+
+        $refreshRoute = route($createRouteEntity."-on-the-fly-refresh-options");
+
+    }else{
+        $activeOnTheFlyCreate = false;
+        $activeOnTheFlyUpdate = false;
+    }
+}
+
+    if ($entity_model::isColumnNullable($field['name'])) {
+        $allows_null = isset($field['allows_null']) ? $field['allows_null'] : true;
+    }else {
+        $allows_null = isset($field['allows_null']) ? $field['allows_null'] : false;
+    }
+
 @endphp
 
 <div @include('crud::inc.field_wrapper_attributes') >
 
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
-
-    <select
+    @if($activeOnTheFlyCreate)
+        @include('crud::buttons.on_the_fly.create', ['name' => $field['name'], 'onTheFlyEntity' => $onTheFlyEntity])
+       @endif
+<select
         name="{{ $field['name'] }}"
+        data-original-name="{{ $field['name'] }}"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2Element"
+        data-is-on-the-fly="{{ $onTheFly ?? 'false' }}"
+        data-field-related-name="{{$onTheFlyEntity}}"
+        data-on-the-fly-create-route="{{$createRoute ?? false}}"
+        data-on-the-fly-update-route="{{$updateRoute ?? false}}"
+        data-on-the-fly-refresh-route="{{$refreshRoute ?? false}}"
+        data-field-multiple="false"
+        data-on-the-fly-related-key="{{$entity_model_instance->getKeyName()}}"
+        data-on-the-fly-related-attribute="{{$field['attribute']}}"
+        data-options-for-select="{{json_encode($options)}}"
+        data-on-the-fly-create-button="{{ $onTheFlyEntity }}-on-the-fly-create-{{$field['name']}}"
+        data-on-the-fly-allow-create="{{var_export($activeOnTheFlyCreate)}}"
+        data-on-the-fly-allow-update="{{var_export($activeOnTheFlyUpdate)}}"
+        data-allows-null="{{var_export($allows_null)}}"
+        data-current-value="{{$current_value}}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_field'])
         >
-
-        @if ($entity_model::isColumnNullable($field['name']))
-            <option value="">-</option>
-        @endif
-
-        @if (count($options))
-            @foreach ($options as $option)
-                @if($current_value == $option->getKey())
-                    <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
-                @else
-                    <option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>
-                @endif
-            @endforeach
-        @endif
     </select>
 
     {{-- HINT --}}
     @if (isset($field['hint']))
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
+
 </div>
 
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+
+@if (!$crud->isAnyTypeLoaded([
+    'select2','select2_multiple'
+]))
+@push('before_scripts')
+<script src="{{ asset('packages/backpack/crud/js/selects.js') }}" ></script>
+@endpush
+@endif
 @if ($crud->fieldTypeNotLoaded($field))
     @php
         $crud->markFieldTypeAsLoaded($field);
@@ -53,6 +103,7 @@
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
+    @stack('on_the_fly_styles')
         <!-- include select2 css-->
         <link href="{{ asset('packages/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
         <link href="{{ asset('packages/select2-bootstrap-theme/dist/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
@@ -60,17 +111,48 @@
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
     @push('crud_fields_scripts')
+    @stack('on_the_fly_scripts')
         <!-- include select2 js-->
         <script src="{{ asset('packages/select2/dist/js/select2.full.min.js') }}"></script>
         @if (app()->getLocale() !== 'en')
         <script src="{{ asset('packages/select2/dist/js/i18n/' . app()->getLocale() . '.js') }}"></script>
+
         @endif
-        <script>
+
+
+
+<script type="text/javascript">
+
+
+
             function bpFieldInitSelect2Element(element) {
+
+                var $onTheFlyField = element.attr('data-is-on-the-fly');
+
+
+                var $onTheFlyCreateRoute = element.attr('data-on-the-fly-create-route');
+                var $onTheFlyRefreshRoute = element.attr('data-on-the-fly-refresh-route');
+
+                var $modalUrls = {
+                        'createUrl' : $onTheFlyCreateRoute,
+                        'refreshUrl': $onTheFlyRefreshRoute
+                    }
+
+                var $selectOptions = element.attr('data-options-for-select');
+
+                triggerSelectOptions(element,$modalUrls['refreshUrl']);
+
+                //Checks if field is not beeing inserted in one on-the-fly modal and setup buttons
+                if($onTheFlyField == "false") {
+
+                    setupOnTheFlyButtons(element, $modalUrls);
+
+                }
                 // element will be a jQuery wrapped DOM node
                 if (!element.hasClass("select2-hidden-accessible")) {
                     element.select2({
-                        theme: "bootstrap"
+                        theme: "bootstrap",
+
                     });
                 }
             }

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -1,37 +1,100 @@
 <!-- select2 multiple -->
 @php
+//i think this is the same as $crud->model dunno why we don't get it from crud directly
+$entity_model = $crud->getRelationModel($field['entity'],  - 1);
+$entity_model_instance = new $field['model']();
+$current_value = old(square_brackets_to_dots($field["name"])) ?? old($field['name']) ?? $field['value'] ?? $field['default'] ?? [];
+
+if(is_object($current_value)) {
+    $current_value = $current_value->pluck($field['attribute'],$entity_model_instance->getKeyName());
+}
+
+
     if (!isset($field['options'])) {
-        $options = $field['model']::all();
+        $options = $field['model']::all()->pluck($field['attribute'],$entity_model_instance->getKeyName());
     } else {
-        $options = call_user_func($field['options'], $field['model']::query());
+        $options = call_user_func($field['options'], $field['model']::query()->pluck($field['attribute'],$entity_model_instance->getKeyName()));
     }
-    $multiple = isset($field['multiple']) && $field['multiple']===false ? '': 'multiple';
+    $multiple = 'multiple';
+
+    $fieldOnTheFlyConfiguration = $field['on_the_fly'] ?? [];
+
+    //if user don't specify 'entity_route' we assume it's the same from $field['entity']
+    $onTheFlyEntity = isset($field['on_the_fly']['entity_route']) ? $field['on_the_fly']['entity_route'] : $field['entity'];
+
+    //we make sure that InstantFieldsOperation is loaded and that user wants to allow field creation
+    $activeOnTheFlyCreate = $crud->has($crud->getOperation().'.on_the_fly') ?
+    isset($field['on_the_fly']['create']) ? $field['on_the_fly']['create'] : false : false;
+
+    $activeOnTheFlyUpdate = $crud->has($crud->getOperation().'.on_the_fly') ?
+    isset($field['on_the_fly']['update']) ? $field['on_the_fly']['update'] : false : false;
+
+    if($activeOnTheFlyCreate || $activeOnTheFlyUpdate) {
+
+    //this checks if field is not beeing added on the fly
+    if(!isset($onTheFly)) {
+        $createRoute = route($onTheFlyEntity."-on-the-fly-create");
+
+        $updateRoute = route($onTheFlyEntity."-on-the-fly-update");
+        $createRouteEntity = explode('/',$crud->route)[1];
+
+        $refreshRoute = route($createRouteEntity."-on-the-fly-refresh-options");
+
+    }else{
+        $activeOnTheFlyCreate = false;
+        $activeOnTheFlyUpdate = false;
+    }
+}
+
+if ($entity_model::isColumnNullable($field['name'])) {
+        $allows_null = isset($field['allows_null']) ? $field['allows_null'] : true;
+    }else {
+        $allows_null = isset($field['allows_null']) ? $field['allows_null'] : false;
+    }
+
+
+
 @endphp
+
+@if (!$crud->isAnyTypeLoaded([
+    'select2','select2_multiple'
+]))
+@push('before_scripts')
+<script src="{{ asset('packages/backpack/crud/js/selects.js') }}" ></script>
+@endpush
+@endif
+
+
 
 <div @include('crud::inc.field_wrapper_attributes') >
     <label>{!! $field['label'] !!}</label>
     @include('crud::inc.field_translatable_icon')
+    @if($activeOnTheFlyCreate)
+    <span class="browse btn btn-sm btn-light move" id="{{ $onTheFlyEntity }}-on-the-fly-create-{{$field['name']}}" type="button"><span class="fa fa-plus"></span> New</span>
+       @endif
     <select
         name="{{ $field['name'] }}[]"
         style="width: 100%"
+        data-original-name="{{$field['name']}}"
         data-init-function="bpFieldInitSelect2MultipleElement"
         data-select-all="{{ var_export($field['select_all'] ?? false)}}"
+        data-is-on-the-fly="{{ $onTheFly ?? 'false' }}"
+        data-field-related-name="{{$onTheFlyEntity}}"
+        data-on-the-fly-create-route="{{$createRoute ?? false}}"
+        data-on-the-fly-update-route="{{$updateRoute ?? false}}"
+        data-on-the-fly-refresh-route="{{$refreshRoute ?? false}}"
+        data-field-multiple="true"
+        data-on-the-fly-related-key="{{$entity_model_instance->getKeyName()}}"
+        data-on-the-fly-related-attribute="{{$field['attribute']}}"
+        data-options-for-select="{{json_encode($options)}}"
+        data-on-the-fly-create-button="{{ $onTheFlyEntity }}-on-the-fly-create-{{$field['name']}}"
+        data-on-the-fly-allow-create="{{var_export($activeOnTheFlyCreate)}}"
+        data-on-the-fly-allow-update="{{var_export($activeOnTheFlyUpdate)}}"
+        data-allows-null="{{var_export($allows_null)}}"
+        data-current-value="{{json_encode($current_value)}}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control select2_multiple'])
         {{$multiple}}>
 
-        @if (isset($field['allows_null']) && $field['allows_null']==true)
-            <option value="">-</option>
-        @endif
-
-        @if (isset($field['model']))
-            @foreach ($options as $option)
-                @if( (old(square_brackets_to_dots($field["name"])) && in_array($option->getKey(), old($field["name"]))) || (is_null(old(square_brackets_to_dots($field["name"]))) && isset($field['value']) && in_array($option->getKey(), $field['value']->pluck($option->getKeyName(), $option->getKeyName())->toArray())))
-                    <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
-                @else
-                    <option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>
-                @endif
-            @endforeach
-        @endif
     </select>
 
     @if(isset($field['select_all']) && $field['select_all'])
@@ -49,6 +112,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+
 @if ($crud->fieldTypeNotLoaded($field))
     @php
         $crud->markFieldTypeAsLoaded($field);
@@ -70,28 +134,47 @@
         @endif
         <script>
             function bpFieldInitSelect2MultipleElement(element) {
-            
+
                 var $select_all = element.attr('data-select-all');
-                
+
+                var $onTheFlyField = element.attr('data-is-on-the-fly');
+
+
+                var $onTheFlyCreateRoute = element.attr('data-on-the-fly-create-route');
+                var $onTheFlyRefreshRoute = element.attr('data-on-the-fly-refresh-route');
+
+                var $modalUrls = {
+                        'createUrl' : $onTheFlyCreateRoute,
+                        'refreshUrl': $onTheFlyRefreshRoute
+                    }
+
+                var $selectOptions = JSON.parse(element.attr('data-options-for-select'));
+                    $optionsIds = [];
+                    for (key in $selectOptions) {
+                        $optionsIds.push(key)
+                }
+
+                triggerSelectOptions(element,$modalUrls['refreshUrl'],false,true);
+
+                if($onTheFlyField == "false") {
+
+                    setupOnTheFlyButtons(element, $modalUrls);
+
+                }
+
                 if (!element.hasClass("select2-hidden-accessible"))
                     {
                         var $obj = element.select2({
                             theme: "bootstrap"
                         });
 
-                        var options = [];
-                        @if (count($options))
-                            @foreach ($options as $option)
-                                options.push({{ $option->getKey() }});
-                            @endforeach
-                        @endif
 
                         if($select_all) {
                             element.parent().find('.clear').on("click", function () {
                                 $obj.val([]).trigger("change");
                             });
                             element.parent().find('.select_all').on("click", function () {
-                                $obj.val(options).trigger("change");
+                                $obj.val($optionsIds).trigger("change");
                             });
                         }
                     }

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -12,6 +12,9 @@
   </div>
 @endif
 
+@php
+    session(['current_crud_loaded_fields' => $crud->getLoadedFieldTypes()]);
+@endphp
 {{-- Define blade stacks so css and js can be pushed from the fields to these sections. --}}
 
 @section('after_styles')
@@ -41,7 +44,7 @@
       }
       selector.find("[data-init-function]").each(function () {
         var element = $(this);
-        var functionName = element.data('init-function');
+        var functionName = element.attr('data-init-function');
 
         if (typeof window[functionName] === "function") {
           window[functionName](element);
@@ -53,7 +56,6 @@
 
       // trigger the javascript for all fields that have their js defined in a separate method
       initializeFieldsWithJavascript('form');
-
 
       // Save button has multiple actions: save and exit, save and edit, save and new
       var saveActions = $('#saveActions'),
@@ -153,6 +155,9 @@
           $("input[name='current_tab']").val(window.location.hash.substr(1));
       }
 
+
+
       });
+
     </script>
 @endsection

--- a/src/resources/views/crud/inc/on-the-fly.blade.php
+++ b/src/resources/views/crud/inc/on-the-fly.blade.php
@@ -1,0 +1,55 @@
+@php
+    if (session()->has('current_crud_loaded_fields')) {
+        $loadedFields = session('current_crud_loaded_fields');
+        session()->forget('current_crud_loaded_fields');
+    }
+
+    $loadedFields = $loadedFields ?? [];
+
+    //mark parent crud fields as loaded in DOM.
+    foreach($loadedFields as $loadedField) {
+        $crud->markFieldTypeAsLoaded($loadedField);
+    }
+
+@endphp
+<div class="modal fade" id="{{$entity}}-on-the-fly-create-dialog" tabindex="-1" role="dialog" aria-labelledby="{{$entity}}-on-the-fly-create-dialog-label" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="{{$entity}}-on-the-fly-create-dialog-label">Modal title</h5>
+        </div>
+        <div class="modal-body">
+            <form method="post"
+            id="{{$entity}}-on-the-fly-create-form"
+            action="#"
+          @if ($crud->hasUploadFields('create'))
+          enctype="multipart/form-data"
+          @endif
+            >
+        {!! csrf_field() !!}
+
+        <!-- load the view from the application if it exists, otherwise load the one in the package -->
+        @if(view()->exists('vendor.backpack.crud.on_the_fly_form_content'))
+            @include('vendor.backpack.crud.on_the_fly_form_content', [ 'fields' => $fields, 'action' => $action])
+        @else
+            @include('crud::on_the_fly_form_content', [ 'fields' => $fields, 'action' => $action])
+        @endif
+
+
+    </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" id="cancelButton" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="saveButton">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  @stack('modal_loaded_fields_styles')
+  @stack('modal_loaded_fields_scripts')
+
+
+        {{-- YOUR JS HERE --}}
+
+
+

--- a/src/resources/views/crud/inc/show_fields.blade.php
+++ b/src/resources/views/crud/inc/show_fields.blade.php
@@ -7,3 +7,11 @@
 
     @include($fieldsViewNamespace.'.'.$field['type'], ['field' => $field])
 @endforeach
+
+@push('crud_scripts_pre')
+@stack('crud_fields_scripts')
+@endpush
+
+@push('crud_styles_pre')
+@stack('crud_fields_styles')
+@endpush

--- a/src/resources/views/crud/inc/show_tabbed_fields_on_the_fly.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields_on_the_fly.blade.php
@@ -1,0 +1,67 @@
+@php
+    $horizontalTabs = $crud->getTabsType()=='horizontal' ? true : false;
+
+    if ($errors->any() && array_key_exists(array_keys($errors->messages())[0], $crud->getCurrentFields()) &&
+        array_key_exists('tab', $crud->getCurrentFields()[array_keys($errors->messages())[0]])) {
+        $tabWithError = ($crud->getCurrentFields()[array_keys($errors->messages())[0]]['tab']);
+    }
+
+@endphp
+
+@push('crud_fields_styles')
+    <style>
+        .nav-tabs-custom {
+            box-shadow: none;
+        }
+        .nav-tabs-custom > .nav-tabs.nav-stacked > li {
+            margin-right: 0;
+        }
+
+        .tab-pane .form-group h1:first-child,
+        .tab-pane .form-group h2:first-child,
+        .tab-pane .form-group h3:first-child {
+            margin-top: 0;
+        }
+    </style>
+@endpush
+
+@if ($crud->getFieldsWithoutATab()->filter(function ($value, $key) { return $value['type'] != 'hidden'; })->count())
+<div class="card">
+    <div class="card-body row">
+
+            @include('crud::inc.show_fields', ['fields' => $crud->getFieldsWithoutATab(), 'onTheFly' => 'true'])
+
+    </div>
+</div>
+@else
+@include('crud::inc.show_fields', ['fields' => $crud->getFieldsWithoutATab(), 'onTheFly' => 'true'])
+@endif
+
+<div class="tab-container {{ $horizontalTabs ? '' : 'container'}} mb-2">
+
+    <div class="nav-tabs-custom {{ $horizontalTabs ? '' : 'row'}}" id="on_the_fly_form_tabs">
+        <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'flex-column nav-pills'}} {{ $horizontalTabs ? '' : 'col-md-3' }}" role="tablist">
+            @foreach ($crud->getTabs() as $k => $tab)
+                <li role="presentation" class="nav-item">
+                    <a href="#on_the_fly_tab_{{ str_slug($tab, "") }}" aria-controls="on_the_fly_tab_{{ str_slug($tab, "") }}" role="tab" tab_name="{{ str_slug($tab, "") }}" data-toggle="tab" class="nav-link {{ isset($tabWithError) ? ($tab == $tabWithError ? 'active' : '') : ($k == 0 ? 'active' : '') }}">{{ $tab }}</a>
+                </li>
+            @endforeach
+        </ul>
+
+        <div class="tab-content p-0 {{$horizontalTabs ? '' : 'col-md-9'}}">
+
+            @foreach ($crud->getTabs() as $k => $tab)
+            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="on_the_fly_tab_{{ str_slug($tab, "") }}">
+
+                <div class="row">
+
+                @include('crud::inc.show_fields', ['fields' => $crud->getTabFields($tab), 'onTheFly' => 'true'])
+
+                </div>
+            </div>
+            @endforeach
+
+        </div>
+    </div>
+</div>
+

--- a/src/resources/views/crud/on_the_fly_form_content.blade.php
+++ b/src/resources/views/crud/on_the_fly_form_content.blade.php
@@ -1,0 +1,22 @@
+<input type="hidden" name="http_referrer" value={{ old('http_referrer') ?? \URL::previous() ?? url($crud->route) }}>
+
+{{-- See if we're using tabs --}}
+@if ($crud->tabsEnabled() && count($crud->getTabs()))
+    @include('crud::inc.show_tabbed_fields_on_the_fly', ['onTheFly' => 'true'])
+    <input type="hidden" name="current_tab" value="{{ str_slug($crud->getTabs()[0], "") }}" />
+@else
+  <div class="card">
+    <div class="card-body row">
+      @include('crud::inc.show_fields', ['fields' => $crud->fields(), 'onTheFly' => 'true'])
+    </div>
+  </div>
+@endif
+@push('modal_loaded_fields_scripts')
+@stack('crud_scripts_pre')
+@endpush
+
+@push('modal_loaded_fields_styles')
+@stack('crud_styles_pre')
+@endpush
+
+


### PR DESCRIPTION
Hello guys!! Here we are again :clinking_glasses: 

Close to Christmas .. New Year .. well I feel the joy and inspiration. :christmas_tree: :santa: :gift_heart: 

Long story short, since nearly 2017 #591 that this feature have been talked about. Some people dig in and created custom solutions, others dived to create a package and shared it with the comunity. Thanks @tswonke and others that contributed. 

With recent v4 implementations I think now we are ready to provide an built-in solution for this problem without major headaches! (i think :roll_eyes: )

This implementation __IS A BREAKING CHANGE__ because specifically select2 fields code had changed to pure JS implementation.

So how do you get all this working ? 

We need `use \Backpack\CRUD\app\Http\Controllers\Operations\InstantFieldsOperation;` in __both crud controllers__. (The one where you will have the select field and in the crud of the entity you are going to allow on the fly creation)

Setup your regular select2 or select2_multiple field and add this:
```
$this->crud->addField([
...
'on_the_fly' => [
//this will setup the create button.
'create' => true,

this is the connected entity route. Imagine here this is a select2 with `entity => 'category'`, and in your CategoryCrudController you route is: admin/category , the `entity_route` in this scenarios is `category`. In this case it would not be needed to specify because they are the same `entity => crud-route (category => category)` 

'entity_route' => 'entity' 
]
]);
```

You are done. Atm is only available for select2 and select2_multiple.

It needs lots of tests in differente scenarios. 

__This code is not ready for production__

I will add more info inline in the PR

Best,
Pedro

