### PR TITLE
[4.1.x] date_range filter - allow passing custom options to JS plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 
 ### Fixed
 - updated npm dependencies;
+- CSS assets inside elFinder views;
 
 
 ## 4.0.41 - 2020-02-16


### PR DESCRIPTION
Build upon https://github.com/Laravel-Backpack/CRUD/pull/2489

Similar to how the ```date_range``` FIELD type works, it allows the developer to specify ```date_range_options``` on the filter, and those options overwrite the default ones.