### PR TITLE
Instantiate controller with Laravel's service container to allow custom dependencies

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Backpack\CRUD;
 
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class BackpackServiceProvider extends ServiceProvider

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD;
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 
 class BackpackServiceProvider extends ServiceProvider
@@ -222,7 +223,7 @@ class BackpackServiceProvider extends ServiceProvider
                 $groupNamespace = '';
             }
             $namespacedController = $groupNamespace.$controller;
-            $controllerInstance = new $namespacedController();
+            $controllerInstance = App::make($namespacedController);
 
             return $controllerInstance->setupRoutes($name, $routeName, $controller);
         });


### PR DESCRIPTION
I like to use a Repository pattern which I am passing to controllers by service container through __construct parameters. Current implementation doesn't allow this since the Controller gets instantiated without parameters.  Simply using Laravel's service container makes this more available and is more Laravelish. 