### PR TITLE
[4.2] Fix old input when submiting empty values

### DIFF
--- a/src/resources/views/crud/fields/address_algolia.blade.php
+++ b/src/resources/views/crud/fields/address_algolia.blade.php
@@ -1,7 +1,7 @@
 <!-- address_algolia input -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
 

--- a/src/resources/views/crud/fields/address_algolia.blade.php
+++ b/src/resources/views/crud/fields/address_algolia.blade.php
@@ -1,6 +1,10 @@
 <!-- address_algolia input -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+
     $field['store_as_json'] = $field['store_as_json'] ?? false;
     $field['wrapper']['algolia-wrapper'] = $field['wrapper']['algolia-wrapper'] ?? 'true';
     $field['config'] = [
@@ -21,9 +25,9 @@
     @include('crud::fields.inc.translatable_icon')
 
     @if($field['store_as_json'])
-    <input type="hidden" 
-        value='{{ $field['value'] }}' 
-        name="{{ $field['name'] }}" 
+    <input type="hidden"
+        value='{{ $field['value'] }}'
+        name="{{ $field['name'] }}"
         data-algolia-hidden-input="{{ $field['name'] }}">
     @endif
 

--- a/src/resources/views/crud/fields/address_google.blade.php
+++ b/src/resources/views/crud/fields/address_google.blade.php
@@ -1,7 +1,9 @@
-<!-- text input -->
-
+<!-- address google -->
 <?php
 
+if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    $field['value'] = '';
+}
 // the field should work whether or not Laravel attribute casting is used
 if (isset($field['value']) && (is_array($field['value']) || is_object($field['value']))) {
     $field['value'] = json_encode($field['value']);

--- a/src/resources/views/crud/fields/address_google.blade.php
+++ b/src/resources/views/crud/fields/address_google.blade.php
@@ -1,7 +1,7 @@
 <!-- address google -->
 <?php
 
-if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
     $field['value'] = '';
 }
 // the field should work whether or not Laravel attribute casting is used

--- a/src/resources/views/crud/fields/base64_image.blade.php
+++ b/src/resources/views/crud/fields/base64_image.blade.php
@@ -13,6 +13,9 @@
     } elseif(isset($field['src']) && isset($entry)) {
         $value = $entry->find($entry->id)->{$field['src']}();
     } else {
+        if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+                $field['value'] = '';
+        }
         $value = $field['value'] ?? $field['default'] ?? '';
     }
 @endphp

--- a/src/resources/views/crud/fields/browse.blade.php
+++ b/src/resources/views/crud/fields/browse.blade.php
@@ -1,5 +1,9 @@
 <!-- browse server input -->
-
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
 
     <label>{!! $field['label'] !!}</label>

--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -1,4 +1,9 @@
 @php
+
+if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    $field['value'] = '';
+}
+
 $multiple = Arr::get($field, 'multiple', true);
 $sortable = Arr::get($field, 'sortable', false);
 $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
