### PR TITLE
fix: does not look for relationship if field entinty = false

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -38,7 +38,7 @@ trait Fields
         $field = $this->makeSureFieldHasEntity($field);
         $field = $this->makeSureFieldHasLabel($field);
 
-        if (isset($field['entity'])) {
+        if (isset($field['entity']) && $field['entity'] !== false) {
             $field = $this->makeSureFieldHasRelationType($field);
             $field = $this->makeSureFieldHasModel($field);
             $field = $this->overwriteFieldNameFromEntity($field);


### PR DESCRIPTION
This fixes #2885. 

Basically, if you don't want Backpack to "guess" the relationship, you set your `field['entity']` to `false`. 
This addresses the suggestion by @pxpm about setting `entity` to `false` - you would "turn off" the relationship guessing. 

Let me know what do you think about this. 
