### PR TITLE
Add visual validation errors also to select fields

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -131,7 +131,7 @@
                         container = field.parents('.form-group');
 
             container.addClass('text-danger');
-            container.children('input, textarea').addClass('is-invalid');
+            container.children('input, textarea, select').addClass('is-invalid');
 
             $.each(messages, function(key, msg){
                 // highlight the input that errored


### PR DESCRIPTION
On validation errors the select fields does not get the 'is-invalid' class.
For this reason the field border is not red and the invalid feedback label is not displayed.