### PR TITLE
Fix radio button bug

### DIFF
--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -1,7 +1,11 @@
 <!-- radio -->
 @php
-    $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? 0;
-    $optionValue = is_bool($optionValue) ? (int)$optionValue : $optionValue;
+    $options = $field['options'];
+    $defaultValue = $field['default'] ?? (count($options) > 0 ? array_key_first($options) : '');
+    $fieldValue = is_null($field['value']) ? $defaultValue : (is_bool($field['value']) ? (int)$field['value'] : $field['value']);
+    $oldValue = old(square_brackets_to_dots($field['name']));
+    $currentValue = is_null($oldValue) ? $fieldValue : (is_bool($oldValue) ? (int)$oldValue : $oldValue);
+    $optionValue = $currentValue;
 
     // if the class isn't overwritten, use 'radio'
     if (!isset($field['attributes']['class'])) {

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -1,7 +1,7 @@
 <!-- radio -->
 @php
     $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? 0;
-    $optionValue = (int)$optionValue;
+    $optionValue = is_bool($optionValue) ? (int)$optionValue : $optionValue;
 
     // if the class isn't overwritten, use 'radio'
     if (!isset($field['attributes']['class'])) {

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -2,7 +2,7 @@
 @php
     $options = $field['options'];
     $defaultValue = $field['default'] ?? (count($options) > 0 ? array_key_first($options) : '');
-    $fieldValue = is_null($field['value']) ? $defaultValue : (is_bool($field['value']) ? (int)$field['value'] : $field['value']);
+    $fieldValue = !isset($field['value']) ? $defaultValue : (is_bool($field['value']) ? (int)$field['value'] : $field['value']);
     $oldValue = old(square_brackets_to_dots($field['name']));
     $currentValue = is_null($oldValue) ? $fieldValue : (is_bool($oldValue) ? (int)$oldValue : $oldValue);
     $optionValue = $currentValue;
@@ -76,6 +76,7 @@
             });
 
             // select the right radios
+            console.log(value);
             element.find('input[type=radio][value="'+value+'"]').prop('checked', true);
         }
     </script>

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -1,6 +1,7 @@
 <!-- radio -->
 @php
-    $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+    $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? 0;
+    $optionValue = (int)$optionValue;
 
     // if the class isn't overwritten, use 'radio'
     if (!isset($field['attributes']['class'])) {


### PR DESCRIPTION
If I **previously** selected a value equal to **0 (false)**, then after I save the record and go back to editing, the values ​​will be empty, by default is **NULL**. If you add `default = 0`, then another bug appears that allows you to select several options (that is, 0 and 1).

If you use boolean vars, also some one else:
```
$optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? 0;
$optionValue = is_bool($optionValue) ? (int)$optionValue : $optionValue;
```

This pull request fixs it!