### PR TITLE
[4.X] Remove null coallescing operator in favor of ternary

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -186,7 +186,7 @@
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $allows_null = element.attr('data-column-nullable') == 'true' ? true : false;
         var $appLang = element.attr('data-app-current-lang');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
+        var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
         var $multiple = element.prop('multiple');
 
         var FetchAjaxFetchSelectedEntry = function (element) {

--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -186,7 +186,7 @@
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $allows_null = element.attr('data-column-nullable') == 'true' ? true : false;
         var $appLang = element.attr('data-app-current-lang');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ?? null);
+        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
         var $multiple = element.prop('multiple');
 
         var FetchAjaxFetchSelectedEntry = function (element) {

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -510,7 +510,7 @@ function bpFieldInitFetchOrCreateElement(element) {
     var $modelKey = element.attr('data-model-local-key');
     var $allows_null = (element.attr('data-allows-null') == 'true') ? true : false;
     var $appLang = element.attr('data-app-current-lang');
-    var $selectedOptions = JSON.parse(element.attr('data-selected-options') ?? null);
+    var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
     var $multiple = element.prop('multiple');
 
     var FetchOrCreateAjaxFetchSelectedEntry = function (element) {

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -510,7 +510,7 @@ function bpFieldInitFetchOrCreateElement(element) {
     var $modelKey = element.attr('data-model-local-key');
     var $allows_null = (element.attr('data-allows-null') == 'true') ? true : false;
     var $appLang = element.attr('data-app-current-lang');
-    var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
+    var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
     var $multiple = element.prop('multiple');
 
     var FetchOrCreateAjaxFetchSelectedEntry = function (element) {

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -143,7 +143,7 @@
         var $includeAllFormFields = element.attr('data-include-all-form-fields') == 'false' ? false : true;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $multiple = element.attr('data-field-multiple')  == 'false' ? false : true;
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
+        var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
         var $allows_null = (element.attr('data-column-nullable') == 'true') ? true : false;
         var $allowClear = $allows_null;
 

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -143,7 +143,7 @@
         var $includeAllFormFields = element.attr('data-include-all-form-fields') == 'false' ? false : true;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $multiple = element.attr('data-field-multiple')  == 'false' ? false : true;
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ?? null);
+        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
         var $allows_null = (element.attr('data-column-nullable') == 'true') ? true : false;
         var $allowClear = $allows_null;
 

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -108,7 +108,7 @@
         var $allowClear = element.attr('data-column-nullable') == 'true' ? true : false;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ?? null);
+        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
 
         var select2AjaxFetchSelectedEntry = function (element) {
             return new Promise(function (resolve, reject) {
@@ -184,11 +184,11 @@
 
         // if we have selected options here we are on a repeatable field, we need to fetch the options with the keys
         // we have stored from the field and append those options in the select.
-        if (typeof $selectedOptions !== typeof undefined && 
-            $selectedOptions !== false &&  
-            $selectedOptions != '' && 
-            $selectedOptions != null && 
-            $selectedOptions != []) 
+        if (typeof $selectedOptions !== typeof undefined &&
+            $selectedOptions !== false &&
+            $selectedOptions != '' &&
+            $selectedOptions != null &&
+            $selectedOptions != [])
         {
             var optionsForSelect = [];
             select2AjaxFetchSelectedEntry(element).then(result => {

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -108,7 +108,7 @@
         var $allowClear = element.attr('data-column-nullable') == 'true' ? true : false;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : null);
+        var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
 
         var select2AjaxFetchSelectedEntry = function (element) {
             return new Promise(function (resolve, reject) {

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -92,7 +92,7 @@
         var $allowClear = element.attr('data-column-nullable') == 'true' ? true : false;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ?? '[]');
+        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : []);
 
         var select2AjaxMultipleFetchSelectedEntries = function (element) {
             return new Promise(function (resolve, reject) {

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -92,7 +92,7 @@
         var $allowClear = element.attr('data-column-nullable') == 'true' ? true : false;
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
-        var $selectedOptions = JSON.parse(element.attr('data-selected-options') ? element.attr('data-selected-options') : []);
+        var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse("[]");
 
         var select2AjaxMultipleFetchSelectedEntries = function (element) {
             return new Promise(function (resolve, reject) {


### PR DESCRIPTION
This issue is referenced here: #2957 

Only after Chrome 80+ the null coallescing operator ( `??` ) was introduced in javascript.

This PR reverts back coallesces to ternary ( ` ? :` ) that way all browser from older versions should support it.