### PR TITLE
Resize DataTable on sidebar toggle

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -313,10 +313,7 @@
         $(window).on('resize', function(e) {
           resizeCrudTableColumnWidths();
         });
-        $(document).on('expanded.pushMenu', function(e) {
-          resizeCrudTableColumnWidths();
-        });
-        $(document).on('collapsed.pushMenu', function(e) {
+        $('.sidebar-toggler').click(function() {
           resizeCrudTableColumnWidths();
         });
       @endif


### PR DESCRIPTION
When responsive DataTables is not enabled, the table needs to be resized whenever the sidebar visibility is toggled.
The logic was still based on AdminLTE, which has been replaced by CoreUI. Old logic is not working with CoreUI. This PR fixes that.