### PR TITLE
get un-casted value for casted attributes in radio

### DIFF
--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -4,7 +4,7 @@
 
 
     //check if attribute is casted, if it is, we get back un-casted values
-    if(in_array($field['name'], array_keys($crud->model->getCasts()))) {
+    if(Arr::get($crud->model->getCasts(), $field['name']) === 'boolean') {
         $optionValue = $optionValue === true ? 1 : 0;
     }
 

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -3,7 +3,7 @@
     $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
 
-    //check if attribute is casted, if it is, we get back un-casted values
+    // check if attribute is casted, if it is, we get back un-casted values
     if(Arr::get($crud->model->getCasts(), $field['name']) === 'boolean') {
         $optionValue = $optionValue === true ? 1 : 0;
     }

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -2,6 +2,12 @@
 @php
     $optionValue = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
 
+
+    //check if attribute is casted, if it is, we get back un-casted values
+    if(in_array($field['name'], array_keys($crud->model->getCasts()))) {
+        $optionValue = $optionValue === true ? 1 : 0;
+    }
+
     // if the class isn't overwritten, use 'radio'
     if (!isset($field['attributes']['class'])) {
         $field['attributes']['class'] = 'radio';


### PR DESCRIPTION
refs: #3019 

problem: when casting the radio field to boolean and selecting an option with `key = 0 (so false)` our code would not pick the correct option. 

solution: check if field is casted on model, if it is, we return it back to un-casted values, beeing it: `true => 1, false => 0`.

 