### PR TITLE
Allow translatable button texts on custom save actions

### DIFF
--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -84,7 +84,7 @@ trait SaveActions
             return $request->has('http_referrer') ? $request->get('http_referrer') : $crud->route;
         };
         $saveAction['visible'] = $saveAction['visible'] ?? true;
-        $saveAction['button_text'] = $saveAction['button_text'] ?? $saveAction['name'];
+        $saveAction['button_text'] = $saveAction['button_text'] ?? trans('backpack::crud.' . $saveAction['name']);
         $saveAction['order'] = isset($saveAction['order']) ? $this->orderSaveAction($saveAction['name'], $saveAction['order']) : $orderCounter;
 
         $actions = $this->getOperationSetting('save_actions') ?? [];


### PR DESCRIPTION
Allow translatable button texts on custom save actions by looking for the name of the save action in the language files.