### PR TITLE
Fix for missing form fields in modal ajax call

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -236,6 +236,8 @@ function setupInlineCreateButtons(element) {
     var $inlineModalRoute = element.attr('data-inline-modal-route');
     var $inlineModalClass = element.attr('data-inline-modal-class');
     var $parentLoadedFields = element.attr('data-parent-loaded-fields');
+    var $includeAllFormFields = element.attr('data-include-all-form-fields')=='false' ? false : true;
+
     $inlineCreateButtonElement.on('click', function () {
 
         //we change button state so users know something is happening.
@@ -248,11 +250,22 @@ function setupInlineCreateButtons(element) {
         }
         $.ajax({
             url: $inlineModalRoute,
-            data: {
-                'entity': $fieldEntity,
-                'modal_class' : $inlineModalClass,
-                'parent_loaded_fields' : $parentLoadedFields,
-            },
+            data: (function() {
+                if ($includeAllFormFields) {
+                    return {
+                        'entity': $fieldEntity,
+                        'modal_class' : $inlineModalClass,
+                        'parent_loaded_fields' : $parentLoadedFields,
+                        'form' : form.serializeArray() // all other form inputs
+                    };
+                } else {
+                    return {
+                        'entity': $fieldEntity,
+                        'modal_class' : $inlineModalClass,
+                        'parent_loaded_fields' : $parentLoadedFields
+                    };
+                }
+            })(),
             type: 'POST',
             success: function (result) {
                 $('body').append(result);

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -231,6 +231,7 @@ var fetchDefaultEntry = function (element) {
 //when clicked, fetches the html for the modal to show
 
 function setupInlineCreateButtons(element) {
+    var form = element.closest('form');
     var $fieldEntity = element.attr('data-field-related-name');
     var $inlineCreateButtonElement = $(element).parent().find('.inline-create-button');
     var $inlineModalRoute = element.attr('data-inline-modal-route');


### PR DESCRIPTION
This PR should be better than my previous one.
I'm trying to send the current form fields to the modal endpoint.
The code was already present in 2 other places in this file, so I integrated it in this ajax call too.