### PR TITLE
Added new widget stacks - before_breadcrumbs and after_breadcrumbs

### DIFF
--- a/src/resources/views/base/blank.blade.php
+++ b/src/resources/views/base/blank.blade.php
@@ -13,6 +13,10 @@
 	}
 @endphp
 
+@section('before_breadcrumbs_widgets')
+	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'before_breadcrumbs')->toArray() ])
+@endsection
+
 @section('before_content_widgets')
 	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'before_content')->toArray() ])
 @endsection

--- a/src/resources/views/base/blank.blade.php
+++ b/src/resources/views/base/blank.blade.php
@@ -17,6 +17,10 @@
 	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'before_breadcrumbs')->toArray() ])
 @endsection
 
+@section('after_breadcrumbs_widgets')
+	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'after_breadcrumbs')->toArray() ])
+@endsection
+
 @section('before_content_widgets')
 	@include(backpack_view('inc.widgets'), [ 'widgets' => app('widgets')->where('section', 'before_content')->toArray() ])
 @endsection

--- a/src/resources/views/base/layouts/top_left.blade.php
+++ b/src/resources/views/base/layouts/top_left.blade.php
@@ -17,6 +17,8 @@
 
     <main class="main pt-2">
 
+       @yield('before_breadcrumbs_widgets')
+
        @includeWhen(isset($breadcrumbs), backpack_view('inc.breadcrumbs'))
 
        @yield('header')

--- a/src/resources/views/base/layouts/top_left.blade.php
+++ b/src/resources/views/base/layouts/top_left.blade.php
@@ -21,6 +21,8 @@
 
        @includeWhen(isset($breadcrumbs), backpack_view('inc.breadcrumbs'))
 
+       @yield('after_breadcrumbs_widgets')
+
        @yield('header')
 
         <div class="container-fluid animated fadeIn">


### PR DESCRIPTION
These new stacks allows developers to push widgets
- before the breadcrumbs and the header (aka page title, for example in CRUD pages);
- between the breadcrumbs and the header (aka page title);

The widgets will show even if breadcrumbs are disabled.