### PR TITLE
Fix League\CommonMark\Converter::convertToHtml() must be of the type string, null given exception

### DIFF
--- a/src/resources/views/crud/columns/markdown.blade.php
+++ b/src/resources/views/crud/columns/markdown.blade.php
@@ -1,1 +1,1 @@
-{!! Illuminate\Mail\Markdown::parse($entry->{$column['name']}) !!}
+{!! Illuminate\Mail\Markdown::parse($entry->{$column['name']} ?? '') !!}


### PR DESCRIPTION
Laravel v6.10.0 switched to "league/commonmark instead of erusev/parsedown for mail markdown"

See: https://github.com/laravel/framework/pull/30982

league/commonmark doesn't accept null to the parse method. So this small update pass in an empty string if it is null.

Alternatively someone can make a PR at laravel/framework too to allow accepting null.