@@ -77,7 +82,7 @@ if($sortable){
     @endphp
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
-    @push('crud_fields_styles')        
+    @push('crud_fields_styles')
         <link href="{{ asset('packages/jquery-colorbox/example2/colorbox.css') }}" rel="stylesheet" type="text/css" />
         <style>
             #cboxContent, #cboxLoadedContent, .cboxIframe {
@@ -87,7 +92,7 @@ if($sortable){
     @endpush
 
     @push('crud_fields_scripts')
-        
+
         <script src="{{ asset('packages/jquery-ui-dist/jquery-ui.min.js') }}"></script>
         <script src="{{ asset('packages/jquery-colorbox/jquery.colorbox-min.js') }}"></script>
         <script>
@@ -97,7 +102,7 @@ if($sortable){
 
             // function to use the files selected inside elfinder
             function processSelectedMultipleFiles(files, requestingField) {
-                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);                
+                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);
                 elfinderTarget = false;
             }
 
@@ -109,7 +114,7 @@ if($sortable){
                 var $multiple = element.attr('data-multiple');
                 var $sortable = element.attr('sortable');
 
-                // show existing items - display visible inputs for each stored path  
+                // show existing items - display visible inputs for each stored path
                 if ($input.val() != '' && $input.val() != null && $multiple === 'true') {
                     $paths = JSON.parse($input.val());
                     if (Array.isArray($paths) && $paths.length) {

--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -1,5 +1,9 @@
 <!-- checkbox field -->
-
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = 0;
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     @include('crud::fields.inc.translatable_icon')
     <div class="checkbox">

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -1,24 +1,28 @@
 <!-- checklist -->
 @php
-  $model = new $field['model'];
-  $key_attribute = $model->getKeyName();
-  $identifiable_attribute = $field['attribute'];
+    $model = new $field['model'];
+    $key_attribute = $model->getKeyName();
+    $identifiable_attribute = $field['attribute'];
 
-  // calculate the checklist options
-  if (!isset($field['options'])) {
-      $field['options'] = $field['model']::all()->pluck($identifiable_attribute, $key_attribute)->toArray();
-  } else {
-      $field['options'] = call_user_func($field['options'], $field['model']::query());
-  }
+    // calculate the checklist options
+    if (!isset($field['options'])) {
+        $field['options'] = $field['model']::all()->pluck($identifiable_attribute, $key_attribute)->toArray();
+    } else {
+        $field['options'] = call_user_func($field['options'], $field['model']::query());
+    }
 
-  // calculate the value of the hidden input
-  $field['value'] = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
-  if ($field['value'] instanceof Illuminate\Database\Eloquent\Collection) {
-    $field['value'] = $field['value']->pluck($key_attribute)->toArray();
-  }
+    // calculate the value of the hidden input
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+    $field['value'] = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
-  // define the init-function on the wrapper
-  $field['wrapper']['data-init-function'] =  $field['wrapper']['data-init-function'] ?? 'bpFieldInitChecklist';
+    if ($field['value'] instanceof Illuminate\Database\Eloquent\Collection) {
+        $field['value'] = $field['value']->pluck($key_attribute)->toArray();
+    }
+
+    // define the init-function on the wrapper
+    $field['wrapper']['data-init-function'] =  $field['wrapper']['data-init-function'] ?? 'bpFieldInitChecklist';
 @endphp
 
 @include('crud::fields.inc.wrapper_start')

--- a/src/resources/views/crud/fields/ckeditor.blade.php
+++ b/src/resources/views/crud/fields/ckeditor.blade.php
@@ -1,5 +1,9 @@
 <!-- CKeditor -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+
+    }
     $field['extra_plugins'] = isset($field['extra_plugins']) ? implode(',', $field['extra_plugins']) : "embed,widget";
 
     $defaultOptions = [

--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 color input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/color_picker.blade.php
+++ b/src/resources/views/crud/fields/color_picker.blade.php
@@ -1,5 +1,10 @@
 <!-- configurable color picker -->
 {{-- https://farbelous.io/bootstrap-colorpicker/ --}}
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/custom_html.blade.php
+++ b/src/resources/views/crud/fields/custom_html.blade.php
@@ -1,4 +1,9 @@
 <!-- used for heading, separators, etc -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
 	{!! $field['value'] !!}
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/date.blade.php
+++ b/src/resources/views/crud/fields/date.blade.php
@@ -1,7 +1,7 @@
 <!-- html5 date input -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
 // if the column has been cast to Carbon or Date (using attribute casting)

--- a/src/resources/views/crud/fields/date.blade.php
+++ b/src/resources/views/crud/fields/date.blade.php
@@ -1,6 +1,9 @@
 <!-- html5 date input -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
 if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterface)) {

--- a/src/resources/views/crud/fields/date_picker.blade.php
+++ b/src/resources/views/crud/fields/date_picker.blade.php
@@ -3,7 +3,7 @@
 <?php
     // if the column has been cast to Carbon or Date (using attribute casting)
     // get the value as a date string
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
 

--- a/src/resources/views/crud/fields/date_picker.blade.php
+++ b/src/resources/views/crud/fields/date_picker.blade.php
@@ -3,6 +3,10 @@
 <?php
     // if the column has been cast to Carbon or Date (using attribute casting)
     // get the value as a date string
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+
     if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterface)) {
         $field['value'] = $field['value']->format('Y-m-d');
     }

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -1,6 +1,13 @@
 <!-- bootstrap daterange picker input -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name'][0]))) && !empty(session()->getOldInput())) {
+        $start_value = '';
+    }
+
+    if(is_null(old(square_brackets_to_dots($field['name'][1]))) && !empty(session()->getOldInput())) {
+        $end_value = '';
+    }
     // if the column has been cast to Carbon or Date (using attribute casting)
     // get the value as a date string
     if (! function_exists('formatDate')) {

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -1,11 +1,11 @@
 <!-- bootstrap daterange picker input -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name'][0]))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name'][0]))) && ! empty(session()->getOldInput())) {
         $start_value = '';
     }
 
