### PR TITLE
[4.1] Fix FetchOperation with custom query

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -58,7 +58,7 @@ trait FetchOperation
         // set configuration defaults
         $config['paginate'] = isset($config['paginate']) ? $config['paginate'] : 10;
         $config['searchable_attributes'] = $config['searchable_attributes'] ?? $model_instance->identifiableAttribute();
-        $config['query'] = isset($config['query']) && is_callable($config['query']) ? $config['query']($config['model']) : $model_instance; // if a closure that has been passed as "query", use the closure - otherwise use the model
+        $config['query'] = isset($config['query']) && is_callable($config['query']) ? $config['query']($model_instance) : $model_instance; // if a closure that has been passed as "query", use the closure - otherwise use the model
 
         // FetchOperation is aware of an optional parameter 'keys' that will fetch you the entity/entities that match the provided keys
         if (request()->has('keys')) {
@@ -88,7 +88,7 @@ trait FetchOperation
         // for each searchable attribute, add a WHERE clause
         foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
             $operation = ($k == 0) ? 'where' : 'orWhere';
-            $columnType = $originalModel->getColumnType($searchColumn);
+            $columnType = $model_instance->getColumnType($searchColumn);
 
             if (in_array($columnType, $textColumnTypes)) {
                 $config['query'] = $config['query']->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -80,10 +80,6 @@ trait FetchOperation
             $config['query']->get();
         }
 
-        // we store the original model so we can use it to check column types
-        // when multiple searchable columns are provided.
-        $originalModel = $config['query'];
-
         $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array'];
         // for each searchable attribute, add a WHERE clause
         foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {


### PR DESCRIPTION
PR related to #2817. 

Fixes a pair of errors caused when passing a custom query to the fetch() operation via an array as shown in the [documentation](https://backpackforlaravel.com/docs/4.1/crud-operation-fetch#how-to-use).

I think this is a simple fix, but I could be totally missing something here! Happy to help test further or do some more digging if needed. 