### PR TITLE
[4.0] Added fallback to select_from_array column

### DIFF
--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -11,7 +11,7 @@
 
                 foreach ($values as $key => $value) {
                     if (! is_null($value)) {
-                        $array_of_values[] = $column['options'][$value] ?? $values;
+                        $array_of_values[] = $column['options'][$value] ?? $value;
                     } else {
                         echo '-';
                         continue;

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -11,7 +11,7 @@
 
                 foreach ($values as $key => $value) {
                     if (! is_null($value)) {
-                        $array_of_values[] = $column['options'][$value];
+                        $array_of_values[] = $column['options'][$value] ?? $values;
                     } else {
                         echo '-';
                         continue;
@@ -24,7 +24,7 @@
                     echo array_first($array_of_values);
                 }
             } else {
-                echo $column['options'][$values];
+                echo $column['options'][$values] ?? $values;
             }
         } else {
             echo '-';


### PR DESCRIPTION
Fixes #2451

In case the value isn't found in the array, it just shows the value.

Ex: if ```xx``` is the value in the DB, but inside the options array there's no such thing as ```'xx' => 'Something'```, it'll just show the ```xx``` value.