### PR TITLE
[4.X] Fix middleware inclusion if you want to override web with your own array.

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -83,6 +83,20 @@ class BackpackServiceProvider extends ServiceProvider
         $middleware_key = config('backpack.base.middleware_key');
         $middleware_class = config('backpack.base.middleware_class');
 
+        //we get the web middleware defined in config, could be a single key: web for example,
+        //or it can be an array of middlewares that replaces the default `web` middleware from Laravel.
+        $web_middleware = config('backpack.base.web_middleware', 'web');
+
+        //if it is an array it means developer would like to replace the default web middleware list with his own MW array.
+        if(is_array($web_middleware)) {
+            $router->middlewareGroup('web', $web_middleware);
+
+            //after replacing the web middleware with the ones we want
+            //we setup the correct middleware key in config so we can get it on runtime.
+            config(['backpack.base.web_middleware' => 'web']);
+
+        }
+
         if (! is_array($middleware_class)) {
             $router->pushMiddlewareToGroup($middleware_key, $middleware_class);
 

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -88,13 +88,12 @@ class BackpackServiceProvider extends ServiceProvider
         $web_middleware = config('backpack.base.web_middleware', 'web');
 
         //if it is an array it means developer would like to replace the default web middleware list with his own MW array.
-        if(is_array($web_middleware)) {
+        if (is_array($web_middleware)) {
             $router->middlewareGroup('web', $web_middleware);
 
             //after replacing the web middleware with the ones we want
             //we setup the correct middleware key in config so we can get it on runtime.
             config(['backpack.base.web_middleware' => 'web']);
-
         }
 
         if (! is_array($middleware_class)) {

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -83,19 +83,6 @@ class BackpackServiceProvider extends ServiceProvider
         $middleware_key = config('backpack.base.middleware_key');
         $middleware_class = config('backpack.base.middleware_class');
 
-        //we get the web middleware defined in config, could be a single key: web for example,
-        //or it can be an array of middlewares that replaces the default `web` middleware from Laravel.
-        $web_middleware = config('backpack.base.web_middleware', 'web');
-
-        //if it is an array it means developer would like to replace the default web middleware list with his own MW array.
-        if (is_array($web_middleware)) {
-            $router->middlewareGroup('web', $web_middleware);
-
-            //after replacing the web middleware with the ones we want
-            //we setup the correct middleware key in config so we can get it on runtime.
-            config(['backpack.base.web_middleware' => 'web']);
-        }
-
         if (! is_array($middleware_class)) {
             $router->pushMiddlewareToGroup($middleware_key, $middleware_class);
 

--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -8,10 +8,10 @@
 
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
-    'middleware' => [
-        config('backpack.base.web_middleware', 'web'),
-        config('backpack.base.middleware_key', 'admin'),
-    ],
+    'middleware' => array_merge(
+        (array)config('backpack.base.web_middleware', 'web'),
+        (array)config('backpack.base.middleware_key', 'admin')
+    ),
     'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes
 }); // this should be the absolute last line of this file

--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -9,8 +9,8 @@
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
     'middleware' => array_merge(
-        (array)config('backpack.base.web_middleware', 'web'),
-        (array)config('backpack.base.middleware_key', 'admin')
+        (array) config('backpack.base.web_middleware', 'web'),
+        (array) config('backpack.base.middleware_key', 'admin')
     ),
     'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes


### PR DESCRIPTION
This problem was reported in #3102 

Developer was unable to follow the documentation on how to overwrite the default laravel `web` middleware. 

This PR fixes it.

 This bug might be around since 4.0 or even earlier versions.


