### PR TITLE
Has many select and pivot

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -191,7 +191,7 @@ trait Create
 
                 //if it's an HasMany relation and we have fields setup in the main field it means it's a repeatable
                 //and developer wants to add the items to the relation.
-                if ($relationData['fields']) {
+                if (isset($relationData['fields'])) {
                     $this->createHasManyEntries($item, $relation, $relationMethod, $relationData);
                 } else {
                     $this->attachHasManyRelation($item, $relation, $relationMethod, $relationData);
@@ -207,8 +207,7 @@ trait Create
     /*
         Used to sync the relations using already stored in database entries.
      */
-    public function syncHasManyRelation($item, $relation, $relationMethod, $relationData)
-    {
+    public function attachHasManyRelation($item, $relation, $relationMethod, $relationData) {
         $modelInstance = $relation->getRelated();
         $relation_column_is_nullable = $modelInstance->isColumnNullable($relation->getForeignKeyName());
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -207,7 +207,8 @@ trait Create
     /*
         Used to sync the relations using already stored in database entries.
      */
-    public function attachHasManyRelation($item, $relation, $relationMethod, $relationData) {
+    public function attachHasManyRelation($item, $relation, $relationMethod, $relationData)
+    {
         $modelInstance = $relation->getRelated();
         $relation_column_is_nullable = $modelInstance->isColumnNullable($relation->getForeignKeyName());
 


### PR DESCRIPTION
handle has many relations


This PR started in #1453, I attemped in #3196 and improved here.

This PR aims to provide the HasMany functionality from both user definitions. 

#### - User would like to select from already created HasMany items.

In this scenario the problem to circumvent is the fact that the `model_key` is stored in the `related_table` and it can be either null or not (nullable in database).

To handle non-nullable value I added two options: 
1- user can setup a fallback_id (idea got from #1453), this allows us to setup a default non-null value (eg. 0 (is not null and will not related to any model key that starts at 1)),
2 - if user does not support a fallback_id we delete the entry from `related_table`

In case it's nullable we just set the relation value to null. (Maybe we should add a `deletes_from_db => true` to make it consistent and allow developer full control)

#### - User creates the related entries in the main form (using repeatable field)

In this scenario we handle it like non-nullable related key and no fallback, so when you create an entry in the repeatable it is created in related table, when you delete is deleted from there too. 

@tabacitu created an excelent article about how to use this functionality here: https://gist.github.com/tabacitu/4db255042a62c7458ee17fe33d65522c but developer need to override some crud functions to make it work. 

This PR aims to remove that need by providing built-in functions to handle this scenario. 

The only thing to take into consideration is using an hidden field with the related model key (maybe we can do this automatically on field setup and remove this from beeing developer responsability) 

```php
if (field is relation hasMany && does not exists yet a field inside repeatable with related model key) {
   we setup an hidden field with the related model key;
}
```

Current field definition for an HasMany relation:

```php
//this model HasMany postalboxes()
 $this->crud->field('postalboxes')
            ->type('repeatable')
            ->label('postalboxes')
            ->fields([
                [
                    'name' => 'id', //mandatory but we might be able to remove this dependency
                    'type' => 'hidden'
                ],
                [
                    'name'    => 'postal_name',
                    'type'    => 'text',
                ]
            ]);
```




