### PR TITLE
validate the order of trait loaded while using inline create operation

### DIFF
--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -34,6 +34,16 @@ trait InlineCreateOperation
      */
     protected function setupInlineCreateDefaults()
     {
+        $inlineFound = false;
+        foreach (class_uses(self::class) as $key => $value) {
+            if (strpos($value, "\InlineCreateOperation") !== false) {
+                $inlineFound = true;
+            }
+            if ($inlineFound && strpos($value, "\CreateOperation") !== false) {
+                abort(500, 'Inline Create Operation trait should be loaded AFTER Create Operation.');
+            }
+        }
+
         if (method_exists($this, 'setup')) {
             $this->setup();
         }

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -36,9 +36,7 @@ trait InlineCreateOperation
     {
         $inlineFound = false;
         foreach (class_uses(self::class) as $key => $value) {
-            if (strpos($value, "\InlineCreateOperation") !== false) {
-                $inlineFound = true;
-            }
+            $inlineFound = strpos($value, "\InlineCreateOperation") !== false;
             if ($inlineFound && strpos($value, "\CreateOperation") !== false) {
                 abort(500, 'Inline Create Operation trait should be loaded AFTER Create Operation.');
             }


### PR DESCRIPTION
reference: https://github.com/Laravel-Backpack/CRUD/issues/2708

validate the order of trait loaded while using inline create operation, to make sure inline create operation trait is loaded after create operation trait

if inline operation is loaded before, will throw an error while opening the inline create modal
![image](https://user-images.githubusercontent.com/13914485/93570183-33229780-f9c5-11ea-9b1f-308739da8db3.png)
![image](https://user-images.githubusercontent.com/13914485/93570313-65cc9000-f9c5-11ea-9e4a-47bb6e5d118f.png)

I don't know how to show the error message to the modal, but that's not a big problem as long as the error trace is available on network tab

still needs some testing I guess