### PR TITLE
[4.1] Fluent syntax for buttons

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -1,0 +1,397 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel;
+
+/**
+ * Adds fluent syntax to Backpack CRUD Buttons.
+ *
+ * In addition to the existing:
+ * - CRUD::addButton('top', 'create', 'view', 'crud::buttons.create');
+ *
+ * Developers can also do:
+ * - CRUD::button('create')->stack('top')->view('crud::buttons.create');
+ *
+ * And if the developer uses CrudButton as Button in their CrudController:
+ * - Button::name('create')->stack('top')->view('crud::butons.create');
+ */
+class CrudButton
+{
+    public $stack;
+    public $name;
+    public $type;
+    public $content;
+    public $position;
+
+    public function __construct($name, $stack = null, $type = null, $content = null, $position = null)
+    {
+        // in case an array was passed as name
+        // assume it's an array that includes [$name, $stack, $type, $content]
+        if (is_array($name)) {
+            extract($name);
+        }
+
+        $this->name = $name ?? 'button_'.rand(1, 999999999);
+        $this->stack = $stack ?? 'top';
+        $this->type = $type ?? 'view';
+        $this->content = $content;
+        $this->position = $position;
+
+        return $this->save();
+    }
+
+    // ------
+    // MAKERS
+    // ------
+    
+    /**
+     * Add a new button to the default stack.
+     * 
+     * @param  string|array $attributes Button name or array that contains name, stack, type and content.
+     */
+    public static function name($attributes = null) {
+        return new static($attributes);
+    }
+
+    /**
+     * Add a new button to the default stack.
+     * 
+     * @param  string|array $attributes Button name or array that contains name, stack, type and content.
+     */
+    public static function add($attributes = null) {
+        return new static($attributes);
+    }
+
+    /**
+     * This method allows one to create a button without attaching it to any 'real'
+     * button stack, by moving it to a 'hidden' stack.
+     *
+     * It exists for one reason: so that developers can add buttons to a custom array, without
+     * adding them to one of the button stacks.
+     *
+     * Ex: when developers need to pass multiple buttons as contents of the
+     * div button. But they don't want them added to the before_content of after_content
+     * stacks. So what they do is basically add them to a 'hidden' stack, that nobody will ever see.
+     *
+     * @param  string|array $attributes Button name or array that contains name, stack, type and content.
+     * @return CrudButton
+     */
+    public static function make($attributes = null) {
+        $button = static::add($attributes);
+        $button->stack('hidden');
+
+        return $button;
+    }
+
+    // -------
+    // SETTERS
+    // -------
+
+    /**
+     * Set the button stack (where the button will be shown).
+     * 
+     * @param  string $stack The name of the stack where the button should be moved.
+     * @return CrudButton
+     */
+    public function stack($stack) 
+    {
+        $this->stack = $stack;
+
+        return $this->save();
+    }
+
+    /**
+     * Sets the button type (view or model_function).
+     * 
+     * @param  string $type The type of button - view or model_function.
+     * @return CrudButton
+     */
+    public function type($type) 
+    {
+        $this->type = $type;
+
+        return $this->save();
+    }
+
+
+    /**
+     * Sets the content of the button.
+     * For the view button type, set it to the view path, including namespace.
+     * For the model_function button type, set it to the name of the method on the model.
+     * 
+     * @param  string $content Path to view or name of method on Model.
+     * @return CrudButton
+     */
+    public function content($content) 
+    {
+        $this->content = $content;
+
+        return $this->save();
+    }
+
+    /**
+     * Sets the namespace and path of the view for this button.
+     * Sets the button type as 'view'.
+     * 
+     * @param  string $value Path to view file.
+     * @return CrudButton
+     */
+    public function view($value)
+    {
+        $this->content = $value;
+        $this->type = 'view';
+
+        return $this->save();
+    }
+
+    /**
+     * Sets the name of the method on the model that contains the HTML for this button.
+     * Sets the button type as 'model_function'.
+     * 
+     * @param  string $value Name of the method on the model.
+     * @return CrudButton
+     */
+    public function modelFunction($value)
+    {
+        $this->content = $value;
+        $this->type = 'model_function';
+        $this->stack = 'line';
+
+        return $this->save();
+    }
+
+    /**
+     * Sets the name of the method on the model that contains the HTML for this button.
+     * Sets the button type as 'model_function'.
+     * Alias of the modelFunction() method.
+     * 
+     * @param  string $value Name of the method on the model.
+     * @return CrudButton
+     */
+    public function model_function($value)
+    {
+        return $this->modelFunction($value);
+    }
+
+    /**
+     * Unserts an property that is set on the current button.
+     * Possible properties: name, stack, type, content.
+     * 
+     * @param  string $property Name of the property that should be cleared.
+     * @return CrudButton
+     */
+    public function forget($property)
+    {
+        $this->{$property} = null;
+
+        return $this->save();
+    }
+
+
+    // --------------
+    // SETTER ALIASES
+    // --------------
+
+
+    /**
+     * Moves the button to a certain button stack.
+     * Alias of stack().
+     * 
+     * @param  string $stack The name of the stack where the button should be moved.
+     * 
+     * @return self
+     */
+    public function to($stack) 
+    {
+        return $this->stack($stack);
+    }
+
+    /**
+     * Moves the button to a certain button stack.
+     * Alias of stack().
+     * 
+     * @param  string $stack The name of the stack where the button should be moved.
+     * 
+     * @return self
+     */
+    public function group($stack) 
+    {
+        return $this->stack($stack);
+    }
+
+    /**
+     * Moves the button to a certain button stack.
+     * Alias of stack().
+     * 
+     * @param  string $stack The name of the stack where the button should be moved.
+     * 
+     * @return self
+     */
+    public function section($stack) 
+    {
+        return $this->stack($stack);
+    }
+
+    // -------
+    // GETTERS
+    // -------
+
+    /**
+     * Get the end result that should be displayed to the user.
+     * The HTML itself of the button.
+     * 
+     * @param  object|null $entry The eloquent Model for the current entry or null if no current entry.
+     * 
+     * @return HTML
+     */
+    public function getHtml($entry = null) {
+        $button = $this;
+        $crud = $this->crud();
+
+        if ($this->type == 'model_function') {
+            if (is_null($entry)) {
+                return $crud->model->{$button->content}($crud);
+            }
+            return $entry->{$button->content}($crud);
+        }
+
+        if ($this->type == 'view') {
+            if (view()->exists($button->content)) {
+                return view($button->content, compact('button', 'crud', 'entry'));
+            } else {
+                abort(500, 'Button view "'.$button->content.'" does not exist');
+            }
+        }
+
+        abort(500, 'Unknown button type');
+    }
+
+    /**
+     * Get the key for this button in the global buttons collection.
+     * 
+     * @return integer
+     */
+    public function getKey()
+    {
+        return $this->crud()->getButtonKey($this->name);
+    }
+
+    // -----
+    // ORDER
+    // -----
+    
+    /**
+     * Move this button to be the first in the buttons list.
+     *
+     * @return CrudButton
+     */
+    public function makeFirst() 
+    {
+        $this->remove();
+        $this->collection()->prepend($this);
+
+        return $this;
+    }
+
+    /**
+     * Move this button to be the last one in the buttons list.
+     *
+     * @return CrudButton
+     */
+    public function makeLast() 
+    {
+        $this->remove();
+        $this->collection()->push($this);
+
+        return $this;
+    }
+
+    /**
+     * Move the current filter after another filter.
+     *
+     * @param  string $destination Name of the destination filter.
+     * @return CrudFilter
+     */
+    public function after($destination)
+    {
+        $this->crud()->moveButton($this->name, 'after', $destinationName);
+
+        return $this;
+    }
+
+    /**
+     * Move the current field before another field.
+     *
+     * @param  string $destination Name of the destination field.
+     * @return CrudFilter
+     */
+    public function before($destination)
+    {
+        $this->crud()->moveButton($this->name, 'before', $destinationName);
+
+        return $this;
+    }
+
+    // ------------------
+    // COLLECTION METHODS
+    // ------------------
+    // Manipulate the button collection (inside the global CrudPanel object).
+
+    /**
+     * Access the global collection when all buttons are stored.
+     * 
+     * @return \Illuminate\Support\Collection
+     */
+    public static function collection()
+    {
+        return app('crud')->buttons();
+    }
+
+    /**
+     * Remove the button from the global button collection.
+     *
+     * @return CrudButton
+     */
+    public function remove()
+    {
+        $this->collection()->pull($this->getKey());
+
+        return $this;
+    }
+
+    /**
+     * Access the global CrudPanel object.
+     * 
+     * @return \Backpack\CRUD\app\Library\CrudPanel\CrudPanel
+     */
+    public function crud()
+    {
+        return app('crud');
+    }
+
+    // ---------------
+    // PRIVATE METHODS
+    // ---------------
+
+    /**
+     * Update the global CrudPanel object with the current button.
+     *
+     * @return CrudButton
+     */
+    private function save()
+    {
+        $itemExists = $this->collection()->contains('name', $this->name);
+        $position = $this->position ?? ($this->stack == 'line' ? 'beginning' : 'end');
+
+        if (! $itemExists) {
+            if ($position == 'beginning') {
+                $this->collection()->prepend($this);
+            } else {
+                $this->collection()->push($this);
+            }
+        } else {
+            $this->collection()->replace([$this->getKey() => $this]);
+        }
+
+        return $this;
+    }
+}

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -42,22 +42,24 @@ class CrudButton
     // ------
     // MAKERS
     // ------
