### PR TITLE
[4.1][Feature][Ready] Setting to disable search inside list operation

### DIFF
--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -28,7 +28,7 @@ return [
             // stores pagination and filters in localStorage for two hours
             // whenever the user tries to see that page, backpack loads the previous pagination and filtration
             'persistentTable' => true,
-            
+
             // show search bar in the top-right corner?
             'searchableTable' => true,
 

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -28,6 +28,9 @@ return [
             // stores pagination and filters in localStorage for two hours
             // whenever the user tries to see that page, backpack loads the previous pagination and filtration
             'persistentTable' => true,
+            
+            // show search bar in the top-right corner?
+            'searchableTable' => true,
 
             // the time the table will be persisted in minutes
             // after this the table info is cleared from localStorage.

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -198,6 +198,7 @@
           },
           processing: true,
           serverSide: true,
+          searching: @json($crud->getOperationSetting('searchableTable') ?? true),
           ajax: {
               "url": "{!! url($crud->route.'/search').'?'.Request::getQueryString() !!}",
               "type": "POST"


### PR DESCRIPTION
After this PR gets merged, you can hide the search bar inside the List view:

A) For all CRUDs, using the ```config/backpack/crud.php``` file:
```php
        /*
         * List Operation
         */
        'list' => [
            // show search bar in the top-right corner?
            'searchableTable' => false,
         ],
```

B) For the current CRUD, inside a ```ProductCrudController```:
```php
public function setupListOperation() {
        // ...
        $this->setOperationSetting('searchableTable', false);
        // ...
}

// or 

public function setup()
{
        // ...
        $this->crud->operation('list', function () {
             $this->setOperationSetting('searchableTable', false);
        });
}
```