### PR TITLE
Update ListOperation.php

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -100,7 +100,7 @@ trait ListOperation
                 // clear any past orderBy rules
                 $this->crud->query->getQuery()->orders = null;
                 // apply the current orderBy rules
-                $this->crud->query->orderByRaw($this->crud->model->getTable().'.'.$column['name'].' '.$column_direction);
+                $this->crud->query->orderByRaw(\DB::getTablePrefix().$this->crud->model->getTable().'.'.$column['name'].' '.$column_direction);
             }
 
             // check for custom order logic in the column definition
@@ -126,7 +126,7 @@ trait ListOperation
             }
         });
         if (! $hasOrderByPrimaryKey) {
-            $this->crud->query->orderByRaw($this->crud->model->getTable().'.'.$this->crud->model->getKeyName().' DESC');
+            $this->crud->query->orderByRaw(\DB::getTablePrefix().$this->crud->model->getTable().'.'.$this->crud->model->getKeyName().' DESC');
         }
 
         $entries = $this->crud->getEntries();


### PR DESCRIPTION
https://github.com/Laravel-Backpack/CRUD/pull/3015/commits/df4ff78408084b5d6bf339b7f6575f1dbb155b8c commit crashed our app because we use database prefix (i know, i will never do it again). 

This PR fix it. This method return empty string in case not using prefixed database names.