### PR TITLE
[4.1.0] Fluent Syntax for Widgets

### DIFF
--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -60,14 +60,21 @@ class Widget extends Fluent
         return $this;
     }
 
+    // TODO: add ability to push a widget right after another widget
     public function after($destination)
     {
     }
 
+    // TODO: add ability to push a widget right before another widget
     public function before($destionation)
     {
     }
 
+    /**
+     * Make this widget the first one in its group.
+     * 
+     * @return Widget
+     */
     public function makeFirst()
     {
         $this->collection()->pull($this->name);
@@ -76,6 +83,11 @@ class Widget extends Fluent
         return $this;
     }
 
+    /**
+     * Make this widget the last one in its group.
+     * 
+     * @return Widget
+     */
     public function makeLast()
     {
         $this->collection()->pull($this->name);
@@ -118,6 +130,11 @@ class Widget extends Fluent
         return app('widgets');
     }
 
+    /**
+     * Remove the widget from its group.
+     * 
+     * @return Widget
+     */
     public function remove()
     {
         $this->collection()->pull($this->name);

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -72,7 +72,7 @@ class Widget extends Fluent
 
     /**
      * Make this widget the first one in its group.
-     * 
+     *
      * @return Widget
      */
     public function makeFirst()
@@ -85,7 +85,7 @@ class Widget extends Fluent
 
     /**
      * Make this widget the last one in its group.
-     * 
+     *
      * @return Widget
      */
     public function makeLast()
@@ -132,7 +132,7 @@ class Widget extends Fluent
 
     /**
      * Remove the widget from its group.
-     * 
+     *
      * @return Widget
      */
     public function remove()


### PR DESCRIPTION
Related to #2513 

This PR adds an optional fluent syntax to Widgets. Inside your Controllers or Views you can now do either of these:

```php
    $widgets['after_content'][] = [
	  'type'         => 'alert',
	  'class'        => 'alert alert-warning bg-dark border-0 mb-2',
	  'heading'      => 'Demo Refreshes Every Hour on the Hour',
	  'content'      => 'At hh:00, all custom entries are deleted, all files, everything. This cleanup is necessary because developers like to joke with their test entries, and mess with stuff. But you know that :-) Go ahead - make a developer smile.' ,
	  'close_button' => true, // show close button or not
	];
```

or

```php
Widget::add([
	  'type'         => 'alert',
	  'class'        => 'alert alert-warning bg-dark border-0 mb-2',
	  'heading'      => 'Demo Refreshes Every Hour on the Hour',
	  'content'      => 'At hh:00, all custom entries are deleted, all files, everything. This cleanup is necessary because developers like to joke with their test entries, and mess with stuff. But you know that :-) Go ahead - make a developer smile.' ,
	  'close_button' => true, // show close button or not
	])->group('after_content');
```

or

```php
Widget::add()
	->type('alert')
        ->group('after_content')
	->class('alert alert-warning bg-dark border-0 mb-2')
	->heading('Demo Refreshes Every Hour on the Hour'),
	->content('At hh:00, all custom entries are deleted, all files, everything. This cleanup is necessary because developers like to joke with their test entries, and mess with stuff. But you know that :-) Go ahead - make a developer smile.')
	->close_button(true);
```

They're the same thing.