### PR TITLE
Fix php requirement incompatibility caused by vendor package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laravel/framework": "^7.0|^6.0",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
-        "ocramius/package-versions": "^1.4",
+        "ocramius/package-versions": "1.4.*",
         "doctrine/dbal": "^2.5",
         "guzzlehttp/guzzle": "^6.3"
     },


### PR DESCRIPTION
Requiring `ocramius/package-versions=^1.4` would install the latest version, which currently requires `php=^7.4.0`. 

This introduce an issue that `backpack/crud` could not be installed on a server with php^7.2.5 as required by `laravel`. It could be easily fixed by all developer using `backpack/crud` also `composer require ocramius/package-versions=1.4.*` but this should be considered as a bug here. 

This PR fixes it to `ocramius/package-versions=1.4.*`, that requires `php=^7.1.0`.

_Side note: `ocramius/package-versions:1.5.*` requires `php=^7.3.0`, and `>1.6.*` requires `php=^7.4.0`._