### PR TITLE
[4.1.x] Fix lonely dot in CRUD when no entries

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -76,15 +76,15 @@ return [
     // DataTables translation
     'emptyTable'     => 'No data available in table',
     'info'           => 'Showing _START_ to _END_ of _TOTAL_ entries',
-    'infoEmpty'      => '',
+    'infoEmpty'      => 'No entries',
     'infoFiltered'   => '(filtered from _MAX_ total entries)',
     'infoPostFix'    => '.',
     'thousands'      => ',',
-    'lengthMenu'     => '_MENU_ records per page',
+    'lengthMenu'     => '_MENU_ entries per page',
     'loadingRecords' => 'Loading...',
     'processing'     => 'Processing...',
     'search'         => 'Search: ',
-    'zeroRecords'    => 'No matching records found',
+    'zeroRecords'    => 'No matching entries found',
     'paginate'       => [
         'first'    => 'First',
         'last'     => 'Last',

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -223,7 +223,7 @@
       $("#crudTable_filter input").removeClass('form-control-sm');
 
       // move "showing x out of y" info to header
-      $("#datatable_info_stack").html($('#crudTable_info')).css('display','inline-flex');
+      $("#datatable_info_stack").html($('#crudTable_info')).css('display','inline-flex').addClass('animated fadeIn');
 
       @if($crud->getOperationSetting('resetButton') ?? true)
         // create the reset button


### PR DESCRIPTION
When there are zero entries in a DB table, the CRUD now shows an empty dot as the subtitle, so the actual heading reads "Categories . Reset" which is ugly and annoying. This PR fixes it my making the "infoEmpty" string on English "No entries". So now the heading shows "Categories. No entries. Reset". Much better I think - my OCD is happier now. While fixing this I've also changed a few lang entries for English - to call db records "entries" always, instead of sometimes "records" sometimes "entries". And I've added a fadeIn animation on the Reset button, so it matches the rest of the table, previously the button appeared to load slightly faster than the table.