### PR TITLE
bugfix options setting in tinymce field declaration

### DIFF
--- a/src/resources/views/crud/fields/tinymce.blade.php
+++ b/src/resources/views/crud/fields/tinymce.blade.php
@@ -15,7 +15,7 @@ $field['options'] = array_merge($defaultOptions, $field['options'] ?? []);
     <textarea
         name="{{ $field['name'] }}"
         data-init-function="bpFieldInitTinyMceElement"
-        data-options="{{ trim(json_encode($field['options'])) }}"
+        data-options='{!! trim(json_encode($field['options'])) !!}'
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control tinymce'])
         >{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}</textarea>
 


### PR DESCRIPTION
Proposal to fix bug in `data-options` for tinymce field. Previously when we set options parameter from the crud controller, it rendered like this
![image](https://user-images.githubusercontent.com/13914485/95716028-59beb000-0c9d-11eb-9570-3e6a278012b2.png)

After this change:
![image](https://user-images.githubusercontent.com/13914485/95716104-7824ab80-0c9d-11eb-8647-c18f116b215f.png)
