### PR TITLE
Add a hint for laravel 8 user model class in config

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -207,7 +207,8 @@ return [
     */
 
     // Fully qualified namespace of the User model
-    'user_model_fqn' => App\User::class,
+    'user_model_fqn' => App\User::class,            // For Laravel 7 and below
+    // 'user_model_fqn' => App\Models\User::class,  // For Laravel 8
 
     // The classes for the middleware to check if the visitor is an admin
     // Can be a single class or an array of classes


### PR DESCRIPTION
Add a hint because Laravel 8 by defaults create models in `Models` folder.