### PR TITLE
[4.2][Bug fix][Ready] List operation - always have an empty first column

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -142,24 +142,11 @@ trait Read
         $this->addColumn([
             'type'            => 'checkbox',
             'name'            => 'bulk_actions',
-            'label'           => ' <input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px;" />',
+            'label'           => ' <span style="display:flex"><input type="checkbox" class="crud_bulk_actions_main_checkbox" style="width: 16px; height: 16px; margin: 2px 0;" /></span>',
             'priority'        => 1,
             'searchLogic'     => false,
             'orderable'       => false,
             'visibleInTable'  => true,
-            'visibleInModal'  => false,
-            'visibleInExport' => false,
-            'visibleInShow'   => false,
-        ])->makeFirstColumn();
-
-        $this->addColumn([
-            'type'            => 'custom_html',
-            'name'            => 'blank_first_column',
-            'label'           => ' ',
-            'priority'        => 1,
-            'searchLogic'     => false,
-            'orderable'       => false,
-            'visibleInTabel'  => true,
             'visibleInModal'  => false,
             'visibleInExport' => false,
             'visibleInShow'   => false,
@@ -174,7 +161,6 @@ trait Read
         $this->setOperationSetting('bulkActions', false);
 
         $this->removeColumn('bulk_actions');
-        $this->removeColumn('blank_first_column');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -208,6 +208,9 @@ trait Search
     {
         $row_items = [];
 
+        // add an empty first column to support details row and/or data table modal
+        $row_items[] = '';
+
         foreach ($this->columns() as $key => $column) {
             $row_items[] = $this->getCellView($column, $entry, $rowNumber);
         }

--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -65,8 +65,12 @@
 		content: "\f142";
 		font-size: 21px;
 		box-shadow: none;
-		/*margin-top: 8px;*/
 		border: none;
+		display: inline;
+		position: relative;
+		left: 0;
+		top: 2px;
+		margin-left: 8px;
 	}
 
 	.dt-buttons {
@@ -82,8 +86,23 @@
 		vertical-align: middle;
 	}
 
-	#crudTable.has-hidden-columns .details-control {
+	#crudTable .details-control,
+	#crudTable .dtr-control {
+		margin-left: 8px;
+		padding-left: 0px;
+	}
+
+	#crudTable.has-hidden-columns .details-control,
+	#crudTable.has-hidden-columns .dtr-control {
 		/*display: none;*/
+		margin-left: 0px;
+		padding-left: 0px;
+	}
+
+	#crudTable tbody > tr > td:first-of-type:empty,
+	#crudTable thead > tr > th:first-of-type:empty,
+	#crudTable tfoot > tr > th:first-of-type:empty {
+		padding: 0;
 	}
 
 	div.dataTables_wrapper div.dataTables_length select {
@@ -204,8 +223,16 @@
 		min-height: calc(100% - 98px);
 	}
 
+	.dataTables_empty {
+		padding: 10px!important;
+	}
+
 	#datatable_search_stack {
 		min-height: 35px;
+	}
+
+	#crudTable thead>tr>th:not(.sorting_disabled), table.dataTable thead>tr>td {		
+		padding-right: 30px;
 	}
 
 	@media(max-width: 576px) {
@@ -223,9 +250,6 @@
 		}
 	}
 
-	#crudTable thead>tr>th, table.dataTable thead>tr>td {
-		padding-right: 30px;
-	}
 
 	.navbar-filters li>a:active,
 	.navbar-filters .navbar-nav>.active>a, .navbar-filters .navbar-nav>.active>a:focus, .navbar-filters .navbar-nav>.active>a:hover,

--- a/src/resources/views/crud/columns/checkbox.blade.php
+++ b/src/resources/views/crud/columns/checkbox.blade.php
@@ -1,5 +1,5 @@
 {{-- checkbox with loose false/null/0 checking --}}
-<span>
+<span style="display:flex">
     <input type="checkbox"
     		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -53,6 +53,15 @@
         <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs" cellspacing="0">
             <thead>
               <tr>
+              <th 
+                data-orderable="false"
+                data-priority="1"
+                data-visible-in-table="false"
+                data-visible="true"
+                data-can-be-visible-in-table="true"
+                data-visible-in-modal="false"
+                data-visible-in-export="false"></th>
+
                 {{-- Table columns --}}
                 @foreach ($crud->columns() as $column)
                   <th
@@ -111,6 +120,8 @@
             </tbody>
             <tfoot>
               <tr>
+                <th></th>
+
                 {{-- Table columns --}}
                 @foreach ($crud->columns() as $column)
                   <th>{!! $column['label'] !!}</th>


### PR DESCRIPTION
Fixes #2839  by merging @promatik 's PR #2891 and adding very few improvements:
- padding on empty table content
- padding on the first column is zero only when it's empty

My tests show this is 100% working and ready to be merged. However, since there are changes in `list.css` and that file does NOT get published by default upon `composer update` (see #2246 ), people who just run `composer update` would get the NEW HTML, but keep the OLD CSS. That means that what they see would be this:

![Screenshot 2020-06-16 at 12 12 52](https://user-images.githubusercontent.com/1032474/84756030-f52f6500-afca-11ea-86e9-b55bed2c44e0.png)

The above doesn't look that bad in Categories, but it DOES in other tables. And there are few other quirks.

This means that we cannot merge this as a non-breaking change. We have to wait until 4.2 to launch it, unfortunately 😢 