### PR TITLE
[4.1] Make header classes configurable

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -50,6 +50,26 @@ trait Views
         return $this->get('create.contentClass') ?? config('backpack.crud.operations.create.contentClass', 'col-md-8 bold-labels');
     }
 
+    /**
+     * Sets the create header class.
+     *
+     * @param string $class header class
+     */
+    public function setCreateHeaderClass(string $class)
+    {
+        return $this->set('create.headerClass', $class);
+    }
+
+    /**
+     * Gets the create header class.
+     *
+     * @return string header class for create view
+     */
+    public function getCreateHeaderClass()
+    {
+        return $this->get('create.headerClass') ?? config('backpack.crud.operations.create.headerClass', 'col-md-8');
+    }
+
     // -------
     // READ
     // -------
@@ -94,6 +114,26 @@ trait Views
     public function getListContentClass()
     {
         return $this->get('list.contentClass') ?? config('backpack.crud.operations.list.contentClass', 'col-md-12');
+    }
+
+    /**
+     * Sets the list header class.
+     *
+     * @param string $class header class
+     */
+    public function setListHeaderClass(string $class)
+    {
+        return $this->set('list.headerClass', $class);
+    }
+
+    /**
+     * Gets the list header class.
+     *
+     * @return string header class for list view
+     */
+    public function getListHeaderClass()
+    {
+        return $this->get('list.headerClass') ?? config('backpack.crud.operations.list.headerClass', 'col-md-12');
     }
 
     /**
@@ -160,6 +200,26 @@ trait Views
         return $this->get('show.contentClass') ?? config('backpack.crud.operations.show.contentClass', 'col-md-8 col-md-offset-2');
     }
 
+    /**
+     * Sets the edit header class.
+     *
+     * @param string $class header class
+     */
+    public function setShowHeaderClass(string $class)
+    {
+        return $this->set('show.headerClass', $class);
+    }
+
+    /**
+     * Gets the edit header class.
+     *
+     * @return string header class for edit view
+     */
+    public function getShowHeaderClass()
+    {
+        return $this->get('show.headerClass') ?? config('backpack.crud.operations.show.headerClass', 'col-md-8 col-md-offset-2');
+    }
+
     // -------
     // UPDATE
     // -------
@@ -207,6 +267,26 @@ trait Views
     }
 
     /**
+     * Sets the edit header class.
+     *
+     * @param string $class header class
+     */
+    public function setEditHeaderClass(string $class)
+    {
+        return $this->set('update.headerClass', $class);
+    }
+
+    /**
+     * Gets the edit header class.
+     *
+     * @return string header class for edit view
+     */
+    public function getEditHeaderClass()
+    {
+        return $this->get('update.headerClass') ?? config('backpack.crud.operations.update.headerClass', 'col-md-8');
+    }
+
+    /**
      * Sets the reorder template.
      *
      * @param string $view name of the template file
@@ -248,6 +328,26 @@ trait Views
         return $this->get('reorder.contentClass') ?? config('backpack.crud.operations.reorder.contentClass', 'col-md-8 col-md-offset-2');
     }
 
+    /**
+     * Sets the reorder header class.
+     *
+     * @param string $class header class
+     */
+    public function setReorderHeaderClass(string $class)
+    {
+        return $this->set('reorder.headerClass', $class);
+    }
+
+    /**
+     * Gets the reorder&nest header class.
+     *
+     * @return string header class for reorder and nest view
+     */
+    public function getReorderHeaderClass()
+    {
+        return $this->get('reorder.headerClass') ?? config('backpack.crud.operations.reorder.headerClass', 'col-md-8 col-md-offset-2');
+    }
+
     // -------
     // ALIASES
     // -------
