### PR TITLE
Changed capitalize headings for all crud views

### DIFF
--- a/src/resources/views/base/inc/breadcrumbs.blade.php
+++ b/src/resources/views/base/inc/breadcrumbs.blade.php
@@ -3,9 +3,9 @@
 	  <ol class="breadcrumb bg-transparent justify-content-end p-0">
 	  	@foreach ($breadcrumbs as $label => $link)
 	  		@if ($link)
-			    <li class="breadcrumb-item text-capitalize"><a href="{{ $link }}">{{ $label }}</a></li>
+			    <li class="breadcrumb-item text-capitalize"><a class="capitalize-first-word" href="{{ $link }}">{{ $label }}</a></li>
 	  		@else
-			    <li class="breadcrumb-item text-capitalize active" aria-current="page">{{ $label }}</li>
+			    <li class="breadcrumb-item text-capitalize active capitalize-first-word" aria-current="page">{{ $label }}</li>
 	  		@endif
 	  	@endforeach
 	  </ol>

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -14,7 +14,33 @@
 @section('header')
 	<section class="container-fluid">
 	  <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+			<script>
+				document.addEventListener('DOMContentLoaded', function(){
+					let obj = document.getElementsByClassName('capitalize-first-word');
+
+					obj.forEach(function(item, i) {
+						let a = obj[i],
+								array = a.innerHTML.split(' ');
+
+						// one word = do nothing
+						if (array.length > 1) {
+							// insert only first word to this tag
+							a.innerHTML = array['0'];
+
+							// create new span and insert it near
+							array.splice(0, 1);
+							let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+							if (a.tagName === 'SPAN'){
+								a.outerHTML += span;
+							} else {
+								a.innerHTML += span;
+							}
+						}
+					});
+				});
+			</script>
+			<span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</small>
 
         @if ($crud->hasAccess('list'))

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -14,7 +14,33 @@
 @section('header')
 	<section class="container-fluid">
 	  <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+			<script>
+				document.addEventListener('DOMContentLoaded', function(){
+					let obj = document.getElementsByClassName('capitalize-first-word');
+
+					obj.forEach(function(item, i) {
+						let a = obj[i],
+								array = a.innerHTML.split(' ');
+
+						// one word = do nothing
+						if (array.length > 1) {
+							// insert only first word to this tag
+							a.innerHTML = array['0'];
+
+							// create new span and insert it near
+							array.splice(0, 1);
+							let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+							if (a.tagName === 'SPAN'){
+								a.outerHTML += span;
+							} else {
+								a.innerHTML += span;
+							}
+						}
+					});
+				});
+			</script>
+			<span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</small>
 
         @if ($crud->hasAccess('list'))

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -14,7 +14,33 @@
 @section('header')
   <div class="container-fluid">
     <h2>
-      <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+      <script>
+          document.addEventListener('DOMContentLoaded', function(){
+              let obj = document.getElementsByClassName('capitalize-first-word');
+
+              obj.forEach(function(item, i) {
+                  let a = obj[i],
+                      array = a.innerHTML.split(' ');
+
+                  // one word = do nothing
+                  if (array.length > 1) {
+                      // insert only first word to this tag
+                      a.innerHTML = array['0'];
+
+                      // create new span and insert it near
+                      array.splice(0, 1);
+                      let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+                      if (a.tagName === 'SPAN'){
+                          a.outerHTML += span;
+                      } else {
+                          a.innerHTML += span;
+                      }
+                  }
+              });
+          });
+      </script>
+      <span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
       <small id="datatable_info_stack">{!! $crud->getSubheading() ?? '' !!}</small>
     </h2>
   </div>

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -14,7 +14,33 @@
 @section('header')
 <div class="container-fluid">
     <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+      <script>
