### PR TITLE
[4.0][Enhancement] Register aliases for Str and Arr

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -309,7 +309,8 @@ class BackpackServiceProvider extends ServiceProvider
     }
 
     //Register extra aliases into laravel container to use in blade views.
-    public function registerExtraAliases() {
+    public function registerExtraAliases()
+    {
         $alias_instance = \Illuminate\Foundation\AliasLoader::getInstance();
         $alias_instance->alias('Str', 'Illuminate\Support\Str');
         $alias_instance->alias('Arr', 'Illuminate\Support\Arr');

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -64,6 +64,9 @@ class BackpackServiceProvider extends ServiceProvider
             $this->addRouteMacro();
         }
 
+        //register global Arr and Str helpers aliases
+        $this->registerExtraAliases();
+
         // register the helper functions
         $this->loadHelpers();
 
@@ -303,5 +306,12 @@ class BackpackServiceProvider extends ServiceProvider
     public function loadHelpers()
     {
         require_once __DIR__.'/helpers.php';
+    }
+
+    //Register extra aliases into laravel container to use in blade views.
+    public function registerExtraAliases() {
+        $alias_instance = \Illuminate\Foundation\AliasLoader::getInstance();
+        $alias_instance->alias('Str', 'Illuminate\Support\Str');
+        $alias_instance->alias('Arr', 'Illuminate\Support\Arr');
     }
 }


### PR DESCRIPTION
Instead of using full namespaced helpers in views we should register this aliases so we can simple use `Arr::first()` instead of `\Illuminate\Support\Arr::first()` in our views.
