### PR TITLE
added setupInlineCreateOperation method that gets called automatically if exists

### DIFF
--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -37,8 +37,12 @@ trait InlineCreateOperation
         if (method_exists($this, 'setup')) {
             $this->setup();
         }
-        if (method_exists($this, 'setupCreateOperation')) {
-            $this->setupCreateOperation();
+        if (method_exists($this, 'setupInlineCreateOperation')) {
+            $this->setupInlineCreateOperation();
+        } else {
+            if (method_exists($this, 'setupCreateOperation')) {
+                $this->setupCreateOperation();
+            }
         }
 
         $this->crud->applyConfigurationFromSettings('create');


### PR DESCRIPTION
Fixes #2925 

@pxpm what do you think? Is this needed - or should `setupInlineCreateOperation()` be called automatically by CrudController, WITHOUT this PR?