### PR TITLE
Fix for elements on long dropdowns being cut off

### DIFF
--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -222,6 +222,12 @@
 		padding-right: 30px;
 	}
 
+	#crudTable_wrapper .dt-buttons .dt-button-collection,
+	#crudTable_wrapper .btn-group .dropdown-menu {
+		max-height: 340px;
+		overflow-y: auto;
+	}
+
 	.navbar-filters li>a:active,
 	.navbar-filters .navbar-nav>.active>a, .navbar-filters .navbar-nav>.active>a:focus, .navbar-filters .navbar-nav>.active>a:hover,
 	.navbar-filters .navbar-nav>.open>a, .navbar-filters .navbar-nav>.open>a:focus, .navbar-filters .navbar-nav>.open>a:hover {

--- a/src/public/packages/backpack/crud/css/list.css
+++ b/src/public/packages/backpack/crud/css/list.css
@@ -223,9 +223,14 @@
 	}
 
 	#crudTable_wrapper .dt-buttons .dt-button-collection,
-	#crudTable_wrapper .btn-group .dropdown-menu {
+	#crudTable_wrapper tr td .btn-group .dropdown-menu {
 		max-height: 340px;
 		overflow-y: auto;
+	}
+
+	#crudTable_wrapper .dt-buttons .dt-button-collection {
+		padding: 0;
+		border: 0;
 	}
 
 	.navbar-filters li>a:active,


### PR DESCRIPTION
Possible fix for: https://github.com/Laravel-Backpack/CRUD/issues/2945.

This is a very simple and easy way to fix the problem, I avoided Javascript to solve this since it has the downside of adding an extra layer of logic and another thing to maintain, here is the result;

- CRUD table with one entry _(Column visibility button)_
![image](https://user-images.githubusercontent.com/1838187/100557335-6c6a6400-32a0-11eb-9f9f-eab6a6ace34d.png)

- CRUD table with 10+ entries _(Column visibility button)_
![image](https://user-images.githubusercontent.com/1838187/100557371-a2a7e380-32a0-11eb-8635-2059d96d5d19.png)

- CRUD table with one entry _(Language picker dropdown)_
![image](https://user-images.githubusercontent.com/1838187/100557591-14346180-32a2-11eb-8760-cf39dd9eb63f.png)

- CRUD table with 10+ entries _(Language picker dropdown)_
![image](https://user-images.githubusercontent.com/1838187/100557582-041c8200-32a2-11eb-8849-1ca957318078.png)

Since this solution uses no Javascript, it is "dumb", it doesn't know when it could use more space or not. And CSS alone is not enough to solve this, because the max sizes are relative to the table height, not the page height.

@tabacitu and @pxpm, do you think this solution is enough, or should we add the javascript layer to optimize the space usage?