### PR TITLE
Fixing arguments to set settings value

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -74,7 +74,7 @@ trait Settings
             return $this->get($key);
         }
 
-        return $this->set($key);
+        return $this->set($key, $value);
     }
 
     /**


### PR DESCRIPTION
The function needs exactly two arguments, but only one provided.
This commit adds the 'value' as second arguments and Fix issues #2617 .

Signed-off-by: Adli I. Ifkar <adly.shadowbane@gmail.com>
