### PR TITLE
Add new feature select2_from_ajax 'return custom option attribute'

### DIFF
--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -35,17 +35,23 @@
                 $item = $connected_entity->find($old_value);
             @endphp
             @if ($item)
+                @php
+                    if (!isset($field['option']))
+                        $attribute = $item->{$field['attribute']};
+                    else
+                        $attribute = call_user_func($field['option'], $field['model']::query()->find($old_value));
+                @endphp
 
-            {{-- allow clear --}}
-            @if ($entity_model::isColumnNullable($field['name']))
-            <option value="" selected>
-                {{ $field['placeholder'] }}
-            </option>
-            @endif
+                {{-- allow clear --}}
+                @if ($entity_model::isColumnNullable($field['name']))
+                    <option value="" selected>
+                        {{ $field['placeholder'] }}
+                    </option>
+                @endif
 
-            <option value="{{ $item->getKey() }}" selected>
-                {{ $item->{$field['attribute']} }}
-            </option>
+                <option value="{{ $item->getKey() }}" selected>
+                    {{ $attribute }}
+                </option>
             @endif
         @endif
     </select>


### PR DESCRIPTION
When using select2_from_ajax we need to use data_source that we can easily modify the options attribute inside API Controller, example:
in API Controller:
```
$results = Order::join('personals', 'orders.personal_id', '=', 'personals.id')
                ->select(
                    "orders.id as id",
                    \DB::raw("concat(orders.id, ' - ', personals.name) as name")
                )->where('personals.name', 'LIKE', "%$search_term%")->paginate(10);
```
- result:
"1 - Personal Name"

but when we try to _edit_ the item from the table, it just returns the attribute name that we cannot modify like inside the API Controller, example:
```
[
    'name'  => 'order_id',
    'label' => 'Order',
    'type'  => 'select2_from_ajax',
    'entity' => 'order',
    'attribute' => "name",
    'data_source' => url("api/order"),
    'placeholder' => "Pilih Order",
    'minimum_input_length' => 1,
    // Optional
    'wrapperAttributes' => ['class' => 'form-group col-md-6'],
],
```
- result:
"Name Only Without Relation Column"

It will return only _name_ attribute, but with this code it will return **custom attribute value** when editing the form:
```
[
    'name'  => 'order_id',
    'label' => 'Order',
    'type'  => 'select2_from_ajax',
    'entity' => 'order',
    'attribute' => "name",
    'data_source' => url("api/order"),
    'placeholder' => "Pilih Order",
    'minimum_input_length' => 1,
    'option'   => (function ($query) {
        $debtorName = Personal::findOrFail($query->personal_id)->name;
        return $query->id . ' - ' . $debtorName;
    }),
    'wrapperAttributes' => ['class' => 'form-group col-md-6'],
],
```
- result:
"1 - Personal Name"