### PR TITLE
adds dump() and dd() methods to fluent syntax objects

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -375,6 +375,37 @@ class CrudButton
         return app('crud');
     }
 
+    // -----------------
+    // DEBUGGING METHODS
+    // -----------------
+    
+    /**
+     * Dump the current object to the screen,
+     * so that the developer can see its contents.
+     * 
+     * @return CrudButton
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
+
+    /**
+     * Dump and die. Duumps the current object to the screen,
+     * so that the developer can see its contents, then stops 
+     * the execution.
+     * 
+     * @return CrudButton
+     */
+    public function dd()
+    {
+        dd($this);
+
+        return $this;
+    }
+
     // ---------------
     // PRIVATE METHODS
     // ---------------

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -133,6 +133,37 @@ class CrudColumn
         return $this;
     }
 
+    // -----------------
+    // DEBUGGING METHODS
+    // -----------------
+    
+    /**
+     * Dump the current object to the screen,
+     * so that the developer can see its contents.
+     * 
+     * @return CrudColumn
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
+
+    /**
+     * Dump and die. Duumps the current object to the screen,
+     * so that the developer can see its contents, then stops 
+     * the execution.
+     * 
+     * @return CrudColumn
+     */
+    public function dd()
+    {
+        dd($this);
+
+        return $this;
+    }
+
     // ---------------
     // PRIVATE METHODS
     // ---------------

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -194,6 +194,38 @@ class CrudField
         return $this;
     }
 
+    // -----------------
+    // DEBUGGING METHODS
+    // -----------------
+    
+    /**
+     * Dump the current object to the screen,
+     * so that the developer can see its contents.
+     * 
+     * @return CrudField
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
+
+    /**
+     * Dump and die. Duumps the current object to the screen,
+     * so that the developer can see its contents, then stops 
+     * the execution.
+     * 
+     * @return CrudField
+     */
+    public function dd()
+    {
+        dd($this);
+
+        return $this;
+    }
+
+
     // -------------
     // MAGIC METHODS
     // -------------

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -495,6 +495,37 @@ class CrudFilter
         }
     }
 
+    // -----------------
+    // DEBUGGING METHODS
+    // -----------------
+    
+    /**
+     * Dump the current object to the screen,
+     * so that the developer can see its contents.
+     * 
+     * @return CrudFilter
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
+
+    /**
+     * Dump and die. Duumps the current object to the screen,
+     * so that the developer can see its contents, then stops 
+     * the execution.
+     * 
+     * @return CrudFilter
+     */
+    public function dd()
+    {
+        dd($this);
+
+        return $this;
+    }
+
     // -------------
     // MAGIC METHODS
     // -------------

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -206,15 +206,14 @@ class Widget extends Fluent
         return $this;
     }
 
-
     // -----------------
     // DEBUGGING METHODS
     // -----------------
-    
+
     /**
      * Dump the current object to the screen,
      * so that the developer can see its contents.
-     * 
+     *
      * @return Widget
      */
     public function dump()
@@ -226,9 +225,9 @@ class Widget extends Fluent
 
     /**
      * Dump and die. Duumps the current object to the screen,
-     * so that the developer can see its contents, then stops 
+     * so that the developer can see its contents, then stops
      * the execution.
-     * 
+     *
      * @return Widget
      */
     public function dd()
@@ -237,7 +236,6 @@ class Widget extends Fluent
 
         return $this;
     }
-    
 
     // -------------
     // MAGIC METHODS

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -206,6 +206,39 @@ class Widget extends Fluent
         return $this;
     }
 
+
+    // -----------------
+    // DEBUGGING METHODS
+    // -----------------
+    
+    /**
+     * Dump the current object to the screen,
+     * so that the developer can see its contents.
+     * 
+     * @return Widget
+     */
+    public function dump()
+    {
+        dump($this);
+
+        return $this;
+    }
+
+    /**
+     * Dump and die. Duumps the current object to the screen,
+     * so that the developer can see its contents, then stops 
+     * the execution.
+     * 
+     * @return Widget
+     */
+    public function dd()
+    {
+        dd($this);
+
+        return $this;
+    }
+    
+
     // -------------
     // MAGIC METHODS
     // -------------


### PR DESCRIPTION
This PR  adds a few convenience methods to the CrudButton, CrudColumn, CrudField and CrudFilter objects, to make it easier for developers to debug their objects using a fluent syntax.

It allows us to do:
```
CRUD::column('address')->dump()->label('Address');
// or
CRUD::column('address')->dd()->label('Address');
```

This way, you can dump the attributes of a column/field/filter/button/widget while you're working on it, using this fluent syntax, instead of having to split the definition into multiple lines to debug it. 