### PR TITLE
Create translate routes only when needed

### DIFF
--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -26,14 +26,6 @@ trait UpdateOperation
             'uses'      => $controller.'@update',
             'operation' => 'update',
         ]);
-
-        if(is_array(config('backpack.crud.locales')) && count(config('backpack.crud.locales'))  > 1){
-            Route::get($segment.'/{id}/translate/{lang}', [
-                'as'        => $routeName.'.translateItem',
-                'uses'      => $controller.'@translateItem',
-                'operation' => 'update',
-            ]);
-        }
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -27,11 +27,13 @@ trait UpdateOperation
             'operation' => 'update',
         ]);
 
-        Route::get($segment.'/{id}/translate/{lang}', [
-            'as'        => $routeName.'.translateItem',
-            'uses'      => $controller.'@translateItem',
-            'operation' => 'update',
-        ]);
+        if(is_array(config('backpack.crud.locales')) && count(config('backpack.crud.locales'))  > 1){
+            Route::get($segment.'/{id}/translate/{lang}', [
+                'as'        => $routeName.'.translateItem',
+                'uses'      => $controller.'@translateItem',
+                'operation' => 'update',
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Prevents unnecessary routes creation by checking if the locales configuration variable contains more than one locale.