### PR TITLE
Fix different date formats in Date Range Field

### DIFF
--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -92,7 +92,7 @@
 
                 $fake.on('apply.daterangepicker hide.daterangepicker', function(e, picker){
                     $start.val( picker.startDate.format('YYYY-MM-DD HH:mm:ss') );
-                    $end.val( picker.endDate.format('YYYY-MM-DD H:mm:ss') );
+                    $end.val( picker.endDate.format('YYYY-MM-DD HH:mm:ss') );
                 });
         }
     </script>


### PR DESCRIPTION
Fix of different date-time formats. Different date-time formats making validation rules like 'date_format:Y-m-d H:i:s' to fail, because payload looks like 9:00:00 instead of 09:00:00.