### PR TITLE
[4.x] Fix column limit override in show operation

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -108,7 +108,7 @@ trait ShowOperation
 
             // remove the character limit on columns that take it into account
             if (in_array($column['type'], ['text', 'email', 'model_function', 'model_function_attribute', 'phone', 'row_number', 'select'])) {
-                $this->crud->modifyColumn($column['key'], ['limit' => 999]);
+                $this->crud->modifyColumn($column['key'], ['limit' => ($column['limit'] ?? 999)]);
             }
         }
 


### PR DESCRIPTION
REFS: #2959 

- Add the possibility for the developer to override the default `999` limit for some columns in show operation. 
