### PR TITLE
Fix #3112 - bulk clone now uses translation strings for error/success messages

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -45,9 +45,9 @@ return [
     'admin'                     => 'Admin',
     'details_row'               => 'This is the details row. Modify as you please.',
     'details_row_loading_error' => 'There was an error loading the details. Please retry.',
-    'clone' => 'Clone',
-    'clone_success' => '<strong>Entry cloned</strong><br>A new entry has been added, with the same information as this one.',
-    'clone_failure' => '<strong>Cloning failed</strong><br>The new entry could not be created. Please try again.',
+    'clone'                     => 'Clone',
+    'clone_success'             => '<strong>Entry cloned</strong><br>A new entry has been added, with the same information as this one.',
+    'clone_failure'             => '<strong>Cloning failed</strong><br>The new entry could not be created. Please try again.',
 
     // Confirmation messages and bubbles
     'delete_confirm'                              => 'Are you sure you want to delete this item?',
@@ -62,12 +62,19 @@ return [
     'bulk_no_entries_selected_title'   => 'No entries selected',
     'bulk_no_entries_selected_message' => 'Please select one or more items to perform a bulk action on them.',
 
-    // Bulk confirmation
+    // Bulk delete
     'bulk_delete_are_you_sure'   => 'Are you sure you want to delete these :number entries?',
     'bulk_delete_sucess_title'   => 'Entries deleted',
     'bulk_delete_sucess_message' => ' items have been deleted',
     'bulk_delete_error_title'    => 'Delete failed',
     'bulk_delete_error_message'  => 'One or more items could not be deleted',
+
+    // Bulk clone
+    'bulk_clone_are_you_sure'   => 'Are you sure you want to clone these :number entries?',
+    'bulk_clone_sucess_title'   => 'Entries cloned',
+    'bulk_clone_sucess_message' => ' items have been cloned.',
+    'bulk_clone_error_title'    => 'Cloning failed',
+    'bulk_clone_error_message'  => 'One or more entries could not be created. Please try again.',
 
     // Ajax errors
     'ajax_error_title' => 'Error',

--- a/src/resources/views/crud/buttons/bulk_clone.blade.php
+++ b/src/resources/views/crud/buttons/bulk_clone.blade.php
@@ -17,7 +17,7 @@
 	      	return;
 	      }
 
-	      var message = "Are you sure you want to clone these :number entries?";
+	      var message = "{!! trans('backpack::crud.bulk_clone_are_you_sure') !!}";
 	      message = message.replace(":number", crud.checkedItems.length);
 
 	      // show confirm message
@@ -54,7 +54,7 @@
 						  // Show an alert with the result
 		    	          new Noty({
 				            type: "success",
-				            text: "<strong>Entries cloned</strong><br>"+crud.checkedItems.length+" new entries have been added."
+				            text: "<strong>{!! trans('backpack::crud.bulk_clone_sucess_title') !!}</strong><br>"+crud.checkedItems.length+" {!! trans('backpack::crud.bulk_clone_sucess_message') !!}"
 				          }).show();
 
 						  crud.checkedItems = [];
@@ -64,7 +64,7 @@
 						  // Show an alert with the result
 		    	          new Noty({
 				            type: "danger",
-				            text: "<strong>Cloning failed</strong><br>One or more entries could not be created. Please try again."
+				            text: "<strong>{!! trans('backpack::crud.bulk_clone_error_title') !!}</strong><br>"+crud.checkedItems.length+" {!! trans('backpack::crud.bulk_clone_error_message') !!}"
 				          }).show();
 						}
 					});


### PR DESCRIPTION
As reported in #3112, bulk clone did not use translation strings for all messages. This fixes it.