### PR TITLE
CSS fix for .crudTable_length on List operation

### DIFF
--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -87,7 +87,8 @@
 	}
 
 	div.dataTables_wrapper div.dataTables_length select {
-		width: auto;
+		min-width: 3.6rem;
+		margin-right: 0.4rem;
 	}
 
 


### PR DESCRIPTION
Hi, Cristian!
The .crudTable_length block began to look better for 1-3-digit numbers.

This will also work for version 4.0

![1](https://user-images.githubusercontent.com/35972279/80908919-0fc8ba00-8d4e-11ea-942e-bd5862d378b7.gif)

**Unfortunately, 4-digit numbers or more still have problems, but this is a rare case**