### PR TITLE
Proposal fow new column (show/details view) to display relationships (hasMany)

### DIFF
--- a/src/resources/views/crud/columns/table_relationships.blade.php
+++ b/src/resources/views/crud/columns/table_relationships.blade.php
@@ -1,0 +1,41 @@
+@php
+      $value = data_get($entry, $column['name']);
+      $columns = $column['columns'];
+@endphp
+
+<span>
+
+    @if ($value && count($columns))
+
+        @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+
+        <table class="table table-bordered table-condensed table-responsive-sm table-sm table-striped m-b-0">
+		<thead>
+			<tr>
+				@foreach($columns as $tableColumnKey => $tableColumnDefinition)
+                    <th>{{ is_array($tableColumnDefinition) ? $tableColumnDefinition['label'] : $tableColumnDefinition }}</th>
+                @endforeach
+			</tr>
+		</thead>
+		<tbody>
+			@foreach ($value as $tableRow)
+                <tr>
+				@foreach($columns as $tableColumnKey => $tableColumnDefinition)
+                    <td>
+                        @if (isset($tableColumnDefinition['callback']) && is_callable($tableColumnDefinition['callback']))
+                            {{ $tableColumnDefinition['callback'](Arr::get($tableRow, $tableColumnDefinition['attribute'] ?? $tableColumnKey), $tableRow) }}
+                        @else
+                            {{ Arr::get($tableRow, $tableColumnDefinition['attribute'] ?? $tableColumnKey) }}
+                        @endif
+
+					</td>
+                @endforeach
+			</tr>
+            @endforeach
+		</tbody>
+    </table>
+
+        @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+
+    @endif
+</span>


### PR DESCRIPTION
Proposal for new column type for show/details view.

I use a backpack for the admin area so I would like to display as much as I can. I mainly use `$this->crud->setFromDb();` but now i want to add more data. Let's take an example user. Users can have roles (1-n), these are advanced models - `SchoolRoles` in relation to `School` (1-1). So I am gonna display his roles in a nice way.

![Screenshot_6](https://user-images.githubusercontent.com/17027876/85745531-0f252200-b706-11ea-8e90-a45ba7f529ca.png)

How to use it:
```php
$this->crud->addColumn([
    'name' => 'schoolRoles', 
    'type' => 'table_relationships', 
    'columns' => [
        'id'          => 'Id',
        'role'        => 'Role name',
        'school.name' => [
            'label' => 'School name', 
            'callback' => static function ($value, $model) {
                return new HtmlString('<a href="' . backpack_url('school/' . $model->school_id) . '/show">' . $value . '</a>');
            }
        ],
]]);
```

We can here use attributes directly, but also nested (in dot notation). Callbacks are helpful to display custom data, I just don't want to display all data from DB, but select columns, make them interactive, translate, etc. 

I think we can also add support for `attribute` as sometimes it could be enough.

Or another approach could use subview - index limited only to the parent model (more complicated). 

What do You think? 