### PR TITLE
[4.1] Fix nested relations on select column

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -430,7 +430,7 @@ class CrudPanel
             } elseif (is_array($relation)) {
                 $currentResults = $relation;
             } elseif ($relation instanceof Model) {
-                $currentResults = array($relation);
+                $currentResults = [$relation];
             } else {
                 $currentResults = [];
             }

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -426,22 +426,17 @@ class CrudPanel
         $results = [];
         if (! is_null($relation)) {
             if ($relation instanceof Collection && ! $relation->isEmpty()) {
-                $currentResults[get_class($relation->first())] = $relation->toArray();
+                $relation = $relation->first();
             } elseif (is_array($relation) && ! empty($relation)) {
-                $currentResults[get_class($relation->first())] = $relation;
-            } else {
-                //relation must be App\Models\Article or App\Models\Category
-                if (! $relation instanceof Collection && ! empty($relation)) {
-                    $currentResults[get_class($relation)] = $relation->toArray();
-                }
+                $relation = Arr::first($relation);
             }
+
+            $currentResults[get_class($relation)] = $relation->toArray();
 
             array_shift($relationArray);
 
             if (! empty($relationArray)) {
-                foreach ($currentResults as $model => $currentResult) {
-                    $results[$model] = array_merge($results[$model], $this->getRelatedEntries($currentResult, implode('.', $relationArray)));
-                }
+                $results = array_merge($currentResults, $this->getRelatedEntries($relation->first(), implode('.', $relationArray)));
             } else {
                 $results = $currentResults;
             }


### PR DESCRIPTION
I ran into some problems when trying to add nested relations on a select column in my admin interface. My setup is:
- Model `App/Models/Category`
- Model `App/Models/Subject`, which `BelongsTo` Category
- Model `App/Models/Skill`, which `BelongsTo` Subject
- Model `App/Models/Exercise`, which `BelongsTo` Skill
- Controller `App/Controllers/Admin/ExerciseCrudController`, which has a column   
`['name' => 'category', 'type' => 'select', 'label' => "Categorie", 'entity' => 'skill.subject.category', 'attribute' => 'title']`
- Backpack version: 4.1.3

When I try to list the Exercises, I get an error `Undefined index: App\Models\Skill` at line `\\vendor\\backpack\\crud\\src\\app\\Library\\CrudPanel\\CrudPanel.php:443`.

I found a few problems with the code below I didn't quite understand, but tried to fix by changing it to the way I guess it was originally intended:  
- The error was caused by the call to `$results[$model]`, which I think makes no sense as `results` is always empty at that point in the code
- The call `$this->getRelatedEntries($currentResult, implode('.', $relationArray))` also seems weird, as `$currentResult` always is forced to be an `array` looking at the preceding code, while `getRelatedEntries` needs a `Model`.
- The call `get_class($relation->first())` when `$relation` is an array was not triggered in my code, but I think it will always fail as an array does not have such a method.