### PR TITLE
Fix for relationship dependencies to work on groups too

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -341,7 +341,7 @@
             // reset the select2 value
             for (var i=0; i < $dependencies.length; i++) {
                 $dependency = $dependencies[i];
-                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                $(`[name="${$dependency}"], [name="${$dependency}[]"]`).change(function () {
                     element.val(null).trigger("change");
                 });
 

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -668,7 +668,7 @@ function bpFieldInitFetchOrCreateElement(element) {
 
         for (var i=0; i < $dependencies.length; i++) {
         $dependency = $dependencies[i];
-        $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+        $(`[name="${$dependency}"], [name="${$dependency}[]"]`).change(function () {
             element.val(null).trigger("change");
         });
     }

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -183,7 +183,7 @@
             // reset the select2 value
             for (var i=0; i < $dependencies.length; i++) {
                 $dependency = $dependencies[i];
-                $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+                $(`[name="${$dependency}"], [name="${$dependency}[]"]`).change(function () {
                     element.val(null).trigger("change");
                 });
 

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -213,7 +213,7 @@
         // reset the select2 value
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
-            $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+            $(`[name="${$dependency}"], [name="${$dependency}[]"]`).change(function () {
                 element.val(null).trigger("change");
             });
         }

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -185,7 +185,7 @@
         // reset the select2 value
         for (var i=0; i < $dependencies.length; i++) {
             $dependency = $dependencies[i];
-            $('input[name='+$dependency+'], select[name='+$dependency+'], checkbox[name='+$dependency+'], radio[name='+$dependency+'], textarea[name='+$dependency+']').change(function () {
+            $(`[name="${$dependency}"], [name="${$dependency}[]"]`).change(function () {
                 element.val(null).trigger("change");
             });
         }


### PR DESCRIPTION
While testing https://github.com/Laravel-Backpack/CRUD/pull/3301, I was using 2 select multiple for Categories and Articles, `categories[]` and `articles[]`. It was driving me crazy because I wasn't able to get the `dependencies` to work 😅
