### PR TITLE
Fix filter fallback doesn't work issue

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -110,6 +110,7 @@ class CrudFilter
             if (is_callable($this->fallbackLogic)) {
                 return ($this->fallbackLogic)();
             }
+
             return;
         }
 
@@ -118,11 +119,6 @@ class CrudFilter
             return ($this->logic)($input->get($this->name));
         } else {
             return $this->applyDefaultLogic($this->name, false);
-        }
-
-        // if fallback logic was supplied and is a closure
-        if (is_callable($this->fallbackLogic)) {
-            return ($this->fallbackLogic)();
         }
     }
 

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -106,6 +106,10 @@ class CrudFilter
         $input = $input ?? new ParameterBag($this->crud()->getRequest()->all());
 
         if (! $input->has($this->name)) {
+            // if fallback logic was supplied and is a closure
+            if (is_callable($this->fallbackLogic)) {
+                return ($this->fallbackLogic)();
+            }
             return;
         }
 


### PR DESCRIPTION
When the GET request doesn't include the name of filter, it should call fallback function if it exists.