### PR TITLE
[4.0][BUGFIX] select2_from_ajax send empty value for clear

### DIFF
--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -149,15 +149,6 @@
                 },
             });
 
-            // show a clear button if the column is nullable
-            if ($allowClear) {
-                element.on('select2:unselecting', function(e) {
-                    $(this).val('').trigger('change');
-                    // console.log('cleared! '+$(this).val());
-                    e.preventDefault();
-                });
-            }
-
             // if any dependencies have been declared
             // when one of those dependencies changes value
             // reset the select2 value


### PR DESCRIPTION
This is a fix for #2264 

Problem is that when using the `unselecting` event in the newest versions of select2 (4++) will cause the field to not be present in the request if cleared. 

This newer versions are able to post a `null` value on clear to reflect in database. No need to listen to the clear event.