### PR TITLE
[4.1][Merged] Remove deprecated helpers and dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "creativeorange/gravatar": "~1.0",
         "nesbot/carbon": "^2.14",
         "ocramius/package-versions": "^1.4",
-        "laravel/helpers": "^1.1",
         "doctrine/dbal": "^2.5",
         "venturecraft/revisionable": "1.*",
         "intervention/image": "^2.3",

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 
 class CrudController extends Controller
 {
@@ -92,7 +93,7 @@ class CrudController extends Controller
     protected function setupConfigurationForCurrentOperation()
     {
         $operationName = $this->crud->getCurrentOperation();
-        $setupClassName = 'setup'.studly_case($operationName).'Operation';
+        $setupClassName = 'setup'.Str::studly($operationName).'Operation';
 
         /*
          * FIRST, run all Operation Closures for this operation.

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -29,6 +29,7 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\Validation;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Views;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\ViewsAndRestoresRevisions;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Arr;
 
 class CrudPanel
 {
@@ -257,7 +258,7 @@ class CrudPanel
      */
     public function getFirstOfItsTypeInArray($type, $array)
     {
-        return array_first($array, function ($item) use ($type) {
+        return Arr::first($array, function ($item) use ($type) {
             return $item['type'] == $type;
         });
     }
@@ -360,7 +361,7 @@ class CrudPanel
     private function getRelationModelInstances($model, $relationString)
     {
         $relationArray = explode('.', $relationString);
-        $firstRelationName = array_first($relationArray);
+        $firstRelationName = Arr::first($relationArray);
         $relation = $model->{$firstRelationName};
 
         $results = [];

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -2,6 +2,9 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
 trait Columns
 {
     // ------------
@@ -72,7 +75,7 @@ trait Columns
 
         // make sure the column has a name
         if (! array_key_exists('name', $column_with_details)) {
-            $column_with_details['name'] = 'anonymous_column_'.str_random(5);
+            $column_with_details['name'] = 'anonymous_column_'.Str::random(5);
         }
 
         // make sure the column has a type
@@ -103,7 +106,7 @@ trait Columns
             $column_with_details['searchLogic'] = $columnExistsInDb ? true : false;
         }
 
-        $columnsArray = array_add($this->columns(), $column_with_details['key'], $column_with_details);
+        $columnsArray = Arr::add($this->columns(), $column_with_details['key'], $column_with_details);
         $this->setOperationSetting('columns', $columnsArray);
 
         // make sure the column has a priority in terms of visibility
@@ -244,7 +247,7 @@ trait Columns
     public function removeColumn($columnKey)
     {
         $columnsArray = $this->columns();
-        array_forget($columnsArray, $columnKey);
+        Arr::forget($columnsArray, $columnKey);
         $this->setOperationSetting('columns', $columnsArray);
     }
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Arr;
 
 trait Create
 {
@@ -26,8 +27,8 @@ trait Create
         $data = $this->compactFakeFields($data);
 
         // omit the n-n relationships when updating the eloquent item
-        $nn_relationships = array_pluck($this->getRelationFieldsWithPivot(), 'name');
-        $item = $this->model->create(array_except($data, $nn_relationships));
+        $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
+        $item = $this->model->create(Arr::except($data, $nn_relationships));
 
         // if there are any relationships available, also sync those
         $this->createRelations($item, $data);
@@ -81,7 +82,7 @@ trait Create
     {
         $all_relation_fields = $this->getRelationFields();
 
-        return array_where($all_relation_fields, function ($value, $key) {
+        return Arr::where($all_relation_fields, function ($value, $key) {
             return isset($value['pivot']) && $value['pivot'];
         });
     }
@@ -209,7 +210,7 @@ trait Create
             $attributeKey = $relationField['name'];
             if (array_key_exists($attributeKey, $data) && empty($relationField['pivot'])) {
                 $key = implode('.relations.', explode('.', $relationField['entity']));
-                $fieldData = array_get($relationData, 'relations.'.$key, []);
+                $fieldData = Arr::get($relationData, 'relations.'.$key, []);
 
                 if (! array_key_exists('model', $fieldData)) {
                     $fieldData['model'] = $relationField['model'];
@@ -221,7 +222,7 @@ trait Create
 
                 $fieldData['values'][$attributeKey] = $data[$attributeKey];
 
-                array_set($relationData, 'relations.'.$key, $fieldData);
+                Arr::set($relationData, 'relations.'.$key, $fieldData);
             }
         }
 

--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Support\Arr;
+
 trait FakeFields
 {
     /**
@@ -60,7 +62,7 @@ trait FakeFields
     private function addCompactedField(&$requestInput, $fakeFieldName, $fakeFieldKey)
     {
         $fakeField = $requestInput[$fakeFieldName];
-        array_pull($requestInput, $fakeFieldName); // remove the fake field from the request
+        Arr::pull($requestInput, $fakeFieldName); // remove the fake field from the request
 
         $requestInput[$fakeFieldKey][$fakeFieldName] = $fakeField;
     }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Support\Arr;
+
 trait Fields
 {
     // ------------
@@ -61,7 +63,7 @@ trait Fields
 
         $fields = $this->getOperationSetting('fields');
         $fieldKey = is_array($newField['name']) ? implode('_', $newField['name']) : $newField['name'];
-        $fields = array_add($this->fields(), $fieldKey, $newField);
+        $fields = Arr::add($this->fields(), $fieldKey, $newField);
         $this->setOperationSetting('fields', $fields);
 
         return $this;
@@ -143,7 +145,7 @@ trait Fields
     public function removeField($name)
     {
         $this->transformFields(function ($fields) use ($name) {
-            array_forget($fields, $name);
+            Arr::forget($fields, $name);
 
             return $fields;
         });
@@ -335,7 +337,7 @@ trait Fields
     public function hasUploadFields()
     {
         $fields = $this->getFields();
-        $upload_fields = array_where($fields, function ($value, $key) {
+        $upload_fields = Arr::where($fields, function ($value, $key) {
             return isset($value['upload']) && $value['upload'] == true;
         });
 
@@ -446,7 +448,7 @@ trait Fields
      */
     public function getAllFieldNames()
     {
-        return array_flatten(array_pluck($this->getCurrentFields(), 'name'));
+        return Arr::flatten(Arr::pluck($this->getCurrentFields(), 'name'));
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Support\Arr;
+
 /**
  * Key-value store for operations.
  */
@@ -55,7 +57,7 @@ trait Settings
      */
     public function settings()
     {
-        return array_sort($this->settings, function ($value, $key) {
+        return Arr::sort($this->settings, function ($value, $key) {
             return $key;
         });
     }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Support\Arr;
 
 trait Update
 {
@@ -29,8 +30,8 @@ trait Update
         $this->createRelations($item, $data);
 
         // omit the n-n relationships when updating the eloquent item
-        $nn_relationships = array_pluck($this->getRelationFieldsWithPivot(), 'name');
-        $data = array_except($data, $nn_relationships);
+        $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
+        $data = Arr::except($data, $nn_relationships);
         $updated = $item->update($data);
 
         return $item;

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\app\Models\Traits;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Traversable;
 
@@ -236,7 +237,7 @@ trait CrudTrait
         if ($files_to_clear) {
             foreach ($files_to_clear as $key => $filename) {
                 \Storage::disk($disk)->delete($filename);
-                $attribute_value = array_where($attribute_value, function ($value, $key) use ($filename) {
+                $attribute_value = Arr::where($attribute_value, function ($value, $key) use ($filename) {
                     return $value != $filename;
                 });
             }

--- a/src/app/Models/Traits/InheritsRelationsFromParentModel.php
+++ b/src/app/Models/Traits/InheritsRelationsFromParentModel.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Models\Traits;
 
+use Illuminate\Support\Str;
 use ReflectionClass;
 
 /**
@@ -40,7 +41,7 @@ trait InheritsRelationsFromParentModel
     public function getTable()
     {
         if (! isset($this->table)) {
-            return str_replace('\\', '', snake_case(str_plural(class_basename($this->getParentClass()))));
+            return str_replace('\\', '', Str::snake(Str::plural(class_basename($this->getParentClass()))));
         }
 
         return $this->table;
@@ -48,7 +49,7 @@ trait InheritsRelationsFromParentModel
 
     public function getForeignKey()
     {
-        return snake_case(class_basename($this->getParentClass())).'_'.$this->primaryKey;
+        return Str::snake(class_basename($this->getParentClass())).'_'.$this->primaryKey;
     }
 
     public function joiningTable($related, $instance = null)
@@ -57,8 +58,8 @@ trait InheritsRelationsFromParentModel
             ? (new $related())->getClassNameForRelationships()
             : class_basename($related);
         $models = [
-            snake_case($relatedClassName),
-            snake_case($this->getClassNameForRelationships()),
+            Str::snake($relatedClassName),
+            Str::snake($this->getClassNameForRelationships()),
         ];
         sort($models);
 

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Models\Traits\SpatieTranslatable;
 
+use Illuminate\Support\Arr;
 use Spatie\Translatable\HasTranslations as OriginalHasTranslations;
 
 trait HasTranslations
@@ -73,7 +74,7 @@ trait HasTranslations
     public static function create(array $attributes = [])
     {
         $locale = $attributes['locale'] ?? \App::getLocale();
-        $attributes = array_except($attributes, ['locale']);
+        $attributes = Arr::except($attributes, ['locale']);
         $non_translatable = [];
 
         $model = new static();
@@ -106,7 +107,7 @@ trait HasTranslations
         }
 
         $locale = $attributes['locale'] ?? \App::getLocale();
-        $attributes = array_except($attributes, ['locale']);
+        $attributes = Arr::except($attributes, ['locale']);
         $non_translatable = [];
 
         // do the actual saving

--- a/src/resources/error_views/layout.blade.php
+++ b/src/resources/error_views/layout.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_user() && (starts_with(\Request::path(), config('backpack.base.route_prefix'))) ? 'backpack::layouts.top_left' : 'backpack::layouts.plain')
+@extends(backpack_user() && (Str::startsWith(\Request::path(), config('backpack.base.route_prefix'))) ? 'backpack::layouts.top_left' : 'backpack::layouts.plain')
 {{-- show error using sidebar layout if looged in AND on an admin page; otherwise use a blank page --}}
 
 @php

--- a/src/resources/views/crud/columns/email.blade.php
+++ b/src/resources/views/crud/columns/email.blade.php
@@ -3,4 +3,4 @@
 	$value = data_get($entry, $column['name']);
 @endphp
 
-<span><a href="mailto:{{ $entry->{$column['name']} }}">{{ str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]") }}</a></span>
+<span><a href="mailto:{{ $entry->{$column['name']} }}">{{ Str::limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]") }}</a></span>

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -4,5 +4,5 @@
 @endphp
 
 <span>
-	{!! (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit($value, array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') !!}
+	{!! (array_key_exists('prefix', $column) ? $column['prefix'] : '').Str::limit($value, array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') !!}
 </span>

--- a/src/resources/views/crud/columns/model_function_attribute.blade.php
+++ b/src/resources/views/crud/columns/model_function_attribute.blade.php
@@ -9,5 +9,5 @@
 	}
 @endphp
 <span>
-	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit($value, array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}
+	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').Str::limit($value, array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}
 </span>

--- a/src/resources/views/crud/columns/phone.blade.php
+++ b/src/resources/views/crud/columns/phone.blade.php
@@ -2,4 +2,4 @@
 @php
 	$value = data_get($entry, $column['name']);
 @endphp
-<span><a href="tel:{{ $entry->{$column['name']} }}">{{ str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]") }}</a></span>
+<span><a href="tel:{{ $entry->{$column['name']} }}">{{ Str::limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]") }}</a></span>

--- a/src/resources/views/crud/columns/row_number.blade.php
+++ b/src/resources/views/crud/columns/row_number.blade.php
@@ -4,5 +4,5 @@
 @endphp
 
 <span>
-	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}
+	{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').Str::limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}
 </span>

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -3,7 +3,7 @@
     <?php
         $attributes = $crud->getModelAttributeFromRelation($entry, $column['entity'], $column['attribute']);
         if (count($attributes)) {
-            echo e(str_limit(strip_tags(implode(', ', $attributes)), array_key_exists('limit', $column) ? $column['limit'] : 40, '[...]'));
+            echo e(Str::limit(strip_tags(implode(', ', $attributes)), array_key_exists('limit', $column) ? $column['limit'] : 40, '[...]'));
         } else {
             echo '-';
         }

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -21,7 +21,7 @@
                 if (count($array_of_values) > 1) {
                     echo implode(', ', $array_of_values);
                 } else {
-                    echo array_first($array_of_values);
+                    echo Arr::first($array_of_values);
                 }
             } else {
                 echo $column['options'][$values] ?? $values;

--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -7,4 +7,4 @@
 	}
 @endphp
 
-<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').str_limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>
+<span>{{ (array_key_exists('prefix', $column) ? $column['prefix'] : '').Str::limit(strip_tags($value), array_key_exists('limit', $column) ? $column['limit'] : 40, "[...]").(array_key_exists('suffix', $column) ? $column['suffix'] : '') }}</span>

--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -1,10 +1,10 @@
 @php
-$multiple = array_get($field, 'multiple', true);
-$sortable = array_get($field, 'sortable', false);
+$multiple = Arr::get($field, 'multiple', true);
+$sortable = Arr::get($field, 'sortable', false);
 $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
 if (!$multiple && is_array($value)) {
-    $value = array_first($value);
+    $value = Arr::first($value);
 }
 
 if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-init-function']))

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -18,7 +18,7 @@
         style="width: 100%"
         data-init-function="bpFieldInitSelect2FromAjaxElement"
         data-column-nullable="{{ $entity_model::isColumnNullable($field['name'])?'true':'false' }}"
-        data-dependencies="{{ isset($field['dependencies'])?json_encode(array_wrap($field['dependencies'])): json_encode([]) }}"
+        data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-placeholder="{{ $field['placeholder'] }}"
         data-minimum-input-length="{{ $field['minimum_input_length'] }}"
         data-data-source="{{ $field['data_source'] }}"

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -17,7 +17,7 @@
         style="width: 100%"
         id="select2_ajax_multiple_{{ $field['name'] }}"
         data-init-function="bpFieldInitSelect2FromAjaxMultipleElement"
-        data-dependencies="{{ isset($field['dependencies'])?json_encode(array_wrap($field['dependencies'])): json_encode([]) }}"
+        data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-placeholder="{{ $field['placeholder'] }}"
         data-minimum-input-length="{{ $field['minimum_input_length'] }}"
         data-data-source="{{ $field['data_source'] }}"

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -18,12 +18,12 @@
     <div class="existing-file">
         @if (isset($field['disk']))
         @if (isset($field['temporary']))
-            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(array_get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
+            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->temporaryUrl(Arr::get($field, 'prefix', '').$field['value'], Carbon\Carbon::now()->addMinutes($field['temporary'])))) }}">
         @else
-            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(array_get($field, 'prefix', '').$field['value']))) }}">
+            <a target="_blank" href="{{ (asset(\Storage::disk($field['disk'])->url(Arr::get($field, 'prefix', '').$field['value']))) }}">
         @endif
         @else
-            <a target="_blank" href="{{ (asset(array_get($field, 'prefix', '').$field['value'])) }}">
+            <a target="_blank" href="{{ (asset(Arr::get($field, 'prefix', '').$field['value'])) }}">
         @endif
             {{ $field['value'] }}
         </a>

--- a/src/resources/views/crud/filters/date.blade.php
+++ b/src/resources/views/crud/filters/date.blade.php
@@ -11,13 +11,13 @@
 		          <span class="input-group-text"><i class="fa fa-calendar"></i></span>
 		        </div>
 		        <input class="form-control pull-right"
-		        		id="datepicker-{{ str_slug($filter->name) }}"
+		        		id="datepicker-{{ Str::slug($filter->name) }}"
 		        		type="text"
 						@if ($filter->currentValue)
 							value="{{ $filter->currentValue }}"
 						@endif
 		        		>
-		        <div class="input-group-append datepicker-{{ str_slug($filter->name) }}-clear-button">
+		        <div class="input-group-append datepicker-{{ Str::slug($filter->name) }}-clear-button">
 		          <a class="input-group-text" href=""><i class="fa fa-times"></i></a>
 		        </div>
 		    </div>
@@ -50,7 +50,7 @@
 	<script src="{{ asset('packages/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js') }}"></script>
   <script>
 		jQuery(document).ready(function($) {
-			var dateInput = $('#datepicker-{{ str_slug($filter->name) }}').datepicker({
+			var dateInput = $('#datepicker-{{ Str::slug($filter->name) }}').datepicker({
 				autoclose: true,
 				format: 'yyyy-mm-dd',
 				todayHighlight: true
@@ -87,18 +87,18 @@
 				}
 			});
 
-			$('li[filter-name={{ str_slug($filter->name) }}]').on('filter:clear', function(e) {
+			$('li[filter-name={{ Str::slug($filter->name) }}]').on('filter:clear', function(e) {
 				// console.log('date filter cleared');
 				$('li[filter-name={{ $filter->name }}]').removeClass('active');
-				$('#datepicker-{{ str_slug($filter->name) }}').datepicker('update', '');
-				$('#datepicker-{{ str_slug($filter->name) }}').trigger('changeDate');
+				$('#datepicker-{{ Str::slug($filter->name) }}').datepicker('update', '');
+				$('#datepicker-{{ Str::slug($filter->name) }}').trigger('changeDate');
 			});
 
 			// datepicker clear button
-			$(".datepicker-{{ str_slug($filter->name) }}-clear-button").click(function(e) {
+			$(".datepicker-{{ Str::slug($filter->name) }}-clear-button").click(function(e) {
 				e.preventDefault();
 
-				$('li[filter-name={{ str_slug($filter->name) }}]').trigger('filter:clear');
+				$('li[filter-name={{ Str::slug($filter->name) }}]').trigger('filter:clear');
 			})
 		});
   </script>

--- a/src/resources/views/crud/filters/date_range.blade.php
+++ b/src/resources/views/crud/filters/date_range.blade.php
@@ -11,7 +11,7 @@
 		          <span class="input-group-text"><i class="fa fa-calendar"></i></span>
 		        </div>
 		        <input class="form-control pull-right"
-		        		id="daterangepicker-{{ str_slug($filter->name) }}"
+		        		id="daterangepicker-{{ Str::slug($filter->name) }}"
 		        		type="text"
 		        		@if ($filter->currentValue)
 							@php
@@ -26,7 +26,7 @@
 					        placeholder="{{ $date_range }}"
 						@endif
 		        		>
-		        <div class="input-group-append daterangepicker-{{ str_slug($filter->name) }}-clear-button">
+		        <div class="input-group-append daterangepicker-{{ Str::slug($filter->name) }}-clear-button">
 		          <a class="input-group-text" href=""><i class="fa fa-times"></i></a>
 		        </div>
 		    </div>
@@ -62,7 +62,7 @@
 	<script type="text/javascript" src="{{ asset('packages/bootstrap-daterangepicker/daterangepicker.js') }}"></script>
   <script>
 
-  		function applyDateRangeFilter{{camel_case($filter->name)}}(start, end) {
+  		function applyDateRangeFilter{{Str::camel($filter->name)}}(start, end) {
   			if (start && end) {
   				var dates = {
 					'from': start.format('YYYY-MM-DD'),
@@ -98,7 +98,7 @@
   		}
 
 		jQuery(document).ready(function($) {
-			var dateRangeInput = $('#daterangepicker-{{ str_slug($filter->name) }}').daterangepicker({
+			var dateRangeInput = $('#daterangepicker-{{ Str::slug($filter->name) }}').daterangepicker({
 				timePicker: false,
 		        ranges: {
 		            'Today': [moment().startOf('day'), moment().endOf('day')],
@@ -117,7 +117,7 @@
 			});
 
 			dateRangeInput.on('apply.daterangepicker', function(ev, picker) {
-				applyDateRangeFilter{{camel_case($filter->name)}}(picker.startDate, picker.endDate);
+				applyDateRangeFilter{{Str::camel($filter->name)}}(picker.startDate, picker.endDate);
 			});
 
 			$('li[filter-name={{ $filter->name }}]').on('hide.bs.dropdown', function () {
@@ -132,9 +132,9 @@
 			});
 
 			// datepicker clear button
-			$(".daterangepicker-{{ str_slug($filter->name) }}-clear-button").click(function(e) {
+			$(".daterangepicker-{{ Str::slug($filter->name) }}-clear-button").click(function(e) {
 				e.preventDefault();
-				applyDateRangeFilter{{camel_case($filter->name)}}(null, null);
+				applyDateRangeFilter{{Str::camel($filter->name)}}(null, null);
 			})
 		});
   </script>

--- a/src/resources/views/crud/filters/range.blade.php
+++ b/src/resources/views/crud/filters/range.blade.php
@@ -38,7 +38,7 @@
 										placeholder = "max value"
 									@endif
 				        		>
-				        <div class="input-group-append range-filter-{{ str_slug($filter->name) }}-clear-button">
+				        <div class="input-group-append range-filter-{{ Str::slug($filter->name) }}-clear-button">
 				          <a class="input-group-text" href=""><i class="fa fa-times"></i></a>
 				        </div>
 				    </div>
@@ -116,10 +116,10 @@ END OF FILTER JAVSCRIPT CHECKLIST --}}
 			});
 
 			// range clear button
-			$(".range-filter-{{ str_slug($filter->name) }}-clear-button").click(function(e) {
+			$(".range-filter-{{ Str::slug($filter->name) }}-clear-button").click(function(e) {
 				e.preventDefault();
 
-				$('li[filter-name={{ str_slug($filter->name) }}]').trigger('filter:clear');
+				$('li[filter-name={{ Str::slug($filter->name) }}]').trigger('filter:clear');
 			})
 
 		});

--- a/src/resources/views/crud/filters/text.blade.php
+++ b/src/resources/views/crud/filters/text.blade.php
@@ -8,13 +8,13 @@
 		<div class="form-group backpack-filter mb-0">
 			<div class="input-group">
 		        <input class="form-control pull-right"
-		        		id="text-filter-{{ str_slug($filter->name) }}"
+		        		id="text-filter-{{ Str::slug($filter->name) }}"
 		        		type="text"
 						@if ($filter->currentValue)
 							value="{{ $filter->currentValue }}"
 						@endif
 		        		>
-		        <div class="input-group-append text-filter-{{ str_slug($filter->name) }}-clear-button">
+		        <div class="input-group-append text-filter-{{ Str::slug($filter->name) }}-clear-button">
 		          <a class="input-group-text" href=""><i class="fa fa-times"></i></a>
 		        </div>
 		    </div>
@@ -33,7 +33,7 @@
 	<!-- include select2 js-->
   <script>
 		jQuery(document).ready(function($) {
-			$('#text-filter-{{ str_slug($filter->name) }}').on('change', function(e) {
+			$('#text-filter-{{ Str::slug($filter->name) }}').on('change', function(e) {
 
 				var parameter = '{{ $filter->name }}';
 				var value = $(this).val();
@@ -58,18 +58,18 @@
 				}
 			});
 
-			$('li[filter-name={{ str_slug($filter->name) }}]').on('filter:clear', function(e) {
+			$('li[filter-name={{ Str::slug($filter->name) }}]').on('filter:clear', function(e) {
 				$('li[filter-name={{ $filter->name }}]').removeClass('active');
-				$('#text-filter-{{ str_slug($filter->name) }}').val('');
+				$('#text-filter-{{ Str::slug($filter->name) }}').val('');
 			});
 
 			// datepicker clear button
-			$(".text-filter-{{ str_slug($filter->name) }}-clear-button").click(function(e) {
+			$(".text-filter-{{ Str::slug($filter->name) }}-clear-button").click(function(e) {
 				e.preventDefault();
 
-				$('li[filter-name={{ str_slug($filter->name) }}]').trigger('filter:clear');
-				$('#text-filter-{{ str_slug($filter->name) }}').val('');
-				$('#text-filter-{{ str_slug($filter->name) }}').trigger('change');
+				$('li[filter-name={{ Str::slug($filter->name) }}]').trigger('filter:clear');
+				$('#text-filter-{{ Str::slug($filter->name) }}').val('');
+				$('#text-filter-{{ Str::slug($filter->name) }}').trigger('change');
 			})
 		});
   </script>

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -3,7 +3,7 @@
 {{-- See if we're using tabs --}}
 @if ($crud->tabsEnabled() && count($crud->getTabs()))
     @include('crud::inc.show_tabbed_fields')
-    <input type="hidden" name="current_tab" value="{{ str_slug($crud->getTabs()[0]) }}" />
+    <input type="hidden" name="current_tab" value="{{ Str::slug($crud->getTabs()[0]) }}" />
 @else
   <div class="card">
     <div class="card-body row">
@@ -85,7 +85,7 @@
       // Place the focus on the first element in the form
       @if( $crud->getAutoFocusOnFirstField() )
         @php
-          $focusField = array_first($fields, function($field) {
+          $focusField = Arr::first($fields, function($field) {
               return isset($field['auto_focus']) && $field['auto_focus'] == true;
           });
         @endphp

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -9,7 +9,7 @@
   <script>
     @if ($crud->getPersistentTable())
 
-        var saved_list_url = localStorage.getItem('{{ str_slug($crud->getRoute()) }}_list_url');
+        var saved_list_url = localStorage.getItem('{{ Str::slug($crud->getRoute()) }}_list_url');
 
         //check if saved url has any parameter or is empty after clearing filters.
 
@@ -30,7 +30,7 @@
         }
 
     @if($crud->getPersistentTableDuration())
-        var saved_list_url_time = localStorage.getItem('{{ str_slug($crud->getRoute()) }}_list_url_time');
+        var saved_list_url_time = localStorage.getItem('{{ Str::slug($crud->getRoute()) }}_list_url_time');
 
         if (saved_list_url_time) {
             var $current_date = new Date();
@@ -78,7 +78,7 @@
       updateUrl : function (new_url) {
         new_url = new_url.replace('/search', '');
         window.history.pushState({}, '', new_url);
-        localStorage.setItem('{{ str_slug($crud->getRoute()) }}_list_url', new_url);
+        localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url', new_url);
       },
       dataTableConfiguration: {
 
@@ -131,7 +131,7 @@
 
         stateSaveParams: function(settings, data) {
 
-            localStorage.setItem('{{ str_slug($crud->getRoute()) }}_list_url_time', data.time);
+            localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url_time', data.time);
 
             data.columns.forEach(function(item, index) {
                 var columnHeading = crud.table.columns().header()[index];
@@ -149,11 +149,11 @@
 
             //if the save time as expired we force datatabled to clear localStorage
             if($saved_time < $current_date) {
-                if (localStorage.getItem('{{ str_slug($crud->getRoute())}}_list_url')) {
-                    localStorage.removeItem('{{ str_slug($crud->getRoute()) }}_list_url');
+                if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url')) {
+                    localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url');
                 }
-                if (localStorage.getItem('{{ str_slug($crud->getRoute())}}_list_url_time')) {
-                    localStorage.removeItem('{{ str_slug($crud->getRoute()) }}_list_url_time');
+                if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url_time')) {
+                    localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url_time');
                 }
                return false;
             }

--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -40,10 +40,10 @@
         <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'flex-column nav-pills'}} {{ $horizontalTabs ? '' : 'col-md-3' }}" role="tablist">
             @foreach ($crud->getTabs() as $k => $tab)
                 <li role="presentation" class="nav-item">
-                    <a href="#tab_{{ str_slug($tab) }}" 
-                        aria-controls="tab_{{ str_slug($tab) }}" 
+                    <a href="#tab_{{ Str::slug($tab) }}" 
+                        aria-controls="tab_{{ Str::slug($tab) }}" 
                         role="tab" 
-                        tab_name="{{ str_slug($tab) }}" 
+                        tab_name="{{ Str::slug($tab) }}" 
                         data-toggle="tab" 
                         class="nav-link {{ isset($tabWithError) ? ($tab == $tabWithError ? 'active' : '') : ($k == 0 ? 'active' : '') }}"
                         >{{ $tab }}</a>
@@ -54,7 +54,7 @@
         <div class="tab-content p-0 {{$horizontalTabs ? '' : 'col-md-9'}}">
 
             @foreach ($crud->getTabs() as $k => $tab)
-            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="tab_{{ str_slug($tab) }}">
+            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="tab_{{ Str::slug($tab) }}">
 
                 <div class="row">
                 @include('crud::inc.show_fields', ['fields' => $crud->getTabFields($tab)])

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -5,6 +5,7 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 use Backpack\CRUD\Tests\Unit\Models\Article;
 use Backpack\CRUD\Tests\Unit\Models\User;
 use Faker\Factory;
+use Illuminate\Support\Arr;
 
 class CrudPanelCreateTest extends BaseDBCrudPanelTest
 {
@@ -171,7 +172,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         //       for relationship fields in the update fields.
         $relationFields = $this->crudPanel->getRelationFields('both');
 
-        $this->assertEquals($this->crudPanel->create_fields['roles'], array_last($relationFields));
+        $this->assertEquals($this->crudPanel->create_fields['roles'], Arr::last($relationFields));
     }
 
     public function testGetRelationFieldsCreateForm()
@@ -182,7 +183,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $relationFields = $this->crudPanel->getRelationFields();
 
-        $this->assertEquals($this->crudPanel->get('create.fields')['roles'], array_last($relationFields));
+        $this->assertEquals($this->crudPanel->get('create.fields')['roles'], Arr::last($relationFields));
     }
 
     public function testGetRelationFieldsUpdateForm()
@@ -193,7 +194,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $relationFields = $this->crudPanel->getRelationFields();
 
-        $this->assertEquals($this->crudPanel->get('update.fields')['roles'], array_last($relationFields));
+        $this->assertEquals($this->crudPanel->get('update.fields')['roles'], Arr::last($relationFields));
     }
 
     public function testGetRelationFieldsUnknownForm()
@@ -218,7 +219,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $relationFields = $this->crudPanel->getRelationFields();
 
-        $this->assertEquals($this->crudPanel->get('create.fields')['street'], array_last($relationFields));
+        $this->assertEquals($this->crudPanel->get('create.fields')['street'], Arr::last($relationFields));
     }
 
     public function testGetRelationFieldsNoRelations()
@@ -245,7 +246,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $relationFields = $this->crudPanel->getRelationFieldsWithPivot();
 
-        $this->assertEquals($this->crudPanel->get('create.fields')['roles'], array_last($relationFields));
+        $this->assertEquals($this->crudPanel->get('create.fields')['roles'], Arr::last($relationFields));
     }
 
     public function testGetRelationFieldsWithPivotNoRelations()

--- a/tests/Unit/CrudPanel/CrudPanelTabsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelTabsTest.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\Article;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 class CrudPanelTabsTest extends BaseDBCrudPanelTest
@@ -171,7 +172,7 @@ class CrudPanelTabsTest extends BaseDBCrudPanelTest
 
         $lastTab = $this->crudPanel->getLastTab();
 
-        $this->assertEquals(array_last($this->expectedTabNames), $lastTab);
+        $this->assertEquals(Arr::last($this->expectedTabNames), $lastTab);
     }
 
     public function testGetLastTabNoTabs()

--- a/tests/config/database/seeds/UsersTableSeeder.php
+++ b/tests/config/database/seeds/UsersTableSeeder.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class UsersTableSeeder extends Seeder
 {
@@ -20,7 +21,7 @@ class UsersTableSeeder extends Seeder
             'name'           => $faker->name,
             'email'          => $faker->safeEmail,
             'password'       => bcrypt('secret'),
-            'remember_token' => str_random(10),
+            'remember_token' => Str::random(10),
             'created_at'     => $now,
             'updated_at'     => $now,
         ]]);


### PR DESCRIPTION
This is the result of running a custom [Shift](https://laravelshift.com) script to convert the global helper functions to their equivalent `Str` and `Arr` class methods. These helper functions were deprecated in Laravel 5.8 and removed in Laravel 6.

---
Closes #2502