### PR TITLE
Using translation on repeatable New Item button

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -142,6 +142,7 @@ return [
     'internal_link_placeholder' => 'Internal slug. Ex: \'admin/page\' (no quotes) for \':url\'',
     'external_link'             => 'External link',
     'choose_file'               => 'Choose file',
+    'new_item'                  => 'New Item',
 
     //Table field
     'table_cant_add'    => 'Cannot add new :entity',

--- a/src/resources/lang/pt-BR/crud.php
+++ b/src/resources/lang/pt-BR/crud.php
@@ -124,8 +124,9 @@ return [
     'select_all'                => 'Selecionar todos',
     'select_files'              => 'Selecionar todos os arquivos',
     'select_file'               => 'Selecionar arquivo',
+    'new_item'                  => 'Novo Item',
 
-    //Table field
+    // Table field
     'table_cant_add'    => 'Não foi possível adicionar um(a) novo(a) :entity',
     'table_max_reached' => 'Limite de :max alcançado',
 

--- a/src/resources/lang/pt_br/crud.php
+++ b/src/resources/lang/pt_br/crud.php
@@ -124,6 +124,7 @@ return [
     'select_all'                => 'Selecionar todos',
     'select_files'              => 'Selecionar todos os arquivos',
     'select_file'               => 'Selecionar arquivo',
+    'new_item'                  => 'Novo Item',
 
     //Table field
     'table_cant_add'    => 'Não foi possível adicionar um(a) novo(a) :entity',

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -40,7 +40,7 @@
     </div>
 
   </div>
-  <button type="button" class="btn btn-outline-primary btn-sm ml-1 add-repeatable-element-button">+ New Item</button>
+  <button type="button" class="btn btn-outline-primary btn-sm ml-1 add-repeatable-element-button">+ {{ trans('backpack::crud.new_item') }}</button>
 
 @include('crud::fields.inc.wrapper_end')
 


### PR DESCRIPTION
Repeatable crud field is using fixed text `New Item`. It should be able to translate. I added the `trans` helper and a translation `backpack::crud.new_item` in en, pt_br, pt-BR files.