### PR TITLE
clear ajax select options when clearing the value

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -342,7 +342,12 @@
             for (var i=0; i < $dependencies.length; i++) {
                 $dependency = $dependencies[i];
                 $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
-                    element.val(null).trigger("change");
+
+                //apart from setting selection to null, we clear the options until the next fetch from server happen.
+                $(element.find('option:not([value=""])')).remove();
+
+                element.val(null).trigger("change");
+
                 });
 
             }

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -669,6 +669,9 @@ function bpFieldInitFetchOrCreateElement(element) {
         for (var i=0; i < $dependencies.length; i++) {
         $dependency = $dependencies[i];
         $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+            //apart from setting selection to null, we clear the options until the next fetch from server happen.
+            $(element.find('option:not([value=""])')).remove();
+
             element.val(null).trigger("change");
         });
     }

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -214,6 +214,10 @@
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
             $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+
+                //apart from setting selection to null, we clear the options until the next fetch from server happen.
+                $(element.find('option:not([value=""])')).remove();
+
                 element.val(null).trigger("change");
             });
         }

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -186,6 +186,10 @@
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
             $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+
+                //apart from setting selection to null, we clear the options until the next fetch from server happen.
+                $(element.find('option:not([value=""])')).remove();
+
                 element.val(null).trigger("change");
             });
         }


### PR DESCRIPTION
refs: #3225 

Problem: When using ajax selects with depencies, we were only setting the value of the select to null when the depency changes. Previous fetched options would still available to select while the fiield fetches the new options from the server.

Solution: When setting the elements value to null when the dependency changes, we also clear all the options from the select to make sure they can't be selected while the field is fetching the new options from server.