-    if(is_null(old(square_brackets_to_dots($field['name'][1]))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name'][1]))) && ! empty(session()->getOldInput())) {
         $end_value = '';
     }
     // if the column has been cast to Carbon or Date (using attribute casting)

--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -1,7 +1,7 @@
 <!-- html5 datetime input -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
 // if the column has been cast to Carbon or Date (using attribute casting)

--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -1,6 +1,9 @@
 <!-- html5 datetime input -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
 if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterface)) {

--- a/src/resources/views/crud/fields/datetime_picker.blade.php
+++ b/src/resources/views/crud/fields/datetime_picker.blade.php
@@ -1,7 +1,7 @@
 <!-- bootstrap datetimepicker input -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
 // if the column has been cast to Carbon or Date (using attribute casting)

--- a/src/resources/views/crud/fields/datetime_picker.blade.php
+++ b/src/resources/views/crud/fields/datetime_picker.blade.php
@@ -1,6 +1,9 @@
 <!-- bootstrap datetimepicker input -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 // if the column has been cast to Carbon or Date (using attribute casting)
 // get the value as a date string
 if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterface)) {

--- a/src/resources/views/crud/fields/easymde.blade.php
+++ b/src/resources/views/crud/fields/easymde.blade.php
@@ -1,4 +1,9 @@
 <!-- Simple MDE - Markdown Editor -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/email.blade.php
+++ b/src/resources/views/crud/fields/email.blade.php
@@ -1,4 +1,9 @@
 <!-- text input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/hidden.blade.php
+++ b/src/resources/views/crud/fields/hidden.blade.php
@@ -1,4 +1,7 @@
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 	// if not otherwise specified, the hidden input should take up no space in the form
   $field['wrapper']['class'] = $field['wrapper']['class'] ?? $field['wrapperAttributes']['class'] ?? "hidden";
 @endphp

--- a/src/resources/views/crud/fields/icon_picker.blade.php
+++ b/src/resources/views/crud/fields/icon_picker.blade.php
@@ -1,5 +1,8 @@
 <!-- icon picker input -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     // if no iconset was provided, set the default iconset to Font-Awesome
     $field['iconset'] = $field['iconset'] ?? 'fontawesome';
 

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -1,4 +1,9 @@
 @php
+
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+
     $prefix = isset($field['prefix']) ? $field['prefix'] : '';
     $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
     $value = $value

--- a/src/resources/views/crud/fields/month.blade.php
+++ b/src/resources/views/crud/fields/month.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 month input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/number.blade.php
+++ b/src/resources/views/crud/fields/number.blade.php
@@ -1,4 +1,9 @@
 <!-- number input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -1,5 +1,8 @@
 <!-- radio -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
     // if the class isn't overwritten, use 'radio'

--- a/src/resources/views/crud/fields/range.blade.php
+++ b/src/resources/views/crud/fields/range.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 range input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -1,9 +1,13 @@
 {{-- REPEATABLE FIELD TYPE --}}
 
 @php
-  $field['value'] = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
-  // make sure the value is a JSON string (not array, if it's cast in the model)
-  $field['value'] = is_array($field['value']) ? json_encode($field['value']) : $field['value'];
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+
+    $field['value'] = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+    // make sure the value is a JSON string (not array, if it's cast in the model)
+    $field['value'] = is_array($field['value']) ? json_encode($field['value']) : $field['value'];
 @endphp
 
 @include('crud::fields.inc.wrapper_start')

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -1,5 +1,8 @@
 <!-- select -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 	$current_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
     $entity_model = $crud->getRelationModel($field['entity'],  - 1);
 

--- a/src/resources/views/crud/fields/select2.blade.php
+++ b/src/resources/views/crud/fields/select2.blade.php
@@ -1,5 +1,8 @@
 <!-- select2 -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     $current_value = old($field['name']) ?? $field['value'] ?? $field['default'] ?? '';
     $entity_model = new $field['model']();
 

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -1,5 +1,8 @@
 <!-- select2 from ajax -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = false;
+    }
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
     $old_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? false;
@@ -184,11 +187,11 @@
 
         // if we have selected options here we are on a repeatable field, we need to fetch the options with the keys
         // we have stored from the field and append those options in the select.
