### PR TITLE
Use Composer Suggestions - add main addons and tools as suggestions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,5 +76,11 @@
                 "Widget": "Backpack\\CRUD\\app\\Library\\Widget"
             }
         }
+    },
+    "suggest": {
+        "backpack/generators": "Required on localhost to easily generate CRUDs, models, controllers etc.",
+        "backpack/filemanager": "Required to use the browse and browse_multiple fields.",
+        "backpack/revise-operation": "Optional operation to remember all entry changes, undo and redo them (aka audit trait).",
+        "digitallyhappy/toggle-field-for-backpack": "Optional field to toggle a boolean. Prettier alternative to the checkbox field."
     }
 }


### PR DESCRIPTION
When doing a `composer install` it should say something like this (see last line):
![Screenshot 2020-11-04 at 17 02 37](https://user-images.githubusercontent.com/1032474/98167578-f9184100-1ef1-11eb-9292-8fd073eae999.png)

It's a small line, that not many people read. But if you do `composer suggest` like it recommends, you'd get an output like this:
![Screenshot 2020-11-04 at 17 05 03](https://user-images.githubusercontent.com/1032474/98167714-341a7480-1ef2-11eb-9734-fc33039e44dc.png)

Which is pretty cool. This PR should add our NOT REQUIRED, but NICE-TO-HAVE packages to this output. So that people who run this also learn a little bit more about the packages we tell people to install across the Backpack docs.

I think that's a good place as any to communicate to people some of the addons we have, that they might want to use. Now, we do have to draw the line somewhere... so:
- I don't think we'll ever include 3rd party add-ons here; 1st party (backpack/digitallyhappy), sure; 2nd party (backpack veterans)... maybe; but 3rd party... probably not smart;
- I didn't include addons like NewsCRUD, BackupManager, etc because... while useful, those packages only cover a very particular use case;
- the packages that I _did_ include here are mentioned throughout the docs, which might be a little too hidden; they're mentioned inside that particular feature; this would make them a little more visible, point people to that particular feature we do offer, but as an optional addon;

I don't know whether this should be merged. Not sure it adds much value, or if anybody actually uses `composer suggest`. Then again... it wouldn't hurt... I don't know...