### PR TITLE
add first draft functionality for saving related items directly when …

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -205,22 +205,22 @@ trait Create
                     $relation->save($modelInstance);
                 }
             } elseif ($relation instanceof HasMany || $relation instanceof MorphMany) {
-                
                 $keys = Arr::pluck($item->{$relationMethod}, $relation->getRelated()->getKeyName());
-                foreach(json_decode($relationData['values'][$relationMethod], true) as $relationItems){
-                    if ($relationItems[$relation->getForeignKeyName()] != "" && $relationItems[$relation->getRelated()->getKeyName()] != "") {
+                foreach (json_decode($relationData['values'][$relationMethod], true) as $relationItems) {
+                    if ($relationItems[$relation->getForeignKeyName()] != '' && $relationItems[$relation->getRelated()->getKeyName()] != '') {
                         $modelInstance = $model::find($relationItems[$relation->getRelated()->getKeyName()]);
                         $modelInstance->update($relationItems);
-                        if (($key = array_search($relationItems[$relation->getRelated()->getKeyName()], $keys)) !== false)
+                        if (($key = array_search($relationItems[$relation->getRelated()->getKeyName()], $keys)) !== false) {
                             unset($keys[$key]);
+                        }
                     } else {
                         $modelInstance = new $model($relationItems);
                         $relation->save($modelInstance);
                     }
-                    
                 }
-                foreach ($keys as $id)
+                foreach ($keys as $id) {
                     $item->{$relationMethod}->find($id)->delete();
+                }
             }
 
             if (isset($relationData['relations'])) {

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -30,10 +30,14 @@ trait Update
 
         // omit the n-n relationships when updating the eloquent item
         $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
+        $repeatable_relationships = Arr::pluck($this->getRelationFieldsWithRepeatable(), 'name');
+        $excluded_relationships = array_merge($nn_relationships, $repeatable_relationships);
 
-        $data = Arr::except($data, $nn_relationships);
+        $data = Arr::except($data, $excluded_relationships);
 
         $updated = $item->update($data);
+        // if there are any relationships available, also sync those
+        $this->createRelations($item, $data);
 
         return $item;
     }


### PR DESCRIPTION
This just puts in a PR the code given by @alan-smith-be  in https://github.com/Laravel-Backpack/CRUD/issues/3103

It should add the ability to:
- put related Models in the `relationship` field
- have the related Models be synced

So basically... this should finalize the old `matrix` field type we talked about. For details please see #3103 

I haven't tested this. AT ALL. For now, I've just made it easier for us to test it, by doing 
```bash
composer require backpack/crud:"fix-3103-dev as 4.1.99"
```

Todo:
- [ ] test if it works
- [ ] polish (at first look at least the items below)
- [ ] create unit tests