### PR TITLE
Replace save with saveQuietly

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -180,7 +180,7 @@ trait Create
                 }
             } elseif ($relation instanceof HasOne) {
                 if ($item->{$relationMethod} != null) {
-                    $item->{$relationMethod}->update($relationData['values']);
+                    $item->{$relationMethod}->fill($relationData['values'])->saveQuietly();
                     $modelInstance = $item->{$relationMethod};
                 } else {
                     $modelInstance = new $model($relationData['values']);

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -174,9 +174,9 @@ trait Create
             if ($relation instanceof BelongsTo) {
                 $modelInstance = $model::find($relationData['values'])->first();
                 if ($modelInstance != null) {
-                    $relation->associate($modelInstance)->save();
+                    $relation->associate($modelInstance)->saveQuietly();
                 } else {
-                    $relation->dissociate()->save();
+                    $relation->dissociate()->saveQuietly();
                 }
             } elseif ($relation instanceof HasOne) {
                 if ($item->{$relationMethod} != null) {
@@ -184,7 +184,7 @@ trait Create
                     $modelInstance = $item->{$relationMethod};
                 } else {
                     $modelInstance = new $model($relationData['values']);
-                    $relation->save($modelInstance);
+                    $relation->saveQuietly($modelInstance);
                 }
             }
 


### PR DESCRIPTION
PR for https://github.com/Laravel-Backpack/CRUD/issues/3372
This PR optimizes saving by not calling the observers for each relation and thus only firing the oberservers only once for each save/update, which can/will prevent unexpected behavior.