### PR TITLE
handle showing fake fields values in the edit form

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -58,11 +58,11 @@ trait Update
                     }
 
                     // handle fake fields
-                } else if (!empty($field['fake'])) {
+                } elseif (! empty($field['fake'])) {
                     // determine the stored-in attribute
                     $fakeStoredInAttribute = $field['store_in'] ?? 'extras';
                     // check if the fake stored-in attribute exists
-                    if (!empty($entry->{$fakeStoredInAttribute})) {
+                    if (! empty($entry->{$fakeStoredInAttribute})) {
                         $fakeStoredInArray = $entry->{$fakeStoredInAttribute};
                         // check if it's a string, decode it
                         // otherwise, it should be an array
@@ -71,7 +71,7 @@ trait Update
                             $fakeStoredInArray = json_decode($fakeStoredInArray, true);
                         }
 
-                        if (!empty($fakeStoredInArray) && is_array($fakeStoredInArray) && isset($fakeStoredInArray[$field['name']])) {
++                        if (! empty($fakeStoredInArray) && is_array($fakeStoredInArray) && isset($fakeStoredInArray[$field['name']])) {
                             $field['value'] = $fakeStoredInArray[$field['name']];
                         }
                     }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -56,6 +56,25 @@ trait Update
                     foreach ($field['subfields'] as $subfield) {
                         $field['value'][] = $entry->{$subfield['name']};
                     }
+
+                    // handle fake fields
+                } else if (!empty($field['fake'])) {
+                    // determine the stored-in attribute
+                    $fakeStoredInAttribute = $field['store_in'] ?? 'extras';
+                    // check if the fake stored-in attribute exists
+                    if (!empty($entry->{$fakeStoredInAttribute})) {
+                        $fakeStoredInArray = $entry->{$fakeStoredInAttribute};
+                        // check if it's a string, decode it
+                        // otherwise, it should be an array
+                        if (is_string($fakeStoredInArray)) {
+                            // decode it
+                            $fakeStoredInArray = json_decode($fakeStoredInArray, true);
+                        }
+
+                        if (!empty($fakeStoredInArray) && is_array($fakeStoredInArray) && isset($fakeStoredInArray[$field['name']])) {
+                            $field['value'] = $fakeStoredInArray[$field['name']];
+                        }
+                    }
                 } else {
                     $field['value'] = $this->getModelAttributeValue($entry, $field);
                 }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -71,7 +71,7 @@ trait Update
                             $fakeStoredInArray = json_decode($fakeStoredInArray, true);
                         }
 
-+                        if (! empty($fakeStoredInArray) && is_array($fakeStoredInArray) && isset($fakeStoredInArray[$field['name']])) {
+                        if (! empty($fakeStoredInArray) && is_array($fakeStoredInArray) && isset($fakeStoredInArray[$field['name']])) {
                             $field['value'] = $fakeStoredInArray[$field['name']];
                         }
                     }


### PR DESCRIPTION
This change, which is not breaking, is necessary to show fake fields' values.
Works well with translatable attributes, as well.