### PR TITLE
Replace help paragraph with small text-muted

### DIFF
--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -20,13 +20,6 @@
 	padding-bottom: 20px;
 }
 
-.help-block {
-	margin-top: .25rem;
-	margin-bottom: .25rem;
-    color: #73818f;
-    font-size: 0.9em;
-}
-
 .nav-tabs .nav-link:hover {
 	border-bottom: none;
 }

--- a/src/resources/views/crud/fields/address_algolia.blade.php
+++ b/src/resources/views/crud/fields/address_algolia.blade.php
@@ -46,7 +46,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/address_google.blade.php
+++ b/src/resources/views/crud/fields/address_google.blade.php
@@ -43,7 +43,7 @@ if (isset($field['value']) && (is_array($field['value']) || is_object($field['va
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/base64_image.blade.php
+++ b/src/resources/views/crud/fields/base64_image.blade.php
@@ -55,7 +55,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/browse.blade.php
+++ b/src/resources/views/crud/fields/browse.blade.php
@@ -25,7 +25,7 @@
 	</div>
 
 	@if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -49,7 +49,7 @@ if($sortable){
     </div>
 
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
     <script type="text/html" data-marker="browse_multiple_template">

--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -21,7 +21,7 @@
 
         {{-- HINT --}}
         @if (isset($field['hint']))
-            <p class="help-block">{!! $field['hint'] !!}</p>
+            <small class="text-muted d-block">{!! $field['hint'] !!}</small>
         @endif
     </div>
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -41,7 +41,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -174,7 +174,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/ckeditor.blade.php
+++ b/src/resources/views/crud/fields/ckeditor.blade.php
@@ -23,7 +23,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/color_picker.blade.php
+++ b/src/resources/views/crud/fields/color_picker.blade.php
@@ -19,7 +19,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/date.blade.php
+++ b/src/resources/views/crud/fields/date.blade.php
@@ -20,6 +20,6 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/date_picker.blade.php
+++ b/src/resources/views/crud/fields/date_picker.blade.php
@@ -34,7 +34,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -57,7 +57,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -20,6 +20,6 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/datetime_picker.blade.php
+++ b/src/resources/views/crud/fields/datetime_picker.blade.php
@@ -28,7 +28,7 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/easymde.blade.php
+++ b/src/resources/views/crud/fields/easymde.blade.php
@@ -12,7 +12,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/email.blade.php
+++ b/src/resources/views/crud/fields/email.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -28,6 +28,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/icon_picker.blade.php
+++ b/src/resources/views/crud/fields/icon_picker.blade.php
@@ -52,7 +52,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -80,7 +80,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/month.blade.php
+++ b/src/resources/views/crud/fields/month.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/number.blade.php
+++ b/src/resources/views/crud/fields/number.blade.php
@@ -17,6 +17,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/page_or_link.blade.php
+++ b/src/resources/views/crud/fields/page_or_link.blade.php
@@ -105,7 +105,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/password.blade.php
+++ b/src/resources/views/crud/fields/password.blade.php
@@ -18,6 +18,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -38,7 +38,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/range.blade.php
+++ b/src/resources/views/crud/fields/range.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -84,7 +84,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -120,7 +120,7 @@ if($activeInlineCreate) {
 </select>
  {{-- HINT --}}
  @if (isset($field['hint']))
- <p class="help-block">{!! $field['hint'] !!}</p>
+ <small class="text-muted d-block">{!! $field['hint'] !!}</small>
 @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -84,7 +84,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -18,7 +18,7 @@
 
   {{-- HINT --}}
   @if (isset($field['hint']))
-      <p class="help-block text-muted text-sm">{!! $field['hint'] !!}</p>
+    <small class="text-muted d-block">{!! $field['hint'] !!}</small>
   @endif
 
   <div class="container-repeatable-elements">

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -42,7 +42,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/select2.blade.php
+++ b/src/resources/views/crud/fields/select2.blade.php
@@ -43,7 +43,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -55,7 +55,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -44,7 +44,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_from_array.blade.php
+++ b/src/resources/views/crud/fields/select2_from_array.blade.php
@@ -44,7 +44,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -57,7 +57,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -41,7 +41,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select2_nested.blade.php
+++ b/src/resources/views/crud/fields/select2_nested.blade.php
@@ -66,7 +66,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/select_and_order.blade.php
+++ b/src/resources/views/crud/fields/select_and_order.blade.php
@@ -27,7 +27,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
     </div>
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -43,6 +43,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -56,6 +56,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -36,7 +36,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
     
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/simplemde.blade.php
+++ b/src/resources/views/crud/fields/simplemde.blade.php
@@ -12,7 +12,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -18,7 +18,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/table.blade.php
+++ b/src/resources/views/crud/fields/table.blade.php
@@ -87,7 +87,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/text.blade.php
+++ b/src/resources/views/crud/fields/text.blade.php
@@ -16,6 +16,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 </div>

--- a/src/resources/views/crud/fields/textarea.blade.php
+++ b/src/resources/views/crud/fields/textarea.blade.php
@@ -10,6 +10,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/time.blade.php
+++ b/src/resources/views/crud/fields/time.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/tinymce.blade.php
+++ b/src/resources/views/crud/fields/tinymce.blade.php
@@ -21,7 +21,7 @@ $field['options'] = array_merge($defaultOptions, $field['options'] ?? []);
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -45,7 +45,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -54,7 +54,7 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/url.blade.php
+++ b/src/resources/views/crud/fields/url.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')

--- a/src/resources/views/crud/fields/video.blade.php
+++ b/src/resources/views/crud/fields/video.blade.php
@@ -47,7 +47,7 @@ $field['wrapper']['data-video'] = '';
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')
 

--- a/src/resources/views/crud/fields/week.blade.php
+++ b/src/resources/views/crud/fields/week.blade.php
@@ -11,6 +11,6 @@
 
     {{-- HINT --}}
     @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
+        <small class="text-muted d-block">{!! $field['hint'] !!}</small>
     @endif
 @include('crud::fields.inc.wrapper_end')


### PR DESCRIPTION
This PR changes the help block elements.
It removes the need for an additional `.help-block` class by using already available styles.
It also fixes the help block for the repeatable field which already used `.text-muted` (overwrites .help-block) and `.text-sm` which is unused