### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^7.0|^6.0",
+        "laravel/framework": "^8.0|^7.0|^6.0",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
         "ocramius/package-versions": "^1.4",


### PR DESCRIPTION
We aim to provide Laravel 8 support as a non-breaking change (aka patch update - Backpack 4.1.22). But it might take a while to test all corner cases and work out any kinks of fully supporting Laravel 8.

If you're in a hurry to use Laravel 8... OR you want to help us test Backpack on Laravel 8, please do: 
```
composer require backpack/crud:"add-support-for-laravel-8-dev as 4.1.99"
```

This will make sure your project uses this development branch. If you get an error similar to `Fatal error: Allowed memory size of 1610612736 bytes exhausted`, you can run the command below, but please also let us know you've encountered the error (reply here): 
```php
COMPOSER_MEMORY_LIMIT=-1 composer require backpack/crud:"add-support-for-laravel-8-dev as 4.1.99"
```