### PR TITLE
only register extra db types in sql databases

### DIFF
--- a/src/app/Models/Traits/HasRelationshipFields.php
+++ b/src/app/Models/Traits/HasRelationshipFields.php
@@ -22,8 +22,8 @@ trait HasRelationshipFields
     {
         $conn = DB::connection($this->getConnectionName());
 
-         // only register the extra types in sql databases
-         if (in_array($conn->getConfig()['driver'], CRUD::getSqlDriverList())) {
+        // only register the extra types in sql databases
+        if (in_array($conn->getConfig()['driver'], CRUD::getSqlDriverList())) {
             // register the enum, json and jsonb column type, because Doctrine doesn't support it
             $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
             $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');

--- a/src/app/Models/Traits/HasRelationshipFields.php
+++ b/src/app/Models/Traits/HasRelationshipFields.php
@@ -22,10 +22,13 @@ trait HasRelationshipFields
     {
         $conn = DB::connection($this->getConnectionName());
 
-        // register the enum, json and jsonb column type, because Doctrine doesn't support it
-        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
-        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
-        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
+         // only register the extra types in sql databases
+         if (in_array($conn->getConfig()['driver'], CRUD::getSqlDriverList())) {
+            // register the enum, json and jsonb column type, because Doctrine doesn't support it
+            $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+            $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
+            $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
+        }
 
         return $conn;
     }


### PR DESCRIPTION
Problem: When using mongoDB, or other non relational database system registering the extra-type mappings is not necessary, and in case of MongoDB it will fail miserably 🗡️ 

Solution: Only add the extra-type mappings in sql databases. 

Solved: Allows the `isColumnNullable()` to work properly with mongoDB.

