### PR TITLE
Shouldn't update sync relations after saving attributes?

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -26,14 +26,13 @@ trait Update
         $data = $this->compactFakeFields($data);
         $item = $this->model->findOrFail($id);
 
-        $this->createRelations($item, $data);
-
-        // omit the n-n relationships when updating the eloquent item
+        // save the item attributes (new or modified)
+        // minus the relationships
         $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
+        $updated = $item->update(Arr::except($data, $nn_relationships));
 
-        $data = Arr::except($data, $nn_relationships);
-
-        $updated = $item->update($data);
+        // then sync the relationships
+        $this->createRelations($item, $data);
 
         return $item;
     }


### PR DESCRIPTION
Fixes #2511 

For the update operation, it moves the relationship syncing _after_ the saving of the main item attributes.

What do you think @pxpm ? Do you understand when/why this is needed? Do you agree we should do this? Do you foresee any problems this would cause?