### PR TITLE
fix usage of repeatable inside inline create modal

### DIFF
--- a/src/resources/views/crud/fields/relationship/inline_create_modal.blade.php
+++ b/src/resources/views/crud/fields/relationship/inline_create_modal.blade.php
@@ -42,7 +42,7 @@
         </div>
         <div class="modal-footer">
         <button type="button" class="btn btn-secondary" id="cancelButton">{{trans('backpack::crud.cancel')}}</button>
-          <button type="button" class="btn btn-primary" id="saveButton">{{trans('backpack::crud.save')}}</button>
+          <button type="button" class="btn btn-primary save-block" id="saveButton">{{trans('backpack::crud.save')}}</button>
         </div>
       </div>
     </div>

--- a/src/resources/views/crud/fields/relationship/show_fields.blade.php
+++ b/src/resources/views/crud/fields/relationship/show_fields.blade.php
@@ -16,6 +16,8 @@
         this is the only available when rendering the modal html.
     -->
 @stack('crud_fields_scripts')
+@stack('before_scripts')
 
 @stack('crud_fields_styles')
+@stack('before_styles')
 

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -139,7 +139,6 @@
             // this way we have a clean element we can clone when the user
             // wants to add a new group of inputs
             var field_group_clone = container.clone();
-            console.log(container);
             container.remove();
             element.parent().find('.add-repeatable-element-button').click(function(){
                 newRepeatableElement(container, field_group_clone);

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -119,6 +119,7 @@
             // element will be a jQuery wrapped DOM node
             var container = $('[data-repeatable-identifier='+field_name+']');
 
+
             // make sure the inputs no longer have a "name" attribute,
             // so that the form will not send the inputs as request variables;
             // use a "data-repeatable-input-name" attribute to store the same information;
@@ -138,8 +139,8 @@
             // this way we have a clean element we can clone when the user
             // wants to add a new group of inputs
             var field_group_clone = container.clone();
+            console.log(container);
             container.remove();
-
             element.parent().find('.add-repeatable-element-button').click(function(){
                 newRepeatableElement(container, field_group_clone);
             });


### PR DESCRIPTION
refs: #2749 

Problem: Using repeatable inside the the inline create operation would not work for two main reasons.
- we didn't have the `before_scripts` tag in inline file so repeatable could not push to an inexistent stack.
- the click in inline modal save button would not trigger the repeatable field to parse the input and store the correct information to be sent with request.

Solution: add the `before_scripts` stack in inline create files. Add the `save-block` class to the inline create save button, that way it will be picked by repeatable as it was the main form save button.

