### PR TITLE
Parametrized project logo URL in header of dashboard

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -26,6 +26,9 @@ return [
     // Project name. Shown in the window title.
     'project_name' => 'Backpack Admin Panel',
 
+    // Project logo URL. Shown in the header.
+    'project_logo_url' => env('APP_URL') . '/admin',
+
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',
 

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -27,7 +27,7 @@ return [
     'project_name' => 'Backpack Admin Panel',
 
     // Project logo URL. Shown in the header.
-    'project_logo_url' => env('APP_URL') . '/admin',
+    'project_logo_url' => env('APP_URL').'/admin',
 
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',

--- a/src/resources/views/base/inc/main_header.blade.php
+++ b/src/resources/views/base/inc/main_header.blade.php
@@ -3,7 +3,7 @@
   <button class="navbar-toggler sidebar-toggler d-lg-none mr-auto" type="button" data-toggle="sidebar-show">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="{{ url('') }}">
+  <a class="navbar-brand" href="{{ config('backpack.base.project_logo_url') }}">
     {!! config('backpack.base.project_logo') !!}
   </a>
   <button class="navbar-toggler sidebar-toggler d-md-down-none" type="button" data-toggle="sidebar-lg-show">


### PR DESCRIPTION
As per issue #2289 creating this PR.

I also thought about some of the solutions mentioned [here](https://github.com/laravel/framework/issues/7671) but I am not sure if we should complicate it more.

This proposed solution is using APP_URL variable from .env.

We could also leave the url hardcoded, but I didn't liked that approach.