### PR TITLE
[4.0][Bug fix] Do not publish elfinder files when chosen not to install file manager

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -128,15 +128,15 @@ class BackpackServiceProvider extends ServiceProvider
 
         // establish the minimum amount of files that need to be published, for Backpack to work; there are the files that will be published by the install command
         $minimum = array_merge(
-            $error_views,
             // $backpack_views,
-            $backpack_public_assets,
             // $backpack_lang_files,
+            // $elfinder_files,
+            $error_views,
+            $backpack_public_assets,
             $backpack_config_files,
             $backpack_menu_contents_view,
             $backpack_custom_routes_file,
-            $gravatar_assets,
-            $elfinder_files
+            $gravatar_assets
         );
 
         // register all possible publish commands and assign tags to each


### PR DESCRIPTION
A bug in the installation process made the elfinder files get published EVEN IF the user chose NOT to install the file manager. That's because the elfinder_files were included in the minimum stack.

This PR fixes it.