### PR TITLE
Fix a bug that caused backpack to crash when a field with an array of names and no label was defined

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -44,7 +44,8 @@ trait Fields
 
         // if the label is missing, we should set it
         if (! isset($newField['label'])) {
-            $newField['label'] = mb_ucfirst(str_replace('_', ' ', $newField['name']));
+            $label = is_array($newField['name']) ? $newField['name'][0] : $newField['name'];
+            $newField['label'] = mb_ucfirst(str_replace('_', ' ', $label));
         }
 
         // if the field type is missing, we should set it


### PR DESCRIPTION
This PR will fix a bug that causes backpack to give the following exception when defining a field with an array of names and no label.
```
        $this->crud->addField([
            'name' => ['icon', 'color_background', 'color_foreground'],
            'type' => 'style_selector',
            'upload' => true,
        ]);
```


`mb_strlen() expects parameter 1 to be string, array given`
