### PR TITLE
WIP Create dummy operation

### DIFF
--- a/src/app/Http/Controllers/Operations/CreateDummyOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateDummyOperation.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+use Illuminate\Support\Facades\Route;
+
+trait CreateDummyOperation
+{
+    /**
+     * Define which routes are needed for this operation.
+     *
+     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
+     * @param string $routeName  Prefix of the route name.
+     * @param string $controller Name of the current CrudController.
+     */
+    protected function setupCreateDummyRoutes($segment, $routeName, $controller)
+    {
+        Route::post($segment . '/create-dummy', [
+            'as' => $routeName . '.createDummy',
+            'uses' => $controller . '@createDummy',
+            'operation' => 'createDummy',
+        ]);
+    }
+
+    /**
+     * Add the default settings, buttons, etc that this operation needs.
+     */
+    protected function setupCreateDummyDefaults()
+    {
+        $this->crud->allowAccess('createDummy');
+
+        $this->crud->operation('createDummy', function () {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
+        $this->crud->operation('list', function () {
+            if (method_exists($this->crud->getModel(), 'factory')) {
+                $this->crud->addButton('top', 'create_dummy', 'view', 'crud::buttons.create_dummy');
+            }
+        });
+    }
+
+    /**
+     * Show the form for creating inserting a new row.
+     *
+     * @return Response
+     */
+    public function createDummy()
+    {
+        // Access
+        $this->crud->hasAccessOrFail('createDummy');
+
+        // Check if Model has Factory trait
+        if (!method_exists($this->crud->getModel(), 'factory')) {
+            return response()->json([
+                'title' => trans('backpack::crud.create_dummy_error_title'),
+                'message' => trans('backpack::crud.create_dummy_error_message'),
+            ], 500);
+        }
+
+        // Options
+        $TRUNCATE = 1;
+        $CREATE = 2;
+
+        $count = request()->input('count');
+        $option = request()->input('option');
+
+        // Truncate table
+        if ($option & $TRUNCATE) {
+            $this->crud->getModel()->truncate();
+            $messages[] = trans('backpack::crud.create_dummy_success_truncate');
+        }
+
+        // Create dummy entries
+        if ($option & $CREATE) {
+            $this->crud->getModel()::factory()->count($count)->create();
+            $messages[] = trans_choice('backpack::crud.create_dummy_sucess_message', $count, ['count' => $count]);
+        }
+
+        return response()->json([
+            'title' => trans('backpack::crud.create_dummy_sucess_title'),
+            'message' => join(' ', $messages),
+        ]);
+    }
+
+}

--- a/src/app/Http/Controllers/Operations/CreateDummyOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateDummyOperation.php
@@ -15,9 +15,9 @@ trait CreateDummyOperation
      */
     protected function setupCreateDummyRoutes($segment, $routeName, $controller)
     {
-        Route::post($segment . '/create-dummy', [
-            'as' => $routeName . '.createDummy',
-            'uses' => $controller . '@createDummy',
+        Route::post($segment.'/create-dummy', [
+            'as' => $routeName.'.createDummy',
+            'uses' => $controller.'@createDummy',
             'operation' => 'createDummy',
         ]);
     }
@@ -51,7 +51,7 @@ trait CreateDummyOperation
         $this->crud->hasAccessOrFail('createDummy');
 
         // Check if Model has Factory trait
-        if (!method_exists($this->crud->getModel(), 'factory')) {
+        if (! method_exists($this->crud->getModel(), 'factory')) {
             return response()->json([
                 'title' => trans('backpack::crud.create_dummy_error_title'),
                 'message' => trans('backpack::crud.create_dummy_error_message'),
@@ -82,5 +82,4 @@ trait CreateDummyOperation
             'message' => join(' ', $messages),
         ]);
     }
-
 }

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -48,6 +48,8 @@ return [
     'clone'                     => 'Clone',
     'clone_success'             => '<strong>Entry cloned</strong><br>A new entry has been added, with the same information as this one.',
     'clone_failure'             => '<strong>Cloning failed</strong><br>The new entry could not be created. Please try again.',
+    'create'                    => 'Create',
+    'truncate_create'           => 'Truncate & Create',
 
     // Confirmation messages and bubbles
     'delete_confirm'                              => 'Are you sure you want to delete this item?',
@@ -75,6 +77,17 @@ return [
     'bulk_clone_sucess_message' => ' items have been cloned.',
     'bulk_clone_error_title'    => 'Cloning failed',
     'bulk_clone_error_message'  => 'One or more entries could not be created. Please try again.',
+
+    // Create Dummy
+    'create_dummy_add'              => 'Add dummy',
+    'create_dummy_alert'            => 'How many dummy items do you want to create?',
+    'create_dummy_confirm_truncate' => 'Are you sure you want to truncate the table before create :number dummy entries?',
+    'create_dummy_confirm_create'   => 'Are you sure you want to create :number dummy entries?',
+    'create_dummy_sucess_title'     => 'Success',
+    'create_dummy_sucess_message'   => '{1} :count dummy entry have been created.|[2,*] :count dummy entries have been created.',
+    'create_dummy_success_truncate' => 'Table was truncated.',
+    'create_dummy_error_title'      => 'Dummy creation failed',
+    'create_dummy_error_message'    => 'One or more entries could not be created. Please make sure your model uses hasFactory trait and try again.',
 
     // Ajax errors
     'ajax_error_title' => 'Error',

--- a/src/resources/views/crud/buttons/create_dummy.blade.php
+++ b/src/resources/views/crud/buttons/create_dummy.blade.php
@@ -1,0 +1,136 @@
+@php
+// Store configs
+$env = \Config::get('backpack.crud.operations.createDummy.environment', ['local', 'testing']);
+$default = \Config::get('backpack.crud.operations.createDummy.default', 25);
+@endphp
+
+@if ($crud->hasAccess('createDummy') && in_array(\App::environment(), $env) )
+<div class="create-dummy">
+    <a href="" class="btn btn-outline-primary btn-dummy">
+        <span class="ladda-label">
+            <i class="la la-plus"></i>
+            <span>{{ trans('backpack::crud.create_dummy_add') }} {{ $crud->entity_name_plural }}</span>
+        </span>
+    </a>
+
+    <form action="{{ url($crud->route.'/create-dummy') }}">
+        <p>{!! trans('backpack::crud.create_dummy_alert') !!}</p>
+        <input name="count" type="number" placeholder="{{ $default }}" class="form-control" />
+        @csrf
+    </form>
+</div>
+@endif
+
+{{-- Button Javascript --}}
+@push('after_scripts')
+<script>
+const crudRoute = '{{ Str::slug($crud->getRoute()) }}';
+
+// Dummy setup
+const dummyBtn = document.querySelector('.create-dummy a');
+const dummyForm = document.querySelector('.create-dummy form');
+const dummyFormInput = dummyForm.querySelector('input[name="count"]');
+const dummyFormToken = dummyForm.querySelector('input[name="_token"]').value;
+
+// Options
+const TRUNCATE = 1;
+const CREATE   = 2;
+
+// API fetch
+const fetchCreateDummy = option => {
+    if(option) {
+        let body = new FormData(dummyForm);
+        body.append("option", option);
+
+        // Fetch the action
+        fetch(dummyForm.getAttribute("action"), {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+                "X-CSRF-Token": dummyFormToken
+            },
+            body,
+        }).then(response => {
+            response.json().then(function(data) {
+                // Show an alert message
+                new Noty({
+                    type: response.ok ? 'success' : 'error',
+                    text: `<strong>${data.title}</strong><br>${data.message}`,
+                }).show();
+                
+                // Redraw table with new entries
+                if(response.ok) {
+                    crud.table.draw(false);
+                }
+            });
+        });
+    }
+}
+
+// Override 
+const openCreateDummyModal = e => {
+    if(e) e.preventDefault();
+
+    // Alert
+    swal({
+        content: dummyForm,
+        icon: 'info',
+        buttons: {
+            truncateAndCreate: {
+                text: "{!! trans('backpack::crud.truncate_create') !!}",
+                value: TRUNCATE | CREATE,
+                visible: true,
+                className: "bg-danger",
+            },
+            create: {
+                text: "{!! trans('backpack::crud.create') !!}",
+                value: CREATE,
+                visible: true,
+                className: "bg-primary",
+            },
+        },
+    }).then(option => {
+        if(option & TRUNCATE) {
+            swal({
+                text: "{!! trans('backpack::crud.create_dummy_confirm_truncate') !!}".replace(':number', dummyFormInput.value),
+                icon: 'warning',
+                buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.truncate_create') !!}"],
+                dangerMode: true,
+            }).then(value => {
+                // Proceed with the fetch or go back to previoud modal
+                value ? fetchCreateDummy(option) : openCreateDummyModal();
+            });
+        } else if(option & CREATE) {
+            fetchCreateDummy(option)
+        }
+    });
+}
+
+dummyBtn.onclick = openCreateDummyModal;
+
+// Save current count value localy
+dummyFormInput.oninput = () => localStorage.setItem(`${crudRoute}_create_dummy_count`, dummyFormInput.value);
+
+// Load count value from local storage
+dummyFormInput.value = localStorage.getItem(`${crudRoute}_create_dummy_count`, {{ $default }});
+</script>
+@endpush
+
+{{-- Button Style --}}
+@push('after_styles')
+<style>
+.create-dummy {
+    display: inline-block;
+}
+.create-dummy form {
+    display: none;
+}
+.swal-modal input {
+    max-width: 65%;
+    margin: auto;
+}
+.swal-modal .swal-text {
+    text-align: center;
+}
+</style>
+@endpush


### PR DESCRIPTION
This is a prototype of a create dummy operation as proposed by @tabacitu on https://github.com/Laravel-Backpack/addons/issues/21;

To use this your CRUD Models must use the new Laravel 8 `HasFactory` Trait.

![ezgif-1-2a45981aa83c](https://user-images.githubusercontent.com/1838187/102147988-95bfee00-3e63-11eb-939a-f0bacd9c5691.gif)

To try this on demo you can switch to the branch https://github.com/Laravel-Backpack/demo/pull/204, which has all models with factories.