### PR TITLE
do not publish prologue/alerts config file upon installation

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -43,18 +43,13 @@ class Install extends Command
         $this->info(' Backpack installation started. Please wait...');
         $this->progressBar->advance();
 
-        $this->line(' Publishing configs, langs, views, js and css files');
+        $this->line(' Publishing configs, views, js and css files');
         $this->executeArtisanProcess('vendor:publish', [
             '--provider' => 'Backpack\CRUD\BackpackServiceProvider',
             '--tag' => 'minimum',
         ]);
 
-        $this->line(' Publishing config for notifications - prologue/alerts');
-        $this->executeArtisanProcess('vendor:publish', [
-            '--provider' => 'Prologue\Alerts\AlertsServiceProvider',
-        ]);
-
-        $this->line(" Generating users table (using Laravel's default migrations)");
+        $this->line(" Creating users table (using Laravel's default migration)");
         $this->executeArtisanProcess('migrate');
 
         $this->line(" Creating App\Http\Middleware\CheckIfAdmin.php");


### PR DESCRIPTION
Very very few people actually need to modify this file. So it's probably better to NOT publish it upon installing Backpack. This makes the installation process a little easier to absorb. They can still publish and modify it after the fact, if they want.