+          document.addEventListener('DOMContentLoaded', function(){
+              let obj = document.getElementsByClassName('capitalize-first-word');
+
+              obj.forEach(function(item, i) {
+                  let a = obj[i],
+                      array = a.innerHTML.split(' ');
+
+                  // one word = do nothing
+                  if (array.length > 1) {
+                      // insert only first word to this tag
+                      a.innerHTML = array['0'];
+
+                      // create new span and insert it near
+                      array.splice(0, 1);
+                      let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+                      if (a.tagName === 'SPAN'){
+                          a.outerHTML += span;
+                      } else {
+                          a.innerHTML += span;
+                      }
+                  }
+              });
+          });
+      </script>
+      <span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}.</small>
 
         @if ($crud->hasAccess('list'))

--- a/src/resources/views/crud/revisions.blade.php
+++ b/src/resources/views/crud/revisions.blade.php
@@ -14,7 +14,34 @@
 @section('header')
   <div class="container-fluid">
     <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+      <script>
+          document.addEventListener('DOMContentLoaded', function(){
+              let obj = document.getElementsByClassName('capitalize-first-word');
+
+              obj.forEach(function(item, i) {
+                  let a = obj[i],
+                      array = a.innerHTML.split(' ');
+
+                  // one word = do nothing
+                  if (array.length > 1) {
+                      // insert only first word to this tag
+                      a.innerHTML = array['0'];
+
+                      // create new span and insert it near
+                      array.splice(0, 1);
+                      let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+                      if (a.tagName === 'SPAN'){
+                          a.outerHTML += span;
+                      } else {
+                          a.innerHTML += span;
+                      }
+                  }
+              });
+          });
+      </script>
+
+      <span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? trans('backpack::crud.revisions') !!}.</small>
 
         @if ($crud->hasAccess('list'))

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -14,7 +14,33 @@
 @section('header')
 	<section class="container-fluid">
 	 <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+		 <script>
+			 document.addEventListener('DOMContentLoaded', function(){
+				 let obj = document.getElementsByClassName('capitalize-first-word');
+
+				 obj.forEach(function(item, i) {
+					 let a = obj[i],
+							 array = a.innerHTML.split(' ');
+
+					 // one word = do nothing
+					 if (array.length > 1) {
+						 // insert only first word to this tag
+						 a.innerHTML = array['0'];
+
+						 // create new span and insert it near
+						 array.splice(0, 1);
+						 let span = " <span style='text-transform: initial !important;'>" + array.join(' ') + "</span>";
+
+						 if (a.tagName === 'SPAN'){
+							 a.outerHTML += span;
+						 } else {
+							 a.innerHTML += span;
+						 }
+					 }
+				 });
+			 });
+		 </script>
+		 <span class="text-capitalize capitalize-first-word">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
         @if ($crud->hasAccess('list'))
           <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>


### PR DESCRIPTION
Hello, Cristian! Sorry for my English.
**Problem**: If the name of an entity consists of two or more words, each of them is capitalized in the title and breadcrumbs.
**Done**: If you apply the class "capitalize-first-word" to the span tag, the code will create another span next to it, because you cannot put span in span. If the tag is different from span, then write it inside it.
**Why not php?** Why spend server time on sticking, assembling strings? Let this one do the client machine. Loading base views is a very popular operation. 
Here is an example php code just in case:
```
$heading = $crud->getHeading() ?? $crud->entity_name_plural;
if (strpos($heading, " ")) {
    $exp = explode(" ", $heading, 2);
    $exp['0'] = '<span class="text-capitalize">'.$exp['0'].'</span>';
    $exp['1'] = '<span>'.$exp['1'].'</span>';
    $heading = implode(' ', $exp);
} else {
    $heading = '<span class="text-capitalize">'.$heading.'</span>';
}
```
I am very not sure if I placed the code in the right place, because we get 6 large pieces of duplicated code. I do not know where to put them, so that they work immediately on all pages. My commit is an idea. If you like this idea, please adjust my code and comments. I wrote them for you, not for production.
Thank you!