### PR TITLE
Relationship column was using an old method name

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -110,6 +110,12 @@ trait ColumnsProtectedMethods
      */
     protected function makeSureColumnHasType($column)
     {
+        // if it's got a method on the model with the same name
+        // then it should be a relationship
+        if (! isset($column['type']) && method_exists($this->model, $column['name'])) {
+            $column['type'] = 'relationship';
+        }
+
         if (! isset($column['type'])) {
             $column['type'] = 'text';
         }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -33,6 +33,14 @@ trait ColumnsProtectedMethods
         $column['orderable'] = $column['orderable'] ?? $columnExistsInDb;
         $column['searchLogic'] = $column['searchLogic'] ?? $columnExistsInDb;
 
+        // check if it's a method on the model,
+        // that means it's a relationship
+        if (!$columnExistsInDb && method_exists($this->model, $column['name'])) {
+            $relatedModel = $this->model->{$column['name']}()->getRelated();
+            $column['entity'] = $column['name'];
+            $column['model'] = get_class($relatedModel);
+        }
+
         return $column;
     }
 

--- a/src/resources/views/crud/columns/relationship.blade.php
+++ b/src/resources/views/crud/columns/relationship.blade.php
@@ -2,11 +2,15 @@
 @php
    $relationshipType = new ReflectionClass($entry->{$column['name']}());
    $relationshipType = $relationshipType->getShortName();
-   $allows_multiple = $crud->relationAllowsMultiple($relationshipType);
+   $allows_multiple = $crud->guessIfFieldHasMultipleFromRelationType($relationshipType);
+
+   if (!$allows_multiple) {
+	   $column['name'] = 'parent_id';
+   }
 @endphp
 
 @if ($allows_multiple)
-    @include('crud::columns.select_multiple')
+	@include('crud::columns.select_multiple')
 @else
-    @include('crud::columns.select')
+	@include('crud::columns.select')
 @endif

--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -11,7 +11,7 @@
     // a crud field like this one.
     $field['type'] = 'fetch';
 
-    $field['multiple'] = $field['multiple'] ?? $crud->relationAllowsMultiple($field['relation_type']);
+    $field['multiple'] = $field['multiple'] ?? $crud->guessIfFieldHasMultipleFromRelationType($field['relation_type']);
     $field['data_source'] = $field['data_source'] ?? url($crud->route.'/fetch/'.$routeEntity);
     $field['attribute'] = $field['attribute'] ?? $connected_entity->identifiableAttribute();
     $field['placeholder'] = $field['placeholder'] ?? $field['multiple'] ? 'Select entities' : 'Select an entity';


### PR DESCRIPTION
- Fixes #2788 
- Columns guess that the type should be `relationship`
- Columns guess the entity and model if it's a `relationship`