### PR TITLE
[4.0][Feature][Ready] Delete operation can respond with Notification Bubbles

### DIFF
--- a/src/resources/views/crud/buttons/bulk_delete.blade.php
+++ b/src/resources/views/crud/buttons/bulk_delete.blade.php
@@ -51,11 +51,34 @@
 						type: 'POST',
 						data: { entries: crud.checkedItems },
 						success: function(result) {
-						    // Show an alert with the result
-							new Noty({
-								type: "success",
-								text: "<strong>{!! trans('backpack::crud.bulk_delete_sucess_title') !!}</strong><br>"+crud.checkedItems.length+"{!! trans('backpack::crud.bulk_delete_sucess_message') !!}"
-							}).show();
+							if (Array.isArray(result)) {
+							  // Show a success notification bubble
+							  new Noty({
+							    type: "success",
+							    text: "<strong>{!! trans('backpack::crud.bulk_delete_sucess_title') !!}</strong><br>"+crud.checkedItems.length+"{!! trans('backpack::crud.bulk_delete_sucess_message') !!}"
+							  }).show();
+							} else {
+							  // if the result is an array, it means 
+							  // we have notification bubbles to show
+								  if (result instanceof Object) {
+								  	// trigger one or more bubble notifications 
+								  	Object.entries(result).forEach(function(entry, index) {
+								  	  var type = entry[0];
+								  	  entry[1].forEach(function(message, i) {
+								      	  new Noty({
+								            type: type,
+								            text: message
+								          }).show();
+								  	  });
+								  	});
+								  } else {
+								  	// Show a warning notification bubble
+									new Noty({
+										type: "warning",
+										text: "<strong>{!! trans('backpack::crud.bulk_delete_error_title') !!}</strong><br>{!! trans('backpack::crud.bulk_delete_error_message') !!}"
+									}).show();
+								  }			          	  
+							}
 
 						  	crud.checkedItems = [];
 							  	crud.table.ajax.reload();

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -43,24 +43,12 @@
 			      url: route,
 			      type: 'DELETE',
 			      success: function(result) {
-			          if (result != 1) {
-			          	// Show an error alert
-			              swal({
-			              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-                            text: result['error'] ? result['error'] : "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
-			              	icon: "error",
-			              	timer: 4000,
-			              	buttons: false,
-			              });
-			          } else {
-			          	  // Show a success message
-			              swal({
-			              	title: "{!! trans('backpack::crud.delete_confirmation_title') !!}",
-			              	text: "{!! trans('backpack::crud.delete_confirmation_message') !!}",
-			              	icon: "success",
-			              	timer: 4000,
-			              	buttons: false,
-			              });
+			          if (result == 1) {
+			          	  // Show a success notification bubble
+			              new Noty({
+		                    type: "success",
+		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
+		                  }).show();
 
 			              // Hide the modal, if any
 			              $('.modal').modal('hide');
@@ -72,13 +60,36 @@
 
 			              // Remove the row from the datatable
 			              row.remove();
+			          } else {
+			              // if the result is an array, it means 
+			              // we have notification bubbles to show
+			          	  if (result instanceof Object) {
+			          	  	// trigger one or more bubble notifications 
+			          	  	Object.entries(result).forEach(function(entry, index) {
+			          	  	  var type = entry[0];
+			          	  	  entry[1].forEach(function(message, i) {
+					          	  new Noty({
+				                    type: type,
+				                    text: message
+				                  }).show();
+			          	  	  });
+			          	  	});
+			          	  } else {// Show an error alert
+				              swal({
+				              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+	                            text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+				              	icon: "error",
+				              	timer: 4000,
+				              	buttons: false,
+				              });
+			          	  }			          	  
 			          }
 			      },
 			      error: function(result) {
 			          // Show an alert with the result
 			          swal({
 		              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-                        text: result['error'] ? result['error'] : "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+                        text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
 		              	icon: "error",
 		              	timer: 4000,
 		              	buttons: false,


### PR DESCRIPTION
Continues the work done in https://github.com/Laravel-Backpack/CRUD/pull/2393 which improves the Delete operation. This PR also adds the same new functionality to the BulkDelete operation.

Non-breaking change.

**You can now overwrite what notification bubbles are triggered by the Delete and BulkDelete operations, with the same ProloguePHP/Alerts syntax we use everywhere else.** 

For example, we can now do:
```php
    public function destroy($id)
    {
        if (true) {
            return \Alert::error("Entry could not be deleted because it's used by another entry.");
        }

        return $this->crud->delete($id);
    }
```

But you can also trigger MULTIPLE notification bubbles, by doing:
```php
    public function destroy($id)
    {
        if (true) {
            \Alert::info('something happened');
            \Alert::success('something good happened');
            \Alert::warning('something questionable has happened');
            \Alert::error('something bad has happened');

            return \Alert::getMessages();
        }

        return $this->crud->delete($id);
    }
```

The result will be:
![2020-02-24 11 33 14](https://user-images.githubusercontent.com/1032474/75141405-88c9e680-56f9-11ea-8138-3f392e813bff.gif)

Apart from the added functionality, this PR also does one more thing - it replaces the result of the Delete operation from a sweet-alert to a noty. That's because:
- we have a PHP+JS system to trigger noty notifications; we don't have that for sweet-alerts;
- it's easier to work with notys;
- I had a problem with using sweet-alert for this anyway - because it's such a big notification it needs to stay on the screen longer - about 4sec; which made it difficult to delete a lot of entries, one by one - you had to wait 4 sec between them; this is no longer a problem if we use noty, since they're a lot smaller;