### PR TITLE
Import "Closure" in CrudFilter for a proper auto-complete

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel;
 
+use Closure;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\ParameterBag;
 


### PR DESCRIPTION
`use Closure;` is missing from imports, resulting in `Closure` used in docblocks being treated as `Backpack\CRUD\app\Library\CrudPanel\Closure` and therefore IDE auto-complete and static code analysis fails, when using something like this
```
$this->crud
    ->filter('created_at')
    ->label('Created at')
    ->type('date_range')
    ->logic(function (string $values) {
        $values = json_decode($values, JSON_OBJECT_AS_ARRAY);
        $from = $values['from'];
        $to = Carbon::parse($values['to'])->addDay()->toDateString();

        $this->crud->addClause('whereBetween', 'created_at', [$from, $to]);
    });
```
in CRUD controllers.