@@ -275,6 +375,11 @@ trait Views
     public function setUpdateContentClass(string $editContentClass)
     {
         return $this->setEditContentClass($editContentClass);
+    }
+
+    public function setUpdateHeaderClass(string $editHeaderClass)
+    {
+        return $this->setEditHeaderClass($editHeaderClass);
     }
 
     public function getUpdateContentClass()

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -21,6 +21,10 @@ return [
             // To override per view use $this->crud->setListContentClass('class-string')
             'contentClass' => 'col-md-12',
 
+            // Define the size/looks of the header div for all CRUDs
+            // To override per view use $this->crud->setListHeaderClass('class-string')
+            'headerClass' => 'col-md-12',
+
             // enable the datatables-responsive plugin, which hides columns if they don't fit?
             // if not, a horizontal scrollbar will be shown instead
             'responsiveTable' => true,
@@ -72,6 +76,10 @@ return [
             // To override per view use $this->crud->setCreateContentClass('class-string')
             'contentClass' => 'col-md-8 bold-labels',
 
+            // Define the size/looks of the header div for all CRUDs
+            // To override per view use $this->crud->setCreateHeaderClass('class-string')
+            'headerClass' => 'col-md-8',
+
             // When using tabbed forms (create & update), what kind of tabs would you like?
             'tabsType' => 'horizontal', //options: horizontal, vertical
 
@@ -108,6 +116,10 @@ return [
             // To override per view use $this->crud->setEditContentClass('class-string')
             'contentClass'   => 'col-md-8 bold-labels',
 
+            // Define the size/looks of the header div for all CRUDs
+            // To override per view use $this->crud->setEditHeaderClass('class-string')
+            'headerClass'   => 'col-md-8',
+
             // When using tabbed forms (create & update), what kind of tabs would you like?
             'tabsType' => 'horizontal', //options: horizontal, vertical
 
@@ -143,6 +155,10 @@ return [
             // Define the size/looks of the content div for all CRUDs
             // To override per Controller use $this->crud->setShowContentClass('class-string')
             'contentClass' => 'col-md-8',
+
+            // Define the size/looks of the header div for all CRUDs
+            // To override per Controller use $this->crud->setShowHeaderClass('class-string')
+            'headerClass' => 'col-md-8',
         ],
 
         /*
@@ -152,6 +168,10 @@ return [
             // Define the size/looks of the content div for all CRUDs
             // To override per Controller use $this->crud->setReorderContentClass('class-string')
             'contentClass'   => 'col-md-8 col-md-offset-2',
+
+            // Define the size/looks of the header div for all CRUDs
+            // To override per Controller use $this->crud->setReorderHeaderClass('class-string')
+            'headerClass'   => 'col-md-8 col-md-offset-2',
         ],
 
     ],

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -13,14 +13,18 @@
 
 @section('header')
 	<section class="container-fluid">
-	  <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</small>
+		<div class="row">
+			<div class="{{ $crud->getCreateHeaderClass() }}">
+				<h2>
+					<span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+					<small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</small>
 
-        @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        @endif
-	  </h2>
+					@if ($crud->hasAccess('list'))
+					<small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+					@endif
+				</h2>
+			</div>
+		</div>
 	</section>
 @endsection
 

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -13,14 +13,18 @@
 
 @section('header')
 	<section class="container-fluid">
-	  <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</small>
+		<div class="row">
+			<div class="{{ $crud->getEditHeaderClass() }}">
+				<h2>
+					<span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+					<small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</small>
 
-        @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        @endif
-	  </h2>
+					@if ($crud->hasAccess('list'))
+					<small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+					@endif
+				</h2>
+			</div>
+		</div>
 	</section>
 @endsection
 

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -13,10 +13,14 @@
 
 @section('header')
   <div class="container-fluid">
-    <h2>
-      <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-      <small id="datatable_info_stack">{!! $crud->getSubheading() ?? '' !!}</small>
-    </h2>
+    <div class="row">
+      <div class="{{ $crud->getListHeaderClass() }}">
+        <h2>
+          <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+          <small id="datatable_info_stack">{!! $crud->getSubheading() ?? '' !!}</small>
+        </h2>
+      </div>
+    </div>
   </div>
 @endsection
 

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -13,14 +13,18 @@
 
 @section('header')
 <div class="container-fluid">
-    <h2>
-        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}.</small>
+  <div class="row">
+    <div class="{{ $crud->getReorderHeaderClass() }}">
+      <h2>
+          <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+          <small>{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}.</small>
 
-        @if ($crud->hasAccess('list'))
-          <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        @endif
-    </h2>
+          @if ($crud->hasAccess('list'))
+            <small><a href="{{ url($crud->route) }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+          @endif
+      </h2>
+    </div>
+  </div>
 </div>
 @endsection
 

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -13,14 +13,18 @@
 
 @section('header')
 	<section class="container-fluid d-print-none">
-    	<a href="javascript: window.print();" class="btn float-right"><i class="la la-print"></i></a>
-		<h2>
-	        <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-	        <small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
-	        @if ($crud->hasAccess('list'))
-	          <small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-	        @endif
-	    </h2>
+		<div class="row">
+			<div class="{{ $crud->getShowHeaderClass() }}">
+				<a href="javascript: window.print();" class="btn float-right"><i class="la la-print"></i></a>
+				<h2>
+					<span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
+					<small>{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}.</small>
+					@if ($crud->hasAccess('list'))
+					<small class=""><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+					@endif
+				</h2>
+			</div>
+		</div>
     </section>
 @endsection
 


### PR DESCRIPTION
While adding some `offset` classes to the content I noticed the header was no longer aligned.
This PR adds the ability to define classes for the CRUD headers, usefull when working with content offset or any other classes you might need.
By default they are the same as the content classes minus `.bold-labels` 