### PR TITLE
fixes #2797 - CrudColumn constructor did not guess missing attributes

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -32,6 +32,9 @@ class CrudColumn
             $this->setAttributeValue('name', $name);
         }
 
+        // guess all attributes that weren't explicitly defined
+        $this->attributes = $this->crud()->makeSureColumnHasNeededAttributes($this->attributes);
+
         return $this->save();
     }
 

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -8,43 +8,6 @@ use Illuminate\Support\Str;
 trait ColumnsProtectedMethods
 {
     /**
-     * The only REALLY MANDATORY attribute for a column is the 'name'.
-     * Everything else, Backpack can probably guess.
-     *
-     * This method checks that all necessary attributes are set.
-     * If not, it tries to guess them.
-     *
-     * @param  string|array $column The column definition array OR column name as string.
-     * @return array                Proper column definition array.
-     */
-    protected function makeSureColumnHasNeededAttributes($column)
-    {
-        $column = $this->makeSureColumnHasName($column);
-        $column = $this->makeSureColumnHasLabel($column);
-        $column = $this->makeSureColumnHasType($column);
-        $column = $this->makeSureColumnHasKey($column);
-        $column = $this->makeSureColumnHasModel($column);
-
-        // check if the column exists in the database (as a db column)
-        $columnExistsInDb = $this->hasDatabaseColumn($this->model->getTable(), $column['name']);
-
-        // make sure column has tableColumn, orderable and searchLogic
-        $column['tableColumn'] = $column['tableColumn'] ?? $columnExistsInDb;
-        $column['orderable'] = $column['orderable'] ?? $columnExistsInDb;
-        $column['searchLogic'] = $column['searchLogic'] ?? $columnExistsInDb;
-
-        // check if it's a method on the model,
-        // that means it's a relationship
-        if (! $columnExistsInDb && method_exists($this->model, $column['name'])) {
-            $relatedModel = $this->model->{$column['name']}()->getRelated();
-            $column['entity'] = $column['name'];
-            $column['model'] = get_class($relatedModel);
-        }
-
-        return $column;
-    }
-
-    /**
      * Add a column to the current operation, using the Setting API.
      *
      * @param array $column Column definition array.


### PR DESCRIPTION
This PR makes the makeSureColumnHasNeededAttributes() public instead of private, and makes sure that CrudColumns call that method inside the constructor, so that by the time it gets saved, it will have proper attributes. 

This makes fixes a problem (#2797) where you could not specify the label using the columns fluent syntax, because the key was different inside CrudColumn than it was inside the CrudPanel object. 

This also makes it easier to debug CrudColumns, because even after their first call, they will have all guessed attributes.