### PR TITLE
Update sidebar.blade.php

### DIFF
--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -58,11 +58,11 @@
       // If not found, look for the link that starts with the url
       if(!$curentPageLink.length > 0){
           $curentPageLink = $navLinks.filter( function() {
-            if ($(this).attr('href').startsWith(full_url)) {
+            if ($(this).attr('href').split('?')[0] === full_url) {
               return true;
             }
 
-            if (full_url.startsWith($(this).attr('href'))) {
+            if (full_url.split('?')[0] === $(this).attr('href')) {
               return true;
             }
 


### PR DESCRIPTION
The current sidebar menu implementation isn't very smart when it comes to detecting which menu item should be "active" - it merely looks for the beginning of the URL in the href (and vice versa) which leads to multiple menu items being highlighted at once when they both begin with the same word, eg. `user` and `usersetting`. See screenshot for my use case:

<img width="462" alt="Screen Shot 2020-08-15 at 10 58 52 AM" src="https://user-images.githubusercontent.com/13803216/90318629-9b71eb00-dee6-11ea-9854-0084fb4444b0.png">
Above, I've got CRUD for models called `trail` and `trailhead` which means that when I'm on the trailhead page, both the Trailheads menu item is active (correctly) and the Trails menu item is active (incorrectly).


This pull request implements improved logic to determine if menu item is active.


It could be made in better by also comparing the URL parameters (URL segment after the `?`) but I think this is a significant improvement already.