### PR TITLE
Add CSS classes to body of CRUD views

### DIFF
--- a/src/resources/views/base/layouts/plain.blade.php
+++ b/src/resources/views/base/layouts/plain.blade.php
@@ -3,7 +3,7 @@
 <head>
     @include(backpack_view('inc.head'))
 </head>
-<body class="app flex-row align-items-center">
+<body class="app flex-row align-items-center @yield('view_classes')">
 
   @yield('header')
 

--- a/src/resources/views/base/layouts/top_left.blade.php
+++ b/src/resources/views/base/layouts/top_left.blade.php
@@ -7,7 +7,7 @@
 
 </head>
 
-<body class="{{ config('backpack.base.body_class') }}">
+<body class="{{ config('backpack.base.body_class') }} @yield('view_classes')">
 
   @include(backpack_view('inc.main_header'))
 
@@ -30,7 +30,7 @@
           @yield('before_content_widgets')
 
           @yield('content')
-          
+
           @yield('after_content_widgets')
 
         </div>

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -1,5 +1,7 @@
 @extends(backpack_view('blank'))
 
+@section('view_classes', 'crud-create crud-' . $crud->model->getTable())
+
 @php
   $defaultBreadcrumbs = [
     trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -1,5 +1,7 @@
 @extends(backpack_view('blank'))
 
+@section('view_classes', 'crud-edit crud-' . $crud->model->getTable())
+
 @php
   $defaultBreadcrumbs = [
     trans('backpack::crud.admin') => backpack_url('dashboard'),

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -1,5 +1,7 @@
 @extends(backpack_view('blank'))
 
+@section('view_classes', 'crud-list crud-' . $crud->model->getTable())
+
 @php
   $defaultBreadcrumbs = [
     trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -1,5 +1,7 @@
 @extends(backpack_view('blank'))
 
+@section('view_classes', 'crud-reorder crud-' . $crud->model->getTable())
+
 @php
   $defaultBreadcrumbs = [
     trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -1,5 +1,7 @@
 @extends(backpack_view('blank'))
 
+@section('view_classes', 'crud-show crud-' . $crud->model->getTable())
+
 @php
   $defaultBreadcrumbs = [
     trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),


### PR DESCRIPTION
As requerst by me in the issue #3060, I have added these classes to the body of each CRUD view to improve the script and style selection associated to a specific CRUD action.

It may be a good work-around while waiting for the possibility to include specific scripts and styles for CRUD views (#3020).

Let me know if it's appreciated and may work for you.