### PR TITLE
fixing select2 from array

### DIFF
--- a/src/resources/views/crud/fields/select2_from_array.blade.php
+++ b/src/resources/views/crud/fields/select2_from_array.blade.php
@@ -1,16 +1,26 @@
+@php
+    $field['placeholder'] = $field['placeholder'] ?? '-';
+    $field['allows_null'] = $field['allows_null'] ?? false;
+    $field['allows_multiple'] = $field['allows_multiple'] ?? false;
+
+@endphp
 <!-- select2 from array -->
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     <select
         name="{{ $field['name'] }}@if (isset($field['allows_multiple']) && $field['allows_multiple']==true)[]@endif"
         style="width: 100%"
+        data-real-name="{{ $field['name'] }}"
+        data-field-placeholder="{{$field['placeholder']}}"
+        data-allows-null="{{var_export($field['allows_null'])}}"
         data-init-function="bpFieldInitSelect2FromArrayElement"
+        data-field-multiple="{{var_export($field['allows_multiple'])}}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_from_array'])
-        @if (isset($field['allows_multiple']) && $field['allows_multiple']==true)multiple @endif
+        @if ($field['allows_multiple'])multiple @endif
         >
 
-        @if (isset($field['allows_null']) && $field['allows_null']==true)
-            <option value="">-</option>
+        @if($field['allows_null'] && !$field['allows_multiple'])
+            <option value="">{{$field['placeholder']}}</option>
         @endif
 
         @if (count($field['options']))
@@ -71,16 +81,163 @@
     <script src="{{ asset('packages/select2/dist/js/i18n/' . app()->getLocale() . '.js') }}"></script>
     @endif
     <script>
