### PR TITLE
[4.0] Prevent SimpleMDE from auto-dowload FontAwesome

### DIFF
--- a/src/resources/views/crud/fields/simplemde.blade.php
+++ b/src/resources/views/crud/fields/simplemde.blade.php
@@ -53,8 +53,13 @@
 
                 configurationObject = Object.assign(configurationObject, simplemdeAttributes, simplemdeAttributesRaw);
 
+                //by default we prevent the loading of fontawesome
+                if(!configurationObject.autoDownloadFontAwesome) {
+                    configurationObject.autoDownloadFontAwesome = false;
+                }
+
                 var smdeObject = new SimpleMDE(configurationObject);
-            
+
                 smdeObject.options.minHeight = smdeObject.options.minHeight || "300px";
                 smdeObject.codemirror.getScrollerElement().style.minHeight = smdeObject.options.minHeight;
                 $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
Related: #2326 

By default simpleMDE will autoload font-awesome to use in toolbar icons. 

This prevents that from happening, but allow developer to overwrite it and force the use of font awesome. 

```
 $this->crud->addField([   // SimpleMDE
            'name'  => 'simplemde',
            'label' => 'SimpleMDE - markdown editor',
            'type'  => 'simplemde',
            'simplemdeAttributes' => [
                'autoDownloadFontAwesome' => true, // by default is false
            ],
           
        ]);
```