### PR TITLE
Do not reinitialize the instance again

### DIFF
--- a/src/app/Models/Traits/HasRelationshipFields.php
+++ b/src/app/Models/Traits/HasRelationshipFields.php
@@ -19,9 +19,7 @@ trait HasRelationshipFields
      */
     public function getConnectionWithExtraTypeMappings()
     {
-        $instance = new self;
-
-        $conn = DB::connection($instance->getConnectionName());
+        $conn = DB::connection($this->getConnectionName());
 
         // register the enum, json and jsonb column type, because Doctrine doesn't support it
         $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');


### PR DESCRIPTION
This was some leftover from refactoring reported in #3063 

When getting the connection in `getConnectionWithExtraTypeMappings()` we were re-initializing the instance, thing that is not needed, because we only call this function with an already initialized instance.

