### PR TITLE
replace url helper in base.php config file

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -27,7 +27,7 @@ return [
     'project_name' => 'Backpack Admin Panel',
 
     // Project logo URL. Shown in the header.
-    'project_logo_url' => url(''),
+    'project_logo_url' => config('app.url'),
 
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',
@@ -74,8 +74,8 @@ return [
 
     // Horizontal navbar classes. Helps make the admin panel look similar to your project's design.
     'header_class' => 'app-header bg-light border-0 navbar',
-        // For background colors use: bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
-        // For links to be visible on different background colors use: "navbar-dark", "navbar-light", "navbar-color"
+    // For background colors use: bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
+    // For links to be visible on different background colors use: "navbar-dark", "navbar-light", "navbar-color"
 
     // ----
     // BODY
@@ -83,13 +83,13 @@ return [
 
     // Body element classes.
     'body_class' => 'app aside-menu-fixed sidebar-lg-show',
-        // Try sidebar-hidden, sidebar-fixed, sidebar-compact, sidebar-lg-show
+    // Try sidebar-hidden, sidebar-fixed, sidebar-compact, sidebar-lg-show
 
     // Sidebar element classes.
     'sidebar_class' => 'sidebar sidebar-pills bg-light',
-        // Remove "sidebar-transparent" for standard sidebar look
-        // Try "sidebar-light" or "sidebar-dark" for dark/light links
-        // You can also add a background class like bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
+    // Remove "sidebar-transparent" for standard sidebar look
+    // Try "sidebar-light" or "sidebar-dark" for dark/light links
+    // You can also add a background class like bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
 
     // ------
     // FOOTER
@@ -97,8 +97,8 @@ return [
 
     // Footer element classes.
     'footer_class' => 'app-footer',
-        // hide it with d-none
-        // change background color with bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
+    // hide it with d-none
+    // change background color with bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
 
     // Developer or company name. Shown in footer.
     'developer_name' => 'Cristian Tabacitu',
@@ -134,7 +134,7 @@ return [
     ],
 
     // JS files that are loaded in all pages, using Laravel's mix() helper
-    'mix_scripts' => [// file_path => manifest_directory_path
+    'mix_scripts' => [ // file_path => manifest_directory_path
         // 'js/app.js' => '',
     ],
 


### PR DESCRIPTION
Fixing a major bug.
Having the url() helper in a config file causes artisan to fail to execute any command!
So, I've replaced
'project_logo_url' => url(''),
with
'project_logo_url' => config('app.url'),
in src/config/backpack/base.php