### PR TITLE
[4.1][FIX] FetchOperation error with multiple search attributes - add fetch single

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -61,11 +61,11 @@ trait FetchOperation
         $config['query'] = isset($config['query']) && is_callable($config['query']) ? $config['query']($config['model']) : $model_instance; // if a closure that has been passed as "query", use the closure - otherwise use the model
 
         // FetchOperation is aware of an optional parameter 'keys' that will fetch you the entity/entities that match the provided keys
-        if(request()->has('keys')) {
+        if (request()->has('keys')) {
             $decoded_keys = json_decode(request()->get('keys'));
-            if(is_array($decoded_keys)) {
+            if (is_array($decoded_keys)) {
                 return $model_instance->whereIn($model_instance->getKeyName(), $decoded_keys)->get();
-            }else{
+            } else {
                 return $model_instance->where($model_instance->getKeyName(), $decoded_keys)->first();
             }
         }

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -74,7 +74,7 @@ trait FetchOperation
         // when multiple searchable columns are provided.
         $originalBuilder = $config['query'];
 
-        $textColumnTypes = ['string', 'json_string', 'text'];
+        $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array'];
         // for each searchable attribute, add a WHERE clause
         foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
             $operation = ($k == 0) ? 'where' : 'orWhere';

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -70,15 +70,15 @@ trait FetchOperation
             $config['query']->get();
         }
 
-        // we store the original builder so we can use it to check column types
+        // we store the original model so we can use it to check column types
         // when multiple searchable columns are provided.
-        $originalBuilder = $config['query'];
+        $originalModel = $config['query'];
 
         $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array'];
         // for each searchable attribute, add a WHERE clause
         foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
             $operation = ($k == 0) ? 'where' : 'orWhere';
-            $columnType = $originalBuilder->getColumnType($searchColumn);
+            $columnType = $originalModel->getColumnType($searchColumn);
 
             if (in_array($columnType, $textColumnTypes)) {
                 $config['query'] = $config['query']->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -22,7 +22,7 @@ trait FetchOperation
 
         if (count($matches[1])) {
             foreach ($matches[1] as $methodName) {
-                Route::post($segment.'/fetch/'.Str::kebab($methodName).'{single?}', [
+                Route::post($segment.'/fetch/'.Str::kebab($methodName).'/{single?}', [
                     'uses'      => $controller.'@fetch'.$methodName,
                     'operation' => 'FetchOperation',
                 ]);

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -70,11 +70,15 @@ trait FetchOperation
             $config['query']->get();
         }
 
+        // we store the original builder so we can use it to check column types
+        // when multiple searchable columns are provided.
+        $originalBuilder = $config['query'];
+
         $textColumnTypes = ['string', 'json_string', 'text'];
         // for each searchable attribute, add a WHERE clause
         foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
             $operation = ($k == 0) ? 'where' : 'orWhere';
-            $columnType = $config['query']->getColumnType($searchColumn);
+            $columnType = $originalBuilder->getColumnType($searchColumn);
 
             if (in_array($columnType, $textColumnTypes)) {
                 $config['query'] = $config['query']->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -71,8 +71,8 @@ trait FetchOperation
         }
 
         // FetchOperation has an optional parameter in url that when present means we want to fetch a single entity.
-        $fetchUriCount = count(explode('/',request()->route()->uri())) - 1;
-        $currentUriCount = count(explode('/',request()->path()));
+        $fetchUriCount = count(explode('/', request()->route()->uri())) - 1;
+        $currentUriCount = count(explode('/', request()->path()));
 
         //in this case last parameter in url was specified so we will trigger the return of single entity
         if ($currentUriCount > $fetchUriCount) {

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -22,7 +22,7 @@ trait FetchOperation
 
         if (count($matches[1])) {
             foreach ($matches[1] as $methodName) {
-                Route::post($segment.'/fetch/'.Str::kebab($methodName), [
+                Route::post($segment.'/fetch/'.Str::kebab($methodName).'{single?}', [
                     'uses'      => $controller.'@fetch'.$methodName,
                     'operation' => 'FetchOperation',
                 ]);
@@ -68,6 +68,15 @@ trait FetchOperation
             return ($config['paginate'] !== false) ?
             $config['query']->paginate($config['paginate']) :
             $config['query']->get();
+        }
+
+        // FetchOperation has an optional parameter in url that when present means we want to fetch a single entity.
+        $fetchUriCount = count(explode('/',request()->route()->uri())) - 1;
+        $currentUriCount = count(explode('/',request()->path()));
+
+        //in this case last parameter in url was specified so we will trigger the return of single entity
+        if ($currentUriCount > $fetchUriCount) {
+            return $model_instance->where($model_instance->getKeyName(), $search_string)->first();
         }
 
         // we store the original model so we can use it to check column types


### PR DESCRIPTION
When we start building our query `$model->where()` or `$model->orWhere()` we no longer have a Model instance, we have a `Builder`, so our function `getColumnType()` to no longer works as it belongs to the model, and not to the builder. 

Also added the complete array of text columns, please @tabacitu when merging #2632 discard the changes in `FetchOperation.php`, the changes in this PR must prevail.

This also adds support to fetching a single entry. 

This fixes #2704 

I will also send the PR to the docs to fix the documentation part.