### PR TITLE
Allow fluent filters to use options() and values() interchangeably

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -291,6 +291,21 @@ class CrudFilter
     }
 
     /**
+     * Set the values for the current filter, for the filters who need values.
+     * For example, the dropdown, select2 and select2 filters let the user select
+     * pre-determined values to filter with. This is how to set those values that will be picked up.
+     *
+     * Alias of the values() method.
+     *
+     * @param  array|function $value Key-value array with values for the user to pick from, or a function which also return a Key-value array.
+     * @return CrudFilter
+     */
+    public function options($value)
+    {
+        return $this->values($value);
+    }
+
+    /**
      * Set the blade view that will be used by the filter.
      * Should NOT include the namespace, that's defined separately using 'viewNamespace'.
      *

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -291,9 +291,9 @@ class CrudFilter
     }
 
     /**
-     * Set the values for the current filter, for the filters who need values.
-     * For example, the dropdown, select2 and select2 filters let the user select
-     * pre-determined values to filter with. This is how to set those values that will be picked up.
+     * Set the values for the current filter, for the filters who need values. For example
+     * the dropdown, select2 and select2 filters let the user select pre-determined 
+     * values to filter with.
      *
      * Alias of the values() method.
      *

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -292,7 +292,7 @@ class CrudFilter
 
     /**
      * Set the values for the current filter, for the filters who need values. For example
-     * the dropdown, select2 and select2 filters let the user select pre-determined 
+     * the dropdown, select2 and select2 filters let the user select pre-determined
      * values to filter with.
      *
      * Alias of the values() method.


### PR DESCRIPTION
This allows devs to define fluent dropdown filter options using the more intuitive `options()` instead of `values()`.

### What I did

Notice the `options` call here:

```php
        CRUD::filter('status')->type('dropdown')->options([
            301 => '301 - Moved Permanently',
            302 => '302 - Moved Temporarily / Found',
        ])->whenActive(function ($value) {
            $this->crud->addClause('where', 'status', $value);
        });
```

### What I expected to happen

![Screenshot 2020-12-02 at 08 25 27](https://user-images.githubusercontent.com/1032474/100872283-40223380-34aa-11eb-944a-347e19d46a67.png)


### What happened

![Screenshot 2020-12-02 at 08 24 50](https://user-images.githubusercontent.com/1032474/100872246-30a2ea80-34aa-11eb-8367-8f457b45476d.png)

That's because there is no `options()` method on `CrudFilter`. What I was looking for is called `values()` which... you know... yeah ok they're values, but _I'd expect_ them to be options, since `select_from_array` and other fields call them that.

Wouldn't you agree? Wouldn't `options()` be more intuitive than `values()`?

### What I've already tried to fix it

Added an `options()` alias to `CrudFilter`. Thoughts anyone? Would this cause some unintended side-effects? Is it used by other filters in other ways? Should we not take up the method for some reason I can't see right now?