### PR TITLE
Fixed license code validation on 32-bit machines

### DIFF
--- a/src/LicenseCheck.php
+++ b/src/LicenseCheck.php
@@ -46,6 +46,6 @@ trait LicenseCheck
      */
     private function validCode($j)
     {
-        $k = str_replace('-', '', $j); $s = substr($k, 0, 8); $c = substr($k, 8, 2); $a = substr($k, 10, 2); $l = substr($k, 12, 2); $p = substr($k, 14, 2); $n = substr($k, 16, 2); $m = substr($k, 18, 2); $z = substr($k, 20, 24); $w = 'ADEFHKLMVWXYZ146'; $x = $s; for ($i = 0; $i < strlen($w); $i++) { $r = $w[$i]; $x = str_replace($r, '-', $x); } $x = str_replace('-', '', $x); if ($x != '') { return false; } if (substr_count($j, '-') != 5) { return false; } $e = substr(crc32(substr($k, 0, 20)), -4); if ($z !== $e) { return false; } $o = strrev(substr(preg_replace('/[0-9]+/', '', strtoupper(sha1($a.'sand('.$s.')'.$n.'tos()'))), 2, 2)); if ($m !== $o) { return false; } return true;
+        $k = str_replace('-', '', $j); $s = substr($k, 0, 8); $c = substr($k, 8, 2); $a = substr($k, 10, 2); $l = substr($k, 12, 2); $p = substr($k, 14, 2); $n = substr($k, 16, 2); $m = substr($k, 18, 2); $z = substr($k, 20, 24); $w = 'ADEFHKLMVWXYZ146'; $x = $s; for ($i = 0; $i < strlen($w); $i++) { $r = $w[$i]; $x = str_replace($r, '-', $x); } $x = str_replace('-', '', $x); if ($x != '') { return false; } if (substr_count($j, '-') != 5) { return false; } $e = substr(hexdec(hash('crc32b', substr($k, 0, 20))), -4); if ($z !== $e) { return false; } $o = strrev(substr(preg_replace('/[0-9]+/', '', strtoupper(sha1($a.'sand('.$s.')'.$n.'tos()'))), 2, 2)); if ($m !== $o) { return false; } return true;
     }
 }


### PR DESCRIPTION
Recently I mailed @tabacitu about a problem with the validation of a license code I purchased.

Even if the license code was correct, the validation function continued to show the unlicensed software notification on production.

After reading about the functions used in the script, Tabacitu noticed that the problem should have been related to the different value returned by `crc32()` on a 32-bit OS architecture which my hosting provider uses.

Following the instructions on the documentation page about that function, we figured out that the solution was using a combination of `hexdec()` and `hash()` function to simulate the `crc32()` algorithm.