### PR TITLE
Fixed #2839 by creating an empty first column

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -142,24 +142,11 @@ trait Read
         $this->addColumn([
             'type'            => 'checkbox',
             'name'            => 'bulk_actions',
-            'label'           => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px;" />',
+            'label'           => ' <span style="display:flex"><input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px; margin: 2px 0;" /></span>',
             'priority'        => 1,
             'searchLogic'     => false,
             'orderable'       => false,
             'visibleInTable'  => true,
-            'visibleInModal'  => false,
-            'visibleInExport' => false,
-            'visibleInShow'   => false,
-        ])->makeFirstColumn();
-
-        $this->addColumn([
-            'type'            => 'custom_html',
-            'name'            => 'blank_first_column',
-            'label'           => ' ',
-            'priority'        => 1,
-            'searchLogic'     => false,
-            'orderable'       => false,
-            'visibleInTabel'  => true,
             'visibleInModal'  => false,
             'visibleInExport' => false,
             'visibleInShow'   => false,
@@ -174,7 +161,6 @@ trait Read
         $this->setOperationSetting('bulkActions', false);
 
         $this->removeColumn('bulk_actions');
-        $this->removeColumn('blank_first_column');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -208,6 +208,9 @@ trait Search
     {
         $row_items = [];
 
+        // add an empty first column to support details row and/or data table modal
+        $row_items[] = '';
+
         foreach ($this->columns() as $key => $column) {
             $row_items[] = $this->getCellView($column, $entry, $rowNumber);
         }

--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -65,8 +65,12 @@
 		content: "\f142";
 		font-size: 21px;
 		box-shadow: none;
-		/*margin-top: 8px;*/
 		border: none;
+		display: inline;
+		position: relative;
+		left: 0;
+		top: 2px;
+		margin-left: 8px;
 	}
 
 	.dt-buttons {
@@ -82,8 +86,19 @@
 		vertical-align: middle;
 	}
 
+	#crudTable .details-control {
+		margin-left: 8px;
+	}
+
 	#crudTable.has-hidden-columns .details-control {
 		/*display: none;*/
+		margin-left: 0px;
+	}
+
+	#crudTable tbody > tr > td:first-of-type,
+	#crudTable thead > tr > th:first-of-type,
+	#crudTable tfoot > tr > th:first-of-type {
+		padding: 0;
 	}
 
 	div.dataTables_wrapper div.dataTables_length select {
@@ -208,7 +223,7 @@
 		min-height: 35px;
 	}
 
-	#crudTable thead>tr>th, table.dataTable thead>tr>td {
+	#crudTable thead>tr>th:not(.sorting_disabled), table.dataTable thead>tr>td {
 		padding-right: 30px;
 	}
 

--- a/src/resources/views/crud/columns/checkbox.blade.php
+++ b/src/resources/views/crud/columns/checkbox.blade.php
@@ -1,5 +1,5 @@
 {{-- checkbox with loose false/null/0 checking --}}
-<span>
+<span style="display:flex">
     <input type="checkbox"
     		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -53,6 +53,15 @@
         <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs" cellspacing="0">
             <thead>
               <tr>
+              <th 
+                data-orderable="false"
+                data-priority="1"
+                data-visible-in-table="false"
+                data-visible="true"
+                data-can-be-visible-in-table="true"
+                data-visible-in-modal="false"
+                data-visible-in-export="false"></th>
+
                 {{-- Table columns --}}
                 @foreach ($crud->columns() as $column)
                   <th
@@ -111,6 +120,8 @@
             </tbody>
             <tfoot>
               <tr>
+                <th></th>
+
                 {{-- Table columns --}}
                 @foreach ($crud->columns() as $column)
                   <th>{!! $column['label'] !!}</th>


### PR DESCRIPTION
This may sound like a bodge, but I'll try to prove my point on how this first empty column is important 😅

When I start to look at the #2839 issue I tried to solve it with javascript, soon I realized it would be very hard because the button were being added as an inner text of the first column, some times the first column was a text (with href), sometimes it was the plus sign to the details row, or even the checkbox for bulk editing.

I found out this solution because at first, I didn't notice the problem because the CRUD I was using as an example had enabled bulk actions, which has a `blank_first_column`, therefore the modal trigger was being added to this first empty column (also, by always adding this blank first column it's no longer necessary on bulk actions).

This first empty column allows it to handle both plus button to details row and the data tables button to the modal. I made some changes to the css so that column is not going to appear if there is neither one. I also made small changes to the css to align the checkboxs:

![image](https://user-images.githubusercontent.com/1838187/83392331-d0dd6100-a3ec-11ea-938e-6565e19f48db.png)

There was also unnecessary padding on non ordering columns, causing odd spacing on the table
![image](https://user-images.githubusercontent.com/1838187/83392409-f4081080-a3ec-11ea-9ad1-73d888d999ba.png)

---

Before:

![image](https://user-images.githubusercontent.com/1838187/83393328-80670300-a3ee-11ea-93ae-139b1f53b9be.png)

![image](https://user-images.githubusercontent.com/1838187/83393480-c2904480-a3ee-11ea-962d-21e9b7506f4e.png)

Now:

![image](https://user-images.githubusercontent.com/1838187/83392922-d4251c80-a3ed-11ea-857c-6a0bfbeda392.png)

![image](https://user-images.githubusercontent.com/1838187/83392858-b788e480-a3ed-11ea-8a94-0b68a141aa82.png)

![image](https://user-images.githubusercontent.com/1838187/83392971-eb640a00-a3ed-11ea-9b73-c1d9769c1655.png)

![image](https://user-images.githubusercontent.com/1838187/83393069-177f8b00-a3ee-11ea-9918-f6003581a02d.png)

![image](https://user-images.githubusercontent.com/1838187/83393090-1ea69900-a3ee-11ea-85f6-53f0d6e3eb61.png)

---

Before (crud with few columns):

![image](https://user-images.githubusercontent.com/1838187/83395944-11d87400-a3f3-11ea-874a-dddbafe19194.png)


Now:

![image](https://user-images.githubusercontent.com/1838187/83395882-f66d6900-a3f2-11ea-894f-0a335f69f3b5.png)


---

There is only one downside on this, there's always the empty first row, even when it's not needed.
![image](https://user-images.githubusercontent.com/1838187/83394676-e2286c80-a3f0-11ea-82db-6fa5dcad1906.png)
Anyway, I think it worth 🤷‍♂️

I think I tested all the possibilities, everything's working nice.
This is not a breaking change, but I think @tabacitu needs to give his opinion on this.
