### PR TITLE
fix Create/Update operation tabs functionality triggering big bad error because of Str::slug()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 
 -----------
 
+## 4.0.48 - 2020-03-06
+
+### Fixed
+- Create/Update operation tabs no longer worked because of Str::slug() helper;
+
+
 ## 4.0.47 - 2020-03-05
 
 ### Fixed

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -3,7 +3,7 @@
 {{-- See if we're using tabs --}}
 @if ($crud->tabsEnabled() && count($crud->getTabs()))
     @include('crud::inc.show_tabbed_fields')
-    <input type="hidden" name="current_tab" value="{{ str_slug($crud->getTabs()[0], "") }}" />
+    <input type="hidden" name="current_tab" value="{{ str_slug($crud->getTabs()[0]) }}" />
 @else
   <div class="card">
     <div class="card-body row">

--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -40,7 +40,13 @@
         <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'flex-column nav-pills'}} {{ $horizontalTabs ? '' : 'col-md-3' }}" role="tablist">
             @foreach ($crud->getTabs() as $k => $tab)
                 <li role="presentation" class="nav-item">
-                    <a href="#tab_{{ str_slug($tab, "") }}" aria-controls="tab_{{ str_slug($tab, "") }}" role="tab" tab_name="{{ str_slug($tab, "") }}" data-toggle="tab" class="nav-link {{ isset($tabWithError) ? ($tab == $tabWithError ? 'active' : '') : ($k == 0 ? 'active' : '') }}">{{ $tab }}</a>
+                    <a href="#tab_{{ str_slug($tab) }}" 
+                        aria-controls="tab_{{ str_slug($tab) }}" 
+                        role="tab" 
+                        tab_name="{{ str_slug($tab) }}" 
+                        data-toggle="tab" 
+                        class="nav-link {{ isset($tabWithError) ? ($tab == $tabWithError ? 'active' : '') : ($k == 0 ? 'active' : '') }}"
+                        >{{ $tab }}</a>
                 </li>
             @endforeach
         </ul>
@@ -48,7 +54,7 @@
         <div class="tab-content p-0 {{$horizontalTabs ? '' : 'col-md-9'}}">
 
             @foreach ($crud->getTabs() as $k => $tab)
-            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="tab_{{ str_slug($tab, "") }}">
+            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="tab_{{ str_slug($tab) }}">
 
                 <div class="row">
                 @include('crud::inc.show_fields', ['fields' => $crud->getTabFields($tab)])


### PR DESCRIPTION
Fixed by using the default "-" separator for slugs instead of the previously used "", which doesn't work any more.