### PR TITLE
Update Fields.php

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -184,7 +184,7 @@ trait Fields
      * @param string $fieldName         The field name
      * @param array  $modifications An array of changes to be made.
      */
-    public function modifyField($fieldName, $modifications)
+    public function modifyField($fieldName, $modifications, $operation)
     {
         $fieldsArray = $this->fields();
         $field = $this->firstFieldWhere('name', $fieldName);
@@ -196,7 +196,7 @@ trait Fields
 
         $this->enableTabsIfFieldUsesThem($modifications);
 
-        $this->setOperationSetting('fields', $fieldsArray);
+        $this->setOperationSetting('fields', $fieldsArray, $operation);
     }
 
     /**


### PR DESCRIPTION
Bring back functionality to set independent configs for create and update actions.

Before 4.0 i could use this:

```
$this->crud->create_fields['field_1']['hint'] = 'Hint only for create';
$this->crud->create_fields['field_2']['hint'] = 'Hint only for create';
$this->crud->create_fields['field_3']['hint'] = 'Hint only for create';
```

After upgrade, we lose direct access to settings. Of course, I see new API but there is no any method to append something to array easily. We need to get an array, append variable, and call method to set (overwrite). 

I would to use it like this:
```$this->crud->modifyField('field_1', ['hint' => 'Hint only for create'], 'create');```
