### PR TITLE
Update form_content.blade.php

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -135,7 +135,7 @@
 
             $.each(messages, function(key, msg){
                 // highlight the input that errored
-                var row = $('<div class="invalid-feedback">' + msg + '</div>');
+                var row = $('<div class="invalid-feedback d-block">' + msg + '</div>');
                 row.appendTo(container);
 
                 // highlight its parent tab


### PR DESCRIPTION
When the field have a prefix or suffix it will not show the validation warning, after added `d-block` class it will show like it should

Before:
   ![before-fixed](https://user-images.githubusercontent.com/35516476/94331217-e1959080-fff4-11ea-8cd9-9af2b0c33b76.png)

After:
   ![after-fixed](https://user-images.githubusercontent.com/35516476/94331183-895e8e80-fff4-11ea-8ce3-942489a2c8d2.png)

References: https://github.com/twbs/bootstrap/issues/23454
