### PR TITLE
Fix for translatable icon inside a multi input fields

### DIFF
--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -10,7 +10,6 @@
 @include('crud::fields.inc.wrapper_start')
 
     <label>{!! $field['label'] !!}</label>
-    @include('crud::fields.inc.translatable_icon')
     <?php
         $entity_model = $crud->getModel();
 
@@ -69,9 +68,9 @@
     <div class="container">
 
       <div class="row">
-
           <div class="col-sm-12">
               <label>{!! $primary_dependency['label'] !!}</label>
+              @include('crud::fields.inc.translatable_icon', ['field' => $primary_dependency])
           </div>
       </div>
 
@@ -122,6 +121,7 @@
       <div class="row">
           <div class="col-sm-12">
               <label>{!! $secondary_dependency['label'] !!}</label>
+              @include('crud::fields.inc.translatable_icon', ['field' => $secondary_dependency])
           </div>
       </div>
 

--- a/src/resources/views/crud/fields/page_or_link.blade.php
+++ b/src/resources/views/crud/fields/page_or_link.blade.php
@@ -18,7 +18,7 @@
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
-    @include('crud::fields.inc.translatable_icon')
+    @include('crud::fields.inc.translatable_icon', ['field' => ['name' => 'link']])
 
     <div class="row" data-init-function="bpFieldInitPageOrLinkElement">
         <div class="col-sm-3">

--- a/src/resources/views/crud/fields/page_or_link.blade.php
+++ b/src/resources/views/crud/fields/page_or_link.blade.php
@@ -18,7 +18,7 @@
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
-    @include('crud::fields.inc.translatable_icon', ['field' => ['name' => 'link']])
+    @include('crud::fields.inc.translatable_icon')
 
     <div class="row" data-init-function="bpFieldInitPageOrLinkElement">
         <div class="col-sm-3">


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/PermissionManager/issues/257.

When a Model `HasTranslations`, this fields were causing the `translatable_icon.blade.php` to fail with an error because it is expecting a single field, and in case of `checklist_dependency` and `page_or_link` fields, they have multiple. 

```
TypeError
Argument 1 passed to App\User::isTranslatableAttribute() must be of the type string, array given
```

Since it makes no sense to evaluate multiple fields, in case of `checklist_dependency` I added 2 flags, for each checklist, and in case of `page_or_link` I added the flag just in case the input `link` is translatable, which is what makes the most sense to be translated.