### PR TITLE
[4.1][Bug fix] enum field could not be added using fluent syntax

### DIFF
--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -13,7 +13,6 @@ trait AutoSet
     public function setFromDb()
     {
         if (! $this->driverIsMongoDb()) {
-            $this->setDoctrineTypesMapping();
             $this->getDbColumnTypes();
         }
 
@@ -53,6 +52,8 @@ trait AutoSet
      */
     public function getDbColumnTypes()
     {
+        $this->setDoctrineTypesMapping();
+            
         $dbColumnTypes = [];
 
         foreach ($this->getDbTableColumns() as $key => $column) {

--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -53,7 +53,7 @@ trait AutoSet
     public function getDbColumnTypes()
     {
         $this->setDoctrineTypesMapping();
-            
+
         $dbColumnTypes = [];
 
         foreach ($this->getDbTableColumns() as $key => $column) {


### PR DESCRIPTION
Fixes #2790 and #2836

Previously the `enum` field type could not be added using fluent syntax. `CRUD::field('status')->type('enum');` inside the `ArticleCrudController`, for example, instead of 
```php
            $this->crud->addField([
                'name' => 'status',
                'label' => 'Status',
                'type' => 'enum',
            ]);
```

triggered an ugly error like @AbbyJanke described in #2790 and #2836 . This was because at the type when the field was added, in AutoSet.php, when it got here:
![Screenshot 2020-06-29 at 10 46 55](https://user-images.githubusercontent.com/1032474/85987110-e185f480-b9f5-11ea-9d71-fa7ddba177b8.png)

the `enum` type did not exist, it wasn't set as a custom doctrine type mapping.

Fixed by always setting the doctrine type mappings beforehand, when autosetting a field type based on the db column type.

**@pxpm do you foresee any problems with this?**