### PR TITLE
Fix for handling undefined translations in relationship field

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -350,18 +350,36 @@
     }
 
     if (typeof processItemText !== 'function') {
-    function processItemText(item, $fieldAttribute, $appLang) {
-        if(typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null)  {
-                        if(item[$fieldAttribute][$appLang] != 'undefined') {
-                            return item[$fieldAttribute][$appLang];
-                        }else{
-                            return item[$fieldAttribute][0];
-                        }
-                    }else{
-                        return item[$fieldAttribute];
+        function processItemText(item, $fieldAttribute, $appLang) {
+            if (typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null) {
+                // Return translated text if a translation is available
+                if(Object.keys(item[$fieldAttribute]).length >= 1) {
+                    let $locale;
+                    // Use current locale to get the translation
+                    if ($appLang in item[$fieldAttribute]) {
+                        $locale = $appLang;
                     }
+                    // Use fallback locale to get the translation
+                    else if ("{{ Lang::getFallback() }}" in item[$fieldAttribute]) {
+                        $locale = "{{ Lang::getFallback() }}";
+                    }
+                    // Use first locale in array to get the translation
+                    else {
+                        $locale = Object.keys(item[$fieldAttribute])[0];
+                    }
+
+                    return item[$fieldAttribute][$locale];
+                }
+                // Report error since no translations are available
+                else {
+                    console.error("No translations for attribute '" + $fieldAttribute + "' found.", item[$fieldAttribute]);
+                    return 'no translations available';
+                }
+            } else {
+                return item[$fieldAttribute];
+            }
+        }
     }
-}
 </script>
 @endpush
 @endif

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -625,18 +625,37 @@ function bpFieldInitFetchOrCreateElement(element) {
     }
 
         }
+
 if (typeof processItemText !== 'function') {
     function processItemText(item, $fieldAttribute, $appLang) {
-        if(typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null)  {
-                if(item[$fieldAttribute][$appLang] != 'undefined') {
-                    return item[$fieldAttribute][$appLang];
-                }else{
-                    return item[$fieldAttribute][0];
+        if (typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null) {
+            // Return translated text if a translation is available
+            if(Object.keys(item[$fieldAttribute]).length >= 1) {
+                let $locale;
+                // Use current locale to get the translation
+                if ($appLang in item[$fieldAttribute]) {
+                    $locale = $appLang;
                 }
-            }else{
-                return item[$fieldAttribute];
+                // Use fallback locale to get the translation
+                else if ("{{ Lang::getFallback() }}" in item[$fieldAttribute]) {
+                    $locale = "{{ Lang::getFallback() }}";
+                }
+                // Use first locale in array to get the translation
+                else {
+                    $locale = Object.keys(item[$fieldAttribute])[0];
+                }
+
+                return item[$fieldAttribute][$locale];
             }
-}
+            // Report error since no translations are available
+            else {
+                console.error("No translations for attribute '" + $fieldAttribute + "' found.", item[$fieldAttribute]);
+                return 'no translations available';
+            }
+        } else {
+            return item[$fieldAttribute];
+        }
+    }
 }
             </script>
         @endpush


### PR DESCRIPTION
In case that no translation is available for the current locale, the relationship field did not show any text or 'undefined'. This fix improves getting an translation by first looking for the current locale, then for the Laravel app's fallback locale and then for the first locale that is available. Further the javascript code was improved and some error cases are handled and reported to console.

Note: Would be nice to factor out the Javascript in order to avoid the code duplication.