### PR TITLE
Replace search label with placeholder

### DIFF
--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -183,7 +183,6 @@
 	}
 
 	.dataTables_filter input {
-		margin-left: 0.5em;
 	    display: inline-block;
 	    width: auto;
 	    border-radius: 25px;
@@ -204,10 +203,6 @@
 		min-height: calc(100% - 98px);
 	}
 
-	#datatable_search_stack {
-		min-height: 35px;
-	}
-
 	@media(max-width: 576px) {
 		#datatable_search_stack {
 			margin-top: .5rem;
@@ -218,7 +213,6 @@
 		}
 	
 		#datatable_search_stack input[type="search"] {
-			margin-left: 0;
 			width: 100%;
 		}
 	}

--- a/src/resources/lang/ar/crud.php
+++ b/src/resources/lang/ar/crud.php
@@ -46,7 +46,7 @@ return [
     'filters'                                 => 'الفلاتر',
     'to'                                      => 'الى',
     'reorder_success_title'                   => 'انتهى',
-    'search'                                  => 'بحث:',
+    'search'                                  => 'بحث',
     'toggle_filters'                          => 'تبديل الفلاتر',
     'undo'                                    => 'تراجع',
     'edit'                                    => 'تعديل',

--- a/src/resources/lang/bg/crud.php
+++ b/src/resources/lang/bg/crud.php
@@ -65,7 +65,7 @@ return [
     'lengthMenu'     => '_MENU_ records per page',
     'loadingRecords' => 'Зареждам...',
     'processing'     => 'Обработка на резултатите...',
-    'search'         => 'Търсене: ',
+    'search'         => 'Търсене',
     'zeroRecords'    => 'Няма намерени резултати',
     'paginate'       => [
         'first'    => 'Първа',

--- a/src/resources/lang/cs/crud.php
+++ b/src/resources/lang/cs/crud.php
@@ -78,7 +78,7 @@ return [
     'lengthMenu'     => '_MENU_ záznamů na stránku',
     'loadingRecords' => 'Načítání...',
     'processing'     => 'Zpracování...',
-    'search'         => 'Hledat: ',
+    'search'         => 'Hledat',
     'zeroRecords'    => 'Nebyly nalezeny žádné odpovídající záznamy',
     'paginate'       => [
         'first'    => 'První',

--- a/src/resources/lang/da-DK/crud.php
+++ b/src/resources/lang/da-DK/crud.php
@@ -62,7 +62,7 @@ return [
     'lengthMenu'     => '_MENU_ felter pr side',
     'loadingRecords' => 'Indlæser...',
     'processing'     => 'Arbejder...',
-    'search'         => 'Søg: ',
+    'search'         => 'Søg',
     'zeroRecords'    => 'Ingen emner blev fundet',
     'paginate'       => [
         'first'    => 'Første',

--- a/src/resources/lang/da_DK/crud.php
+++ b/src/resources/lang/da_DK/crud.php
@@ -62,7 +62,7 @@ return [
     'lengthMenu'     => '_MENU_ felter pr side',
     'loadingRecords' => 'Indlæser...',
     'processing'     => 'Arbejder...',
-    'search'         => 'Søg: ',
+    'search'         => 'Søg',
     'zeroRecords'    => 'Ingen emner blev fundet',
     'paginate'       => [
         'first'    => 'Første',

--- a/src/resources/lang/de/crud.php
+++ b/src/resources/lang/de/crud.php
@@ -63,7 +63,7 @@ return [
     'lengthMenu'     => '_MENU_ Einträge pro Seite',
     'loadingRecords' => 'Laden...',
     'processing'     => 'Verarbeiten...',
-    'search'         => 'Suchen: ',
+    'search'         => 'Suchen',
     'zeroRecords'    => 'Keine passenden Einträge gefunden',
     'paginate'       => [
         'first'    => 'Erste',

--- a/src/resources/lang/el/crud.php
+++ b/src/resources/lang/el/crud.php
@@ -65,7 +65,7 @@ return [
     'lengthMenu'                              => '_MENU_ εγγραφές ανά σελίδα',
     'loadingRecords'                          => 'Loading...',
     'processing'                              => 'Processing...',
-    'search'                                  => 'Αναζήτηση: ',
+    'search'                                  => 'Αναζήτηση',
     'zeroRecords'                             => 'Δεν βρέθηκε καμία σχετική εγγραφή',
     'paginate'                                => [
         'first'    => 'Πρώτη',

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -83,7 +83,7 @@ return [
     'lengthMenu'     => '_MENU_ entries per page',
     'loadingRecords' => 'Loading...',
     'processing'     => 'Processing...',
-    'search'         => 'Search: ',
+    'search'         => 'Search',
     'zeroRecords'    => 'No matching entries found',
     'paginate'       => [
         'first'    => 'First',

--- a/src/resources/lang/es/crud.php
+++ b/src/resources/lang/es/crud.php
@@ -79,7 +79,7 @@ return [
     'lengthMenu'     => '_MENU_ elementos por página',
     'loadingRecords' => 'Cargando...',
     'processing'     => 'Procesando...',
-    'search'         => 'Buscar: ',
+    'search'         => 'Buscar',
     'zeroRecords'    => 'No se encontraron elementos',
     'paginate'       => [
         'first'    => 'Primero',

--- a/src/resources/lang/fa/crud.php
+++ b/src/resources/lang/fa/crud.php
@@ -78,7 +78,7 @@ return [
     'lengthMenu'     => '_MENU_ رکورد در صفحه',
     'loadingRecords' => 'درحال بارگذاری...',
     'processing'     => 'درحال پردازش...',
-    'search'         => 'جستجو: ',
+    'search'         => 'جستجو',
     'zeroRecords'    => 'مورد مطابقت داده شده یافت نشد',
     'paginate'       => [
         'first'    => 'اولین',

--- a/src/resources/lang/fr-CA/crud.php
+++ b/src/resources/lang/fr-CA/crud.php
@@ -66,7 +66,7 @@ return [
     'lengthMenu'     => '_MENU_ enregistrements par page',
     'loadingRecords' => 'Chargement...',
     'processing'     => 'Traitement...',
-    'search'         => 'Recherche : ',
+    'search'         => 'Recherche',
     'zeroRecords'    => 'Aucun enregistrement correspondant trouvé',
     'paginate'       => [
         'first'    => 'Premier',

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -83,7 +83,7 @@ return [
     'lengthMenu'     => '_MENU_ enregistrements par page',
     'loadingRecords' => 'Chargement...',
     'processing'     => 'Traitement...',
-    'search'         => 'Recherche : ',
+    'search'         => 'Recherche',
     'zeroRecords'    => 'Aucun enregistrement correspondant trouvé',
     'paginate'       => [
         'first'    => 'Premier',

--- a/src/resources/lang/fr_CA/crud.php
+++ b/src/resources/lang/fr_CA/crud.php
@@ -66,7 +66,7 @@ return [
     'lengthMenu'     => '_MENU_ enregistrements par page',
     'loadingRecords' => 'Chargement...',
     'processing'     => 'Traitement...',
-    'search'         => 'Recherche : ',
+    'search'         => 'Recherche',
     'zeroRecords'    => 'Aucun enregistrement correspondant trouvé',
     'paginate'       => [
         'first'    => 'Premier',

--- a/src/resources/lang/id/crud.php
+++ b/src/resources/lang/id/crud.php
@@ -81,7 +81,7 @@ return [
     'lengthMenu'     => '_MENU_ masukan per halaman',
     'loadingRecords' => 'Memuat...',
     'processing'     => 'Memproses...',
-    'search'         => 'Cari: ',
+    'search'         => 'Cari',
     'zeroRecords'    => 'Tidak ada data yang cocok ditemukan',
     'paginate'       => [
         'first'    => 'Pertama',

--- a/src/resources/lang/it/crud.php
+++ b/src/resources/lang/it/crud.php
@@ -77,7 +77,7 @@ return [
     'lengthMenu'     => '_MENU_ record per pagina',
     'loadingRecords' => 'Caricamento...',
     'processing'     => 'Elaborazione...',
-    'search'         => 'Cerca: ',
+    'search'         => 'Cerca',
     'zeroRecords'    => 'Nessun record corrispondente',
     'paginate'       => [
         'first'    => 'Primo',

--- a/src/resources/lang/ja/crud.php
+++ b/src/resources/lang/ja/crud.php
@@ -78,7 +78,7 @@ return [
     'lengthMenu'                              => '_MENU_ 件表示',
     'loadingRecords'                          => '読み込み中...',
     'processing'                              => '実行中...',
-    'search'                                  => '検索: ',
+    'search'                                  => '検索',
     'zeroRecords'                             => '一致するレコードが見つかりませんでした',
     'paginate'                                => [
         'first'    => '先頭',

--- a/src/resources/lang/lv/crud.php
+++ b/src/resources/lang/lv/crud.php
@@ -66,7 +66,7 @@ return [
     'lengthMenu'     => '_MENU_ ieraksti uz lapu',
     'loadingRecords' => 'Ielādē...',
     'processing'     => 'Apstrādā...',
-    'search'         => 'Meklēšana: ',
+    'search'         => 'Meklēšana',
     'zeroRecords'    => 'Peimēroti ieraksti nav atrasti',
     'paginate'       => [
         'first'    => 'Pirmā',

--- a/src/resources/lang/nl/crud.php
+++ b/src/resources/lang/nl/crud.php
@@ -83,7 +83,7 @@ return [
     'lengthMenu'     => '_MENU_ items per pagina',
     'loadingRecords' => 'Laden...',
     'processing'     => 'Verwerken...',
-    'search'         => 'Zoeken: ',
+    'search'         => 'Zoeken',
     'zeroRecords'    => 'Geen overeenkomend item gevonden',
     'paginate'       => [
         'first'    => 'Eerste',

--- a/src/resources/lang/pt-BR/crud.php
+++ b/src/resources/lang/pt-BR/crud.php
@@ -83,7 +83,7 @@ return [
     'lengthMenu'     => '_MENU_ registros por página',
     'loadingRecords' => 'Carregando...',
     'processing'     => 'Processando...',
-    'search'         => 'Pesquisar: ',
+    'search'         => 'Pesquisar',
     'zeroRecords'    => 'Nenhum registro encontrado',
     'paginate'       => [
         'first'    => 'Primeira',

--- a/src/resources/lang/pt/crud.php
+++ b/src/resources/lang/pt/crud.php
@@ -78,7 +78,7 @@ return [
     'lengthMenu'     => '_MENU_ itens por página',
     'loadingRecords' => 'A carregar...',
     'processing'     => 'A processar...',
-    'search'         => 'Procurar: ',
+    'search'         => 'Procurar',
     'zeroRecords'    => 'Nenhum item encontrado',
     'paginate'       => [
         'first'    => 'Primeiro',

--- a/src/resources/lang/pt_br/crud.php
+++ b/src/resources/lang/pt_br/crud.php
@@ -83,7 +83,7 @@ return [
     'lengthMenu'     => '_MENU_ registros por página',
     'loadingRecords' => 'Carregando...',
     'processing'     => 'Processando...',
-    'search'         => 'Pesquisar: ',
+    'search'         => 'Pesquisar',
     'zeroRecords'    => 'Nenhum registro encontrado',
     'paginate'       => [
         'first'    => 'Primeira',

--- a/src/resources/lang/ro/crud.php
+++ b/src/resources/lang/ro/crud.php
@@ -66,7 +66,7 @@ return [
     'lengthMenu'                              => '_MENU_ pe pagină',
     'loadingRecords'                          => 'Se încarcă...',
     'processing'                              => 'Se procesează...',
-    'search'                                  => 'Caută: ',
+    'search'                                  => 'Caută',
     'zeroRecords'                             => 'Nu au fost găsite intrări care să se potrivească',
     'paginate'                                => [
         'first'             => 'Prima pagină',

--- a/src/resources/lang/ru/crud.php
+++ b/src/resources/lang/ru/crud.php
@@ -81,7 +81,7 @@ return [
     'lengthMenu'                              => '_MENU_ записей на странице',
     'loadingRecords'                          => 'Загрузка...',
     'processing'                              => 'Обработка...',
-    'search'                                  => 'Поиск: ',
+    'search'                                  => 'Поиск',
     'zeroRecords'                             => 'Совпадений не найдено',
     'paginate'                                => [
         'first'    => 'Первая',

--- a/src/resources/lang/sr/crud.php
+++ b/src/resources/lang/sr/crud.php
@@ -82,7 +82,7 @@ return [
     'lengthMenu'     => '_MENU_ stavki po stranici',
     'loadingRecords' => 'Učitavanje...',
     'processing'     => 'Pricesiranje...',
-    'search'         => 'Pretraga: ',
+    'search'         => 'Pretraga',
     'zeroRecords'    => 'Nije pronadjeno ništa',
     'paginate'       => [
         'first'    => 'Prvi',

--- a/src/resources/lang/tr/crud.php
+++ b/src/resources/lang/tr/crud.php
@@ -69,7 +69,7 @@ return [
     'lengthMenu'     => '_MENU_ kayıt sayfa başına',
     'loadingRecords' => 'Yükleniyor...',
     'processing'     => 'İşleniyor...',
-    'search'         => 'Arama: ',
+    'search'         => 'Arama',
     'zeroRecords'    => 'Hiçbir eşleşen kayıt bulunamadı',
     'paginate'       => [
         'first'    => 'İlk',

--- a/src/resources/lang/zh-Hant/crud.php
+++ b/src/resources/lang/zh-Hant/crud.php
@@ -66,7 +66,7 @@ return [
     'lengthMenu'     => '每頁 _MENU_ 項紀錄',
     'loadingRecords' => '載入中...',
     'processing'     => '處理中...',
-    'search'         => '搜尋: ',
+    'search'         => '搜尋',
     'zeroRecords'    => '找不到相關紀錄',
     'paginate'       => [
         'first'    => '第一頁',

--- a/src/resources/lang/zh-cn/crud.php
+++ b/src/resources/lang/zh-cn/crud.php
@@ -81,7 +81,7 @@ return [
     'lengthMenu'     => '每页 _MENU_ 条记录',
     'loadingRecords' => '加载中...',
     'processing'     => '处理中...',
-    'search'         => '搜索: ',
+    'search'         => '搜索',
     'zeroRecords'    => '找不到相关记录',
     'paginate'       => [
         'first'    => '首页',

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -175,7 +175,8 @@
               "lengthMenu":     "{{ trans('backpack::crud.lengthMenu') }}",
               "loadingRecords": "{{ trans('backpack::crud.loadingRecords') }}",
               "processing":     "<img src='{{ asset('packages/backpack/crud/img/ajax-loader.gif') }}' alt='{{ trans('backpack::crud.processing') }}'>",
-              "search":         "<span class='d-none d-sm-inline'>{{ trans('backpack::crud.search') }}</span>",
+              "search": "_INPUT_",
+              "searchPlaceholder": "{{ trans('backpack::crud.search') }}...",
               "zeroRecords":    "{{ trans('backpack::crud.zeroRecords') }}",
               "paginate": {
                   "first":      "{{ trans('backpack::crud.paginate.first') }}",

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -39,7 +39,7 @@
             @endif
           </div>
           <div class="col-sm-6">
-            <div id="datatable_search_stack"></div>
+            <div id="datatable_search_stack" class="mt-sm-0 mt-2"></div>
           </div>
         </div>
 


### PR DESCRIPTION
Since the search label is hidden on smaller devices, it might be a better idea to add a placeholder to the search field.
This commit removes the label and adds a placeholder also the translation strings are updated by removing `:`

Some unnecessary CSS introduced with commit https://github.com/Laravel-Backpack/CRUD/commit/9081c1bf5acf1b1405e026ef6e9e865714047721 is also removed.

Personally I would also remove the border-radius from the input field, it is not really consistent with the styling since no other form elements have a 25px border radius. This is not done in this PR.
