### PR TITLE
Allow camelCase crud field methods

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel;
 
+use Illuminate\Support\Str;
+
 /**
  * Adds fluent syntax to Backpack CRUD Fields.
  *
@@ -255,7 +257,7 @@ class CrudField
      */
     public function __call($method, $parameters)
     {
-        $this->setAttributeValue($method, $parameters[0]);
+        $this->setAttributeValue(Str::snake($method), $parameters[0]);
 
         return $this->save();
     }


### PR DESCRIPTION
This PR enables users to write camelCase methods along with snake_case ones.

This

```php
$this->crud
      ->field('role_id')
      ->type('select2_grouped')
      ->group_by('department')
      ->group_by_attribute('name')
      ->group_by_relationship_back('roles');
```

now can be written also like this:

```php
$this->crud
      ->field('role_id')
      ->type('select2_grouped')
      ->groupBy('department')
      ->groupByAttribute('name')
      ->groupByRelationshipBack('roles');
```