### PR TITLE
Fix for when checklist value is empty

### DIFF
--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -25,7 +25,7 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
 
-    <input type="hidden" value='@json($field['value'])' name="{{ $field['name'] }}">
+    <input type="hidden" value='@if($field['value'])@json($field['value'])@endif' name="{{ $field['name'] }}">
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -15,6 +15,8 @@
   $field['value'] = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? [];
   if ($field['value'] instanceof Illuminate\Database\Eloquent\Collection) {
     $field['value'] = $field['value']->pluck($key_attribute)->toArray();
+  } elseif (is_string($field['value'])){
+    $field['value'] = json_decode($field['value']);
   }
 
   // define the init-function on the wrapper

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -12,7 +12,7 @@
   }
 
   // calculate the value of the hidden input
-  $field['value'] = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+  $field['value'] = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? [];
   if ($field['value'] instanceof Illuminate\Database\Eloquent\Collection) {
     $field['value'] = $field['value']->pluck($key_attribute)->toArray();
   }
@@ -25,7 +25,7 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
 
-    <input type="hidden" value='@if($field['value'])@json($field['value'])@endif' name="{{ $field['name'] }}">
+    <input type="hidden" value='@json($field['value'])' name="{{ $field['name'] }}">
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)


### PR DESCRIPTION
Since the change of `value=""` to `value=''`, it now renders as `'""'`, causing `JSON.parse(hidden_input.val())` to throw error.
Previously, it was rendering as `value=""""`, but the browser converted it to `value=""`.

