### PR TITLE
[4.1][Feature] Add option to define custom messages in the delete button action

### DIFF
--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -47,9 +47,9 @@
 			          	// Show an error alert
 			              swal({
 			              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-			              	text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+                            text: result['error'] ? result['error'] : "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
 			              	icon: "error",
-			              	timer: 2000,
+			              	timer: 4000,
 			              	buttons: false,
 			              });
 			          } else {
@@ -78,7 +78,7 @@
 			          // Show an alert with the result
 			          swal({
 		              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-		              	text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+                        text: result['error'] ? result['error'] : "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
 		              	icon: "error",
 		              	timer: 4000,
 		              	buttons: false,


### PR DESCRIPTION
Right now when a delete action fails the user receives a generic error message. When overwriting the destroy action in the controller it sometimes is useful to inform the user why deleting something isn't possible. (For example because the item is still used somewhere). 

With this small PR change it will be possible to do this: 

```   
 public function destroy($id)
    {
        $categories = query;
        if (\count($categories) > 0) {
            return response(['error' => 'This layer cannot be deleted, because it is still in use!']);
        }
        return $this->crud->delete($id);
    }
```

This PR won't break existing things and will only show the custom message if its in the response.

Let me know what you guys think of this!