### PR TITLE
[Bug] Fix php artisan backpack:version command

### DIFF
--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -30,13 +30,15 @@ class Version extends Command
     public function handle()
     {
         $this->comment('### PHP VERSION:');
-        $this->runConsoleCommand('php -v');
+        $this->runConsoleCommand(['php', '-v']);
 
         $this->comment('### LARAVEL VERSION:');
-        $this->runConsoleCommand('composer show | grep "laravel/framework"');
+        $this->line(\PackageVersions\Versions::getVersion('laravel/framework'));
+        $this->line('');
 
         $this->comment('### BACKPACK VERSION:');
-        $this->runConsoleCommand('composer show | grep "backpack"');
+        $this->line(\PackageVersions\Versions::getVersion('backpack/crud'));
+        $this->line('');
     }
 
     /**


### PR DESCRIPTION
fixes #2518 ```backpack:version``` command under new Symphony Process component was failing. It was receiving string instead of array.