### PR TITLE
fixed widgets are not shown with after_content

### DIFF
--- a/src/resources/views/base/blank.blade.php
+++ b/src/resources/views/base/blank.blade.php
@@ -21,7 +21,5 @@
 @endsection
 
 @section('after_content_widgets')
-	@if (isset($widgets['after_content']))
-		@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'after_content')->toArray() ])
-	@endif
+	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'after_content')->toArray() ])
 @endsection


### PR DESCRIPTION
Hi All,

I had a problem when I was using Widgets.

## (A) what you did

I added widgets to `after_content` section using [Widgets API](https://backpackforlaravel.com/docs/4.1/base-widgets#widgets-api) in my admin dashboard using `blank.blade.php`.

Like:

```
Widget::add($widget_definition_array)->to('after_content');
Widget::add($widget_definition_array)->section('after_content');
Widget::add($widget_definition_array)->group('after_content');
```

## (B) what you expected to happen

I expected they are shown after content section.

## (C) what happened

They are not appeared anywhere.

## (D) what have you already tried to fix it?

Widgets are now stored into `Fluent` class before rendering.
But, `after_content_widgets` section in `blank.blade.php`, `$widgets` variable is still checked.
I think it is no longer necessary.

Thanks,
