### PR TITLE
add a counter widget

### DIFF
--- a/src/resources/views/base/widgets/counter.blade.php
+++ b/src/resources/views/base/widgets/counter.blade.php
@@ -1,0 +1,16 @@
+<div class="{{ $widget['wrapperClass'] ?? 'col-sm-6 col-md-3' }}">
+    <div class="{{ $widget['class'] ?? 'card mb-2' }}">
+        <div class="card-body p-3 d-flex align-items-center"><i class="la {{$widget['content']['icon']}} {{$widget['content']['icon_bg']}} p-3 font-5xl mr-3"></i>
+            <div>
+                <div class="text-value-sm text-primary">{{$widget['content']['number']}}</div>
+                <div class="text-muted text-uppercase font-weight-bold small">{{$widget['content']['title']}}</div>
+            </div>
+        </div>
+        <div class="card-footer px-3 py-2">
+            <a class="btn-block text-muted d-flex justify-content-between align-items-center" href="{{$widget['content']['link']}}">
+                <span class="small font-weight-bold">{{$widget['content']['link_title']}}</span>
+                <i class="fa fa-angle-right"></i>
+            </a>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
it a simple widget but really useful.

it uses LineAwesome

How to use:
```
$normalUsers = count(\App\User::all());
[ 'type' => 'counter',
                'content' => [
                    'icon' => 'la-users',
                    'icon_bg' => 'bg-primary',
                    'title' => 'Users',
                    'link' => 'user',
                    'number' => $normalUsers,
                    'link_title' => 'Show All'
                ]
          ]
```
Here's how it looks like in my demo dashboard.
![Capture d’écran 2020-05-15 à 21 17 27](https://user-images.githubusercontent.com/1247248/82088355-e581df80-96f1-11ea-8dca-0f94f018b658.png)
