### PR TITLE
Ability to display associative array with table

### DIFF
--- a/src/resources/views/crud/columns/table.blade.php
+++ b/src/resources/views/crud/columns/table.blade.php
@@ -12,6 +12,13 @@
 	if (is_string($value)) {
 	    $value = json_decode($value);
 	}
+    
+    // if the json value is marked as only one assoc array, let's adapt it
+	// when json attribute is stored as {key: val, key: val} not [{key: val, key: val}]
+	if ((!empty($column['only_assoc'])) && ($column['only_assoc'] === true)) {
+		$value = [$value];
+	}
+
 
 @endphp
 


### PR DESCRIPTION
Some JSON stored attributes can be {key: val, key: val} not [{key: val, key: val}] if there is only one object
A new parameter like for example 'only_assoc' (i don't mind about the name) could inform about this.
Or why not an automatic test to check wether we have [[][][][]] structure or only a simple []
I'm proposing it because, of course I was stuck trying to display my json associative array and table is really convenient, and already exists, less to maintain without compromising the spirit.