### PR TITLE
[4.1.0][Refactoring] Split addColumns method into multiple smaller methods

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -4,6 +4,8 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 trait Columns
 {
+    use ColumnsProtectedMethods;
+
     // ------------
     // COLUMNS
     // ------------
@@ -62,64 +64,9 @@ trait Columns
      */
     public function addColumn($column)
     {
-        // if a string was passed, not an array, change it to an array
-        if (! is_array($column)) {
-            $column = ['name' => $column];
-        }
+        $column = $this->makeSureColumnHasNeededAttributes($column);
 
-        // make sure the column has a label
-        $column_with_details = $this->addDefaultLabel($column);
-
-        // make sure the column has a name
-        if (! array_key_exists('name', $column_with_details)) {
-            $column_with_details['name'] = 'anonymous_column_'.str_random(5);
-        }
-
-        // make sure the column has a type
-        if (! array_key_exists('type', $column_with_details)) {
-            $column_with_details['type'] = 'text';
-        }
-
-        // make sure the column has a key
-        if (! array_key_exists('key', $column_with_details)) {
-            $column_with_details['key'] = str_replace('.', '__', $column_with_details['name']);
-        }
-
-        // check if the column exists in the database table
-        $columnExistsInDb = $this->hasColumn($this->model->getTable(), $column_with_details['name']);
-
-        // make sure the column has a tableColumn boolean
-        if (! array_key_exists('tableColumn', $column_with_details)) {
-            $column_with_details['tableColumn'] = $columnExistsInDb ? true : false;
-        }
-
-        // make sure the column has a orderable boolean
-        if (! array_key_exists('orderable', $column_with_details)) {
-            $column_with_details['orderable'] = $columnExistsInDb ? true : false;
-        }
-
-        // make sure the column has a searchLogic
-        if (! array_key_exists('searchLogic', $column_with_details)) {
-            $column_with_details['searchLogic'] = $columnExistsInDb ? true : false;
-        }
-
-        $columnsArray = array_add($this->columns(), $column_with_details['key'], $column_with_details);
-        $this->setOperationSetting('columns', $columnsArray);
-
-        // make sure the column has a priority in terms of visibility
-        // if no priority has been defined, use the order in the array plus one
-        if (! array_key_exists('priority', $column_with_details)) {
-            $position_in_columns_array = (int) array_search($column_with_details['key'], array_keys($this->columns()));
-            $columnsArray[$column_with_details['key']]['priority'] = $position_in_columns_array + 1;
-        }
-
-        // if this is a relation type field and no corresponding model was specified, get it from the relation method
-        // defined in the main model
-        if (isset($column_with_details['entity']) && ! isset($column_with_details['model'])) {
-            $columnsArray[$column_with_details['key']]['model'] = $this->getRelationModel($column_with_details['entity']);
-        }
-
-        $this->setOperationSetting('columns', $columnsArray);
+        $this->addColumnToOperationSettings($column);
 
         return $this;
     }
@@ -174,32 +121,6 @@ trait Columns
     }
 
     /**
-     * Move the most recently added column before or after the given target column. Default is before.
-     *
-     * @param string|array $targetColumn The target column name or array.
-     * @param bool         $before       If true, the column will be moved before the target column, otherwise it will be moved after it.
-     */
-    private function moveColumn($targetColumn, $before = true)
-    {
-        // TODO: this and the moveField method from the Fields trait should be refactored into a single method and moved
-        //       into a common class
-        $targetColumnName = is_array($targetColumn) ? $targetColumn['name'] : $targetColumn;
-        $columnsArray = $this->columns();
-
-        if (array_key_exists($targetColumnName, $columnsArray)) {
-            $targetColumnPosition = $before ? array_search($targetColumnName, array_keys($columnsArray)) :
-                array_search($targetColumnName, array_keys($columnsArray)) + 1;
-
-            $element = array_pop($columnsArray);
-            $beginningPart = array_slice($columnsArray, 0, $targetColumnPosition, true);
-            $endingArrayPart = array_slice($columnsArray, $targetColumnPosition, null, true);
-
-            $columnsArray = array_merge($beginningPart, [$element['name'] => $element], $endingArrayPart);
-            $this->setOperationSetting('columns', $columnsArray);
-        }
-    }
-
-    /**
      * Add the default column type to the given Column, inferring the type from the database column type.
      *
      * @param array $column
@@ -215,25 +136,6 @@ trait Columns
         }
 
         return false;
-    }
-
-    /**
-     * If a field or column array is missing the "label" attribute, an ugly error would be show.
-     * So we add the field Name as a label - it's better than nothing.
-     *
-     * @param array $array
-     *
-     * @return array
-     */
-    public function addDefaultLabel($array)
-    {
-        if (! array_key_exists('label', (array) $array) && array_key_exists('name', (array) $array)) {
-            $array = array_merge(['label' => mb_ucfirst($this->makeLabel($array['name']))], $array);
-
-            return $array;
-        }
-
-        return $array;
     }
 
     /**
@@ -374,29 +276,6 @@ trait Columns
         $result = array_slice($this->columns(), $column_number, 1);
 
         return reset($result);
-    }
-
-    /**
-     * @param string $table
-     * @param string $name
-     *
-     * @return bool
-     */
-    protected function hasColumn($table, $name)
-    {
-        static $cache = [];
-
-        if ($this->driverIsMongoDb()) {
-            return true;
-        }
-
-        if (isset($cache[$table])) {
-            $columns = $cache[$table];
-        } else {
-            $columns = $cache[$table] = $this->getSchema()->getColumnListing($table);
-        }
-
-        return in_array($name, $columns);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
+
+trait ColumnsProtectedMethods
+{
+    /**
+     * The only REALLY MANDATORY attribute for a column is the 'name'.
+     * Everything else, Backpack can probably guess.
+     *
+     * This method checks that all necessary attributes are set.
+     * If not, it tries to guess them.
+     * 
+     * @param  string|array $column The column definition array OR column name as string.
+     * @return array                Proper column definition array.
+     */
+    protected function makeSureColumnHasNeededAttributes($column) {
+        $column = $this->makeSureColumnHasName($column);
+        $column = $this->makeSureColumnHasLabel($column);
+        $column = $this->makeSureColumnHasType($column);
+        $column = $this->makeSureColumnHasKey($column);
+        $column = $this->makeSureColumnHasModel($column);
+
+        // check if the column exists in the database (as a db column)
+        $columnExistsInDb = $this->hasColumn($this->model->getTable(), $column['name']);
+
+        // make sure column has tableColumn, orderable and searchLogic
+        $column['tableColumn'] = $column['tableColumn'] ?? $columnExistsInDb;
+        $column['orderable'] = $column['orderable'] ?? $columnExistsInDb;
+        $column['searchLogic'] = $column['searchLogic'] ?? $columnExistsInDb;
+
+        return $column;
+    }
+
+    /**
+     * Add a column to the current operation, using the Setting API.
+     * 
+     * @param array $column Column definition array.
+     */
+    protected function addColumnToOperationSettings($column) {
+        $allColumns = $this->columns();
+        $allColumns = array_add($allColumns, $column['key'], $column);
+
+        $this->setOperationSetting('columns', $allColumns);
+
+        // make sure the column has a priority in terms of visibility
+        // if no priority has been defined, use the order in the array plus one
+        if (! array_key_exists('priority', $column)) {
+            $position_in_columns_array = (int) array_search($column['key'], array_keys($this->columns()));
+            $allColumns[$column['key']]['priority'] = $position_in_columns_array + 1;
+        }
+
+        $this->setOperationSetting('columns', $allColumns);
+    }
+
+    /**
+     * If the field definition array is actually a string, it means the programmer was lazy
+     * and has only passed the name of the column. Turn that into a proper array.
+     * 
+     * @param array $column Column definition array.
+     * @return array         Proper array defining the column.
+     */
+    protected function makeSureColumnHasName($column)
+    {
+        if (is_string($column)) {
+            $column = ['name' => $column];
+        }
+
+        if (is_array($column) && !isset($column['name'])) {
+            $column['name'] = 'anonymous_column_'.str_random(5);
+        }
+
+        return $column;
+    }
+
+    /**
+     * If a column array is missing the "label" attribute, an ugly error would be show.
+     * So we add the field Name as a label - it's better than nothing.
+     *
+     * @param array     $array  Column definition array.
+     * @return array            Proper array defining the column.
+     */
+    protected function makeSureColumnHasLabel($column)
+    {
+        if (! isset($column['label'])) {
+            $column['label'] = mb_ucfirst($this->makeLabel($column['name']));
+        }
+
+        return $column;
+    }
+
+    /**
+     * If a column definition is missing the type, set a default.
+     * 
+     * @param array $column Column definition array.
+     * @return array        Column definition array with type.
+     */
+    protected function makeSureColumnHasType($column)
+    {
+        if (! isset($column['type'])) {
+            $column['type'] = 'text';
+        }
+
+        return $column;
+    }
+
+    /**
+     * If a column definition is missing the key, set the default.
+     * The key is used when storing all columns using the Settings API,
+     * it is used as the "key" of the associative array that holds all columns.
+     * 
+     * @param array $column Column definition array.
+     * @return array        Column definition array with key.
+     */
+    protected function makeSureColumnHasKey($column)
+    {
+        if (! isset($column['key'])) {
+            $column['key'] = str_replace('.', '__', $column['name']);
+        }
+
+        return $column;
+    }
+
+    /**
+     * If an entity has been defined for the column, but no model,
+     * determine the model from that relationship.
+     * 
+     * @param array $column Column definition array.
+     * @return array        Column definition array with model.
+     */
+    protected function makeSureColumnHasModel($column)
+    {
+        // if this is a relation type field and no corresponding model was specified, 
+        // get it from the relation method defined in the main model
+        if (isset($column['entity']) && ! isset($column['model'])) {
+            $column['model'] = $this->getRelationModel($column['entity']);
+        }
+
+        return $column;
+    }
+
+    /**
+     * Move the most recently added column before or after the given target column. Default is before.
+     *
+     * @param string|array $targetColumn The target column name or array.
+     * @param bool         $before       If true, the column will be moved before the target column, otherwise it will be moved after it.
+     */
+    protected function moveColumn($targetColumn, $before = true)
+    {
+        // TODO: this and the moveField method from the Fields trait should be refactored into a single method and moved
+        //       into a common class
+        $targetColumnName = is_array($targetColumn) ? $targetColumn['name'] : $targetColumn;
+        $columnsArray = $this->columns();
+
+        if (array_key_exists($targetColumnName, $columnsArray)) {
+            $targetColumnPosition = $before ? array_search($targetColumnName, array_keys($columnsArray)) :
+                array_search($targetColumnName, array_keys($columnsArray)) + 1;
+
+            $element = array_pop($columnsArray);
+            $beginningPart = array_slice($columnsArray, 0, $targetColumnPosition, true);
+            $endingArrayPart = array_slice($columnsArray, $targetColumnPosition, null, true);
+
+            $columnsArray = array_merge($beginningPart, [$element['name'] => $element], $endingArrayPart);
+            $this->setOperationSetting('columns', $columnsArray);
+        }
+    }
+
+    /**
+     * Check if the column exists in the database, as a DB column.
+     * 
+     * @param string $table
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function hasColumn($table, $name)
+    {
+        static $cache = [];
+
+        if ($this->driverIsMongoDb()) {
+            return true;
+        }
+
+        if (isset($cache[$table])) {
+            $columns = $cache[$table];
+        } else {
+            $columns = $cache[$table] = $this->getSchema()->getColumnListing($table);
+        }
+
+        return in_array($name, $columns);
+    }
+}

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -2,6 +2,9 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
 trait ColumnsProtectedMethods
 {
     /**
@@ -41,7 +44,7 @@ trait ColumnsProtectedMethods
     protected function addColumnToOperationSettings($column)
     {
         $allColumns = $this->columns();
-        $allColumns = array_add($allColumns, $column['key'], $column);
+        $allColumns = Arr::add($allColumns, $column['key'], $column);
 
         $this->setOperationSetting('columns', $allColumns);
 
@@ -69,7 +72,7 @@ trait ColumnsProtectedMethods
         }
 
         if (is_array($column) && ! isset($column['name'])) {
-            $column['name'] = 'anonymous_column_'.str_random(5);
+            $column['name'] = 'anonymous_column_'.Str::random(5);
         }
 
         return $column;
@@ -79,7 +82,7 @@ trait ColumnsProtectedMethods
      * If a column array is missing the "label" attribute, an ugly error would be show.
      * So we add the field Name as a label - it's better than nothing.
      *
-     * @param array     $array  Column definition array.
+     * @param array     $column  Column definition array.
      * @return array            Proper array defining the column.
      */
     protected function makeSureColumnHasLabel($column)

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -10,11 +10,12 @@ trait ColumnsProtectedMethods
      *
      * This method checks that all necessary attributes are set.
      * If not, it tries to guess them.
-     * 
+     *
      * @param  string|array $column The column definition array OR column name as string.
      * @return array                Proper column definition array.
      */
-    protected function makeSureColumnHasNeededAttributes($column) {
+    protected function makeSureColumnHasNeededAttributes($column)
+    {
         $column = $this->makeSureColumnHasName($column);
         $column = $this->makeSureColumnHasLabel($column);
         $column = $this->makeSureColumnHasType($column);
@@ -34,10 +35,11 @@ trait ColumnsProtectedMethods
 
     /**
      * Add a column to the current operation, using the Setting API.
-     * 
+     *
      * @param array $column Column definition array.
      */
-    protected function addColumnToOperationSettings($column) {
+    protected function addColumnToOperationSettings($column)
+    {
         $allColumns = $this->columns();
         $allColumns = array_add($allColumns, $column['key'], $column);
 
@@ -56,7 +58,7 @@ trait ColumnsProtectedMethods
     /**
      * If the field definition array is actually a string, it means the programmer was lazy
      * and has only passed the name of the column. Turn that into a proper array.
-     * 
+     *
      * @param array $column Column definition array.
      * @return array         Proper array defining the column.
      */
@@ -66,7 +68,7 @@ trait ColumnsProtectedMethods
             $column = ['name' => $column];
         }
 
-        if (is_array($column) && !isset($column['name'])) {
+        if (is_array($column) && ! isset($column['name'])) {
             $column['name'] = 'anonymous_column_'.str_random(5);
         }
 
@@ -91,7 +93,7 @@ trait ColumnsProtectedMethods
 
     /**
      * If a column definition is missing the type, set a default.
-     * 
+     *
      * @param array $column Column definition array.
      * @return array        Column definition array with type.
      */
@@ -108,7 +110,7 @@ trait ColumnsProtectedMethods
      * If a column definition is missing the key, set the default.
      * The key is used when storing all columns using the Settings API,
      * it is used as the "key" of the associative array that holds all columns.
-     * 
+     *
      * @param array $column Column definition array.
      * @return array        Column definition array with key.
      */
@@ -124,13 +126,13 @@ trait ColumnsProtectedMethods
     /**
      * If an entity has been defined for the column, but no model,
      * determine the model from that relationship.
-     * 
+     *
      * @param array $column Column definition array.
      * @return array        Column definition array with model.
      */
     protected function makeSureColumnHasModel($column)
     {
-        // if this is a relation type field and no corresponding model was specified, 
+        // if this is a relation type field and no corresponding model was specified,
         // get it from the relation method defined in the main model
         if (isset($column['entity']) && ! isset($column['model'])) {
             $column['model'] = $this->getRelationModel($column['entity']);
@@ -167,7 +169,7 @@ trait ColumnsProtectedMethods
 
     /**
      * Check if the column exists in the database, as a DB column.
-     * 
+     *
      * @param string $table
      * @param string $name
      *


### PR DESCRIPTION
In 4.0, ```Fields.php``` and ```Columns.php``` are the worst classes in terms of code quality. And that's primarily because of the ```addField()``` and ```addColumn()``` methods, that do A LOT of stuff.

![Screenshot 2020-02-20 at 11 49 48](https://user-images.githubusercontent.com/1032474/74922096-696c4a00-53d7-11ea-9ec6-f4d1b152572f.png)

This PR splits ```addColumn()``` into multiple smaller methods.

PS. The same thing is done for ```addField()``` in PR https://github.com/Laravel-Backpack/CRUD/pull/2311 . After merging both, I expect both classes to go from F to B, at least.