### PR TITLE
Fix for 'clause is ambiguous' when searching on joined tables, when tables have similar columns (eg id)

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -66,7 +66,7 @@ trait Search
                 case 'email':
                 case 'text':
                 case 'textarea':
-                    $query->orWhere($column['name'], 'like', '%'.$searchTerm.'%');
+                    $query->orWhere($query->getModel()->getTableWithPrefix().'.'.$column['name'], 'like', '%'.$searchTerm.'%');
                     break;
 
                 case 'date':
@@ -77,13 +77,13 @@ trait Search
                         break;
                     }
 
-                    $query->orWhereDate($column['name'], Carbon::parse($searchTerm));
+                    $query->orWhereDate($query->getModel()->getTableWithPrefix().'.'.$column['name'], Carbon::parse($searchTerm));
                     break;
 
                 case 'select':
                 case 'select_multiple':
                     $query->orWhereHas($column['entity'], function ($q) use ($column, $searchTerm) {
-                        $q->where($column['attribute'], 'like', '%'.$searchTerm.'%');
+                        $q->where($q->getModel()->getTableWithPrefix().'.'.$column['attribute'], 'like', '%'.$searchTerm.'%');
                     });
                     break;
 


### PR DESCRIPTION
This fix for https://github.com/Laravel-Backpack/CRUD/issues/3396 uses tablename.fieldname in all search queries to avoid ambiguous clauses when joined table have similar fieldnames that can searched and sorted on. 

EDITED:

Problem: 
When backpack needs to add something to query, we were not using the `table.column` notation and that would cause conflicts with ambiguous column names. We already had some troubles with this in the **order clauses**. We fixed it there but forgot to fix in the `searchLogic`.

Solution:
Apply `table.column` to backpack added queries in the search logic.
