### PR TITLE
Migrated deprecated PHP Unit schema

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,19 +14,19 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src/PanelTraits/</directory>
             <file>./src/CrudPanel.php</file>
-            <exclude>
-                <file>./src/PanelTraits/AutoFocus.php</file>
-                <file>./src/PanelTraits/Errors.php</file>
-                <file>./src/PanelTraits/Filters.php</file>
-                <file>./src/PanelTraits/Query.php</file>
-                <file>./src/PanelTraits/Reorder.php</file>
-                <file>./src/PanelTraits/Views.php</file>
-                <file>./src/PanelTraits/ViewsAndRestoresRevisions.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <file>./src/PanelTraits/AutoFocus.php</file>
+            <file>./src/PanelTraits/Errors.php</file>
+            <file>./src/PanelTraits/Filters.php</file>
+            <file>./src/PanelTraits/Query.php</file>
+            <file>./src/PanelTraits/Reorder.php</file>
+            <file>./src/PanelTraits/Views.php</file>
+            <file>./src/PanelTraits/ViewsAndRestoresRevisions.php</file>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Migrated deprecated PHP Unit schema

```
PHPUnit 9.4.3 by Sebastian Bergmann and contributors.
Warning:       Your XML configuration validates against a deprecated schema.
```