### PR TITLE
[4.X] Remove overflow hidden from crud table wrapper

### DIFF
--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -48,9 +48,9 @@
           @include('crud::inc.filters_navbar')
         @endif
 
-        <div class="overflow-hidden mt-2">
+        <div class="mt-2">
 
-        <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs" cellspacing="0">
+        <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs " cellspacing="0">
             <thead>
               <tr>
                 {{-- Table columns --}}

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -26,7 +26,6 @@
 
     <!-- THE ACTUAL CONTENT -->
     <div class="{{ $crud->getListContentClass() }}">
-      <div class="">
 
         <div class="row mb-0">
           <div class="col-sm-6">
@@ -48,9 +47,7 @@
           @include('crud::inc.filters_navbar')
         @endif
 
-        <div class="mt-2">
-
-        <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs " cellspacing="0">
+        <table id="crudTable" class="bg-white table table-striped table-hover nowrap rounded shadow-xs border-xs mt-2" cellspacing="0">
             <thead>
               <tr>
                 {{-- Table columns --}}
@@ -131,9 +128,6 @@
           </div>
           @endif
 
-        </div><!-- /.box-body -->
-
-      </div><!-- /.box -->
     </div>
 
   </div>


### PR DESCRIPTION
Like proposed in #2329 and reported again in #2945 this removes the `overflow-hidden` from crud table wrapper classes. Class `mt-2` was already in use. 

From my tests this fixed #2945 issue. Nothing seemd broken around, but I am not fully aware of the main implications of removing this class, this means I don't know what that class was fixing/provinding in terms of funcionality other than hiding the overflow in the table thus preventing this use cases from working.