### PR TITLE
Fixing undesired value on datetime inputs

### DIFF
--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -1,12 +1,16 @@
 <!-- html5 datetime input -->
 
-<?php
+@php
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
 if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterface)) {
     $field['value'] = $field['value']->toDateTimeString();
 }
-?>
+
+$timestamp = strtotime(old(square_brackets_to_dots($field['name'])) ? old(square_brackets_to_dots($field['name'])) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )));
+
+$value = $timestamp ? strftime('%Y-%m-%dT%H:%M:%S', $timestamp) : '';
+@endphp
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
@@ -14,7 +18,7 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
     <input
         type="datetime-local"
         name="{{ $field['name'] }}"
-        value="{{ strftime('%Y-%m-%dT%H:%M:%S', strtotime(old(square_brackets_to_dots($field['name'])) ? old(square_brackets_to_dots($field['name'])) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )))) }}"
+        value="{{ $value }}"
         @include('crud::fields.inc.attributes')
         >
 


### PR DESCRIPTION
Inputs with type `datetime` where being populated with value `1970-01-01T00:00:00` when old, value and default where not set. This is the return for `strftime('%Y-%m-%dT%H:%M:%S', false)`. This function should only be applied when a valid timestamp is used.