### PR TITLE
Change default redirect path

### DIFF
--- a/src/app/Library/Auth/RedirectsUsers.php
+++ b/src/app/Library/Auth/RedirectsUsers.php
@@ -15,6 +15,6 @@ trait RedirectsUsers
             return $this->redirectTo();
         }
 
-        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
+        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/dashboard';
     }
 }


### PR DESCRIPTION
Change default redirect after registering to /dashboard instead of /home.
/home route doesn't exist by default.