### PR TITLE
Fixing datatable searchbox overlap in small screens

### DIFF
--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -208,6 +208,21 @@
 		min-height: 35px;
 	}
 
+	@media(max-width: 576px) {
+		#datatable_search_stack {
+			margin-top: .5rem;
+		}
+
+		#datatable_search_stack label {
+			width: 100%;
+		}
+	
+		#datatable_search_stack input[type="search"] {
+			margin-left: 0;
+			width: 100%;
+		}
+	}
+
 	#crudTable thead>tr>th, table.dataTable thead>tr>td {
 		padding-right: 30px;
 	}

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -39,7 +39,7 @@
             @endif
           </div>
           <div class="col-sm-6">
-            <div id="datatable_search_stack" class="float-right mt-2 mt-sm-0"></div>
+            <div id="datatable_search_stack"></div>
           </div>
         </div>
 

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -21,7 +21,7 @@
 @endsection
 
 @section('content')
-<!-- Default box -->
+  <!-- Default box -->
   <div class="row">
 
     <!-- THE ACTUAL CONTENT -->
@@ -29,17 +29,17 @@
       <div class="">
 
         <div class="row mb-0">
-          <div class="col-6">
+          <div class="col-sm-6">
             @if ( $crud->buttons()->where('stack', 'top')->count() ||  $crud->exportButtons())
-            <div class="hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
+              <div class="hidden-print {{ $crud->hasAccess('create')?'with-border':'' }}">
 
-              @include('crud::inc.button_stack', ['stack' => 'top'])
+                @include('crud::inc.button_stack', ['stack' => 'top'])
 
-            </div>
+              </div>
             @endif
           </div>
-          <div class="col-6">
-              <div id="datatable_search_stack" class="float-right"></div>
+          <div class="col-sm-6">
+            <div id="datatable_search_stack" class="float-right mt-2 mt-sm-0"></div>
           </div>
         </div>
 
@@ -71,33 +71,33 @@
 
                     {{-- If it is an export field only, we are done. --}}
                     @if(isset($column['exportOnlyField']) && $column['exportOnlyField'] === true)
-                        data-visible="false"
-                        data-visible-in-table="false"
-                        data-can-be-visible-in-table="false"
-                        data-visible-in-modal="false"
-                        data-visible-in-export="true"
-                        data-force-export="true"
+                      data-visible="false"
+                      data-visible-in-table="false"
+                      data-can-be-visible-in-table="false"
+                      data-visible-in-modal="false"
+                      data-visible-in-export="true"
+                      data-force-export="true"
 
                     @else
 
-                        data-visible-in-table="{{var_export($column['visibleInTable'] ?? false)}}"
-                        data-visible="{{var_export($column['visibleInTable'] ?? true)}}"
-                        data-can-be-visible-in-table="true"
-                        data-visible-in-modal="{{var_export($column['visibleInModal'] ?? true)}}"
-                        @if(isset($column['visibleInExport']))
-                            @if($column['visibleInExport'] === false)
-                            data-visible-in-export="false"
-                            data-force-export="false"
-                            @else
-                            data-visible-in-export="true"
-                            data-force-export="true"
-                            @endif
+                      data-visible-in-table="{{var_export($column['visibleInTable'] ?? false)}}"
+                      data-visible="{{var_export($column['visibleInTable'] ?? true)}}"
+                      data-can-be-visible-in-table="true"
+                      data-visible-in-modal="{{var_export($column['visibleInModal'] ?? true)}}"
+                      @if(isset($column['visibleInExport']))
+                        @if($column['visibleInExport'] === false)
+                          data-visible-in-export="false"
+                          data-force-export="false"
                         @else
-                            data-visible-in-export="true"
-                            data-force-export="false"
+                          data-visible-in-export="true"
+                          data-force-export="true"
                         @endif
+                      @else
+                        data-visible-in-export="true"
+                        data-force-export="false"
+                      @endif
                     @endif
-                    >
+                  >
                     {!! $column['label'] !!}
                   </th>
                 @endforeach
@@ -155,7 +155,7 @@
 @endsection
 
 @section('after_scripts')
-    @include('crud::inc.datatables_logic')
+  @include('crud::inc.datatables_logic')
   <script src="{{ asset('packages/backpack/crud/js/crud.js') }}"></script>
   <script src="{{ asset('packages/backpack/crud/js/form.js') }}"></script>
   <script src="{{ asset('packages/backpack/crud/js/list.js') }}"></script>


### PR DESCRIPTION
In crud list view, stack top buttons and datatable searchbox where overlapping in small screens. I changed `col-6` to `col-sm-6` so that the columns can stretch. Also I styled the searchbox input in small screens to be full width and have some marging top using media queries in `list.css` (do not know if that is the best aproach).