### PR TITLE
tinymce stores full image path instead of server relative path

### DIFF
--- a/src/resources/views/crud/fields/tinymce.blade.php
+++ b/src/resources/views/crud/fields/tinymce.blade.php
@@ -4,6 +4,9 @@ $defaultOptions = [
     'file_picker_callback' => 'elFinderBrowser',
     'selector' => 'textarea.tinymce',
     'plugins' => 'image,link,media,anchor',
+    //these two options allow tinymce to save the full path of images "https://domain.com/upload/image.jpg" instead of the relative server path "../../../uploads/image.jpg"
+    'relative_urls' =>  false,
+    'remove_script_host' => false,
 ];
 
 $field['options'] = array_merge($defaultOptions, $field['options'] ?? []);

--- a/src/resources/views/crud/fields/tinymce.blade.php
+++ b/src/resources/views/crud/fields/tinymce.blade.php
@@ -4,9 +4,9 @@ $defaultOptions = [
     'file_picker_callback' => 'elFinderBrowser',
     'selector' => 'textarea.tinymce',
     'plugins' => 'image,link,media,anchor',
-    //these two options allow tinymce to save the full path of images "https://domain.com/upload/image.jpg" instead of the relative server path "../../../uploads/image.jpg"
+    //these two options allow tinymce to save the path of images "/upload/image.jpg" instead of the relative server path "../../../uploads/image.jpg"
     'relative_urls' =>  false,
-    'remove_script_host' => false,
+    'remove_script_host' => true,
 ];
 
 $field['options'] = array_merge($defaultOptions, $field['options'] ?? []);


### PR DESCRIPTION
refs: #871 (I don't remember linking an issue under 1000, this one is ooooooooold!!!!!) 

Problem: When using tinymce with elfinder connector, if you select an image, tinymce would save the relative server path into database thus rendering the usability of the image useless after fetching from database.

Instead of saving `https://backpack.com/uploads/image.jpg` it would store `../../../uploads/image.jpg` 

This makes tinymce store the full image path instead of the relative one.

