### PR TITLE
allow translating custom range in datepicker

### DIFF
--- a/src/resources/views/crud/filters/date_range.blade.php
+++ b/src/resources/views/crud/filters/date_range.blade.php
@@ -20,6 +20,7 @@
             'format' => config('backpack.base.default_date_format'),
             'applyLabel'=> trans('backpack::crud.apply'),
             'cancelLabel'=> trans('backpack::crud.cancel'),
+            'customRangeLabel' => trans('backpack::crud.custom_range')
         ],
 
 


### PR DESCRIPTION
refs: #3384 

Problem: missing translated key in datepicker file for `Custom Range`. 

Solution: get the translated string from crud lang file (was already there)