### PR TITLE
[4.0] Make sure routes can be generated even if developer uses phpcbf; don't generate route and sidebar item if it already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All Notable changes to `Backpack CRUD` will be documented in this file.
 
 -----------
 
+## 4.0.53 - 2020-03-10
+
+### Fixed
+- #2532 during installation, the published elFinder menu item had its quotes doubled;
+
+
 ## 4.0.52 - 2020-03-09
 
 ### Fixed

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -51,6 +51,12 @@ class AddCustomRouteContent extends Command
 
             // insert the given code before the file's last line
             $file_lines = file($old_file_path, FILE_IGNORE_NEW_LINES);
+
+            // if the code already exists in the file, abort
+            if ($this->getLastLineNumberThatContains($code, $file_lines)) {
+                return $this->info('Route already exists!');
+            }
+
             $end_line_number = $this->customRoutesFileEndLine($file_lines);
             $file_lines[$end_line_number + 1] = $file_lines[$end_line_number];
             $file_lines[$end_line_number] = '    '.$code;

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -62,13 +62,12 @@ class AddSidebarContent extends Command
         }
     }
 
-
     /**
      * Parse the given file stream and return the line number where a string is found.
-     * 
+     *
      * @param  string $needle   The string that's being searched for.
      * @param  array $haystack  The file where the search is being performed.
-     * @return bool|int         The last line number where the string was found. Or false.              
+     * @return bool|int         The last line number where the string was found. Or false.
      */
     private function getLastLineNumberThatContains($needle, $haystack)
     {

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -45,7 +45,12 @@ class AddSidebarContent extends Command
         $code = $this->argument('code');
 
         if ($disk->exists($path)) {
-            $contents = Storage::disk($disk_name)->get($path);
+            $contents = $disk->get($path);
+            $file_lines = file($disk->path($path), FILE_IGNORE_NEW_LINES);
+
+            if ($this->getLastLineNumberThatContains($code, $file_lines)) {
+                return $this->info('Sidebar item already exists!');
+            }
 
             if ($disk->put($path, $contents.PHP_EOL.$code)) {
                 $this->info('Successfully added code to sidebar_content file.');
@@ -55,5 +60,26 @@ class AddSidebarContent extends Command
         } else {
             $this->error('The sidebar_content file does not exist. Make sure Backpack is properly installed.');
         }
+    }
+
+
+    /**
+     * Parse the given file stream and return the line number where a string is found.
+     * 
+     * @param  string $needle   The string that's being searched for.
+     * @param  array $haystack  The file where the search is being performed.
+     * @return bool|int         The last line number where the string was found. Or false.              
+     */
+    private function getLastLineNumberThatContains($needle, $haystack)
+    {
+        $matchingLines = array_filter($haystack, function ($k) use ($needle) {
+            return strpos($k, $needle) !== false;
+        });
+
+        if ($matchingLines) {
+            return array_key_last($matchingLines);
+        }
+
+        return false;
     }
 }

--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -10,5 +10,7 @@ Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
     'middleware' => ['web', config('backpack.base.middleware_key', 'admin')],
     'namespace'  => 'App\Http\Controllers\Admin',
-], function () { // custom admin routes
+], function () {
+	// beginning of generated Backpack routes;
+	// end of generated Backpack routes; DO NOT delete or modify this comment;
 }); // this should be the absolute last line of this file


### PR DESCRIPTION
Fixes #2536

Makes the route generator check for these line contents, in this order, and places the route BEFORE that line:
- ```// end of generated Backpack routes; DO NOT delete or modify this comment;```
- ```}); // this should be the absolute last line of this file```
- ```});```
- nothing?! then the last line of the file - 1;
- no lines?! ok, then return 0;

In addition:
- it checks that the route doesn't exist before writing content;
- sidebar also checks that it doesn't exist before writing content;

Now if you're trying to generate a CRUD that already exists, the end result is similar with the model, view, controller:

<img width="452" alt="Screenshot 2020-03-11 at 12 31 08" src="https://user-images.githubusercontent.com/1032474/76407560-3690f280-6394-11ea-9609-2d2c6925ccfb.png">
