### PR TITLE
Fix docblock in Validation trait

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -58,7 +58,7 @@ trait Validation
     /**
      * Run the authorization and validation the currently set FormRequest.
      *
-     * @return Request
+     * @return \Illuminate\Http\Request
      */
     public function validateRequest()
     {


### PR DESCRIPTION
`Request` is not imported so your IDE doesn't know what it is. Fixed by specifying the FQCN.