### PR TITLE
[4.1.x] do not add route or sidebar content if it already exists

### DIFF
--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -56,7 +56,7 @@ class AddCustomRouteContent extends Command
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
                 return $this->info('Route already exists!');
             }
-            
+
             $end_line_number = $this->customRoutesFileEndLine($file_lines);
             $file_lines[$end_line_number + 1] = $file_lines[$end_line_number];
             $file_lines[$end_line_number] = '    '.$code;

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -51,6 +51,12 @@ class AddCustomRouteContent extends Command
 
             // insert the given code before the file's last line
             $file_lines = file($old_file_path, FILE_IGNORE_NEW_LINES);
+
+            // if the code already exists in the file, abort
+            if ($this->getLastLineNumberThatContains($code, $file_lines)) {
+                return $this->info('Route already exists!');
+            }
+            
             $end_line_number = $this->customRoutesFileEndLine($file_lines);
             $file_lines[$end_line_number + 1] = $file_lines[$end_line_number];
             $file_lines[$end_line_number] = '    '.$code;
@@ -104,5 +110,25 @@ class AddCustomRouteContent extends Command
 
             return $end_line_number;
         }
+    }
+
+    /**
+     * Parse the given file stream and return the line number where a string is found.
+     *
+     * @param  string $needle   The string that's being searched for.
+     * @param  array $haystack  The file where the search is being performed.
+     * @return bool|int         The last line number where the string was found. Or false.
+     */
+    private function getLastLineNumberThatContains($needle, $haystack)
+    {
+        $matchingLines = array_filter($haystack, function ($k) use ($needle) {
+            return strpos($k, $needle) !== false;
+        });
+
+        if ($matchingLines) {
+            return array_key_last($matchingLines);
+        }
+
+        return false;
     }
 }

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -45,7 +45,12 @@ class AddSidebarContent extends Command
         $code = $this->argument('code');
 
         if ($disk->exists($path)) {
-            $contents = Storage::disk($disk_name)->get($path);
+            $contents = $disk->get($path);
+            $file_lines = file($disk->path($path), FILE_IGNORE_NEW_LINES);
+
+            if ($this->getLastLineNumberThatContains($code, $file_lines)) {
+                return $this->info('Sidebar item already exists!');
+            }
 
             if ($disk->put($path, $contents.PHP_EOL.$code)) {
                 $this->info('Successfully added code to sidebar_content file.');
@@ -55,5 +60,25 @@ class AddSidebarContent extends Command
         } else {
             $this->error('The sidebar_content file does not exist. Make sure Backpack is properly installed.');
         }
+    }
+    
+    /**
+     * Parse the given file stream and return the line number where a string is found.
+     *
+     * @param  string $needle   The string that's being searched for.
+     * @param  array $haystack  The file where the search is being performed.
+     * @return bool|int         The last line number where the string was found. Or false.
+     */
+    private function getLastLineNumberThatContains($needle, $haystack)
+    {
+        $matchingLines = array_filter($haystack, function ($k) use ($needle) {
+            return strpos($k, $needle) !== false;
+        });
+
+        if ($matchingLines) {
+            return array_key_last($matchingLines);
+        }
+
+        return false;
     }
 }

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -61,7 +61,7 @@ class AddSidebarContent extends Command
             $this->error('The sidebar_content file does not exist. Make sure Backpack is properly installed.');
         }
     }
-    
+
     /**
      * Parse the given file stream and return the line number where a string is found.
      *


### PR DESCRIPTION
This PR separates from #2537 only this bit of logic - that the sidebar-content and route commands do not introduce duplicates when called.