### PR TITLE
Remove Animate.css from bundle.js

### DIFF
--- a/src/resources/assets/js/bundle.js
+++ b/src/resources/assets/js/bundle.js
@@ -5,6 +5,5 @@ window.Noty = require('noty'); // Unobtrusive alert or notification bubbles
 require('bootstrap'); // Bootstrap for tabs, dropdowns, carousels etc
 require('@coreui/coreui'); // CoreUI for sidemenu
 require('pace-js'); // Pace JS for a slim progress bar at the top of the screen during AJAX calls
-require('animate.css');
 
 import swal from 'sweetalert';

--- a/src/resources/assets/scss/bundle.scss
+++ b/src/resources/assets/scss/bundle.scss
@@ -6,5 +6,5 @@
 @import "node_modules/@digitallyhappy/backstrap/src/scss/_custom";
 // @import "node_modules/line-awesome/css/line-awesome";
 // @import "node_modules/source-sans-pro/source-sans-pro";
-@import "node_modules/animate.css/source/_base";
+@import "~animate.css/animate.min.css";
 @import "node_modules/noty/src/noty";


### PR DESCRIPTION
For some reason the Animate.css CSS is loaded inside bundle.js, this is not very efficient.
Updated the bundles to remove Animate.css from the javascript bundle and include it in the CSS bundle.