### PR TITLE
Fix to avoid odd dash (not null entry) on select multiple

### DIFF
--- a/src/resources/views/crud/fields/inc/attributes.blade.php
+++ b/src/resources/views/crud/fields/inc/attributes.blade.php
@@ -1,6 +1,9 @@
 @php
     $field['attributes'] = $field['attributes'] ?? [];
     $field['attributes']['class'] = $field['attributes']['class'] ?? $default_class ?? 'form-control';
+    if(isset($field['allows_null']) && !$field['allows_null']) {
+        $field['attributes']['required'] = $field['attributes']['required'] ?? true;
+    }
 @endphp
 
 @foreach ($field['attributes'] as $attribute => $value)

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -76,7 +76,7 @@
         multiple
         @endif
         >
-        @if ($field['allows_null'])
+        @if ($field['allows_null'] && !$field['multiple'])
             <option value="">-</option>
         @endif
 

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -56,7 +56,7 @@
     <label>{!! $field['label'] !!}</label>
 
     <select
-        style="width:100%"
+        style="width: 100%; min-height: 38px!important;"
         name="{{ $field['name'].($field['multiple']?'[]':'') }}"
         data-init-function="bpFieldInitRelationshipSelectElement"
         data-column-nullable="{{ var_export($field['allows_null']) }}"

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -18,16 +18,12 @@
     @include('crud::fields.inc.translatable_icon')
     <select
         name="{{ $field['name'] }}[]"
-        style="width: 100%"
+        style="width: 100%; min-height: 38px!important;"
         data-init-function="bpFieldInitSelect2MultipleElement"
         data-select-all="{{ var_export($field['select_all'] ?? false)}}"
         data-options-for-js="{{json_encode(array_values($options_ids_array))}}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_multiple'])
         {{ $field['multiple'] ? 'multiple' : '' }}>
-
-        @if (isset($field['allows_null']) && $field['allows_null']==true)
-            <option value="">-</option>
-        @endif
 
         @if (isset($field['model']))
             @foreach ($field['options'] as $option)


### PR DESCRIPTION
When clearing a select2 **multiple**, even though it allows nulls, it shouldn't place the empty dash `<option>-</option>`.
It creates a strange behavior:

![ezgif-5-880297826b77](https://user-images.githubusercontent.com/1838187/98228796-00bb0280-1f51-11eb-9787-330618696cd4.gif)

With this fix:

![ezgif-5-3d63a5b574ad](https://user-images.githubusercontent.com/1838187/98228723-dec18000-1f50-11eb-944c-5d17089406ce.gif)

