### PR TITLE
Bugfix "select2 grouped" not working

### DIFF
--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -9,9 +9,9 @@
     @php
         $entity_model = $crud->model;
         $related_model = $crud->getRelationModel($field['entity']);
-        $group_by_model = (new $entity_model)->{$field['group_by']}()->getRelated();
+        $group_by_model = (new $related_model)->{$field['group_by']}()->getRelated();
         $categories = $group_by_model::with($field['group_by_relationship_back'])->get();
-        
+
         if (isset($field['model'])) {
             $categorylessEntries = $related_model::doesnthave($field['group_by'])->get();
         }


### PR DESCRIPTION
Fixed a bug (see https://github.com/Laravel-Backpack/CRUD/issues/1821 ) referencing the relation to the entity_model() rather than the related_model().

Note: "select_grouped" does not have this bug