### PR TITLE
[Bug fix][4.2] Fix init value for browse_multiple field when multiple is true

### DIFF
--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -1,7 +1,7 @@
 @php
 $multiple = Arr::get($field, 'multiple', true);
 $sortable = Arr::get($field, 'sortable', false);
-$value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+$value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? ($multiple ? [] : '');
 
 if (!$multiple && is_array($value)) {
     $value = Arr::first($value);
@@ -59,7 +59,7 @@ if($sortable){
                 <button type="button" class="browse remove btn btn-sm btn-light">
                     <i class="la la-trash"></i>
                 </button>
-                @if($sortable)
+                @if($sortable && $multiple)
                     <button type="button" class="browse move btn btn-sm btn-light"><span class="la la-sort"></span></button>
                 @endif
             </div>
@@ -77,7 +77,7 @@ if($sortable){
     @endphp
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
-    @push('crud_fields_styles')        
+    @push('crud_fields_styles')
         <link href="{{ asset('packages/jquery-colorbox/example2/colorbox.css') }}" rel="stylesheet" type="text/css" />
         <style>
             #cboxContent, #cboxLoadedContent, .cboxIframe {
@@ -87,7 +87,7 @@ if($sortable){
     @endpush
 
     @push('crud_fields_scripts')
-        
+
         <script src="{{ asset('packages/jquery-ui-dist/jquery-ui.min.js') }}"></script>
         <script src="{{ asset('packages/jquery-colorbox/jquery.colorbox-min.js') }}"></script>
         <script>
@@ -97,7 +97,7 @@ if($sortable){
 
             // function to use the files selected inside elfinder
             function processSelectedMultipleFiles(files, requestingField) {
-                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);                
+                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);
                 elfinderTarget = false;
             }
 
@@ -109,7 +109,7 @@ if($sortable){
                 var $multiple = element.attr('data-multiple');
                 var $sortable = element.attr('sortable');
 
-                // show existing items - display visible inputs for each stored path  
+                // show existing items - display visible inputs for each stored path
                 if ($input.val() != '' && $input.val() != null && $multiple === 'true') {
                     $paths = JSON.parse($input.val());
                     if (Array.isArray($paths) && $paths.length) {
@@ -158,7 +158,6 @@ if($sortable){
                     var $paths = element.find('input').not('[type=hidden]').map(function (idx, item) {
                         return $(item).val();
                     }).toArray();
-
                     // save the JSON inside the hidden input
                     $input.val(JSON.stringify($paths));
                 });
@@ -174,7 +173,6 @@ if($sortable){
                     // clear button
                     element.on('click', 'button.clear', function (event) {
                         event.preventDefault();
-
                         $('.input-group', $list).remove();
                         element.trigger('saveToJson');
                     });


### PR DESCRIPTION
refs: #3220 

As we discussed, this will save an empty array into database instead of an empty string when the field allows multiple selection and should be casted as array in model. 

This might be a breaking change if people uses the fact the the column is not an array to check if any files have been uploaded.

So people might be using something like:

```
if (is_array($model->column)) {
foreach ($model->column as $picture) {
...
}
}else{
echo 'no pictures availabe';
}
```

With this change the result will ALLWAYS be an array, even if empty.

I also added a constrain to don't show sortable html when the field is not multiple (no sense in ordering a single value).

Also added to the docs that when using `multiple => false` you should NOT cast your field to array. https://github.com/Laravel-Backpack/docs/pull/183
