### PR TITLE
Fixed `select_multiple.blade.php` result limit

### DIFF
--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -13,8 +13,8 @@
         $lastKey = array_key_last($results_array);
     }
 
-    foreach ($results_array as $key => $text) {
-        $text = Str::limit($text, $column['limit'], '[...]');
+    foreach ($results_array as $key => $text) { 
+        $results_array[$key] = Str::limit($text, $column['limit'], '[...]');
     }
 @endphp
 


### PR DESCRIPTION
It wasn't really applying the limit to the text.