### PR TITLE
Added ability to grouping fields in tab

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -493,13 +493,13 @@ trait Fields
     }
 
     /**
-     * Grouping fields in tab
+     * Grouping fields in tab.
      *
      * @param  string  $name
      * @param  array  $fields
      * @return void
      */
-    public function tab(string $name, array $fields) :void
+    public function tab(string $name, array $fields): void
     {
         foreach ($fields as $field) {
             if ($field instanceof CrudField) {
@@ -514,7 +514,7 @@ trait Fields
             if (is_string($field)) {
                 $field = [
                     'name' => $field,
-                    'tab' => $name,
+                    'tab'  => $name,
                 ];
                 $this->addField($field);
             }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -491,4 +491,33 @@ trait Fields
     {
         return new CrudField($name);
     }
+
+    /**
+     * Grouping fields in tab
+     *
+     * @param  string  $name
+     * @param  array  $fields
+     * @return void
+     */
+    public function tab(string $name, array $fields) :void
+    {
+        foreach ($fields as $field) {
+            if ($field instanceof CrudField) {
+                $field->tab($name);
+            }
+
+            if (is_array($field)) {
+                $field['tab'] = $name;
+                $this->addField($field);
+            }
+
+            if (is_string($field)) {
+                $field = [
+                    'name' => $field,
+                    'tab' => $name,
+                ];
+                $this->addField($field);
+            }
+        }
+    }
 }


### PR DESCRIPTION
In some project, i have many tabs and fields in tabs, so this can save time)

## Usage

```
CRUD::tab(
            'Test Fluent Field',
            [
                CRUD::field('title')->type('text')->label('Title'),
                CRUD::field('description')->type('text')->label('Description'),
            ]
        );
```
or
```
CRUD::tab(
            'Test Array Field',
            [
                [
                    'name'  => 'seo_title',
                    'label' => 'Seo Title'
                ],
                [
                    'name'  => 'seo_description',
                    'label' => 'Seo Description'
                ],
            ]
        );
```
or
```
CRUD::tab(
            'Test String Field',
            [
                'number',
                'text'
            ]
        );
```