### PR TITLE
[Bug fix] allow the check column type to use the wrapper functionality

### DIFF
--- a/src/resources/views/crud/columns/check.blade.php
+++ b/src/resources/views/crud/columns/check.blade.php
@@ -15,15 +15,15 @@
 @endphp
 
 <span>
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
     <i class="la {{ $icon }}"></i>
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
 </span>
 
 <span class="sr-only">
-    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
-        @if($column['escaped'])
-            {{ $column['text'] }}
-        @else
-            {!! $column['text'] !!}
-        @endif
-    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+    @if($column['escaped'])
+        {{ $column['text'] }}
+    @else
+        {!! $column['text'] !!}
+    @endif
 </span>


### PR DESCRIPTION
Previously this did not work because the wrapper was only output for screen-readers. Which doesn't makes sense, that's where you DON'T need the wrapper. This allows one to change the checkbox color, and stuff like that:

![Screenshot 2020-08-27 at 09 44 55](https://user-images.githubusercontent.com/1032474/91450165-ab91af00-e884-11ea-874f-886db375b5cb.png)

@pxpm would you please double-check and review?