### PR TITLE
Added functionality to allow for callables as wrapper elements

### DIFF
--- a/src/resources/views/crud/columns/inc/wrapper_end.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_end.blade.php
@@ -4,9 +4,9 @@
 
     // define the wrapper element
     $wrapperElement = $column['wrapper']['element'] ?? 'a';
-    $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
-        ? $wrapperElement($crud, $column, $entry, $related_key)
-        : $wrapperElement ?? 'a';
+    if(!is_string($wrapperElement) && is_callable($wrapperElement)) {
+        $wrapperElement = $wrapperElement($crud, $column, $entry, $related_key);
+    }
 @endphp
 
-</{{$wrapperElement}}>
+</{{ $wrapperElement }}>

--- a/src/resources/views/crud/columns/inc/wrapper_end.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_end.blade.php
@@ -1,1 +1,9 @@
-</{{$column['wrapper']['element'] ?? 'a'}}>
+@php
+    // define the wrapper element
+    $wrapperElement = isset($column['wrapper']['element']) ? $column['wrapper']['element'] : 'a';
+    $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
+        ? $wrapperElement($crud, $column, $entry, $related_key)
+        : $wrapperElement ?? 'a';
+@endphp
+
+</{{$wrapperElement}}>

--- a/src/resources/views/crud/columns/inc/wrapper_end.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_end.blade.php
@@ -1,4 +1,7 @@
 @php
+    // this is made available by columns like select and select_multiple
+    $related_key = $related_key ?? null;
+
     // define the wrapper element
     $wrapperElement = $column['wrapper']['element'] ?? 'a';
     $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)

--- a/src/resources/views/crud/columns/inc/wrapper_end.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_end.blade.php
@@ -1,6 +1,6 @@
 @php
     // define the wrapper element
-    $wrapperElement = isset($column['wrapper']['element']) ? $column['wrapper']['element'] : 'a';
+    $wrapperElement = $column['wrapper']['element'] ?? 'a';
     $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
         ? $wrapperElement($crud, $column, $entry, $related_key)
         : $wrapperElement ?? 'a';

--- a/src/resources/views/crud/columns/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_start.blade.php
@@ -2,12 +2,6 @@
     // this is made available by columns like select and select_multiple
     $related_key = $related_key ?? null;
 
-    // define the wrapper element
-    $wrapperElement = $column['wrapper']['element'] ?? 'a';
-    $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
-        ? $wrapperElement($crud, $column, $entry, $related_key)
-        : $wrapperElement ?? 'a';
-
     // each wrapper attribute can be a callback or a string
     // for those that are callbacks, run the callbacks to get the final string to use
     foreach($column['wrapper'] as $attribute => $value) {
@@ -15,8 +9,8 @@
     }
 @endphp
 
-<{{$wrapperElement}}
-@foreach(Arr::where($column['wrapper'],function($value, $key) { return $key != 'element'; }) as $element => $value)
+<{{ $column['wrapper']['element'] ?? 'a' }}
+@foreach(Arr::except($column['wrapper'], 'element') as $element => $value)
     {{$element}}="{{$value}}"
 @endforeach
 >

--- a/src/resources/views/crud/columns/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_start.blade.php
@@ -3,7 +3,7 @@
     $related_key = $related_key ?? null;
 
     // define the wrapper element
-    $wrapperElement = isset($column['wrapper']['element']) ? $column['wrapper']['element'] : 'a';
+    $wrapperElement = $column['wrapper']['element'] ?? 'a';
     $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
         ? $wrapperElement($crud, $column, $entry, $related_key)
         : $wrapperElement ?? 'a';

--- a/src/resources/views/crud/columns/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_start.blade.php
@@ -2,6 +2,12 @@
     // this is made available by columns like select and select_multiple
     $related_key = $related_key ?? null;
 
+    // define the wrapper element
+    $wrapperElement = isset($column['wrapper']['element']) ? $column['wrapper']['element'] : 'a';
+    $wrapperElement = !is_string($wrapperElement) && is_callable($wrapperElement)
+        ? $wrapperElement($crud, $column, $entry, $related_key)
+        : $wrapperElement ?? 'a';
+
     // each wrapper attribute can be a callback or a string
     // for those that are callbacks, run the callbacks to get the final string to use
     foreach($column['wrapper'] as $attribute => $value) {
@@ -9,7 +15,7 @@
     }
 @endphp
 
-<{{ $column['wrapper']['element'] ?? 'a' }}
+<{{$wrapperElement}}
 @foreach(Arr::where($column['wrapper'],function($value, $key) { return $key != 'element'; }) as $element => $value)
     {{$element}}="{{$value}}"
 @endforeach


### PR DESCRIPTION
Hi all!

I was working with column wrappers when I realized that I needed to be able to define different wrapper elements under different circumstances, and I noticed that that functionality was not available.

This PR adds that functionality. Just like wrapper attributes you can define a callable in which you can add your own functionality that determines which element should be returned under which conditions.

As always: let me know what you think, if you feel like I should change something or if you think this PR is not a good addition to your project!