### PR TITLE
Add support for pronouns (🍳au 🧀)

### DIFF
--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -57,7 +57,7 @@ trait CreateOperation
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();
-        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.add').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.add').' '.$this->crud->entity_pronoun_singular_indefinite.$this->crud->entity_name;
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getCreateView(), $this->data);

--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -63,7 +63,7 @@ trait ReorderOperation
         // get all results for that entity
         $this->data['entries'] = $this->crud->getEntries();
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.reorder').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.reorder').' '.$this->crud->entity_pronoun_plural_definite.$this->crud->entity_name_plural;
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getReorderView(), $this->data);

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -76,7 +76,7 @@ trait ShowOperation
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
-        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.preview').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.preview').' '.$this->crud->entity_pronoun_singular_indefinite.$this->crud->entity_name;
 
         // set columns from db
         if ($setFromDb) {

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -71,7 +71,7 @@ trait UpdateOperation
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();
-        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_pronoun_singular_indefinite.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_pronoun_singular_definite.$this->crud->entity_name;
 
         $this->data['id'] = $id;
 

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -71,7 +71,7 @@ trait UpdateOperation
         $this->data['entry'] = $this->crud->getEntry($id);
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();
-        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_name;
+        $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_pronoun_singular_indefinite.$this->crud->entity_name;
 
         $this->data['id'] = $id;
 

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -219,9 +219,9 @@ class CrudPanel
      */
     public function setEntityPronounStrings($singular_indefinite, $singular_definite, $plural_indefinite = '', $plural_definite = '')
     {
-        foreach(['singular_indefinite', 'singular_definite', 'plural_indefinite', 'plural_definite'] as $var) {
+        foreach (['singular_indefinite', 'singular_definite', 'plural_indefinite', 'plural_definite'] as $var) {
             // add a space after the pronoun when need
-            if ($$var && !in_array(substr($$var, -1), ["'", "‘"])) {
+            if ($$var && ! in_array(substr($$var, -1), ["'", '‘'])) {
                 $$var .= ' ';
             }
             // set the variable

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -52,6 +52,10 @@ class CrudPanel
     public $route; // what route have you defined for your entity? used for links.
     public $entity_name = 'entry'; // what name will show up on the buttons, in singural (ex: Add entity)
     public $entity_name_plural = 'entries'; // what name will show up on the buttons, in plural (ex: Delete 5 entities)
+    public $entity_pronoun_singular_indefinite = '';
+    public $entity_pronoun_singular_definite = '';
+    public $entity_pronoun_plural_indefinite = '';
+    public $entity_pronoun_plural_definite = '';
 
     public $entry;
 
@@ -202,6 +206,27 @@ class CrudPanel
     {
         $this->entity_name = $singular;
         $this->entity_name_plural = $plural;
+    }
+
+    /**
+     * Set the entity pronouns in singular and plural.
+     * Used all over the CRUD interface (header, add button, reorder button, breadcrumbs).
+     *
+     * @param string $singular_indefinite Entity name, in singular. Ex: un
+     * @param string $singular_definite   Entity name, in plural. Ex: le
+     * @param string $plural_indefinite   Entity name, in plural. Ex: des
+     * @param string $plural_definite   Entity name, in plural. Ex: les
+     */
+    public function setEntityPronounStrings($singular_indefinite, $singular_definite, $plural_indefinite = '', $plural_definite = '')
+    {
+        foreach(['singular_indefinite', 'singular_definite', 'plural_indefinite', 'plural_definite'] as $var) {
+            // add a space after the pronoun when need
+            if ($$var && !in_array(substr($$var, -1), ["'", "‘"])) {
+                $$var .= ' ';
+            }
+            // set the variable
+            $this->{'entity_pronoun_'.$var} = $$var;
+        }
     }
 
     // -----------------------------------------------

--- a/src/resources/lang/fr/base.php
+++ b/src/resources/lang/fr/base.php
@@ -11,7 +11,7 @@ return [
     'registration_closed'    => 'Inscription fermée.',
     'first_page_you_see'     => 'La première page que vous voyez après connexion',
     'login_status'           => 'Etat de connexion',
-    'logged_in'              => 'Vous êtes connecté!',
+    'logged_in'              => 'Vous êtes connecté !',
     'toggle_navigation'      => 'Afficher/masquer la navigation',
     'administration'         => 'ADMINISTRATION',
     'user'                   => 'UTILISATEUR',
@@ -48,11 +48,11 @@ return [
     'account_updated'        => 'Compte mis à jour avec succès.',
     'unknown_error'          => 'Un erreur s’est produite. Veuillez réessayer.',
     'error_saving'           => 'Erreur lors de l’enregistrement. Veuillez réessayer.',
-    'welcome'                => 'Bienvenue!',
+    'welcome'                => 'Bienvenue !',
     'use_sidebar'            => 'Utilisez la barre latérale pour ajouter, modifier ou supprimer du contenu.',
 
     'password_reset' => [
-        'greeting' => 'Bonjour!',
+        'greeting' => 'Bonjour !',
         'subject'  => 'Réinitialisation du mot de passe',
         'line_1'   => 'Vous recevez cet email car nous avons reçu une demande de réinitialisation de votre mot de passe.',
         'line_2'   => 'Cliquez sur le lien suivant pour le réinitialiser:',

--- a/src/resources/lang/fr/base.php
+++ b/src/resources/lang/fr/base.php
@@ -40,6 +40,7 @@ return [
     'cancel'                 => 'Annuler',
     'error'                  => 'Erreur',
     'success'                => 'Succès',
+    'warning'                => 'Attention',
     'old_password_incorrect' => 'L’ancien mot de passe est erroné.',
     'password_dont_match'    => 'Les mots de passe ne correspondent pas.',
     'password_empty'         => 'Assurez-vous de bien avoir rempli les champs de mot de passe.',

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -35,10 +35,10 @@ return [
     'language'          => 'Langue',
 
     // CRUD table view
-    'all'                       => 'Tous les ',
+    'all'                       => 'Tous ',
     'in_the_database'           => 'dans la base de données',
     'list'                      => 'Liste',
-    'reset'                     => 'Reset',
+    'reset'                     => 'Réinitialiser',
     'actions'                   => 'Actions',
     'preview'                   => 'Aperçu',
     'delete'                    => 'Supprimer',

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -35,7 +35,7 @@ return [
     'language'          => 'Langue',
 
     // CRUD table view
-    'all'                       => 'Tous ',
+    'all'                       => 'Tous les ',
     'in_the_database'           => 'dans la base de données',
     'list'                      => 'Liste',
     'reset'                     => 'Réinitialiser',

--- a/src/resources/lang/fr/crud.php
+++ b/src/resources/lang/fr/crud.php
@@ -50,7 +50,7 @@ return [
     'clone_failure' => '<strong>Clonage échoué</strong><br>Le nouvel élément n\'a pu être créé. Merci de réessayer.',
 
     // Confirmation messages and bubbles
-    'delete_confirm'                              => 'Souhaitez-vous réellement supprimer cet élément?',
+    'delete_confirm'                              => 'Souhaitez-vous réellement supprimer cet élément ?',
     'delete_confirmation_title'                   => 'Élément supprimé',
     'delete_confirmation_message'                 => 'L’élément a été supprimé avec succès.',
     'delete_confirmation_not_title'               => 'NON supprimé',
@@ -63,7 +63,7 @@ return [
     'bulk_no_entries_selected_message' => 'Veuillez sélectionner un ou plusieurs éléments pour faire une action groupée',
 
     // Bulk confirmation
-    'bulk_delete_are_you_sure'   => 'Souhaitez-vous vraiment supprimer ces :number éléments?',
+    'bulk_delete_are_you_sure'   => 'Souhaitez-vous vraiment supprimer ces :number éléments ?',
     'bulk_delete_sucess_title'   => 'Éléments supprimés',
     'bulk_delete_sucess_message' => ' éléments ont été supprimés',
     'bulk_delete_error_title'    => 'Échec de la suppression',

--- a/src/resources/views/crud/buttons/create.blade.php
+++ b/src/resources/views/crud/buttons/create.blade.php
@@ -1,3 +1,3 @@
 @if ($crud->hasAccess('create'))
-	<a href="{{ url($crud->route.'/create') }}" class="btn btn-primary" data-style="zoom-in"><span class="ladda-label"><i class="la la-plus"></i> {{ trans('backpack::crud.add') }} {{ $crud->entity_name }}</span></a>
+	<a href="{{ url($crud->route.'/create') }}" class="btn btn-primary" data-style="zoom-in"><span class="ladda-label"><i class="la la-plus"></i> {{ trans('backpack::crud.add') }} {{ $crud->entity_pronoun_singular_indefinite.$crud->entity_name }}</span></a>
 @endif

--- a/src/resources/views/crud/buttons/reorder.blade.php
+++ b/src/resources/views/crud/buttons/reorder.blade.php
@@ -1,3 +1,3 @@
 @if ($crud->get('reorder.enabled') && $crud->hasAccess('reorder'))
-  <a href="{{ url($crud->route.'/reorder') }}" class="btn btn-outline-primary" data-style="zoom-in"><span class="ladda-label"><i class="la la-arrows"></i> {{ trans('backpack::crud.reorder') }} {{ $crud->entity_name_plural }}</span></a>
+  <a href="{{ url($crud->route.'/reorder') }}" class="btn btn-outline-primary" data-style="zoom-in"><span class="ladda-label"><i class="la la-arrows"></i> {{ trans('backpack::crud.reorder') }} {{ $crud->entity_pronoun_plural_definite.$crud->entity_name_plural }}</span></a>
 @endif

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -15,10 +15,10 @@
 	<section class="container-fluid">
 	  <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_pronoun_singular_indefinite.$crud->entity_name !!}.</small>
 
         @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>
         @endif
 	  </h2>
 	</section>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -15,10 +15,10 @@
 	<section class="container-fluid">
 	  <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_pronoun_singular_indefinite.$crud->entity_name !!}.</small>
 
         @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>
         @endif
 	  </h2>
 	</section>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -15,7 +15,7 @@
 	<section class="container-fluid">
 	  <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_pronoun_singular_indefinite.$crud->entity_name !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_pronoun_singular_definite.$crud->entity_name !!}.</small>
 
         @if ($crud->hasAccess('list'))
           <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -15,7 +15,7 @@
 <div class="container-fluid">
     <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_pronoun_plural_definite.$crud->entity_name_plural !!}.</small>
 
         @if ($crud->hasAccess('list'))
           <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -18,7 +18,7 @@
         <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}.</small>
 
         @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>
         @endif
     </h2>
 </div>

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -18,7 +18,7 @@
 	        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
 	        <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
 	        @if ($crud->hasAccess('list'))
-	          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+	          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_pronoun_plural_indefinite.$crud->entity_name_plural }}</span></a></small>
 	        @endif
 	    </h2>
     </section>


### PR DESCRIPTION
In languages other than English (French in my case), pronouns were missing, making some translations grammatically incorrect. Some PR attempted to fix it in an unnatural way, eg. #1790.

This is an attempt to fix it. It may not be perfect for all languages but it should work for German (as far as I remember).

Speaking about German, I first thought of doing a masculine/feminine thing but German has neutral so we need to handle that too. Also, in some cases `le` or `la` in French becomes `l'` (when the noun begins by a vowel). Even English could benefit from it, eg. `Add an entry` vs `Add a page`.

If you want to use this code, just add the following in your controller:

```CRUD::setEntityPronounStrings('un', 'le', 'des', 'les');```

1. indefinite singular pronoun
2. definite singular pronoun
3. indefinite plural pronoun
4. definite plural pronoun

I believe this should address most cases due to flexibility. If no pronoun is set, no change is visible.

_I also added two missing French translations and corrected some typos in French in this PR._