### PR TITLE
Load Once blade directive

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Backpack\CRUD;
 
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+use Blade;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
@@ -43,6 +45,7 @@ class BackpackServiceProvider extends ServiceProvider
         $this->registerMiddlewareGroup($this->app->router);
         $this->setupRoutes($this->app->router);
         $this->setupCustomRoutes($this->app->router);
+        $this->registerBladeDirectives();
         $this->publishFiles();
         $this->checkLicenseCodeExists();
         $this->sendUsageStats();
@@ -281,6 +284,18 @@ class BackpackServiceProvider extends ServiceProvider
                 'provider' => 'backpack',
             ],
         ];
+    }
+
+    public function registerBladeDirectives()
+    {
+        // CRUD Load Once
+        Blade::directive('crudLoadOnce', function ($tag) {
+            return "<?php if (CRUD::addLoadedFieldType($tag)) { ?>";
+        });
+
+        Blade::directive('endCrudLoadOnce', function () {
+            return '<?php } ?>';
+        });
     }
 
     /**

--- a/src/resources/views/crud/filters/date.blade.php
+++ b/src/resources/views/crud/filters/date.blade.php
@@ -46,7 +46,6 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_list_scripts')
-	<!-- include select2 js-->
 	<script src="{{ asset('packages/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js') }}"></script>
   <script>
 		jQuery(document).ready(function($) {

--- a/src/resources/views/crud/filters/date_range.blade.php
+++ b/src/resources/views/crud/filters/date_range.blade.php
@@ -67,7 +67,6 @@
 {{-- push things in the after_styles section --}}
 
 @push('crud_list_styles')
-    <!-- include select2 css-->
 	<link rel="stylesheet" type="text/css" href="{{ asset('packages/bootstrap-daterangepicker/daterangepicker.css') }}" />
 	<style>
 		.input-group.date {

--- a/src/resources/views/crud/filters/select2.blade.php
+++ b/src/resources/views/crud/filters/select2.blade.php
@@ -31,6 +31,7 @@
 {{-- push things in the after_styles section --}}
 
 @push('crud_list_styles')
+	@crudLoadOnce("select2.css")
     <!-- include select2 css-->
     <link href="{{ asset('packages/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('packages/select2-bootstrap-theme/dist/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
@@ -57,6 +58,7 @@
 	  	top: 0px!important;
 	  }
     </style>
+	@endCrudLoadOnce
 @endpush
 
 
@@ -64,11 +66,13 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_list_scripts')
+	@crudLoadOnce("select2.js")
 	<!-- include select2 js-->
     <script src="{{ asset('packages/select2/dist/js/select2.full.min.js') }}"></script>
     @if (app()->getLocale() !== 'en')
     <script src="{{ asset('packages/select2/dist/js/i18n/' . app()->getLocale() . '.js') }}"></script>
     @endif
+	@endCrudLoadOnce
 
     <script>
         jQuery(document).ready(function($) {

--- a/src/resources/views/crud/filters/select2_ajax.blade.php
+++ b/src/resources/views/crud/filters/select2_ajax.blade.php
@@ -22,6 +22,7 @@
 {{-- push things in the after_styles section --}}
 
 @push('crud_list_styles')
+	@crudLoadOnce("select2.css")
     <!-- include select2 css-->
     <link href="{{ asset('packages/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('packages/select2-bootstrap-theme/dist/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
@@ -48,6 +49,7 @@
 	  	top: 0px!important;
 	  }
     </style>
+	@endCrudLoadOnce
 @endpush
 
 
@@ -55,11 +57,13 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_list_scripts')
+	@crudLoadOnce("select2.js")
 	<!-- include select2 js-->
     <script src="{{ asset('packages/select2/dist/js/select2.full.min.js') }}"></script>
     @if (app()->getLocale() !== 'en')
     <script src="{{ asset('packages/select2/dist/js/i18n/' . app()->getLocale() . '.js') }}"></script>
     @endif
+	@endCrudLoadOnce
 
     <script>
         jQuery(document).ready(function($) {

--- a/src/resources/views/crud/filters/select2_multiple.blade.php
+++ b/src/resources/views/crud/filters/select2_multiple.blade.php
@@ -28,8 +28,8 @@
 
 {{-- FILTERS EXTRA CSS  --}}
 {{-- push things in the after_styles section --}}
-
 @push('crud_list_styles')
+	@crudLoadOnce("select2.css")
     <!-- include select2 css-->
     <link href="{{ asset('packages/select2/dist/css/select2.min.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ asset('packages/select2-bootstrap-theme/dist/select2-bootstrap.min.css') }}" rel="stylesheet" type="text/css" />
@@ -56,6 +56,7 @@
 	  	top: 0px!important;
 	  }
     </style>
+	@endCrudLoadOnce
 @endpush
 
 
@@ -63,11 +64,13 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_list_scripts')
+	@crudLoadOnce("select2.js")
 	<!-- include select2 js-->
     <script src="{{ asset('packages/select2/dist/js/select2.full.min.js') }}"></script>
     @if (app()->getLocale() !== 'en')
     <script src="{{ asset('packages/select2/dist/js/i18n/' . app()->getLocale() . '.js') }}"></script>
     @endif
+	@endCrudLoadOnce
 
     <script>
         jQuery(document).ready(function($) {

--- a/src/resources/views/crud/filters/text.blade.php
+++ b/src/resources/views/crud/filters/text.blade.php
@@ -31,7 +31,6 @@
 {{-- push things in the after_scripts section --}}
 
 @push('crud_list_scripts')
-	<!-- include select2 js-->
   <script>
 		jQuery(document).ready(function($) {
 			$('#text-filter-{{ $filter->key }}').on('change', function(e) {


### PR DESCRIPTION
I noticed many styles and scripts were loaded multiple times, when they were in use by multiple filters/columns/fields.

> ![image](https://user-images.githubusercontent.com/1838187/102521643-1a418500-408d-11eb-99ed-4803103aa000.png)

> ![image](https://user-images.githubusercontent.com/1838187/102521591-0bf36900-408d-11eb-8049-93b604dd194c.png)

This Blade directive uses the already existing methods on `CrudPanel\Traits\Fields` to evaluate if the asset was already loaded.

I applied this to filters only, just to "prove the point", this can be used _a lot_ more in fields.

```php
@if ($crud->fieldTypeNotLoaded($field))
    @php
        $crud->markFieldTypeAsLoaded($field);
    @endphp
```

may become;

```php
@crudLoadOnce($field)
```

This directive works great with `$fields` and tags like `"select2.js"` or `"jquery.js"`.