### PR TITLE
Allow multiple page_or_link

### DIFF
--- a/src/resources/views/crud/fields/page_or_link.blade.php
+++ b/src/resources/views/crud/fields/page_or_link.blade.php
@@ -10,6 +10,10 @@
     $field['allows_null'] = false;
     $page_model = $field['page_model'];
     $active_pages = $page_model::all();
+
+    $entry_link = $field['name']['link'] ?? 'link';
+    $entry_type = $field['name']['type'] ?? 'type';
+    $entry_page_id = $field['name']['page_id'] ?? 'page_id';
 ?>
 
 @include('crud::fields.inc.wrapper_start')
@@ -20,7 +24,7 @@
         <div class="col-sm-3">
             <select
                 data-identifier="page_or_link_select"
-                name="type"
+                name="{!! $entry_type !!}"
                 @include('crud::fields.inc.attributes')
                 >
 
@@ -31,7 +35,7 @@
                     @if (count($field['options']))
                         @foreach ($field['options'] as $key => $value)
                             <option value="{{ $key }}"
-                                @if (isset($crud->entry) && $key==$crud->entry->type)
+                                @if (isset($entry) && $key==$entry->$entry_type)
                                      selected
                                 @endif
                             >{{ $value }}</option>
@@ -41,57 +45,57 @@
         </div>
         <div class="col-sm-9">
             <!-- external link input -->
-              <div class="page_or_link_value page_or_link_external_link <?php if (! isset($entry) || $entry->type != 'external_link') {
+              <div class="page_or_link_value page_or_link_external_link <?php if (! isset($entry) || $entry->$entry_type != 'external_link') {
     echo 'd-none';
 } ?>">
                 <input
                     type="url"
                     class="form-control"
-                    name="link"
+                    name="{!! $entry_link !!}"
                     placeholder="{{ trans('backpack::crud.page_link_placeholder') }}"
 
-                    @if (!isset($entry) || $entry->type!='external_link')
+                    @if (!isset($entry) || $entry->$entry_type !='external_link')
                         disabled="disabled"
                       @endif
 
-                    @if (isset($entry) && $entry->type=='external_link' && isset($entry->link) && $entry->link!='')
-                        value="{{ $entry->link }}"
+                    @if (isset($entry) && $entry->$entry_type =='external_link' && isset($entry->$entry_link) && $entry->$entry_link!='')
+                        value="{{ $entry->$entry_link }}"
                     @endif
                     >
               </div>
               <!-- internal link input -->
-              <div class="page_or_link_value page_or_link_internal_link <?php if (! isset($entry) || $entry->type != 'internal_link') {
+              <div class="page_or_link_value page_or_link_internal_link <?php if (! isset($entry) || $entry->$entry_type != 'internal_link') {
     echo 'd-none';
 } ?>">
                 <input
                     type="text"
                     class="form-control"
-                    name="link"
+                    name="{!! $entry_link !!}"
                     placeholder="{{ trans('backpack::crud.internal_link_placeholder', ['url', url(config('backpack.base.route_prefix').'/page')]) }}"
 
-                    @if (!isset($entry) || $entry->type!='internal_link')
+                    @if (!isset($entry) || $entry->$entry_type!='internal_link')
                         disabled="disabled"
                       @endif
 
-                    @if (isset($entry) && $entry->type=='internal_link' && isset($entry->link) && $entry->link!='')
-                        value="{{ $entry->link }}"
+                    @if (isset($entry) && $entry->$entry_type=='internal_link' && isset($entry->$entry_link) && $entry->$entry_link!='')
+                        value="{{ $entry->$entry_link }}"
                     @endif
                     >
               </div>
               <!-- page slug input -->
-              <div class="page_or_link_value page_or_link_page <?php if (isset($entry) && $entry->type != 'page_link') {
+              <div class="page_or_link_value page_or_link_page <?php if (isset($entry) && $entry->$entry_type != 'page_link') {
     echo 'd-none';
 } ?>">
                 <select
                     class="form-control"
