### PR TITLE
[4.1][BugFix] Fix widget assets loading

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -27,13 +27,14 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\Tabs;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Update;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Validation;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Views;
+use Backpack\CRUD\app\Library\CrudPanel\Traits\Widgets;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\ViewsAndRestoresRevisions;
 use Illuminate\Database\Eloquent\Collection;
 
 class CrudPanel
 {
     // load all the default CrudPanel features
-    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings;
+    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, ViewsAndRestoresRevisions, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Widgets;
     // allow developers to add their own closures to this object
     use Macroable;
 

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -27,8 +27,8 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\Tabs;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Update;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Validation;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Views;
-use Backpack\CRUD\app\Library\CrudPanel\Traits\Widgets;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\ViewsAndRestoresRevisions;
+use Backpack\CRUD\app\Library\CrudPanel\Traits\Widgets;
 use Illuminate\Database\Eloquent\Collection;
 
 class CrudPanel

--- a/src/app/Library/CrudPanel/Traits/Widgets.php
+++ b/src/app/Library/CrudPanel/Traits/Widgets.php
@@ -36,8 +36,8 @@ trait Widgets
         return $widgetType;
     }
 
-     /**
-     * Set an array of widget type names as already loaded
+    /**
+     * Set an array of widget type names as already loaded.
      *
      * @param array $fieldTypes
      */
@@ -66,6 +66,4 @@ trait Widgets
     {
         return in_array($this->getWidgetTypeWithNamespace($widget), $this->getLoadedWidgetTypes());
     }
-
-
 }

--- a/src/app/Library/CrudPanel/Traits/Widgets.php
+++ b/src/app/Library/CrudPanel/Traits/Widgets.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
+
+trait Widgets
+{
+    /**
+     * Mark widget type as loaded.
+     *
+     * @param string $widget Widget array
+     * @return  bool Successful operation true/false.
+     */
+    public function markWidgetTypeAsLoaded($widget)
+    {
+        $alreadyLoaded = $this->getLoadedWidgetTypes();
+        $type = $this->getWidgetTypeWithNamespace($widget);
+
+        if (! in_array($type, $this->getLoadedWidgetTypes(), true)) {
+            $alreadyLoaded[] = $type;
+            $this->setLoadedWidgetTypes($alreadyLoaded);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getWidgetTypeWithNamespace($widget)
+    {
+        $widgetType = $widget['type'];
+
+        if (isset($widget['view_namespace'])) {
+            $widgetType = implode('.', [$widget['view_namespace'], $widget['type']]);
+        }
+
+        return $widgetType;
+    }
+
+     /**
+     * Set an array of widget type names as already loaded
+     *
+     * @param array $fieldTypes
+     */
+    public function setLoadedWidgetTypes($fieldTypes)
+    {
+        $this->set('widgets.loadedWidgetTypes', $fieldTypes);
+    }
+
+    /**
+     * Get all the widget types whose resources (JS and CSS) have already been loaded on page.
+     *
+     * @return array Array with the names of the widget types.
+     */
+    public function getLoadedWidgetTypes()
+    {
+        return $this->get('widgets.loadedWidgetTypes') ?? [];
+    }
+
+    /**
+     * Check if a widget type's reasources (CSS and JS) have already been loaded.
+     *
+     * @param string $widget Field array
+     * @return  bool Whether the widget type has been marked as loaded.
+     */
+    public function widgetTypeLoaded($widget)
+    {
+        return in_array($this->getWidgetTypeWithNamespace($widget), $this->getLoadedWidgetTypes());
+    }
+
+
+}

--- a/src/resources/views/base/inc/widgets.blade.php
+++ b/src/resources/views/base/inc/widgets.blade.php
@@ -1,11 +1,12 @@
 @if (!empty($widgets))
-	@foreach ($widgets as $widget)
-
+    @foreach ($widgets as $widget)
 		@if (isset($widget['viewNamespace']))
 			@include($widgetsViewNamespace.'.'.$widget['type'], ['widget' => $widget])
 		@else
 			@include(backpack_view('widgets.'.$widget['type']), ['widget' => $widget])
 		@endif
-
+        @if(!CRUD::widgetTypeLoaded($widget))
+            @php(CRUD::markWidgetTypeAsLoaded($widget))
+        @endif
 	@endforeach
 @endif

--- a/src/resources/views/base/widgets/alert.blade.php
+++ b/src/resources/views/base/widgets/alert.blade.php
@@ -1,6 +1,6 @@
 <div class="{{ $widget['class'] ?? 'alert alert-primary' }}" role="alert">
 
-	@if (isset($widget['close_button']) && $widget['close_button'])	
+	@if (isset($widget['close_button']) && $widget['close_button'])
 	<button class="close" type="button" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
 	@endif
 
@@ -13,3 +13,7 @@
 	@endif
 
 </div>
+
+@if(!CRUD::widgetTypeLoaded($widget))
+    <!-- Prevent multiple times loading of assets. -->
+@endif

--- a/src/resources/views/base/widgets/card.blade.php
+++ b/src/resources/views/base/widgets/card.blade.php
@@ -6,3 +6,7 @@
 	  <div class="card-body">{!! $widget['content']['body'] !!}</div>
 	</div>
 </div>
+
+@if(!CRUD::widgetTypeLoaded($widget))
+ <!-- Prevent multiple times loading of assets. -->
+@endif


### PR DESCRIPTION
Hello guys. REF: #2074 

I have spent some time in this issue, and I think it's a very tricky one. 

Mainly we have two issues with widgets:

### 1 - Widget loads the same assets multiple times.

When using the same widget multiple times it will load the same assets for every time you included the same widget.

> SOLUTION: I did something similar to what we use in fields. We can now check if widget type is loaded before loading the assets. 

```php
@if(!CRUD::widgetTypeLoaded($widget))
 <!-- Prevent multiple times loading of assets. -->
@endif
```

### 2 - Push widget assets to the header

>SOLUTION: **NONE**

This is waaaaaaay more trickier, I will keep digging on this, but I am not sure we can achieve that without massively changing backpack layout files. 


@tabacitu let me know if I am going in the right direction with this one ..! 