### PR TITLE
Updates progress bar count

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -33,7 +33,7 @@ class Install extends Command
      */
     public function handle()
     {
-        $this->progressBar = $this->output->createProgressBar(6);
+        $this->progressBar = $this->output->createProgressBar(5);
         $this->progressBar->minSecondsBetweenRedraws(0);
         $this->progressBar->maxSecondsBetweenRedraws(120);
         $this->progressBar->setRedrawFrequency(1);


### PR DESCRIPTION
Just started a new project and installed backpack, noticed when installing the progress count looked like this:

```
 0/6 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0% Backpack installation started. Please wait...
 1/6 [▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░]  16% Publishing configs, langs, views, js and css files
 2/6 [▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░]  33% Publishing config for notifications - prologue/alerts
 3/6 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50% Generating users table (using Laravel's default migrations)
 4/6 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░]  66% Creating App\Http\Middleware\CheckIfAdmin.php
 6/6 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% Backpack installation finished.
```

This is due to the changes made in this PR: https://github.com/Laravel-Backpack/CRUD/pull/2863

This fixes that