### PR TITLE
Allow doctrine/dbal ^3.0 as laravel 8.15 supports it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
         "composer/package-versions-deprecated": "^1.8",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "^2.5|^3.0",
         "guzzlehttp/guzzle": "^7.0|^6.3"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 8.15 support dbal 3.0

https://laravel-news.com/laravel-8-15-0

So this PR adds a |^3.0