### PR TITLE
fix icon change after fetching video preview

### DIFF
--- a/src/resources/views/crud/fields/video.blade.php
+++ b/src/resources/views/crud/fields/video.blade.php
@@ -275,8 +275,8 @@ $field['wrapper']['data-video'] = '';
             .css('backgroundImage', 'url('+video.image+')');
 
             pIcon
-            .removeClass('fa-vimeo fa-youtube')
-            .addClass('fa-' + video.provider);
+            .removeClass('la-vimeo la-youtube')
+            .addClass('la-' + video.provider);
             pWrap.fadeIn();
         };
 


### PR DESCRIPTION
hi folks
just a super-minor-unimportant fix to reflect your movement from `fa` to `la` icons 
(current behaviour - after loading video preview, both icons disappear) 