### PR TITLE
Refactor delete

### DIFF
--- a/src/resources/views/crud/buttons/clone.blade.php
+++ b/src/resources/views/crud/buttons/clone.blade.php
@@ -26,6 +26,9 @@
                     text: "{!! trans('backpack::crud.clone_success') !!}"
                   }).show();
 
+                  // Hide the modal, if any
+                  $('.modal').modal('hide');
+
                   if (typeof crud !== 'undefined') {
                     crud.table.ajax.reload();
                   }

--- a/src/resources/views/crud/buttons/clone.blade.php
+++ b/src/resources/views/crud/buttons/clone.blade.php
@@ -26,9 +26,6 @@
                     text: "{!! trans('backpack::crud.clone_success') !!}"
                   }).show();
 
-                  // Hide the modal, if any
-                  $('.modal').modal('hide');
-
                   if (typeof crud !== 'undefined') {
                     crud.table.ajax.reload();
                   }

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -35,8 +35,11 @@
 		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
 		                  }).show();
 
+						// Hide the modal, if any
+						$('.modal').modal('hide');
+
 			              // Remove the row from the datatable
-						  crud.table.row($("#crudTable a[data-route='"+route+"']").parents('tr')).remove().draw();
+						  crud.table.row($("#crudTable a[data-route='"+route+"']").parents('tr')).remove().draw(false);
 			          } else {
 			              // if the result is an array, it means 
 			              // we have notification bubbles to show

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -29,17 +29,17 @@
 			      type: 'DELETE',
 			      success: function(result) {
 			          if (result == 1) {
+						  // Redraw the table
+						  crud.table.draw(false);
+
 			          	  // Show a success notification bubble
 			              new Noty({
 		                    type: "success",
 		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
 		                  }).show();
 
-						// Hide the modal, if any
-						$('.modal').modal('hide');
-
-			              // Remove the row from the datatable
-						  crud.table.row($("#crudTable a[data-route='"+route+"']").parents('tr')).remove().draw(false);
+			              // Hide the modal, if any
+			              $('.modal').modal('hide');
 			          } else {
 			              // if the result is an array, it means 
 			              // we have notification bubbles to show

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -14,29 +14,14 @@
 	  function deleteEntry(button) {
 		// ask for confirmation before deleting an item
 		// e.preventDefault();
-		var button = $(button);
-		var route = button.attr('data-route');
-		var row = $("#crudTable a[data-route='"+route+"']").closest('tr');
+		var route = $(button).attr('data-route');
 
 		swal({
 		  title: "{!! trans('backpack::base.warning') !!}",
 		  text: "{!! trans('backpack::crud.delete_confirm') !!}",
 		  icon: "warning",
-		  buttons: {
-		  	cancel: {
-			  text: "{!! trans('backpack::crud.cancel') !!}",
-			  value: null,
-			  visible: true,
-			  className: "bg-secondary",
-			  closeModal: true,
-			},
-		  	delete: {
-			  text: "{!! trans('backpack::crud.delete') !!}",
-			  value: true,
-			  visible: true,
-			  className: "bg-danger",
-			}
-		  },
+		  buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+		  dangerMode: true,
 		}).then((value) => {
 			if (value) {
 				$.ajax({
@@ -50,16 +35,8 @@
 		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
 		                  }).show();
 
-			              // Hide the modal, if any
-			              $('.modal').modal('hide');
-
-			              // Remove the details row, if it is open
-			              if (row.hasClass("shown")) {
-			                  row.next().remove();
-			              }
-
 			              // Remove the row from the datatable
-			              row.remove();
+						  crud.table.row($("#crudTable a[data-route='"+route+"']").parents('tr')).remove().draw();
 			          } else {
 			              // if the result is an array, it means 
 			              // we have notification bubbles to show


### PR DESCRIPTION
This PR fixes the following:
- _[minor bug]_ When an item was deleted, _Showing x to x of x entries_ was not updated. Fixed that by using the DataTables API to redraw the table
- ~~Removed _(old?)_ call to close a modal. (I can't think of any modal that should be closed in the list view)~~
- Refactor the delete button code by using some Sweetalert defaults. Which also makes the cancel button the default selected button (for data safety this is better).