### PR TITLE
add prefix and suffix for text column which is written in documentation 

### DIFF
--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -5,7 +5,9 @@
 
     $column['escaped'] = $column['escaped'] ?? true;
     $column['limit'] = $column['limit'] ?? 40;
-    $column['text'] = Str::limit($value, $column['limit'], '[...]');
+    $column['prefix'] = $column['prefix'] ?? '';
+    $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], '[...]').$column['suffix'];
 @endphp
 
 <span>


### PR DESCRIPTION
I am wondering why the documentation mention suffix and prefix are available, but the text column has no such code.
![image](https://user-images.githubusercontent.com/26017547/93200811-e5b6e800-f782-11ea-9730-e0cd99518294.png)

I did a quick search found no open issue or pull request. hope it is not repeating pull request.