### PR TITLE
[4.1] Fix HasMany relation

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -194,6 +194,17 @@ trait Create
                 if ($relationData['values'][$relationMethod] !== null) {
                     $modelInstance->whereIn($modelInstance->getKeyName(), $relationData['values'][$relationMethod])
                             ->update([$relation->getForeignKeyName() => $item->{$relation->getLocalKeyName()}]);
+
+                    //we clear up any values that were removed from model relation.
+                    if(!$modelInstance->isColumnNullable($relation->getForeignKeyName())) {
+                        $modelInstance->whereNotIn($modelInstance->getKeyName(), $relationData['values'][$relationMethod])
+                                ->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})
+                                ->delete();
+                    }else{
+                        $modelInstance->whereNotIn($modelInstance->getKeyName(), $relationData['values'][$relationMethod])
+                                ->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})
+                                ->update([$relation->getForeignKeyName() => null]);
+                    }
                 }else{
                     //if the foreign key is not nullable we delete the record from the table.
                     if(!$modelInstance->isColumnNullable($relation->getForeignKeyName())) {

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -3,8 +3,8 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
 
 trait Create
@@ -196,20 +196,20 @@ trait Create
                             ->update([$relation->getForeignKeyName() => $item->{$relation->getLocalKeyName()}]);
 
                     //we clear up any values that were removed from model relation.
-                    if(!$modelInstance->isColumnNullable($relation->getForeignKeyName())) {
+                    if (! $modelInstance->isColumnNullable($relation->getForeignKeyName())) {
                         $modelInstance->whereNotIn($modelInstance->getKeyName(), $relationData['values'][$relationMethod])
                                 ->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})
                                 ->delete();
-                    }else{
+                    } else {
                         $modelInstance->whereNotIn($modelInstance->getKeyName(), $relationData['values'][$relationMethod])
                                 ->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})
                                 ->update([$relation->getForeignKeyName() => null]);
                     }
-                }else{
+                } else {
                     //if the foreign key is not nullable we delete the record from the table.
-                    if(!$modelInstance->isColumnNullable($relation->getForeignKeyName())) {
+                    if (! $modelInstance->isColumnNullable($relation->getForeignKeyName())) {
                         $modelInstance->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})->delete();
-                    }else{
+                    } else {
                         $modelInstance->where($relation->getForeignKeyName(), $item->{$relation->getLocalKeyName()})
                                 ->update([$relation->getForeignKeyName() => null]);
                     }
@@ -247,7 +247,6 @@ trait Create
         foreach ($relation_fields as $relation_field) {
             $attributeKey = $this->parseRelationFieldNamesFromHtml([$relation_field])[0]['name'];
 
-
             if (isset($relation_field['pivot']) && $relation_field['pivot'] !== true) {
                 $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));
 
@@ -263,6 +262,7 @@ trait Create
                 Arr::set($relationData, 'relations.'.$key, $fieldData);
             }
         }
+
         return $relationData;
     }
 

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -330,6 +330,7 @@ function ajaxSearch(element, created) {
     var $relatedKeyName = element.attr('data-connected-entity-key-name');
     var $searchString = created[$relatedAttribute];
     var $appLang = element.attr('data-app-current-lang');
+    var $forceSelect = (element.attr('data-force-select') == 'true') ? true : false;
 
     //we run the promise with ajax call to search endpoint to check if we got the created entity back
     //in case we do, we add it to the selected options.
@@ -345,7 +346,7 @@ function ajaxSearch(element, created) {
                 }
         });
 
-        if(inCreated.length) {
+        if(inCreated.length && $forceSelect) {
             selectOption(element, created);
         }
     });


### PR DESCRIPTION
This PR covers the HasMany relation in depth. 

In a situation like: Monster HasMany PostalBox, using `monster_id` in `postalboxes` table. 

IF `monster_id` is nullable, when de-selecting it from the monster we would set `NULL` on database. Case it's not nullable we completely delete the record from `postalboxes`.

I think this will fix: https://github.com/Laravel-Backpack/CRUD/issues/659#issuecomment-690036882 and #2708 

