### PR TITLE
[4.x] Fix google field initialization 

### DIFF
--- a/src/resources/views/crud/fields/address_google.blade.php
+++ b/src/resources/views/crud/fields/address_google.blade.php
@@ -75,6 +75,12 @@ if (isset($field['value']) && (is_array($field['value']) || is_object($field['va
         <script>
 
             function bpFieldInitAddressGoogleElement(element) {
+
+                //this script is async loaded so it does not prevent other scripts in page to load while this is fetched from outside url.
+                //at somepoint our initialization script might run before the script is on page throwing undesired errors.
+                //this makes sure that when this script is run, it has google available either on our field initialization or when the callback function is called.
+                if(typeof google === "undefined") { return; }
+
                 var $addressConfig = element.data('google-address');
                 var $field = $('[name="' + $addressConfig.field + '"]');
 


### PR DESCRIPTION
refs: #3161 

Sometimes the script might not be available on our form initialization script and throw an error. 

This check makes sure we only proceed the initialization when the script is on page.

- If it's available in our initialization we use it, otherwise it will be available when it finishes loading and recall the initialization via callback.

