### PR TITLE
[4.0][FIX] Add Print Button to show page missing from 3.6

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -100,7 +100,7 @@ return [
     // ------
 
     // Footer element classes.
-    'footer_class' => 'app-footer',
+    'footer_class' => 'app-footer d-print-none',
     // hide it with d-none
     // change background color with bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
 

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -13,14 +13,14 @@
 
 @section('header')
 	<section class="container-fluid d-print-none">
-	 <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
-        @if ($crud->hasAccess('list'))
-          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        @endif
-        <a href="javascript: window.print();" class="float-right"><i class="fa fa-print"></i></a>
-     </h2>
+    	<a href="javascript: window.print();" class="btn float-right"><i class="fa fa-print"></i></a>
+		<h2>
+	        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+	        <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
+	        @if ($crud->hasAccess('list'))
+	          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+	        @endif
+	    </h2>
     </section>
 @endsection
 

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -12,13 +12,14 @@
 @endphp
 
 @section('header')
-	<section class="container-fluid">
+	<section class="container-fluid d-print-none">
 	 <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
         <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
         @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
         @endif
+        <a href="javascript: window.print();" class="float-right"><i class="fa fa-print"></i></a>
      </h2>
     </section>
 @endsection


### PR DESCRIPTION
Fixes: #2296 
This adds the simple print button in show page that we had before on 3.6. 

The class to hide elements from printing changed in BS 4 + to `d-print-none` 

I could not find in 3.6 any css specific to print with `@media print` query, maybe i missed or there isn't ? So I just hidden the same elements as in 3.6.

Best,
Pedro