### PR TITLE
[4.1] Fix crud table css selector

### DIFF
--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -217,7 +217,7 @@
 		}
 	}
 
-	#crudTable thead>tr>th, table.dataTable thead>tr>td {
+	#crudTable thead>tr>th, table.dataTable thead>tr>th {
 		padding-right: 30px;
 	}
 


### PR DESCRIPTION
When a crudtable is not responsive, header items are not correctly aligned.
This PR fixes the css selector that is supposed to fix that.