### PR TITLE
[4.1] Fix repeatable fields initialization

### DIFF
--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -31,8 +31,12 @@
               $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
               $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
               $subfield['showAsterisk'] = false;
+              //we add this class to the field so that we can exclude it from the main form initialization.
+              //this field will be initialized when the parent repeatable container initializes.
+              $subfield['attributes']['class'] = isset($subfield['attributes']['class']) ?
+                                                $subfield['attributes']['class'] . ' repeatable-field-input' :
+                                                'repeatable-field-input';
           @endphp
-
           @include($fieldViewPath, ['field' => $subfield])
         @endforeach
 

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -35,12 +35,21 @@
     <script>
     function initializeFieldsWithJavascript(container) {
       var selector;
+
       if (container instanceof jQuery) {
         selector = container;
       } else {
         selector = $(container);
       }
-      selector.find("[data-init-function]").not("[data-initialized=true]").each(function () {
+
+      var $elements = selector.find("[data-init-function]").not("[data-initialized=true]");
+
+      // If it's not a repeatable container we exclude all the repeatable fields from the initialization
+      if (!selector.hasClass('repeatable-element')) {
+        $elements = $elements.not(".repeatable-field-input");
+      }
+
+      $elements.each(function (key, el) {
         var element = $(this);
         var functionName = element.data('init-function');
 


### PR DESCRIPTION
refs: #3141 , #3137 

Adds a new class to identify the repeatable fields.

Using the `data-repeatable-input-name` does not work because repeatable fields initialization is after we need it.

Excludes the repeatable fields from initialization if the selector is not a `repeatable-element` container.

more info: https://github.com/Laravel-Backpack/CRUD/issues/3141#issuecomment-678677179
