### PR TITLE
[4.1.0] Fluent Fields - "size()" convenience method to set the wrapper size

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -354,7 +354,7 @@ class CrudButton
     // GLOBAL OBJECTS
     // --------------
     // Access to the objects stored in Laravel's service container.
-    
+
     /**
      * Access the global collection when all buttons are stored.
      *
@@ -364,7 +364,7 @@ class CrudButton
     {
         return $this->crud()->buttons();
     }
-    
+
     /**
      * Access the global CrudPanel object.
      *
@@ -395,7 +395,7 @@ class CrudButton
                 $this->collection()->push($this);
             }
 
-            // clear the custom position, so that the next daisy chained method 
+            // clear the custom position, so that the next daisy chained method
             // doesn't move it yet again
             $this->position = null;
         } else {

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -128,6 +128,28 @@ class CrudField
         return $this;
     }
 
+    // -------------------
+    // CONVENIENCE METHODS
+    // -------------------
+    // These methods don't do exactly what advertised by their name.
+    // They exist because the original syntax was too long.
+
+    /**
+     * Set the wrapper width at this many number of columns.
+     * For example, to set a field wrapper to span across 6 columns, you can do both:
+     * ->wrapper(['class' => 'form-group col-md-6'])
+     * ->size(6)
+     * 
+     * @param  integer $numberOfColumns How many columns should this field span across (1-12)?
+     * @return CrudField
+     */
+    public function size($numberOfColumns)
+    {
+        $this->attributes['wrapper']['class'] = 'form-group col-md-'.$numberOfColumns;
+
+        return $this->save();
+    }
+
     // ---------------
     // PRIVATE METHODS
     // ---------------

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -138,9 +138,9 @@ class CrudField
      * Set the wrapper width at this many number of columns.
      * For example, to set a field wrapper to span across 6 columns, you can do both:
      * ->wrapper(['class' => 'form-group col-md-6'])
-     * ->size(6)
-     * 
-     * @param  integer $numberOfColumns How many columns should this field span across (1-12)?
+     * ->size(6).
+     *
+     * @param  int $numberOfColumns How many columns should this field span across (1-12)?
      * @return CrudField
      */
     public function size($numberOfColumns)


### PR DESCRIPTION
![giphy](https://user-images.githubusercontent.com/1032474/78455557-c2eab880-76a7-11ea-9dae-b59b6bfe1166.gif)


This PR adds:
- the concept of "_convenience methods_"; methods we can create thanks to the new fluent syntax for Fields, Columns, Filters, Buttons, Widgets, that will provide a much shorter API for doing something that's very common;
- a new ```size()``` convenience method, so that we now have all these options to do the same very common thing - make a field smaller/bigger by setting the ```class``` of the wrapping div:
```php
// only option in Backpack 4.0 - still works in Backpack 4.1
CRUD::addField([
    'name' => 'description',
    'type' => 'textarea',
    'label' => 'Event Description',
    'wrapperAttributes' => ['class' => 'form-group col-md-6'],
]); // very difficult to remember... was it form-group or form-class?! damn it;

// new in Backpack 4.1 - wrapperAttributes was renamed to wrapper
CRUD::addField([
    'name' => 'description',
    'type' => 'textarea',
    'label' => 'Event Description',
    'wrapper' => ['class' => 'form-group col-md-6'],
]); // a little shorter, ok, but not a whole lot better

// new in Backpack 4.1 - fluent syntax
CRUD::field('description')
    ->type('textarea')
    ->label('Event Description')
    ->wrapper(['class' => 'form-group col-md-6']); // meh...

// --------------------------------
// AND NOW, THANKS TO THIS PR 
// --------------------------------
// ******* drumroll please ********

CRUD::field('description')
    ->type('textarea')
    ->label('Event Description')
    ->size(6); // SAY WHAAAT?! That easy? Yes. THAT EASY.

// same thing on one line
CRUD::field('description')->type('textarea')->label('Event Description')->size(6);

// or use the field() method to define an array, 
// but then fluently define the size
CRUD::field([
    'name' => 'description',
    'type' => 'textarea',
    'label' => 'Event Description',
])->size(6); // this reads "me no like fluent syntax, but it's useful sometimes"
```

**Are you convinced now @pxpm ? Have you seen the light?! Do you prefer the fluent syntax now?** 😆 How much easier is it to do ```->size(6)``` than ```'wrapper' => ['class' => 'form-group col-md-6']```?

Anyway. I'm open to suggestions for better names for this, or possible problems/conflicts with some field types. I've checked, it looks like no fields use the ```size``` attribute, so I _think_ we're good. I've also considered ```width``` and we could even make an alias for this one too, but I imagine people would much rather write ```size``` than ```width``` because... you know... it's easier to type.

Thoughts anyone? **I'm open to suggestions for other convenience methods like this one.** Things that take way too many characters in 4.0, that we can make faster in 4.1 using the fluent syntax. 🎉 🎈 🎂 