### PR TITLE
Fixed undefined id error when no items are available for relationship field

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -225,7 +225,7 @@ var fetchDefaultEntry = function (element) {
                     $key = result.data[0][$relatedKeyName];
                     $value = processItemText(result.data[0], $relatedAttribute, $appLang);
                 }else{
-                    $key = result[0][$relatedKeyName];
+                    $key = null;
                     $value = processItemText(result[0], $relatedAttribute, $appLang);
                 }
 
@@ -674,18 +674,23 @@ function bpFieldInitFetchOrCreateElement(element) {
     }
 
         }
+
 if (typeof processItemText !== 'function') {
     function processItemText(item, $fieldAttribute, $appLang) {
+        if (!item) {
+            return item; // Should return `null` or `undefined`.
+        }
+
         if(typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null)  {
-                if(item[$fieldAttribute][$appLang] != 'undefined') {
-                    return item[$fieldAttribute][$appLang];
-                }else{
-                    return item[$fieldAttribute][0];
-                }
+            if(item[$fieldAttribute][$appLang] != 'undefined') {
+                return item[$fieldAttribute][$appLang];
             }else{
-                return item[$fieldAttribute];
+                return item[$fieldAttribute][0];
             }
-}
+        }else{
+            return item[$fieldAttribute];
+        }
+    }
 }
             </script>
         @endpush


### PR DESCRIPTION
Fixes the first console error described by me in #3062:

```
create:572 Uncaught TypeError: Cannot read property 'id' of undefined
    at Object.success (create:572)
    at l (bundle.js?v=4.1.15@6c751de946a9c8511dd32eb7bfa3ca6a568849f5:2)
    at Object.fireWith [as resolveWith] (bundle.js?v=4.1.15@6c751de946a9c8511dd32eb7bfa3ca6a568849f5:2)
    at T (bundle.js?v=4.1.15@6c751de946a9c8511dd32eb7bfa3ca6a568849f5:2)
    at XMLHttpRequest.<anonymous> (bundle.js?v=4.1.15@6c751de946a9c8511dd32eb7bfa3ca6a568849f5:2)
```