### PR TITLE
[4.1.0][Feature][Ready] Relationship & relationship_count columns

### DIFF
--- a/src/resources/views/crud/columns/relationship.blade.php
+++ b/src/resources/views/crud/columns/relationship.blade.php
@@ -1,0 +1,12 @@
+{{-- relationships (switchboard; supports both single and multiple: 1-1, 1-n, n-n) --}}
+@php
+   $relationshipType = new ReflectionClass($entry->{$column['name']}());
+   $relationshipType = $relationshipType->getShortName();
+   $allows_multiple = $crud->relationAllowsMultiple($relationshipType);
+@endphp
+
+@if ($allows_multiple)
+    @include('crud::columns.select_multiple')
+@else
+    @include('crud::columns.select')
+@endif

--- a/src/resources/views/crud/columns/relationship_count.blade.php
+++ b/src/resources/views/crud/columns/relationship_count.blade.php
@@ -1,3 +1,4 @@
+{{-- relationship_count (works for n-n relationships) --}}
 @php
    $column['text'] = data_get($entry, $column['name'])->count();
    $column['prefix'] = $column['prefix'] ?? '';
@@ -7,6 +8,6 @@
 
 <span>
     @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
-            {{ $column['text'] }}
+        {{ $column['text'] }}
     @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
 </span>

--- a/src/resources/views/crud/columns/relationship_count.blade.php
+++ b/src/resources/views/crud/columns/relationship_count.blade.php
@@ -1,0 +1,12 @@
+@php
+   $column['text'] = data_get($entry, $column['name'])->count();
+   $column['prefix'] = $column['prefix'] ?? '';
+   $column['suffix'] = $column['suffix'] ?? '  items';
+   $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+@endphp
+
+<span>
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+            {{ $column['text'] }}
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+</span>


### PR DESCRIPTION
This PR adds two new columns:

1) ```relationship``` - basically a switchboard; depending on the relationship type it loads the ```select``` or the ```select_multiple``` columns;

2) ```relationship_count``` - shows the number of related items; what's nice about this is that thanks to the column anchors, you can also place a link from this column to the CRUD for that entity, with the filter enabled, so you see all related entries;

Todo:
- [ ] add documentation