-                    name="page_id"
+                    name="{!! $entry_page_id !!}"
                     >
                     @if (!count($active_pages))
                         <option value="">-</option>
                     @else
                         @foreach ($active_pages as $key => $page)
                             <option value="{{ $page->id }}"
-                                @if (isset($entry) && isset($entry->page_id) && $page->id==$entry->page_id)
+                                @if (isset($entry) && isset($entry->$entry_page_id) && $page->id==$entry->$entry_page_id)
                                      selected
                                 @endif
                             >{{ $page->name }}</option>
@@ -128,27 +132,25 @@
     @push('crud_fields_scripts')
         <script>
             function bpFieldInitPageOrLinkElement(element) {
-                $wrapper = element;
-
-                $wrapper.find('[data-identifier=page_or_link_select]').change(function(e) {
-                    $wrapper.find(".page_or_link_value input").attr('disabled', 'disabled');
-                    $wrapper.find(".page_or_link_value select").attr('disabled', 'disabled');
-                    $wrapper.find(".page_or_link_value").removeClass("d-none").addClass("d-none");
+                element.find('[data-identifier=page_or_link_select]').change(function(e) {
+                    $(this).closest('.row').find(".page_or_link_value input").attr('disabled', 'disabled');
+                    $(this).closest('.row').find(".page_or_link_value select").attr('disabled', 'disabled');
+                    $(this).closest('.row').find(".page_or_link_value").removeClass("d-none").addClass("d-none");
 
                     switch($(this).val()) {
                         case 'external_link':
-                            $wrapper.find(".page_or_link_external_link input").removeAttr('disabled');
-                            $wrapper.find(".page_or_link_external_link").removeClass('d-none');
+                            $(this).closest('.row').find(".page_or_link_external_link input").removeAttr('disabled');
+                            $(this).closest('.row').find(".page_or_link_external_link").removeClass('d-none');
                             break;
 
                         case 'internal_link':
-                            $wrapper.find(".page_or_link_internal_link input").removeAttr('disabled');
-                            $wrapper.find(".page_or_link_internal_link").removeClass('d-none');
+                            $(this).closest('.row').find(".page_or_link_internal_link input").removeAttr('disabled');
+                            $(this).closest('.row').find(".page_or_link_internal_link").removeClass('d-none');
                             break;
 
                         default: // page_link
-                            $wrapper.find(".page_or_link_page select").removeAttr('disabled');
-                            $wrapper.find(".page_or_link_page").removeClass('d-none');
+                            $(this).closest('.row').find(".page_or_link_page select").removeAttr('disabled');
+                            $(this).closest('.row').find(".page_or_link_page").removeClass('d-none');
                     }
                 });
             }


### PR DESCRIPTION
This closes #3027

## New Example Usage
### CRUD Controller
```php
<?php 
for ($i = 1; $i <= 10; $i++) {
  $numStr  = strval($i);
  $this->crud->addField([
    'name' => ['type' => 'type_'.$numStr, 'link' => 'link_'.$numStr, 'page_id' => 'page_id_'.$numStr],
    'label' => 'Link '.$numStr,
    'type' => 'page_or_link',
    'page_model' => '\Backpack\PageManager\app\Models\Page',
    'fake' => true,
    'store_in' => 'extras',
  ]);
}
```

### In your Laravel Application 
```php
<?php

$links = [];
for ($i = 1; $i <= 10; $i++) {
  $numStr  = strval($i);

  $linkField = 'link_'.$numStr;
  $typeField = 'type_'.$numStr;
  $pageIdField = 'page_id_'.$numStr;
  $link = "#";
  switch ($page->$typeField) {
    case 'external_link':
      $link = $page->$linkField;
      break;

    case 'internal_link':
      $link = is_null($page->$linkField) ? '#' : url($page->$linkField);
      break;

    default: //page_link
      if ($page->$pageIdField) {
        $linkPage = Page::find($page->$pageIdField);
        $link = url($linkPage->slug);
      }
      break;
  }
  $links[] = $link;
}
```
