### PR TITLE
[4.0] Fix widget styles not loading

### DIFF
--- a/src/resources/views/base/blank.blade.php
+++ b/src/resources/views/base/blank.blade.php
@@ -1,4 +1,16 @@
 @extends(backpack_view('layouts.top_left'))
 
+@section('before_content_widgets')
+	@if (isset($widgets['before_content']))
+		@include(backpack_view('inc.widgets'), [ 'widgets' => $widgets['before_content'] ])
+	@endif
+@endsection
+
 @section('content')
+@endsection
+
+@section('after_content_widgets')
+	@if (isset($widgets['after_content']))
+		@include(backpack_view('inc.widgets'), [ 'widgets' => $widgets['after_content'] ])
+	@endif
 @endsection

--- a/src/resources/views/base/layouts/top_left.blade.php
+++ b/src/resources/views/base/layouts/top_left.blade.php
@@ -22,16 +22,12 @@
        @yield('header')
 
         <div class="container-fluid animated fadeIn">
-          
-          @if (isset($widgets['before_content']))
-            @include(backpack_view('inc.widgets'), [ 'widgets' => $widgets['before_content'] ])
-          @endif
-          
+
+          @yield('before_content_widgets')
+
           @yield('content')
           
-          @if (isset($widgets['after_content']))
-            @include(backpack_view('inc.widgets'), [ 'widgets' => $widgets['after_content'] ])
-          @endif
+          @yield('after_content_widgets')
 
         </div>
 

--- a/src/resources/views/base/my_account.blade.php
+++ b/src/resources/views/base/my_account.blade.php
@@ -1,4 +1,4 @@
-@extends('backpack::layouts.top_left')
+@extends(backpack_view('blank'))
 
 @section('after_styles')
     <style media="screen">

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [

--- a/src/resources/views/crud/revisions.blade.php
+++ b/src/resources/views/crud/revisions.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_view('layouts.top_left'))
+@extends(backpack_view('blank'))
 
 @php
   $defaultBreadcrumbs = [


### PR DESCRIPTION
Fixes #2074

Previously, if you did ```@push('after_styles'``` in a widget, that content was NOT loaded, because of the order in which blade stacks and sections were loaded. This PR fixes that.

If you do something like:
```php
    $widgets['after_content'][] = [
        'type' => 'demo',
        'wrapperClass' => 'col-sm-12',
        'content' => 'This text will be in the demo widget.',
    ];
```
To load the following widget:

```php
<div class="{{ $widget['wrapperClass'] ?? 'col-sm-6 col-md-4' }}">
  <div class="{{ $widget['class'] ?? 'well mb-2' }}">
    {!! $widget['content'] !!}
  </div>
  <div class="should-be-green">Testing CSS</div>
  <div class="should-be-red">Testing JS</div>
</div>

@push('after_styles')
  <style>
    .should-be-green {
      color: green;
    }
  </style>
@endpush

@push('after_scripts')
  <script>
      jQuery(document).ready(function($) {
          $('.should-be-red').css('color', 'red');
      });
  </script>
@endpush
```

The output will be:
![Screenshot 2020-03-23 at 14 01 07](https://user-images.githubusercontent.com/1032474/77314676-c75dbb80-6d0e-11ea-8e02-c59aa37fb571.png)

Both the CSS and the JS get loaded and executed now.

---

AFAIK we can consider this a non-breaking change. There's only one mention though - all custom Backpack views should NOT extend ```layouts.top_left```, but instead extend the ```blank``` blade template - since that's where the fix is. I was NOT able to fix it any other way.