### PR TITLE
Change include_all_form_fields data attribute to explicitly output string true/false

### DIFF
--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -25,7 +25,7 @@
         data-method="{{ $field['method'] ?? 'GET' }}"
         data-field-attribute="{{ $field['attribute'] }}"
         data-connected-entity-key-name="{{ $connected_entity_key_name }}"
-        data-include-all-form-fields="{{ $field['include_all_form_fields'] ?? 'true' }}"
+        data-include-all-form-fields="{{ isset($field['include_all_form_fields']) ? ($field['include_all_form_fields'] ? 'true' : 'false') : 'true' }}"
         data-ajax-delay="{{ $field['delay'] }}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control'])
         >

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -24,7 +24,7 @@
         data-method="{{ $field['method'] ?? 'GET' }}"
         data-field-attribute="{{ $field['attribute'] }}"
         data-connected-entity-key-name="{{ $connected_entity_key_name }}"
-        data-include-all-form-fields="{{ $field['include_all_form_fields'] ?? 'true' }}"
+        data-include-all-form-fields="{{ isset($field['include_all_form_fields']) ? ($field['include_all_form_fields'] ? 'true' : 'false') : 'true' }}"
         data-ajax-delay="{{ $field['delay'] }}"
         @include('crud::inc.field_attributes', ['default_class' =>  'form-control'])
         multiple>


### PR DESCRIPTION
For select2_from_ajax and select2_from_ajax_multiple fields, setting include_all_form_fields to the boolean false (as shown in the docs) had the same effect as setting it to true, because it would output an empty string.

This PR changes the behavior to explicitly output a string 'true' or 'false' and fixes this issue.