### PR TITLE
[4.1] Allow empty array in searchable_attributes in FetchOperation

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -100,8 +100,11 @@ trait FetchOperation
                         $tempQuery = $query->{$operation}($searchColumn, $search_string);
                     }
                 }
-
-                return $tempQuery;
+                // If developer provide an empty searchable_attributes array it means he don't want us to search
+                // in any specific column, or try to guess the column from model identifiableAttribute.
+                // In that scenario we will not have any $tempQuery here, so we just return the query, is up to the developer
+                // to do his own search.
+                return $tempQuery ?? $query;
             });
         } else {
             foreach ((array) $config['searchable_attributes'] as $k => $searchColumn) {


### PR DESCRIPTION
If developer does not provide `searchable_attributes` we will infer it from the model/table. 

So there is no way of doing a custom search, let's say, a fuzzy search without explicitly providing all the attributes.

With this change, we allow the developer to pass an empty array so we will not try to infer the attribute from the model and no need to specify any column, we just bail out with the developer query.

This is related to #2994 