### PR TITLE
support new version of ocramius/package-versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laravel/framework": "^8.0|^7.0|^6.0",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
-        "ocramius/package-versions": "^2.0|^1.4",
+        "composer/package-versions-deprecated": "^1.8",
         "doctrine/dbal": "^2.5",
         "guzzlehttp/guzzle": "^7.0|^6.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laravel/framework": "^8.0|^7.0|^6.0",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
-        "ocramius/package-versions": "^1.4",
+        "ocramius/package-versions": "^2.0|^1.4",
         "doctrine/dbal": "^2.5",
         "guzzlehttp/guzzle": "^7.0|^6.3"
     },


### PR DESCRIPTION
Currently all our builds show up as `failing` because of `ocramius/package-versions`. Again. It's not a critical part of our software, but it has been a pain in the backend with the updates. It's the second time they push a change and break something for us, while they consider that "_it's not their fault_". 

If we can somehow remove this dependency in the next versions, we should do so.