### PR TITLE
[4.X] Fix Select All in select2 multiple fields

### DIFF
--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -10,7 +10,7 @@
     $model_instance = new $field['model'];
     $options_ids_array = $field['options']->pluck($model_instance->getKeyName())->toArray();
 
-    $field['multiple'] = isset($field['multiple']) && $field['multiple']===false ? '': 'multiple';
+    $field['multiple'] = $field['multiple'] ?? true;
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -23,7 +23,7 @@
         data-select-all="{{ var_export($field['select_all'] ?? false)}}"
         data-options-for-js="{{json_encode(array_values($options_ids_array))}}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_multiple'])
-        {{$multiple}}>
+        {{ $field['multiple'] ? 'multiple' : '' }}>
 
         @if (isset($field['allows_null']) && $field['allows_null']==true)
             <option value="">-</option>

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -1,11 +1,16 @@
 <!-- select2 multiple -->
 @php
     if (!isset($field['options'])) {
-        $options = $field['model']::all();
+        $field['options'] = $field['model']::all();
     } else {
-        $options = call_user_func($field['options'], $field['model']::query());
+        $field['options'] = call_user_func($field['options'], $field['model']::query());
     }
-    $multiple = isset($field['multiple']) && $field['multiple']===false ? '': 'multiple';
+
+    //build option keys array to use with Select All in javascript.
+    $model_instance = new $field['model'];
+    $options_ids_array = $field['options']->pluck($model_instance->getKeyName())->toArray();
+
+    $field['multiple'] = isset($field['multiple']) && $field['multiple']===false ? '': 'multiple';
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -16,6 +21,7 @@
         style="width: 100%"
         data-init-function="bpFieldInitSelect2MultipleElement"
         data-select-all="{{ var_export($field['select_all'] ?? false)}}"
+        data-options-for-js="{{json_encode(array_values($options_ids_array))}}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_multiple'])
         {{$multiple}}>
 
@@ -24,7 +30,7 @@
         @endif
 
         @if (isset($field['model']))
-            @foreach ($options as $option)
+            @foreach ($field['options'] as $option)
                 @if( (old(square_brackets_to_dots($field["name"])) && in_array($option->getKey(), old($field["name"]))) || (is_null(old(square_brackets_to_dots($field["name"]))) && isset($field['value']) && in_array($option->getKey(), $field['value']->pluck($option->getKeyName(), $option->getKeyName())->toArray())))
                     <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
                 @else
@@ -72,19 +78,14 @@
             function bpFieldInitSelect2MultipleElement(element) {
 
                 var $select_all = element.attr('data-select-all');
-
                 if (!element.hasClass("select2-hidden-accessible"))
                     {
                         var $obj = element.select2({
                             theme: "bootstrap"
                         });
 
-                        var options = [];
-                        @if (count($options))
-                            @foreach ($options as $option)
-                                options.push('{{ $option->getKey() }}');
-                            @endforeach
-                        @endif
+                        //get options ids stored in the field.
+                        var options = JSON.parse(element.attr('data-options-for-js'));
 
                         if($select_all) {
                             element.parent().find('.clear').on("click", function () {


### PR DESCRIPTION
Issue described here: #3028 

Just refactored some variables in file like `$multiple` to use `$field['multiple']` or `$options` to use `$field['options']`.

Also added options ids encoded in the field data so we can get it in javascript when clicking select all. 

