### PR TITLE
Allow dependant fields inside repeatable

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -341,10 +341,20 @@
             // reset the select2 value
             for (var i=0; i < $dependencies.length; i++) {
                 $dependency = $dependencies[i];
-                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-                    element.val(null).trigger("change");
-                });
 
+                //if element has name it means is not in repeatable, because in repeatable we strip the names out.
+                if(typeof element.attr('name') != 'undefined') {
+                    $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                        element.val(null).trigger("change");
+                    });
+                }else{
+                    //this is a repeatable field, we will find the dependency base on row
+                    let elementRow = element.closest('div[data-repeatable-identifier]').attr('data-repeatable-row-number');
+
+                    $('input[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], select[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], checkbox[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], radio[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], textarea[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+']').change(function () {
+                        element.val(null).trigger("change");
+                    });
+                }
             }
         }
     }

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -667,26 +667,37 @@ function bpFieldInitFetchOrCreateElement(element) {
             }
 
         for (var i=0; i < $dependencies.length; i++) {
-        $dependency = $dependencies[i];
-        $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-            element.val(null).trigger("change");
-        });
+            $dependency = $dependencies[i];
+            //if element has name it means is not in repeatable, because in repeatable we strip the names out.
+            if(typeof element.attr('name') != 'undefined') {
+                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }else{
+                //this is a repeatable field, we will find the dependency base on row
+                let elementRow = element.closest('div[data-repeatable-identifier]').attr('data-repeatable-row-number');
+
+                $('input[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], select[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], checkbox[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], radio[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], textarea[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }
+        }
     }
 
-        }
 if (typeof processItemText !== 'function') {
     function processItemText(item, $fieldAttribute, $appLang) {
         if(typeof item[$fieldAttribute] === 'object' && item[$fieldAttribute] !== null)  {
-                if(item[$fieldAttribute][$appLang] != 'undefined') {
-                    return item[$fieldAttribute][$appLang];
-                }else{
-                    return item[$fieldAttribute][0];
-                }
+            if(item[$fieldAttribute][$appLang] != 'undefined') {
+                return item[$fieldAttribute][$appLang];
+            }else{
+                return item[$fieldAttribute][0];
+            }
             }else{
                 return item[$fieldAttribute];
             }
+    }
 }
-}
+
             </script>
         @endpush
 

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -183,10 +183,19 @@
             // reset the select2 value
             for (var i=0; i < $dependencies.length; i++) {
                 $dependency = $dependencies[i];
-                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-                    element.val(null).trigger("change");
-                });
+                //if element has name it means is not in repeatable, because in repeatable we strip the names out.
+                if(typeof element.attr('name') != 'undefined') {
+                    $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                        element.val(null).trigger("change");
+                    });
+                }else{
+                    //this is a repeatable field, we will find the dependency base on row
+                    let elementRow = element.closest('div[data-repeatable-identifier]').attr('data-repeatable-row-number');
 
+                    $('input[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], select[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], checkbox[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], radio[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], textarea[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+']').change(function () {
+                        element.val(null).trigger("change");
+                    });
+                }
             }
         }
     }

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -184,6 +184,9 @@
                     $(el).trigger('backpack_field.deleted');
                 });
                 $(this).parent().remove();
+
+                //we reassure row numbers
+                setupElementRowsNumbers(container_holder);
             });
 
             if (values != null) {
@@ -204,7 +207,23 @@
             }
             //we push the fields to the correct container in page.
             container_holder.append(new_field_group);
+
+            //after appending to the container we reassure row numbers
+            setupElementRowsNumbers(container_holder);
+
             initializeFieldsWithJavascript(container_holder);
+        }
+
+        //this function is responsible for managing rows numbers upon creation/deletion of elements
+        function setupElementRowsNumbers(container) {
+            container.children().each(function(i, el) {
+                var rowNumber = i+1;
+                $(el).attr('data-repeatable-row-number', rowNumber);
+                //also attach the row number to all the input elements inside
+                $(el).find('input, select, textarea').each(function(i, el) {
+                    $(el).attr('data-repeatable-row-number', rowNumber);
+                });
+            });
         }
     </script>
   @endpush

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -213,9 +213,20 @@
         // reset the select2 value
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
-            $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-                element.val(null).trigger("change");
-            });
+
+            //if element has name it means is not in repeatable, because in repeatable we strip the names out.
+            if(typeof element.attr('name') != 'undefined') {
+                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }else{
+                //this is a repeatable field, we will find the dependency base on row
+                let elementRow = element.closest('div[data-repeatable-identifier]').attr('data-repeatable-row-number');
+
+                $('input[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], select[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], checkbox[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], radio[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], textarea[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }
         }
 
     }

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -185,9 +185,20 @@
         // reset the select2 value
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
-            $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-                element.val(null).trigger("change");
-            });
+
+            //if element has name it means is not in repeatable, because in repeatable we strip the names out.
+            if(typeof element.attr('name') != 'undefined') {
+                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }else{
+                //this is a repeatable field, we will find the dependency base on row
+                let elementRow = element.closest('div[data-repeatable-identifier]').attr('data-repeatable-row-number');
+
+                $('input[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], select[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], checkbox[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], radio[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+'], textarea[data-repeatable-input-name='+$dependency+'][data-repeatable-row-number='+elementRow+']').change(function () {
+                    element.val(null).trigger("change");
+                });
+            }
         }
     }
 </script>


### PR DESCRIPTION
refs: #3218 

#### The problem:

Dependant fields worked by finding the inputs with the matching name. In repeatable we strip out the name so breaking dependant functionality. 

Also in repeatable there are multiple inputs with the same name, so even if we already had the `repeatable-input-name` if we search only by name we could find more than one input, thus leading to unwanted scenarios.

#### Solution:

Add rows numbers to repeatable so we can identify specifically by name and row number what element we should reset. 

