### PR TITLE
Active class on topbar .app-header not header

### DIFF
--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -48,7 +48,7 @@
   <script>
       // Set active state on menu element
       var full_url = "{{ Request::fullUrl() }}";
-      var $navLinks = $(".sidebar-nav li a, header li a");
+      var $navLinks = $(".sidebar-nav li a, .app-header li a");
 
       // First look for an exact match including the search string
       var $curentPageLink = $navLinks.filter(


### PR DESCRIPTION
Changed `.sidebar-nav li a, header li a` to `.sidebar-nav li a, .app-header li a` so that it doesn't do that for ALL header DOM elements that have a `li` inside. Maybe developers include `header` elements in their custom pages. But it's unlikely they'll include elements with `app-header` which is part of the navbar styling.