+         // if nullable, make sure the Clear button uses the translated string
+    document.styleSheets[0].addRule('.select2-selection__clear::after','content:  "{{ trans('backpack::crud.clear') }}";');
+
         function bpFieldInitSelect2FromArrayElement(element) {
-            if (!element.hasClass("select2-hidden-accessible"))
-                {
+            var $placeholder = element.attr('data-field-placeholder');
+            var $allows_null = element.attr('data-allows-null') == 'true' ? true : false;
+            var $multiple = element.attr('data-field-multiple') == 'true' ? true : false;
+            var $real_name = element.attr('data-real-name');
+            var $attr_multiple_name = $real_name+'[]';
+
+            //this variable checks if there are any options selected in the multi-select field
+            //if there is no options the field will initialize as a single select.
+            var $multiple_init = (Array.isArray(element.val()) && element.val().length > 0 && $multiple) ? true : false;
+
+            if (!element.hasClass("select2-hidden-accessible")) {
+                    //if we determined that the field has no value, is multiple and allows null
+                    //we create the placeholder option
+                    if(!$multiple_init && $multiple && $allows_null) {
+                        element.append('<option value="" selected></option>');
+                    }
+
+                    //if we are initing a single select and null is not allowed, the first option will be selected
+                    //so we init this variable to know when selecting that this one was forced
+                    if(!$multiple_init && $multiple && !$allows_null) {
+                        element.data('force-select', true);
+                    }
+
                     element.select2({
-                        theme: "bootstrap"
-                    }).on('select2:unselect', function(e) {
-                        if ($(this).attr('multiple') && $(this).val().length == 0) {
-                            $(this).val(null).trigger('change');
+                        theme: "bootstrap",
+                        placeholder: $placeholder,
+                        allowClear: $allows_null,
+                        multiple: $multiple_init
+                    }).on('select2:unselect', function (e) {
+
+                        if ($multiple && Array.isArray(element.val()) && element.val().length == 0) {
+                            //if there are no options selected we make sure the field name is reverted to single selection
+                            //this way browser will send the empty value, otherwise it will omit the multiple input when empty
+                            if(typeof element.attr('name') !== typeof undefined && element.attr('name') !== false) {
+                                element.attr('name', $real_name);
+                            }
+
+                            //we also change the multiple attribute from field
+                            element.attr('multiple',false);
+
+                            //we destroy the current select
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+                            //we reinitialize the select as a single select
+                            setTimeout(function() {
+                                element.select2({
+                                    theme: "bootstrap",
+                                    placeholder: $placeholder,
+                                    allowClear: false,
+                                    multiple: false
+                                });
+                                //if the field does not allow null
+                                //we make sure that atleast one option is always selected.
+                                if(!$allows_null) {
+                                    //this variable is used to unselect this option in a multiple select because was "forced" by
+                                    //developer not allowing null in the field
+                                    element.data('force-select', true);
+                                    element.val(element.find('option:eq(0)').val()).trigger('change');
+                                }else{
+                                    //otherwise we append the placeholder
+                                    element.append('<option value="">'+$placeholder+'</option>');
+                                    element.val('').trigger('change');
+                                }
+                            });
+                        }
+                    }).on('select2:opening', function() {
+                            //this prevents the selection from opening upon clearing the field
+                            if (element.data('unselecting') === true) {
+                                element.data('unselecting', false);
+                                return false;
+                            }
+                            return true;
+                    }).on('select2:unselecting', function(e) {
+                        //we set a variable in the field that indicates that an unselecting operation is running
+                        //we will read this variable in the opening event to determine if we should open the options
+                        element.data('unselecting',true);
+                        return true;
+                    }).on('select2:selecting', function(e) {
+                        //when we select an option, if the element does not have the multiple attribute
+                        //but is indeed a multiple field, we know that this happened because we setup a single select while there is no selection
+                        //and now that user selected atleast one option we will make it multiple again.
+                        //the reason for this is because multiple selects are not sent by browser in request when empty
+                        //making it a single select when empty, will, send the value empty in request.
+                        if(typeof element.attr('multiple') === typeof undefined && $multiple) {
+                            //set the element attribute multiple back to true
+                            element.attr('multiple',true);
+
+                            //revert the name to array
+                            if(typeof element.attr('name') !== typeof undefined && element.attr('name') !== false && element.attr('name') !== $attr_multiple_name) {
+                                element.attr('name', $attr_multiple_name);
+                            }
+
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+
+                            //we remove the placeholder option
+                            $(element.find('option[value=""]')).remove();
+
+                                setTimeout(function() {
+                                    element.select2({
+                                        theme: "bootstrap",
+                                        placeholder: $placeholder,
+                                        allowClear: true,
+                                        multiple: true
+                                });
+                            });
+                        }
+
+                        //when selecting an option, if the one that is selected was forced by developer not allowing null
+                        //we remove it from the selection when the user chooses his first option
+                        if(element.data('force-select') === true) {
+                            element.data('force-select', false);
+                            element.val('').trigger('change');
+                        }
+                    }).on('select2:clear', function(e) {
+                        //when clearing the selection we revert the field back to a "select single" state if it's multiple.
+                        if($multiple) {
+
+                            if(typeof element.attr('name') !== typeof undefined && element.attr('name') !== false) {
+                                element.attr('name', $real_name);
+                            }
+
+                            element.attr('multiple',false);
+
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+
+                            setTimeout(function() {
+
+
+                                element.select2({
+                                    theme: "bootstrap",
+                                    placeholder: $placeholder,
+                                    allowClear: false,
+                                    multiple: false
+                                });
+
+                                if($allows_null) {
+                                    element.append('<option value="">'+$placeholder+'</option>');
+                                    element.val('').trigger('change');
+                                }else{
+                                    element.data('force-select', true);
+                                }
+
+                            });
+
                         }
                     });
+
+
                 }
         }
     </script>


### PR DESCRIPTION
This is a fix for #1224 

It's an old issue, and I think it's a problem that persists with all select2 that allows the clear of all options.

The main problem is that a select multiple without selected value does not get posted by the browser.

We need to send an empty value (so laravel will convert empty to null with ConvertEmptyStringsToNull) thus updating the value in the database accordingly.

The easiest solution would be to have an hidden input that gets sent in case nothing is selected in the multiple select, but that does not work for us because of repeatable. 

This solution might be applicable to all select2 inputs. 

Best,
Pedro


 