### PR TITLE
Make compatible with UUIDs

### DIFF
--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -66,7 +66,7 @@
                 checkboxes.each(function(key, option) {
                   var id = $(this).val();
 
-                  if (selected_options.includes(id)) {
+                  if (selected_options.map(String).includes(id)) {
                     $(this).prop('checked', 'checked');
                   } else {
                     $(this).prop('checked', false);

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -25,7 +25,7 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
 
-    <input type="hidden" value="@json($field['value'])" name="{{ $field['name'] }}">
+    <input type="hidden" value='@json($field['value'])' name="{{ $field['name'] }}">
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)
@@ -64,7 +64,7 @@
 
                 // set the default checked/unchecked states on checklist options
                 checkboxes.each(function(key, option) {
-                  var id = parseInt($(this).val());
+                  var id = $(this).val();
 
                   if (selected_options.includes(id)) {
                     $(this).prop('checked', 'checked');
@@ -80,7 +80,7 @@
 
                   checkboxes.each(function() {
                     if ($(this).is(':checked')) {
-                      var id = parseInt($(this).val());
+                      var id = $(this).val();
                       newValue.push(id);
                     }
                   });


### PR DESCRIPTION
closes #3350 

The Checkbox field cannot accept uuids by default as it will convert them into Integers. Causing them to be saved as 8,null or 36 etc.  instead of 8dc63ff0-90ab-4a12-9db0-cd0d158127b7.