### PR TITLE
make inactive tabs hover more obvious

### DIFF
--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -29,4 +29,5 @@
 
 .nav-tabs .nav-link:hover {
 	border-bottom: none;
+	color: #384c74;
 }


### PR DESCRIPTION
After the latest update it looks like there's no hover state for inactive tabs, which makes them look disabled. I think it's best to make it obvious to the user that the inactive tabs are clickable:

![2020-12-09 09 40 55](https://user-images.githubusercontent.com/1032474/101637125-ff3f9700-3a34-11eb-8ea4-324a00a60bc8.gif)

This PR just adds a text color to the hover state of inactive tabs, inside the `form.css`.