-        if (typeof $selectedOptions !== typeof undefined && 
-            $selectedOptions !== false &&  
-            $selectedOptions != '' && 
-            $selectedOptions != null && 
-            $selectedOptions != []) 
+        if (typeof $selectedOptions !== typeof undefined &&
+            $selectedOptions !== false &&
+            $selectedOptions != '' &&
+            $selectedOptions != null &&
+            $selectedOptions != [])
         {
             var optionsForSelect = [];
             select2AjaxFetchSelectedEntry(element).then(result => {

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -1,5 +1,8 @@
 <!-- select2 from ajax multiple -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = false;
+    }
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
     $old_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? false;

--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -1,5 +1,8 @@
 <!-- select2 -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     $current_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
 @endphp
 
@@ -11,7 +14,7 @@
         $related_model = $crud->getRelationModel($field['entity']);
         $group_by_model = (new $entity_model)->{$field['group_by']}()->getRelated();
         $categories = $group_by_model::with($field['group_by_relationship_back'])->get();
-        
+
         if (isset($field['model'])) {
             $categorylessEntries = $related_model::doesnthave($field['group_by'])->get();
         }

--- a/src/resources/views/crud/fields/select2_nested.blade.php
+++ b/src/resources/views/crud/fields/select2_nested.blade.php
@@ -7,6 +7,9 @@
 {{-- 2. depth, lft attributes --}}
 
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     $current_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
 
     if (!function_exists('echoSelect2NestedEntry')) {

--- a/src/resources/views/crud/fields/select_and_order.blade.php
+++ b/src/resources/views/crud/fields/select_and_order.blade.php
@@ -1,5 +1,8 @@
 <!-- select_and_order -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = [];
+    }
     $values = old($field['name']) ?? $field['value'] ?? $field['default'] ?? [];
     $values = (array)$values;
 @endphp
@@ -17,8 +20,8 @@
 
             {{-- The results will be stored here --}}
             <div data-identifier="results">
-                <select class="d-none" 
-                    name="{{ $field['name'] }}[]" 
+                <select class="d-none"
+                    name="{{ $field['name'] }}[]"
                     data-selected-options='@json($values)'
                     multiple>
                 </select>

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -1,5 +1,8 @@
 <!-- select2 -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     $current_value = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
 @endphp
 
@@ -11,7 +14,7 @@
         $related_model = $crud->getRelationModel($field['entity']);
         $group_by_model = (new $related_model)->{$field['group_by']}()->getRelated();
         $categories = $group_by_model::with($field['group_by_relationship_back'])->get();
-        
+
         if (isset($field['model'])) {
             $categorylessEntries = $related_model::doesnthave($field['group_by'])->get();
         }

--- a/src/resources/views/crud/fields/simplemde.blade.php
+++ b/src/resources/views/crud/fields/simplemde.blade.php
@@ -1,4 +1,9 @@
 <!-- Simple MDE - Markdown Editor -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -1,5 +1,8 @@
 <!-- summernote editor -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     // make sure that the options array is defined
     // and at the very least, dialogsInBody is true;
     // that's needed for modals to show above the overlay in Bootstrap 4

--- a/src/resources/views/crud/fields/table.blade.php
+++ b/src/resources/views/crud/fields/table.blade.php
@@ -1,7 +1,7 @@
 <!-- Backpack Table Field Type -->
 
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = [];
     }
     $max = isset($field['max']) && (int) $field['max'] > 0 ? $field['max'] : -1;

--- a/src/resources/views/crud/fields/table.blade.php
+++ b/src/resources/views/crud/fields/table.blade.php
@@ -1,6 +1,9 @@
 <!-- Backpack Table Field Type -->
 
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = [];
+    }
     $max = isset($field['max']) && (int) $field['max'] > 0 ? $field['max'] : -1;
     $min = isset($field['min']) && (int) $field['min'] > 0 ? $field['min'] : -1;
     $item_name = strtolower(isset($field['entity_singular']) && ! empty($field['entity_singular']) ? $field['entity_singular'] : $field['label']);
@@ -38,9 +41,9 @@
             data-init-function="bpFieldInitTableElement"
             name="{{ $field['name'] }}"
             value="{{ $items }}"
