### PR TITLE
[4.X] Fix button variable name

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -320,7 +320,7 @@ class CrudButton
      */
     public function after($destination)
     {
-        $this->crud()->moveButton($this->name, 'after', $destinationName);
+        $this->crud()->moveButton($this->name, 'after', $destination);
 
         return $this;
     }
@@ -333,7 +333,7 @@ class CrudButton
      */
     public function before($destination)
     {
-        $this->crud()->moveButton($this->name, 'before', $destinationName);
+        $this->crud()->moveButton($this->name, 'before', $destination);
 
         return $this;
     }


### PR DESCRIPTION
Also while working on this I noticed we have:

```php
public function addButton($stack, $name, $type, $content, $position = false, $replaceExisting = true)
    {
        if ($replaceExisting) {
            $this->removeButton($name, $stack);
        }

        return new CrudButton($name, $stack, $type, $content, $position);
    }
```

Even if we setup `$replaceExisting = false`, if the button has the same name of some previously added button it will be replaced:
```php
    private function save()
    {
        $itemExists = $this->collection()->contains('name', $this->name);

        if (! $itemExists) {
            if ($this->position == 'beginning') {
                $this->collection()->prepend($this);
            } else {
                $this->collection()->push($this);
            }

            // clear the custom position, so that the next daisy chained method
            // doesn't move it yet again
            $this->position = null;
        } else {

            $this->collection()->replace([$this->getKey() => $this]); // <------ HERE IF ITEM WITH 
                                                                    // NAME EXISTS WE REPLACE
        }

        return $this;
    }
```

Should the `$replaceExisting` be removed and the docs updated to reflect that change ? 

ATM you can't have 2 buttons with same name.

Let me know @tabacitu 