### PR TITLE
[4.1.0] Show operation adds a "Save and Preview" save action

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -37,6 +37,25 @@ trait ShowOperation
         $this->crud->operation('list', function () {
             $this->crud->addButton('line', 'show', 'view', 'crud::buttons.show', 'beginning');
         });
+
+        $this->crud->operation(['create', 'update'], function () {
+            $this->crud->addSaveAction([
+                'name' => 'save_and_preview',
+                'visible' => function ($crud) {
+                    return $crud->hasAccess('show');
+                },
+                'redirect' => function ($crud, $request, $itemId = null) {
+                    $itemId = $itemId ?: $request->input('id');
+                    $redirectUrl = $crud->route.'/'.$itemId.'/show';
+                    if ($request->has('locale')) {
+                        $redirectUrl .= '?locale='.$request->input('locale');
+                    }
+
+                    return $redirectUrl;
+                },
+                'button_text' => trans('backpack::crud.save_action_save_and_preview'),
+            ]);
+        });
     }
 
     /**

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -17,6 +17,7 @@ return [
     'save_action_save_and_new'         => 'Save and new item',
     'save_action_save_and_edit'        => 'Save and edit this item',
     'save_action_save_and_back'        => 'Save and back',
+    'save_action_save_and_preview'     => 'Save and preview',
     'save_action_changed_notification' => 'Default behaviour after saving has been changed.',
 
     // Create form

--- a/src/resources/lang/es/crud.php
+++ b/src/resources/lang/es/crud.php
@@ -17,6 +17,7 @@ return [
     'save_action_save_and_new'         => 'Guardar y crear nuevo',
     'save_action_save_and_edit'        => 'Guardar y continuar editando',
     'save_action_save_and_back'        => 'Guardar y regresar',
+    'save_action_save_and_preview'     => 'Guardar y vista previa',
     'save_action_changed_notification' => 'La acción por defecto del botón guardar ha sido modificada.',
 
     // Create form

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -17,6 +17,7 @@ return [
     'save_action_save_and_new'         => 'Enregistrer et créer un nouveau',
     'save_action_save_and_edit'        => 'Enregistrer et éditer',
     'save_action_save_and_back'        => 'Enregistrer et retour',
+    'save_action_save_and_preview'     => 'Enregistrer et aperçu',
     'save_action_changed_notification' => 'Action par défaut changée',
 
     // Create form

--- a/src/resources/lang/ro/crud.php
+++ b/src/resources/lang/ro/crud.php
@@ -17,6 +17,7 @@ return [
     'save_action_save_and_new'                => 'Salvează și adaugă o nouă intrare',
     'save_action_save_and_edit'               => 'Salvează și editează intrarea',
     'save_action_save_and_back'               => 'Salvează și mergi la listă',
+    'save_action_save_and_preview'            => 'Salvează și previzualizează',
     'save_action_changed_notification'        => 'A fost salvată preferința redirecționării după salvare.',
 
     // Create form


### PR DESCRIPTION
Thanks to https://github.com/Laravel-Backpack/CRUD/pull/2356 , the Show operation can automatically add a new Save Action to the Create/Update forms. So that admins can do "Save and Preview".

/depends on #2356