### PR TITLE
[4.1][Feature] JSON Editor Field Type

### DIFF
--- a/src/resources/views/crud/fields/json_editor.blade.php
+++ b/src/resources/views/crud/fields/json_editor.blade.php
@@ -55,7 +55,7 @@
                 const hiddenField = document.getElementById('{{ $field['name'] }}');
                 hiddenField.value = window['editor_{{ $field['name'] }}'].getText();
             },
-            modes: @json($modes ?? ['form', 'tree', 'code']),
+            modes: @json($field['modes'] ?? ['form', 'tree', 'code']),
         };
 
         window['editor_{{ $field['name'] }}'] = new JSONEditor(container, options, JSON.parse(jsonString));

--- a/src/resources/views/crud/fields/json_editor.blade.php
+++ b/src/resources/views/crud/fields/json_editor.blade.php
@@ -1,0 +1,64 @@
+{{-- json field based on: https://github.com/josdejong/jsoneditor --}}
+@php
+    $value = new stdClass();
+
+    if (old($field['name'])) {
+        $value = old($field['name']);
+    } elseif (isset($field['value']) && isset($field['default'])) {
+        $value = array_merge_recursive($field['default'], $field['value']);
+    } elseif (isset($field['value'])) {
+        $value = $field['value'];
+    } elseif (isset($field['default'])) {
+        $value = $field['default'];
+    }
+
+    // if attribute casting is used, convert to JSON
+    if (is_array($value) || is_object($value) ) {
+        $value = json_encode($value);
+    }
+@endphp
+
+@if ($crud->checkIfFieldIsFirstOfItsType($field, $fields))
+    @push('crud_fields_styles')
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/7.0.5/jsoneditor.min.css" />
+    @endpush
+
+    @push('crud_fields_scripts')
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/7.0.5/jsoneditor.min.js"></script>
+        <script>
+            let container, jsonString, options, editor;
+        </script>
+    @endpush
+@endif
+
+<div @include('crud::inc.field_wrapper_attributes') >
+    <label>{!! $field['label'] !!}</label>
+
+    <div id="jsoneditor-{{ $field['name'] }}" style="height: 400px;"></div>
+
+    <input type="hidden" id="{{ $field['name'] }}"
+           name="{{ $field['name'] }}"
+        @include('crud::inc.field_attributes') />
+
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+</div>
+
+@push('crud_fields_scripts')
+    <script>
+        container = document.getElementById('jsoneditor-{{ $field['name'] }}');
+        jsonString = @json($value);
+
+        options = {
+            onChange: function() {
+                const hiddenField = document.getElementById('{{ $field['name'] }}');
+                hiddenField.value = window['editor_{{ $field['name'] }}'].getText();
+            },
+            modes: @json($modes ?? ['form', 'tree', 'code']),
+        };
+
+        window['editor_{{ $field['name'] }}'] = new JSONEditor(container, options, JSON.parse(jsonString));
+        document.getElementById('{{ $field['name'] }}').value = window['editor_{{ $field['name'] }}'].getText();
+    </script>
+@endpush


### PR DESCRIPTION
Reopening of the JSON Editor Field in

https://github.com/Laravel-Backpack/CRUD/pull/1655

That was built by me and @vesper8 

Just added the ability to specify the allowed modes as well.

Brief Usage Instructions:

```php
[
     'name'  => 'column_name',
     'type'  => 'json_editor',
     'modes' => ['form', 'tree', 'code'] // Optional. 1st item in this array will be the default mode

    // Optional. default json value in php array style. If there is an actual value in the json column, it will do an array_merge_recursive. With the json column values replacing the 1s with the same keys
   // May need better docs to show an example.
    'default' => [] 
],
```

Also see: https://github.com/josdejong/jsoneditor

Feel free to make edits yourselves as needed. In the event if modes is not specified, I wonder if I should leave out 'code' in the default modes array.

Maybe somebody can use this widget to replace my simple backpack json column as well but in read only mode.

https://github.com/Laravel-Backpack/CRUD/blob/master/src/resources/views/crud/columns/json.blade.php

Enjoy!