### PR TITLE
[4.1] Clean up Request usage inside CrudController and CrudPanel

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -28,7 +28,7 @@ class CrudController extends Controller
         // ---------------------------
         // Used by developers inside their ProductCrudControllers as
         // $this->crud or using the CRUD facade.
-        //  
+        //
         // It's done inside a middleware closure in order to have
         // the complete request inside the CrudPanel object.
         $this->middleware(function ($request, $next) {

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
@@ -11,34 +12,22 @@ class CrudController extends Controller
 {
     use DispatchesJobs, ValidatesRequests;
 
-    public $data = [];
-    public $request;
-
     /**
      * @var \Backpack\CRUD\app\Library\CrudPanel\CrudPanel
      */
     public $crud;
+    public $data = [];
+    public $request;
 
-    public function __construct()
+    public function __construct(CrudPanel $crud, Request $request)
     {
-        if ($this->crud) {
-            return;
-        }
+        $this->request = $request;
+        $this->crud = $crud;
+        $this->crud->setRequest($request);
 
-        // call the setup function inside this closure to also have the request there
-        // this way, developers can use things stored in session (auth variables, etc)
-        $this->middleware(function ($request, $next) {
-            // make a new CrudPanel object, from the one stored in Laravel's service container
-            $this->crud = app()->make('crud');
-            // ensure crud has the latest request
-            $this->crud->setRequest($request);
-            $this->request = $request;
-            $this->setupDefaults();
-            $this->setup();
-            $this->setupConfigurationForCurrentOperation();
-
-            return $next($request);
-        });
+        $this->setupDefaults();
+        $this->setup();
+        $this->setupConfigurationForCurrentOperation();
     }
 
     /**

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
-use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
@@ -17,17 +16,31 @@ class CrudController extends Controller
      */
     public $crud;
     public $data = [];
-    public $request;
 
-    public function __construct(CrudPanel $crud, Request $request)
+    public function __construct()
     {
-        $this->request = $request;
-        $this->crud = $crud;
-        $this->crud->setRequest($request);
+        if ($this->crud) {
+            return;
+        }
 
-        $this->setupDefaults();
-        $this->setup();
-        $this->setupConfigurationForCurrentOperation();
+        // ---------------------------
+        // Create the CrudPanel object
+        // ---------------------------
+        // Used by developers inside their ProductCrudControllers as
+        // $this->crud or using the CRUD facade.
+        //  
+        // It's done inside a middleware closure in order to have
+        // the complete request inside the CrudPanel object.
+        $this->middleware(function ($request, $next) {
+            $this->crud = app()->make('crud');
+            $this->crud->setRequest($request);
+
+            $this->setupDefaults();
+            $this->setup();
+            $this->setupConfigurationForCurrentOperation();
+
+            return $next($request);
+        });
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -50,7 +50,7 @@ trait BulkCloneOperation
     {
         $this->crud->hasAccessOrFail('bulkClone');
 
-        $entries = $this->request->input('entries');
+        $entries = request()->input('entries');
         $clonedEntries = [];
 
         foreach ($entries as $key => $id) {

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -48,7 +48,7 @@ trait BulkDeleteOperation
     {
         $this->crud->hasAccessOrFail('bulkDelete');
 
-        $entries = $this->request->input('entries');
+        $entries = request()->input('entries');
         $deletedEntries = [];
 
         foreach ($entries as $key => $id) {

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -73,26 +73,26 @@ trait ListOperation
 
         $totalRows = $this->crud->model->count();
         $filteredRows = $this->crud->count();
-        $startIndex = $this->request->input('start') ?: 0;
+        $startIndex = request()->input('start') ?: 0;
         // if a search term was present
-        if ($this->request->input('search') && $this->request->input('search')['value']) {
+        if (request()->input('search') && request()->input('search')['value']) {
             // filter the results accordingly
-            $this->crud->applySearchTerm($this->request->input('search')['value']);
+            $this->crud->applySearchTerm(request()->input('search')['value']);
             // recalculate the number of filtered rows
             $filteredRows = $this->crud->count();
         }
         // start the results according to the datatables pagination
-        if ($this->request->input('start')) {
-            $this->crud->skip((int) $this->request->input('start'));
+        if (request()->input('start')) {
+            $this->crud->skip((int) request()->input('start'));
         }
         // limit the number of results according to the datatables pagination
-        if ($this->request->input('length')) {
-            $this->crud->take((int) $this->request->input('length'));
+        if (request()->input('length')) {
+            $this->crud->take((int) request()->input('length'));
         }
         // overwrite any order set in the setup() method with the datatables order
-        if ($this->request->input('order')) {
-            $column_number = $this->request->input('order')[0]['column'];
-            $column_direction = $this->request->input('order')[0]['dir'];
+        if (request()->input('order')) {
+            $column_number = request()->input('order')[0]['column'];
+            $column_direction = request()->input('order')[0]['dir'];
             $column = $this->crud->findColumnById($column_number);
             if ($column['tableColumn']) {
                 // clear any past orderBy rules

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -48,7 +48,7 @@ trait UpdateOperation
                 $this->crud->addField([
                     'name' => 'locale',
                     'type' => 'hidden',
-                    'value' => $this->request->input('locale') ?? app()->getLocale(),
+                    'value' => request()->input('locale') ?? app()->getLocale(),
                 ]);
             }
         });

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -51,6 +51,8 @@ class CrudPanel
 
     public $entry;
 
+    protected $request;
+
     // The following methods are used in CrudController or your EntityCrudController to manipulate the variables above.
 
     public function __construct()
@@ -69,10 +71,16 @@ class CrudPanel
      */
     public function setRequest($request = null)
     {
-        if (! $request) {
-            $request = \Request::instance();
-        }
-        $this->request = $request;
+        $this->request = $request ?? \Request::instance();
+    }
+
+    /**
+     * [getRequest description]
+     * @return [type] [description]
+     */
+    public function getRequest()
+    {
+        return $this->request;
     }
 
     // ------------------------------------------------------
@@ -205,7 +213,7 @@ class CrudPanel
      */
     public function getAction()
     {
-        return $this->request->route()->getAction();
+        return $this->getRequest()->route()->getAction();
     }
 
     /**
@@ -216,7 +224,7 @@ class CrudPanel
      */
     public function getActionName()
     {
-        return $this->request->route()->getActionName();
+        return $this->getRequest()->route()->getActionName();
     }
 
     /**
@@ -227,7 +235,7 @@ class CrudPanel
      */
     public function getActionMethod()
     {
-        return $this->request->route()->getActionMethod();
+        return $this->getRequest()->route()->getActionMethod();
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -75,7 +75,7 @@ class CrudPanel
     }
 
     /**
-     * [getRequest description]
+     * [getRequest description].
      * @return [type] [description]
      */
     public function getRequest()

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -458,13 +458,13 @@ trait Fields
         $setting = $this->getOperationSetting('saveAllInputsExcept');
 
         if ($setting == false || $setting == null) {
-            return $this->request->only($this->getAllFieldNames());
+            return $this->getRequest()->only($this->getAllFieldNames());
         }
 
         if (is_array($setting)) {
-            return $this->request->except($this->getOperationSetting('saveAllInputsExcept'));
+            return $this->getRequest()->except($this->getOperationSetting('saveAllInputsExcept'));
         }
 
-        return $this->request->only($this->getAllFieldNames());
+        return $this->getRequest()->only($this->getAllFieldNames());
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -86,7 +86,7 @@ trait Filters
             $input = new ParameterBag($input);
         }
 
-        $input = $input ?? new ParameterBag($this->request->all());
+        $input = $input ?? new ParameterBag($this->getRequest()->all());
 
         if ($input->has($filter->options['name'])) {
             // if a closure was passed as "filterLogic"
@@ -112,7 +112,7 @@ trait Filters
      */
     public function addDefaultFilterLogic($name, $operator, $input = null)
     {
-        $input = $input ?? $this->request->all();
+        $input = $input ?? $this->getRequest()->all();
 
         // if this filter is active (the URL has it as a GET parameter)
         switch ($operator) {

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -5,7 +5,6 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 trait Query
 {
     public $query;
-    public $request;
 
     // ----------------
     // ADVANCED QUERIES
@@ -54,7 +53,7 @@ trait Query
      */
     public function orderBy($field, $order = 'asc')
     {
-        if ($this->request->has('order')) {
+        if ($this->getRequest()->has('order')) {
             return $this->query;
         }
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -22,7 +22,7 @@ trait Read
 
         return  // use the entity name to get the current entry
                 // this makes sure the ID is corrent even for nested resources
-                $this->request->input($this->entity_name) ??
+                $this->getRequest()->input($this->entity_name) ??
                 // otherwise use the next to last parameter
                 array_values($params)[count($params) - 1] ??
                 // otherwise return false

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -118,7 +118,7 @@ trait SaveActions
         }
 
         // if the request is AJAX, return a JSON response
-        if ($this->request->ajax()) {
+        if ($this->getRequest()->ajax()) {
             return [
                 'success'      => true,
                 'data'         => $this->entry,

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -319,7 +319,7 @@ trait Search
         }
 
         return [
-            'draw'            => (isset($this->request['draw']) ? (int) $this->request['draw'] : 0),
+            'draw'            => (isset($this->getRequest()['draw']) ? (int) $this->getRequest()['draw'] : 0),
             'recordsTotal'    => $totalRows,
             'recordsFiltered' => $filteredRows,
             'data'            => $rows,

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -70,7 +70,7 @@ trait Validation
             // because form requests implement ValidatesWhenResolved
             $request = app($formRequest);
         } else {
-            $request = $this->request;
+            $request = $this->getRequest();
         }
 
         return $request;

--- a/src/resources/views/crud/buttons/clone.blade.php
+++ b/src/resources/views/crud/buttons/clone.blade.php
@@ -5,7 +5,7 @@
 {{-- Button Javascript --}}
 {{-- - used right away in AJAX operations (ex: List) --}}
 {{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
-@push('after_scripts') @if ($crud->request->ajax()) @endpush @endif
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
 <script>
 	if (typeof cloneEntry != 'function') {
 	  $("[data-button-type=clone]").unbind('click');
@@ -47,4 +47,4 @@
 	// make it so that the function above is run after each DataTable draw event
 	// crud.addFunctionToDataTablesDrawEventQueue('cloneEntry');
 </script>
-@if (!$crud->request->ajax()) @endpush @endif
+@if (!request()->ajax()) @endpush @endif

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -5,7 +5,7 @@
 {{-- Button Javascript --}}
 {{-- - used right away in AJAX operations (ex: List) --}}
 {{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
-@push('after_scripts') @if ($crud->request->ajax()) @endpush @endif
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
 <script>
 
 	if (typeof deleteEntry != 'function') {
@@ -105,4 +105,4 @@
 	// make it so that the function above is run after each DataTable draw event
 	// crud.addFunctionToDataTablesDrawEventQueue('deleteEntry');
 </script>
-@if (!$crud->request->ajax()) @endpush @endif
+@if (!request()->ajax()) @endpush @endif

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -45,7 +45,7 @@
 		    	<!-- Single button -->
 				<div class="btn-group">
 				  <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[$crud->request->input('locale')?$crud->request->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
+				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('locale')?request()->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
 				  </button>
 				  <ul class="dropdown-menu">
 				  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -36,7 +36,7 @@
 				<!-- Change translation button group -->
 				<div class="btn-group float-right">
 				  <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[$crud->request->input('locale')?$crud->request->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
+				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('locale')?request()->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
 				  </button>
 				  <ul class="dropdown-menu">
 				  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)

--- a/tests/Unit/Http/CrudControllerTest.php
+++ b/tests/Unit/Http/CrudControllerTest.php
@@ -17,8 +17,10 @@ class CrudControllerTest extends BaseTest
     {
         parent::getEnvironmentSetUp($app);
         $controller = '\Backpack\CRUD\Tests\Unit\Http\Controllers\UserCrudController';
+
         $app['router']->get('users/{id}/edit', "$controller@edit");
         $app['router']->put('users/{id}', "$controller@update");
+
         $app->singleton('crud', function ($app) {
             return new CrudPanel($app);
         });
@@ -26,18 +28,23 @@ class CrudControllerTest extends BaseTest
 
     public function testCrudRequestUpdatesOnEachRequest()
     {
-        $app = $this->app;
+        $crud = app('crud');
 
-        $firstRequest = $app->get('request')->create('/users/1/edit', 'GET');
-        $app->handle($firstRequest);
+        // create a first request
+        $firstRequest = request()->create('/users/1/edit', 'GET');
+        app()->handle($firstRequest);
 
-        $this->assertSame($app->get('crud')->request, $firstRequest);
+        // see if the first global request has been passed to the CRUD object
+        $this->assertSame($crud->getRequest(), $firstRequest);
 
-        $secondRequest = $app->get('request')->create('/users/1', 'PUT', ['name' => 'foo']);
-        $app->handle($secondRequest);
+        // create a second request
+        $secondRequest = request()->create('/users/1', 'PUT', ['name' => 'foo']);
+        app()->handle($secondRequest);
 
-        $this->assertSame($app->get('crud')->request, $secondRequest);
+        // see if the second global requesst has been passed to the CRUD object
+        $this->assertSame($crud->getRequest(), $secondRequest);
 
-        $this->assertNotSame($app->get('crud')->request, $firstRequest);
+        // the CRUD object's request should no longer hold the first request, but the second one
+        $this->assertNotSame($crud->getRequest(), $firstRequest);
     }
 }


### PR DESCRIPTION
In Backpack 4.0, when working inside a ```ProductCrudController``` we had:
- ```$this->request```
- ```$this->crud->request```

which is superfluous and confusing, since:
- ```$this->request``` never gets overwritten, and is unavailable inside the CrudPanel object; so it's the same exact thing like using Laravel's ```request()``` helper - which I'd argue is cleaner and more intuitive (it looks like a global object); so let's use ```request()``` instead of ```$this->request``` which does nothing extra;
- ```$this->crud->request``` has a setter (```$this->crud->setRequest()```), but no getter - it's used as a property, which makes it difficult to change what it does;

### Needs to be documented

- [x] inside your ```ProductCrudController```s, if you're using ```$this->request```, please replace it with ```request()```; that CrudController property is no longer available, since it basically did the same thing as ```request()```;
- [ ] inside your ```ProductCrudController```s, if you're using ```$this->crud->request```, please replace it with its setter or getter (```$this->crud->getRequest()``` or ```$this->crud->setRequest()```); the property is now protected;