### PR TITLE
Allow repeatable fields to init custom rows and have a maximum of rows

### DIFF
--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -266,12 +266,12 @@
             initializeFieldsWithJavascript(container_holder);
         }
 
-        /* Find all "delete buttons" inside a repeatable container and add a class to hide them from page */
+        // find all "delete buttons" inside a repeatable container and add a class to hide them from page
         function hideRemoveButtonsFromRepeatableContainer(container) {
             container.find('.delete-element').addClass('d-none');
         }
 
-        /* Find all "delete buttons" inside a repeatable container and remove the non-display class so they show up in page */
+        // find all "delete buttons" inside a repeatable container and remove the non-display class so they show up in page
         function enableRemoveButtonsFromRepeatableContainer(container) {
             container.find('.delete-element').removeClass('d-none');
         }

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -5,7 +5,7 @@
   // make sure the value is a JSON string (not array, if it's cast in the model)
   $field['value'] = is_array($field['value']) ? json_encode($field['value']) : $field['value'];
   $field['init_rows'] = $field['init_rows'] ?? 1;
-  $field['max_rows'] = $field['max_rows'] ?? false;
+  $field['max_rows'] = $field['max_rows'] ?? 0;
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -126,8 +126,8 @@
             var container = $('[data-repeatable-identifier='+field_name+']');
             var container_holder = $('[data-repeatable-holder='+field_name+']');
 
-            var max_rows = container_holder.attr('max-rows');
-            var init_rows = container_holder.attr('init-rows');
+            var max_rows = Number(container_holder.attr('max-rows')) || Infinity;
+            var init_rows = Number(container_holder.attr('init-rows'));
 
             // make sure the inputs no longer have a "name" attribute,
             // so that the form will not send the inputs as request variables;
@@ -163,10 +163,10 @@
                 }
             } else {
                 var container_rows = 0;
-                while(init_rows >= 1 && container_rows < max_rows) {
-                    init_rows--;
+                var add_entry_button = element.parent().find('.add-repeatable-element-button');
+                for(let i = 0; i < Math.min(init_rows, max_rows || init_rows); i++) {
                     container_rows++;
-                    element.parent().find('.add-repeatable-element-button').trigger('click');
+                    add_entry_button.trigger('click');
                 }
             }
 
@@ -193,7 +193,7 @@
             // this is the container that holds the group of fields inside the main form.
             var container_holder = $('[data-repeatable-holder='+field_name+']');
 
-            var max_rows = container_holder.attr('max-rows');
+            var max_rows = Number(container_holder.attr('max-rows')) || Infinity;
 
             new_field_group.find('.delete-element').click(function(){
                 new_field_group.find('input, select, textarea').each(function(i, el) {

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -131,7 +131,7 @@
 
             var max_rows = Number(container_holder.attr('data-max-rows')) || Infinity;
             var init_rows = Number(container_holder.attr('data-init-rows'));
-            var min_rows = Number(container_holder.attr('data-min-rows'));
+            var min_rows = Number(container_holder.attr('data-min-rows')) || Infinity;
 
             // make sure the inputs no longer have a "name" attribute,
             // so that the form will not send the inputs as request variables;
@@ -251,6 +251,11 @@
             // we check if we are above the minimum options, if yes we re-enable the delete buttons from rows
             if(container_holder.attr('number-of-rows') > min_rows) {
                 enableRemoveButtonsFromRepeatableContainer(container_holder);
+            }
+
+            // we check if we still under the minimum rows, in case yes we remove the delete buttons from container
+            if(container_holder.attr('number-of-rows') <= min_rows) {
+                hideRemoveButtonsFromRepeatableContainer(container_holder);
             }
 
             // we check for maximum row limit, if hit we hide the "Add Row" button

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -30,7 +30,7 @@
     <div
         data-repeatable-holder="{{ $field['name'] }}"
         init-rows="{{$field['init_rows']}}"
-        max-rows="{{var_export($field['max_rows'])}}"
+        max-rows="{{ $field['max_rows'] }}"
     ></div>
 
     @push('before_scripts')


### PR DESCRIPTION
Problem: 

- There is no way of telling repeatable "initialize this number of rows instead of default 1", 0 is also valid as a don't initialize any row. 👍 
- There is no way to limit the number of rows that a user can add in repeatable field.

Solution:

Create `max_rows` and `init_rows` in repeatable that would allow to configure/fix the mentioned problems.

To use:

```php

    CRUD::addField([
        'name'     => 'field_name',
        'label'    => 'field_label',
        'type'     => 'repeatable',
        'init_rows' => 0,
        'max_rows' => 3,
        'fields'   => [['name' => 'field_name']],
    ]);
```