### PR TITLE
[4.1.x] Avoid odd white space before commas on every list/array column

### DIFF
--- a/src/resources/views/crud/columns/array.blade.php
+++ b/src/resources/views/crud/columns/array.blade.php
@@ -18,11 +18,11 @@
             @endphp
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $text }}<?
+                    {{ $text }}<?php
                 ?>@else
-                    {!! $text !!}<?
-                ?>@endif<?
-            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+                    {!! $text !!}<?php
+                ?>@endif<?php
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?php
 
             ?>@if(!$loop->last), @endif
         @endforeach

--- a/src/resources/views/crud/columns/array.blade.php
+++ b/src/resources/views/crud/columns/array.blade.php
@@ -10,12 +10,7 @@
 @endphp
 
 <span>
-
     @if($value && count($value))
-        @php
-            $lastKey = array_key_last($value);
-        @endphp
-
         @foreach($value as $key => $text)
             @php
                 $column['text'] = $text;
@@ -23,16 +18,15 @@
             @endphp
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $column['text'] }}
-                @else
-                    {!! $column['text'] !!}
-                @endif
-            @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+                    {{ $text }}<?
+                ?>@else
+                    {!! $text !!}<?
+                ?>@endif<?
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
 
-            @if($key != $lastKey), @endif
+            ?>@if(!$loop->last), @endif
         @endforeach
     @else
         -
     @endif
-
 </span>

--- a/src/resources/views/crud/columns/multidimensional_array.blade.php
+++ b/src/resources/views/crud/columns/multidimensional_array.blade.php
@@ -31,12 +31,12 @@
             @endphp
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $column['text'] }}<?
+                    {{ $column['text'] }}<?php
                 ?>@else
-                    {!! $column['text'] !!}<?
-                ?>@endif<?
-            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
-        
+                    {!! $column['text'] !!}<?php
+                ?>@endif<?php
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?php
+
             ?>@if(!$loop->last), @endif
         @endforeach
     @else

--- a/src/resources/views/crud/columns/multidimensional_array.blade.php
+++ b/src/resources/views/crud/columns/multidimensional_array.blade.php
@@ -17,7 +17,6 @@
                 $list[$column['visible_key']][] = $item[$column['visible_key']];
             }
         }
-        $lastKey = array_key_last($list[$column['visible_key']]);
     }
 
     $column['escaped'] = $column['escaped'] ?? true;
@@ -32,12 +31,13 @@
             @endphp
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $column['text'] }}
-                @else
-                    {!! $column['text'] !!}
-                @endif
-            @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-        @if($lastKey != $key),@endif
+                    {{ $column['text'] }}<?
+                ?>@else
+                    {!! $column['text'] !!}<?
+                ?>@endif<?
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+        
+            ?>@if(!$loop->last), @endif
         @endforeach
     @else
         -

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -12,9 +12,6 @@
 
 <span>
     @if(count($attributes))
-        @php
-            $lastKey = array_key_last($attributes)
-        @endphp
 
         @foreach($attributes as $key => $text)
             @php
@@ -23,12 +20,13 @@
 
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $text }}
-                @else
-                    {!! $text !!}
-                @endif
-            @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-                @if($lastKey != $key), @endif
+                    {{ $text }}<?
+                ?>@else
+                    {!! $text !!}<?
+                ?>@endif<?
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+            
+            ?>@if(!$loop->last), @endif
         @endforeach
     @else
         -

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -20,12 +20,12 @@
 
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $text }}<?
+                    {{ $text }}<?php
                 ?>@else
-                    {!! $text !!}<?
-                ?>@endif<?
-            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
-            
+                    {!! $text !!}<?php
+                ?>@endif<?php
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?php
+
             ?>@if(!$loop->last), @endif
         @endforeach
     @else

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -13,7 +13,6 @@
                 $value = $column['options'][$values] ?? $values;
                 $list[$values] = $value;
             }
-            $lastKey = array_key_last($list);
         }
 
     $column['escaped'] = $column['escaped'] ?? true;
@@ -27,12 +26,13 @@
         @endphp
         @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
             @if($column['escaped'])
-                {{ $text }}
-            @else
-                {!! $text !!}
-            @endif
-        @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-        @if($lastKey != $key),@endif
+                {{ $text }}<?
+            ?>@else
+                {!! $text !!}<?
+            ?>@endif<?
+        ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+
+        ?>@if(!$loop->last), @endif
         @endforeach
     @endif
 </span>

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -26,11 +26,11 @@
         @endphp
         @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
             @if($column['escaped'])
-                {{ $text }}<?
+                {{ $text }}<?php
             ?>@else
-                {!! $text !!}<?
-            ?>@endif<?
-        ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+                {!! $text !!}<?php
+            ?>@endif<?php
+        ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?php
 
         ?>@if(!$loop->last), @endif
         @endforeach

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -26,11 +26,11 @@
 
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $text }}<?
+                    {{ $text }}<?php
                 ?>@else
-                    {!! $text !!}<?
-                ?>@endif<?
-            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
+                    {!! $text !!}<?php
+                ?>@endif<?php
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?php
 
             ?>@if(!$loop->last), @endif
 

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -9,12 +9,11 @@
 
     if(!$results->isEmpty()) {
         $related_key = $results->first()->getKeyName();
-        $results_array = $results->pluck($column['attribute'],$related_key)->toArray();
-        $lastKey = array_key_last($results_array);
+        $results_array = $results->pluck($column['attribute'], $related_key)->toArray();
     }
 
-    foreach ($results_array as $key => $text) {
-        $text = Str::limit($text, $column['limit'], '[...]');
+    foreach ($results_array as $key => $text) { 
+        $results_array[$key] = Str::limit($text, $column['limit'], '[...]');
     }
 @endphp
 
@@ -27,13 +26,14 @@
 
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
                 @if($column['escaped'])
-                    {{ $text }}
-                @else
-                    {!! $text !!}
-                @endif
-            @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+                    {{ $text }}<?
+                ?>@else
+                    {!! $text !!}<?
+                ?>@endif<?
+            ?>@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')<?
 
-            @if($lastKey != $key), @endif
+            ?>@if(!$loop->last), @endif
+
         @endforeach
     @else
         -


### PR DESCRIPTION
**Problem**
![image](https://user-images.githubusercontent.com/1838187/81488860-bb01d380-9266-11ea-9764-a8e7fe8e177f.png)

This is not an easy fix, to fix the odd white space before commas there were two options, either concat all PHP, in a one line solution, which is very ugly, or add the php tags `<?` `?>` at the end and start of blade tags. Like this:
```
{!! $text !!}<?
?>@endif<?
?>@includeWhen...
```
The result in the PHP code is not very nice, but the HTML output is correct.
Took this idea from [this answer](https://stackoverflow.com/a/5078297/1192479) on Stackoverflow.

**Result**
![image](https://user-images.githubusercontent.com/1838187/81488870-de2c8300-9266-11ea-97ce-ff59b88fc6b3.png)


Also, replaced `array_key_last` for blade `$loop->last`, and fix a minor bug on `select_multiple.blade.php` it was not limiting the text.