### PR TITLE
Remove some old CSS and fix selector

### DIFF
--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -9,17 +9,6 @@
     color: #ff0000;
 }
 
-.tab-container .nav-tabs-custom {
-	padding-bottom: 0;
-	margin-bottom: 0;
-	background: none;
-}
-
-.tab-content {
-	padding-top: 20px;
-	padding-bottom: 20px;
-}
-
 .help-block {
 	margin-top: .25rem;
 	margin-bottom: .25rem;
@@ -27,6 +16,6 @@
     font-size: 0.9em;
 }
 
-.nav-tabs .nav-link:hover {
+.nav-tabs-custom  .nav-tabs .nav-link:hover {
 	border-bottom: none;
 }

--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -17,5 +17,5 @@
 }
 
 .nav-tabs-custom  .nav-tabs .nav-link:hover {
-	border-bottom: none;
+	border-bottom: 1px solid #fff;
 }


### PR DESCRIPTION
This PR removes some old CSS which does nothing, `.tab-content` has a `.p-0` class for example.
It also fixes the `.nav-tabs` selector to only select elements in the custom nav-tabs bar, otherwise it also selects menu items in `top_right_content` blade file.

Maybe it's an idea to move the remaining CSS and the list.css contents to the Backstap package (https://github.com/DigitallyHappy/BackStrap/blob/master/src/scss/_custom.scss)
And use this files strictly for user overrides.