-    
+
     /**
      * Add a new button to the default stack.
-     * 
+     *
      * @param  string|array $attributes Button name or array that contains name, stack, type and content.
      */
-    public static function name($attributes = null) {
+    public static function name($attributes = null)
+    {
         return new static($attributes);
     }
 
     /**
      * Add a new button to the default stack.
-     * 
+     *
      * @param  string|array $attributes Button name or array that contains name, stack, type and content.
      */
-    public static function add($attributes = null) {
+    public static function add($attributes = null)
+    {
         return new static($attributes);
     }
 
@@ -75,7 +77,8 @@ class CrudButton
      * @param  string|array $attributes Button name or array that contains name, stack, type and content.
      * @return CrudButton
      */
-    public static function make($attributes = null) {
+    public static function make($attributes = null)
+    {
         $button = static::add($attributes);
         $button->stack('hidden');
 
@@ -88,11 +91,11 @@ class CrudButton
 
     /**
      * Set the button stack (where the button will be shown).
-     * 
+     *
      * @param  string $stack The name of the stack where the button should be moved.
      * @return CrudButton
      */
-    public function stack($stack) 
+    public function stack($stack)
     {
         $this->stack = $stack;
 
@@ -101,27 +104,26 @@ class CrudButton
 
     /**
      * Sets the button type (view or model_function).
-     * 
+     *
      * @param  string $type The type of button - view or model_function.
      * @return CrudButton
      */
-    public function type($type) 
+    public function type($type)
     {
         $this->type = $type;
 
         return $this->save();
     }
 
-
     /**
      * Sets the content of the button.
      * For the view button type, set it to the view path, including namespace.
      * For the model_function button type, set it to the name of the method on the model.
-     * 
+     *
      * @param  string $content Path to view or name of method on Model.
      * @return CrudButton
      */
-    public function content($content) 
+    public function content($content)
     {
         $this->content = $content;
 
@@ -131,7 +133,7 @@ class CrudButton
     /**
      * Sets the namespace and path of the view for this button.
      * Sets the button type as 'view'.
-     * 
+     *
      * @param  string $value Path to view file.
      * @return CrudButton
      */
@@ -146,7 +148,7 @@ class CrudButton
     /**
      * Sets the name of the method on the model that contains the HTML for this button.
      * Sets the button type as 'model_function'.
-     * 
+     *
      * @param  string $value Name of the method on the model.
      * @return CrudButton
      */
@@ -163,7 +165,7 @@ class CrudButton
      * Sets the name of the method on the model that contains the HTML for this button.
      * Sets the button type as 'model_function'.
      * Alias of the modelFunction() method.
-     * 
+     *
      * @param  string $value Name of the method on the model.
      * @return CrudButton
      */
@@ -175,7 +177,7 @@ class CrudButton
     /**
      * Unserts an property that is set on the current button.
      * Possible properties: name, stack, type, content.
-     * 
+     *
      * @param  string $property Name of the property that should be cleared.
      * @return CrudButton
      */
@@ -186,21 +188,19 @@ class CrudButton
         return $this->save();
     }
 
-
     // --------------
     // SETTER ALIASES
     // --------------
 
-
     /**
      * Moves the button to a certain button stack.
      * Alias of stack().
-     * 
+     *
      * @param  string $stack The name of the stack where the button should be moved.
-     * 
+     *
      * @return self
      */
-    public function to($stack) 
+    public function to($stack)
     {
         return $this->stack($stack);
     }
@@ -208,12 +208,12 @@ class CrudButton
     /**
      * Moves the button to a certain button stack.
      * Alias of stack().
-     * 
+     *
      * @param  string $stack The name of the stack where the button should be moved.
-     * 
+     *
      * @return self
      */
-    public function group($stack) 
+    public function group($stack)
     {
         return $this->stack($stack);
     }
@@ -221,12 +221,12 @@ class CrudButton
     /**
      * Moves the button to a certain button stack.
      * Alias of stack().
-     * 
+     *
      * @param  string $stack The name of the stack where the button should be moved.
-     * 
+     *
      * @return self
      */
-    public function section($stack) 
+    public function section($stack)
     {
         return $this->stack($stack);
     }
@@ -238,12 +238,13 @@ class CrudButton
     /**
      * Get the end result that should be displayed to the user.
      * The HTML itself of the button.
-     * 
+     *
      * @param  object|null $entry The eloquent Model for the current entry or null if no current entry.
-     * 
+     *
      * @return HTML
      */
-    public function getHtml($entry = null) {
+    public function getHtml($entry = null)
+    {
         $button = $this;
         $crud = $this->crud();
 
@@ -251,6 +252,7 @@ class CrudButton
             if (is_null($entry)) {
                 return $crud->model->{$button->content}($crud);
             }
+
             return $entry->{$button->content}($crud);
         }
 
@@ -267,8 +269,8 @@ class CrudButton
 
     /**
      * Get the key for this button in the global buttons collection.
-     * 
-     * @return integer
+     *
+     * @return int
      */
     public function getKey()
     {
@@ -278,13 +280,13 @@ class CrudButton
     // -----
     // ORDER
     // -----
-    
+
     /**
      * Move this button to be the first in the buttons list.
      *
      * @return CrudButton
      */
-    public function makeFirst() 
+    public function makeFirst()
     {
         $this->remove();
         $this->collection()->prepend($this);
@@ -297,7 +299,7 @@ class CrudButton
      *
      * @return CrudButton
      */
-    public function makeLast() 
+    public function makeLast()
     {
         $this->remove();
         $this->collection()->push($this);
@@ -338,7 +340,7 @@ class CrudButton
 
     /**
      * Access the global collection when all buttons are stored.
-     * 
+     *
      * @return \Illuminate\Support\Collection
      */
     public static function collection()
@@ -360,7 +362,7 @@ class CrudButton
 
     /**
      * Access the global CrudPanel object.
-     * 
+     *
      * @return \Backpack\CRUD\app\Library\CrudPanel\CrudPanel
      */
     public function crud()

--- a/src/app/Library/CrudPanel/Traits/Buttons.php
+++ b/src/app/Library/CrudPanel/Traits/Buttons.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Support\Collection;
+use Backpack\CRUD\app\Library\CrudPanel\CrudButton;
 
 trait Buttons
 {
@@ -67,38 +68,15 @@ trait Buttons
      *                                     'beginning' for the line stack or 'end' otherwise.
      * @param bool        $replaceExisting True if a button with the same name on the given stack should be replaced.
      *
-     * @return \Backpack\CRUD\app\Library\CrudPanel\Traits\CrudButton The new CRUD button.
+     * @return \Backpack\CRUD\app\Library\CrudPanel\CrudButton The new CRUD button.
      */
     public function addButton($stack, $name, $type, $content, $position = false, $replaceExisting = true)
     {
-        if ($position == false) {
-            switch ($stack) {
-                case 'line':
-                    $position = 'beginning';
-                    break;
-
-                default:
-                    $position = 'end';
-                    break;
-            }
-        }
-
         if ($replaceExisting) {
             $this->removeButton($name, $stack);
         }
 
-        $button = new CrudButton($stack, $name, $type, $content);
-        switch ($position) {
-            case 'beginning':
-                $this->setOperationSetting('buttons', $this->buttons()->prepend($button));
-                break;
-
-            default:
-                $this->setOperationSetting('buttons', $this->buttons()->push($button));
-                break;
-        }
-
-        return $button;
+        return new CrudButton($name, $stack, $type, $content, $position);
     }
 
     public function addButtonFromModelFunction($stack, $name, $model_function_name, $position = false)
@@ -193,20 +171,89 @@ trait Buttons
             return $button->name == $name && $button->stack == $stack;
         }));
     }
-}
 
-class CrudButton
-{
-    public $stack;
-    public $name;
-    public $type = 'view';
-    public $content;
-
-    public function __construct($stack, $name, $type, $content)
+    /**
+     * Move the most recently added button before or after the given target button. Default is before.
+     *
+     * @param string|array $target      The target button name or array.
+     * @param string|array $destination The destination button name or array.
+     * @param bool         $before      If true, the button will be moved before the target button, otherwise it will be moved after it.
+     */
+    public function moveButton($target, $where, $destination)
     {
-        $this->stack = $stack;
-        $this->name = $name;
-        $this->type = $type;
-        $this->content = $content;
+        $targetButton = $this->firstButtonWhere('name', $target);
+        $destinationButton = $this->firstButtonWhere('name', $destination);
+        $destinationKey = $this->getButtonKey($destination);
+        $newDestinationKey = ($where == 'before' ? $destinationKey : $destinationKey + 1);
+        $newButtons = $this->buttons()->filter(function ($value, $key) use ($target) {
+            return $value->name != $target;
+        });
+
+        if (! $targetButton) {
+            return;
+        }
+
+        if (! $destinationButton) {
+            return;
+        }
+
+        $firstSlice = $newButtons->slice(0, $newDestinationKey);
+        $lastSlice = $newButtons->slice($newDestinationKey, null);
+
+        $newButtons = $firstSlice->push($targetButton);
+        $lastSlice->each(function ($item, $key) use ($newButtons) {
+            $newButtons->push($item);
+        });
+
+        $this->setOperationSetting('buttons', $newButtons);
+    }
+
+    /**
+     * Check if a filter exists, by any given attribute.
+     *
+     * @param  string  $attribute   Attribute name on that filter definition array.
+     * @param  string  $value       Value of that attribute on that filter definition array.
+     * @return bool
+     */
+    public function hasButtonWhere($attribute, $value)
+    {
+        return $this->buttons()->contains($attribute, $value);
+    }
+
+    /**
+     * Get the first filter where a given attribute has the given value.
+     *
+     * @param  string  $attribute   Attribute name on that filter definition array.
+     * @param  string  $value       Value of that attribute on that filter definition array.
+     * @return bool
+     */
+    public function firstButtonWhere($attribute, $value)
+    {
+        return $this->buttons()->firstWhere($attribute, $value);
+    }
+
+
+    public function getButtonKey($buttonName)
+    {
+        $array = $this->buttons()->toArray();
+
+        foreach ($array as $key => $value) {
+            if ($value->name == $buttonName) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Add a new button to the current CRUD operation.
+     * 
+     * @param  string|array $attributes Button name or array that contains name, stack, type and content.
+     * @return \Backpack\CRUD\app\Library\CrudPanel\CrudButton
+     */
+    public function button($attributes = null) 
+    {
+        return new CrudButton($attributes);
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Buttons.php
+++ b/src/app/Library/CrudPanel/Traits/Buttons.php
@@ -2,8 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Support\Collection;
 use Backpack\CRUD\app\Library\CrudPanel\CrudButton;
+use Illuminate\Support\Collection;
 
 trait Buttons
 {
@@ -232,7 +232,6 @@ trait Buttons
         return $this->buttons()->firstWhere($attribute, $value);
     }
 
-
     public function getButtonKey($buttonName)
     {
         $array = $this->buttons()->toArray();
@@ -242,17 +241,15 @@ trait Buttons
                 return $key;
             }
         }
-
-        return null;
     }
 
     /**
      * Add a new button to the current CRUD operation.
-     * 
+     *
      * @param  string|array $attributes Button name or array that contains name, stack, type and content.
      * @return \Backpack\CRUD\app\Library\CrudPanel\CrudButton
      */
-    public function button($attributes = null) 
+    public function button($attributes = null)
     {
         return new CrudButton($attributes);
     }

--- a/src/resources/views/crud/inc/button_stack.blade.php
+++ b/src/resources/views/crud/inc/button_stack.blade.php
@@ -1,13 +1,5 @@
 @if ($crud->buttons()->where('stack', $stack)->count())
 	@foreach ($crud->buttons()->where('stack', $stack) as $button)
-	  @if ($button->type == 'model_function')
-		@if ($stack == 'line')
-	  		  {!! $entry->{$button->content}($crud); !!}
-		@else
-			  {!! $crud->model->{$button->content}($crud); !!}
-		@endif
-	  @else
-		@include($button->content, ['button' => $button])
-	  @endif
+	  {!! $button->getHtml($entry ?? null) !!}
 	@endforeach
 @endif


### PR DESCRIPTION
Completes https://github.com/Laravel-Backpack/CRUD/pull/2513

This PR brings add the option to add/manipulate buttons using the same fluent syntax that we've added to Fields, Columns, Filters, Widgets:

```php

$this->crud->addButton('top', 'create', 'view', 'crud::buttons.create'); // OLD
CRUD::button('create')->stack('top')->view('crud::buttons.create'); // NEW

$this->crud->addButton('line', 'update', 'view', 'crud::buttons.update', 'end'); // OLD
CRUD::button('edit')->stack('line')->view('crud::buttons.edit'); // NEW

// OLD
$this->crud->addButtonFromModelFunction('line', 'open_google', 'openGoogle', 'beginning');
// NEW
CRUD::button('open_google')
	->stack('line')
	->type('model_function')
	->content('openGoogle')
	->makeFirst();
// but you don't have to give it a name, so you can also do
CRUD::button()->stack('line')->type('model_function')->content('openGoogle')->makeFirst();
// and we also have helpers for setting both the type to view/model_function and its content
CRUD::button()->stack('line')->modelFunction('openGoogle')->makeFirst();

// OLD
$this->crud->addButtonFromView('top', 'create', 'crud::buttons.create', 'beginning');
// NEW
CRUD::button('create')->stack('top')->view('crud::buttons.create');


$this->crud->removeButton('create'); // OLD
CRUD::button('create')->remove(); // NEW
```

The result, in my opinion:
- the syntax is much cleaner, and easier to remember
- you get IDE autocompletion