### PR TITLE
Allow BelongsTo relations to be created on item creation when using relationship name as field name

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -28,10 +28,12 @@ trait Create
 
         // omit the n-n relationships when updating the eloquent item
         $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
-        $item = $this->model->create(Arr::except($data, $nn_relationships));
+        $item = $this->model->make(Arr::except($data, $nn_relationships));
 
         // if there are any relationships available, also sync those
         $this->createRelations($item, $data);
+        
+        $item->save();
 
         return $item;
     }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
@@ -33,10 +34,7 @@ trait Create
         $item = $this->model->make(Arr::except($data, $nn_relationships));
 
         // handle BelongsTo 1:1 relations
-        foreach ($this->getBelongsToRelationFields() as $relationField) {
-            $item->{$this->getOnlyRelationEntity($relationField)}()
-                ->associate($relationField['model']::find(Arr::get($data, $relationField['name']))->first());
-        }
+        $item = $this->handleBelongsToRelations($item, $data);
         $item->save();
 
         // if there are any relationships available, also sync those
@@ -81,7 +79,24 @@ trait Create
 
         return $relationFields;
     }
-    
+
+    /**
+     * Associate and dissociate.
+     *
+     * @param  Model
+     * @param  array The form data.
+     * @return Model Model with relationships set up.
+     */
+    public function handleBelongsToRelations($item, array $data)
+    {
+        foreach ($this->getBelongsToRelationFields() as $relationField) {
+            $item->{$this->getOnlyRelationEntity($relationField)}()
+                ->associate($relationField['model']::find(Arr::get($data, $relationField['name'])));
+        }
+
+        return $item;
+    }
+
     /**
      * Get all BelongsTo relationship fields.
      *

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -32,7 +32,6 @@ trait Create
 
         // if there are any relationships available, also sync those
         $this->createRelations($item, $data);
-        
         $item->save();
 
         return $item;

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -33,7 +33,10 @@ trait Update
 
         $data = Arr::except($data, $nn_relationships);
 
-        $updated = $item->update($data);
+        // handle BelongsTo 1:1 relations
+        $item = $this->handleBelongsToRelations($item, $data);
+        $item->fill($data);
+        $item->save();
 
         return $item;
     }


### PR DESCRIPTION
Main context:
https://github.com/Laravel-Backpack/CRUD/issues/1568
Also:
https://github.com/Laravel-Backpack/CRUD/issues/2826

@tabacitu mentioned here:
https://github.com/Laravel-Backpack/CRUD/issues/3011#issuecomment-655917152
that there are some changes in relationship logic in 4.x. I tried and I agree, now it is possible to save relationships directly, without making foreign key fillable (in my opinion still is not the best practice to do it :).  But I see one problem.

Example with simple 1:1 relationship to user:
```php
$this->crud->addField([
    'name'  => 'user',
    'label' => 'User',
    'type'  => 'relationship',
]);
```
If user_id column is nullable, I do not have any problem with saving a new entity because in the first step we are saving the model without the user, and in the next step will be associated with the user model. But if user_id is not nullable it will crash because:
`General error: 1364 Field 'user_id' doesn't have a default value`
This PR change only the moment where we saving the final model.

What do you think?