### PR TITLE
[4.1.0][Feature] Allow Counting for select_multiple records

### DIFF
--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -5,7 +5,9 @@
 
 <span>
     <?php
-        if ($results && $results->count()) {
+    	if($column['count']) {
+    		echo $results->count();
+    	} elseif ($results && $results->count()) {
             $results_array = $results->pluck($column['attribute']);
             echo implode(', ', $results_array->toArray());
         } else {

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -5,9 +5,9 @@
 
 <span>
     <?php
-    	if($column['count']) {
-    		echo $results->count();
-    	} elseif ($results && $results->count()) {
+        if ($column['count']) {
+            echo $results->count();
+        } elseif ($results && $results->count()) {
             $results_array = $results->pluck($column['attribute']);
             echo implode(', ', $results_array->toArray());
         } else {


### PR DESCRIPTION
Currently if you want to just display a count of related records in the list view you have to create a custom function, view, etc to do so. This adds a first `if statement` checking if a value of `count` is set to true on the column. Also removes the need for `attribute` on column data.

Example:
```php
$this->crud->addColumn([
   'name' => 'monster_likes',
   'label' => 'Total Monster Likes',
   'type' => 'select_multiple',
   'entity' => 'monsters',
   'model' => "App\Models\Monsters",
   'count' => true,
]);
```

Essentially it helps replace the probably of having to create a custom model_function just to call the relationship with a count at the end.  2 lines of code saves many and makes it easier for developers in future. Ooh and its non-breaking.