### PR TITLE
[Feature] Edit extra pivot fields on a BelongsToMany relation, using the repeatable field

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -110,11 +110,10 @@ trait Create
         $fields_with_relationships = $this->getRelationFields();
         foreach ($fields_with_relationships as $key => $field) {
             if (isset($field['pivot']) && $field['pivot']) {
-
                 $values = isset($data[$field['name']]) ? $data[$field['name']] : [];
 
                 //we override the values if the field is repeatable and pivot == true
-                if($field['type'] == 'repeatable') {
+                if ($field['type'] == 'repeatable') {
                     $values = $this->parseRepeatableValues($field, $values);
                 }
                 // if a JSON was passed instead of an array, turn it into an array
@@ -130,7 +129,7 @@ trait Create
                         foreach ($field['pivotFields'] as $pivot_field_name) {
                             $pivot_data[$pivot_field_name] = $data[$pivot_field_name][$pivot_id];
                         }
-                    }else{
+                    } else {
                         if ($field['type'] == 'repeatable') {
                             $field_name = $field['name'];
                             $field_data = json_decode($data[$field_name], true);
@@ -159,12 +158,14 @@ trait Create
         }
     }
 
-    public function parseRepeatableValues($field, $values) {
+    public function parseRepeatableValues($field, $values)
+    {
         $decoded_values = json_decode($values, true);
         $related_keys = [];
-        foreach($decoded_values as $value) {
+        foreach ($decoded_values as $value) {
             $related_keys[] = $value[$field['name']];
         }
+
         return $related_keys;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -115,7 +115,6 @@ trait Create
                 // if pivot is true and there is `fields` array in this field we are trying to sync a pivot with
                 // extra attributes on it. It's a Repeatable Field so its values are sent as json.
                 if (isset($field['fields']) && is_array($field['fields'])) {
-                    $pivot_extra_fields_repeatable = true;
                     $decoded_values = json_decode($values, true);
                     $values = [];
                     foreach ($decoded_values as $value) {
@@ -135,7 +134,7 @@ trait Create
                             $pivot_data[$pivot_field_name] = $data[$pivot_field_name][$pivot_id];
                         }
                     } else {
-                        if (isset($pivot_extra_fields_repeatable) && $pivot_extra_fields_repeatable) {
+                        if (isset($field['fields']) && is_array($field['fields'])) {
                             $field_data = json_decode($data[$field['name']], true);
 
                             //we grab from the request the specific data for this pivot

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -104,7 +104,7 @@ trait Update
                 // extra attributes on it. It's a Repeatable Field so its values are sent as json.
                 if (isset($field['pivot']) && $field['pivot'] && isset($field['fields']) && is_array($field['fields'])) {
                     //we remove the first field from repeatable because it is our relation.
-                    $pivot_fields = Arr::where($field['fields'], function($item) use ($field) {
+                    $pivot_fields = Arr::where($field['fields'], function ($item) use ($field) {
                         return $field['name'] != $item['name'];
                     });
 

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -86,7 +86,6 @@ trait Update
      */
     private function getModelAttributeValue($model, $field)
     {
-
         if (isset($field['entity'])) {
             $relational_entity = $this->parseRelationFieldNamesFromHtml([$field])[0]['name'];
 
@@ -113,7 +112,6 @@ trait Update
                         $item[$field['name']] = $related_model->getKey();
                         //for any given related model, we attach the pivot fields.
                         foreach ($field['fields'] as $pivot_field) {
-
                             $item[$pivot_field['name']] = $related_model->pivot->{$pivot_field['name']};
                         }
                         $return[] = $item;
@@ -121,6 +119,7 @@ trait Update
                     //we return the json encoded result as expected by repeatable field.
                     return json_encode($return);
                 } //endif repeatable
+
                 return $relatedModel->{$relationMethod};
             }
         }


### PR DESCRIPTION
Last ref: #2860

Like the title describes and some issues have arised concerning this scenario we decided to give it a go and see where we can go with it.

So... the basic idea is to create a repeatable field that can accomodate the belongsToMany relation and any extra fields in that pivot table.

For it to work, you must have the pivot table and the relation must expose the pivot fields.

By example:

```php
//relation, the important part here is the ->withPivot() part.

public function products() {
     return $this->belongsToMany('App\Products', 'pivot_table_name')->withPivot(['attr1','attr2']);
}
```
```php
[                'label'     => 'BelongsToMany edit pivot fields.',
                'type'      => 'repeatable',
                'name'      => 'products', //the name of the BelongsToMany relation
                'fields' => [
                    [
                        'name' => 'products', //the name of the relation
                        'multiple' => false //this is mandatory.
                    ],
                    [
                            'name' => 'attr1',
                            'type' => 'text',
                            'label' => 'first extra attribute in pivot'
                     ],
                     [
                            'name' => 'attr2',
                            'type' => 'text',
                            'label' => 'second extra attribute in pivot'
                     ],
            ],
        ],
```

You are all set. Enjoy.

Notes: 
- Using `multiple => false` is mandatory as per relation definition belongsToMany allows multiple, but we only want one per line.

ping @tabacitu wanna give this a go ?


