### PR TITLE
[4.1] Fix tab highlight. 

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -140,8 +140,8 @@
 
                 // highlight its parent tab
                 @if ($crud->tabsEnabled())
-                var tab_id = $(container).parent().attr('id');
-                $("#form_tabs [aria-controls="+tab_id+"]").addClass('text-red');
+                var tab_id = $(container).closest('[role="tabpanel"]').attr('id');
+                $("#form_tabs [aria-controls="+tab_id+"]").addClass('text-danger');
                 @endif
             });
         });


### PR DESCRIPTION
When hitting error on a form submition the tab where the error occured should be highlighted as it was before.

