### PR TITLE
[4.1] Fixing FetchOperation behaviour when clauses are already applied.

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -88,8 +88,8 @@ trait FetchOperation
         // .... 'query' => function($model) { return $model->where('active', 1); }
         // So it reads: SELECT ... WHERE active = 1 AND (XXX = x OR YYY = y) and not SELECT ... WHERE active = 1 AND XXX = x OR YYY = y;
 
-        if (!empty($config['query']->getQuery()->wheres)) {
-            $config['query'] = $config['query']->where(function($query) use ($model_instance, $config, $search_string, $textColumnTypes) {
+        if (! empty($config['query']->getQuery()->wheres)) {
+            $config['query'] = $config['query']->where(function ($query) use ($model_instance, $config, $search_string, $textColumnTypes) {
                 foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
                     $operation = ($k == 0) ? 'where' : 'orWhere';
                     $columnType = $model_instance->getColumnType($searchColumn);
@@ -100,9 +100,10 @@ trait FetchOperation
                         $tempQuery = $query->{$operation}($searchColumn, $search_string);
                     }
                 }
+
                 return $tempQuery;
             });
-        }else{
+        } else {
             foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
                 $operation = ($k == 0) ? 'where' : 'orWhere';
                 $columnType = $model_instance->getColumnType($searchColumn);

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -81,15 +81,37 @@ trait FetchOperation
         }
 
         $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array'];
-        // for each searchable attribute, add a WHERE clause
-        foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
-            $operation = ($k == 0) ? 'where' : 'orWhere';
-            $columnType = $model_instance->getColumnType($searchColumn);
 
-            if (in_array($columnType, $textColumnTypes)) {
-                $config['query'] = $config['query']->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');
-            } else {
-                $config['query'] = $config['query']->{$operation}($searchColumn, $search_string);
+        // if the query builder brings any where clause already defined by the user we must
+        // ensure that the where prevails and we should only use our search as a complement to the query constraints.
+        // e.g user want only the active products, so in fetch he would return something like:
+        // .... 'query' => function($model) { return $model->where('active', 1); }
+        // So it reads: SELECT ... WHERE active = 1 AND (XXX = x OR YYY = y) and not SELECT ... WHERE active = 1 AND XXX = x OR YYY = y;
+
+        if (!empty($config['query']->getQuery()->wheres)) {
+            $config['query'] = $config['query']->where(function($query) use ($model_instance, $config, $search_string, $textColumnTypes) {
+                foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
+                    $operation = ($k == 0) ? 'where' : 'orWhere';
+                    $columnType = $model_instance->getColumnType($searchColumn);
+
+                    if (in_array($columnType, $textColumnTypes)) {
+                        $tempQuery = $query->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');
+                    } else {
+                        $tempQuery = $query->{$operation}($searchColumn, $search_string);
+                    }
+                }
+                return $tempQuery;
+            });
+        }else{
+            foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {
+                $operation = ($k == 0) ? 'where' : 'orWhere';
+                $columnType = $model_instance->getColumnType($searchColumn);
+
+                if (in_array($columnType, $textColumnTypes)) {
+                    $config['query'] = $config['query']->{$operation}($searchColumn, 'LIKE', '%'.$search_string.'%');
+                } else {
+                    $config['query'] = $config['query']->{$operation}($searchColumn, $search_string);
+                }
             }
         }
 


### PR DESCRIPTION
Like described in #2882 

If you use fetch with pre-defined conditions that will mess with the way we add searchable conditions to the query. 

The description provided in the issue is pretty explanatory to understand what is going wrong. I hope my comment inline also helps.

Best,
Pedro

