### PR TITLE
[bug-fix] multiple click event registering in image field

### DIFF
--- a/src/resources/views/crud/fields/base64_image.blade.php
+++ b/src/resources/views/crud/fields/base64_image.blade.php
@@ -211,21 +211,7 @@
                                         $hiddenImage.val(imageURL);
                                         return true;
                                     });
-                                    $rotateLeft.click(function() {
-                                        $mainImage.cropper("rotate", 90);
-                                    });
-                                    $rotateRight.click(function() {
-                                        $mainImage.cropper("rotate", -90);
-                                    });
-                                    $zoomIn.click(function() {
-                                        $mainImage.cropper("zoom", 0.1);
-                                    });
-                                    $zoomOut.click(function() {
-                                        $mainImage.cropper("zoom", -0.1);
-                                    });
-                                    $reset.click(function() {
-                                        $mainImage.cropper("reset");
-                                    });
+
                                     $rotateLeft.show();
                                     $rotateRight.show();
                                     $zoomIn.show();
@@ -246,6 +232,30 @@
                             }).show();
                         }
                     });
+
+                    //moved the click binds outside change event, or we would register as many click events for the same amout of times
+                    //we triggered the image change
+                    if(crop) {
+                        $rotateLeft.click(function() {
+                            $mainImage.cropper("rotate", 90);
+                        });
+
+                        $rotateRight.click(function() {
+                            $mainImage.cropper("rotate", -90);
+                        });
+
+                        $zoomIn.click(function() {
+                            $mainImage.cropper("zoom", 0.1);
+                        });
+
+                        $zoomOut.click(function() {
+                            $mainImage.cropper("zoom", -0.1);
+                        });
+
+                        $reset.click(function() {
+                            $mainImage.cropper("reset");
+                        });
+                    }
             }
         </script>
 

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -232,21 +232,8 @@
                                         $hiddenImage.val(imageURL);
                                         return true;
                                     });
-                                    $rotateLeft.click(function() {
-                                        $mainImage.cropper("rotate", 90);
-                                    });
-                                    $rotateRight.click(function() {
-                                        $mainImage.cropper("rotate", -90);
-                                    });
-                                    $zoomIn.click(function() {
-                                        $mainImage.cropper("zoom", 0.1);
-                                    });
-                                    $zoomOut.click(function() {
-                                        $mainImage.cropper("zoom", -0.1);
-                                    });
-                                    $reset.click(function() {
-                                        $mainImage.cropper("reset");
-                                    });
+
+
                                     $rotateLeft.show();
                                     $rotateRight.show();
                                     $zoomIn.show();
@@ -267,6 +254,30 @@
                             }).show();
                         }
                     });
+
+                    //moved the click binds outside change event, or we would register as many click events for the same amout of times
+                    //we triggered the image change
+                    if(crop) {
+                        $rotateLeft.click(function() {
+                            $mainImage.cropper("rotate", 90);
+                        });
+
+                        $rotateRight.click(function() {
+                            $mainImage.cropper("rotate", -90);
+                        });
+
+                        $zoomIn.click(function() {
+                            $mainImage.cropper("zoom", 0.1);
+                        });
+
+                        $zoomOut.click(function() {
+                            $mainImage.cropper("zoom", -0.1);
+                        });
+
+                        $reset.click(function() {
+                            $mainImage.cropper("reset");
+                        });
+                    }
             }
         </script>
 


### PR DESCRIPTION
refs: #2934 

Before this fix, the click events for crop functionality were registered inside the change event. The problem relies in fact that if we change the image in the input 10 times, we will register 10 click events for the same buttons, and they will trigger when you click the button. 

To avoid this, we register the events outside of the change event, so we make sure they are registered only once.