### PR TITLE
Change redirect route after logout

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -49,7 +49,7 @@ class LoginController extends Controller
 
         // Redirect here after logout.
         $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
-            : backpack_url();
+            : backpack_url('login');
     }
 
     /**


### PR DESCRIPTION
I believe the correct route after logging out is a `login` route. Currently, we are redirected with `backpack_url()` to `admin`, and that in turn redirects us to `admin/login` because now we are logged out. 

This middle step causes the `url.intended` key to be saved in the session with `admin` route. Because of this, when you log out of the admin panel, go to your regular website's login page and log in, you will be redirected to `admin` route (because it is saved under the `url.intended` key)

What do you think about that?