-            data-max="{{$max}}" 
-            data-min="{{$min}}" 
-            data-maxErrorTitle="{{trans('backpack::crud.table_cant_add', ['entity' => $item_name])}}" 
+            data-max="{{$max}}"
+            data-min="{{$min}}"
+            data-maxErrorTitle="{{trans('backpack::crud.table_cant_add', ['entity' => $item_name])}}"
             data-maxErrorMessage="{{trans('backpack::crud.table_max_reached', ['max' => $max])}}">
 
     <div class="array-container form-group">

--- a/src/resources/views/crud/fields/text.blade.php
+++ b/src/resources/views/crud/fields/text.blade.php
@@ -1,4 +1,9 @@
 <!-- text input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/textarea.blade.php
+++ b/src/resources/views/crud/fields/textarea.blade.php
@@ -1,4 +1,9 @@
 <!-- textarea -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/time.blade.php
+++ b/src/resources/views/crud/fields/time.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 time input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/tinymce.blade.php
+++ b/src/resources/views/crud/fields/tinymce.blade.php
@@ -1,5 +1,8 @@
 <!-- Tiny MCE -->
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
 $defaultOptions = [
     'file_picker_callback' => 'elFinderBrowser',
     'selector' => 'textarea.tinymce',

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -1,4 +1,7 @@
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
    if (!isset($field['wrapper']) || !isset($field['wrapper']['data-init-function'])){
         $field['wrapper']['data-init-function'] = 'bpFieldInitUploadElement';
     }

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -1,4 +1,7 @@
 @php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
     if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-init-function'])){
         $field['wrapperAttributes']['data-init-function'] = 'bpFieldInitUploadMultipleElement';
     }

--- a/src/resources/views/crud/fields/url.blade.php
+++ b/src/resources/views/crud/fields/url.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 url input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')

--- a/src/resources/views/crud/fields/video.blade.php
+++ b/src/resources/views/crud/fields/video.blade.php
@@ -1,23 +1,25 @@
 <!-- text input -->
 <?php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+    $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
-$value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+    // if attribute casting is used, convert to JSON
+    if (is_array($value)) {
+        $value = json_encode((object) $value);
+    } elseif (is_object($value)) {
+        $value = json_encode($value);
+    } else {
+        $value = $value;
+    }
 
-// if attribute casting is used, convert to JSON
-if (is_array($value)) {
-    $value = json_encode((object) $value);
-} elseif (is_object($value)) {
-    $value = json_encode($value);
-} else {
-    $value = $value;
-}
+    $field['youtube_api_key'] = $field['youtube_api_key'] ?? 'AIzaSyBLRoVYovRmbIf_BH3X12IcTCudAEDRlCE';
 
-$field['youtube_api_key'] = $field['youtube_api_key'] ?? 'AIzaSyBLRoVYovRmbIf_BH3X12IcTCudAEDRlCE';
-
-$field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
-$field['wrapper']['data-init-function'] = 'bpFieldInitVideoElement';
-$field['wrapper']['data-youtube-api-key'] = $field['youtube_api_key'];
-$field['wrapper']['data-video'] = '';
+    $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
+    $field['wrapper']['data-init-function'] = 'bpFieldInitVideoElement';
+    $field['wrapper']['data-youtube-api-key'] = $field['youtube_api_key'];
+    $field['wrapper']['data-video'] = '';
 ?>
 
 

--- a/src/resources/views/crud/fields/video.blade.php
+++ b/src/resources/views/crud/fields/video.blade.php
@@ -1,6 +1,6 @@
 <!-- text input -->
 <?php
-    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+    if (is_null(old(square_brackets_to_dots($field['name']))) && ! empty(session()->getOldInput())) {
         $field['value'] = '';
     }
     $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';

--- a/src/resources/views/crud/fields/week.blade.php
+++ b/src/resources/views/crud/fields/week.blade.php
@@ -1,4 +1,9 @@
 <!-- html5 week input -->
+@php
+    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
+        $field['value'] = '';
+    }
+@endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')


### PR DESCRIPTION
This is an old issue. Discussion about it here: #1816 

Fields not touched:

- checklist dependency
- enum (no sense)
- page_or_link
- select_from_array
- select_multiple
- select2_from_array
- select2_multiple
- view (no sense)

The ones I did not touch was mainly because they don't have fallbacks as the fields I added. Only followed field `default fallback` of the field that had them. Eg from text:

```php
value="{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}"
```
I fall back to:

```php
    if(is_null(old(square_brackets_to_dots($field['name']))) && !empty(session()->getOldInput())) {
        $field['value'] = '';
    }
```


