### PR TITLE
Cleanup sidebar.blade.php

### DIFF
--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -1,23 +1,23 @@
 @if (backpack_auth()->check())
-    <!-- Left side column. contains the sidebar -->
+    {{-- Left side column. contains the sidebar  --}}
     <div class="{{ config('backpack.base.sidebar_class') }}">
-      <!-- sidebar: style can be found in sidebar.less -->
+      {{-- sidebar: style can be found in sidebar.less  --}}
       <nav class="sidebar-nav overflow-hidden">
-        <!-- sidebar menu: : style can be found in sidebar.less -->
+        {{-- sidebar menu: : style can be found in sidebar.less  --}}
         <ul class="nav">
-          <!-- <li class="nav-title">{{ trans('backpack::base.administration') }}</li> -->
-          <!-- ================================================ -->
-          <!-- ==== Recommended place for admin menu items ==== -->
-          <!-- ================================================ -->
+          {{-- <li class="nav-title">{{ trans('backpack::base.administration') }}</li>  --}}
+          {{-- ================================================  --}}
+          {{-- ==== Recommended place for admin menu items ====  --}}
+          {{-- ================================================  --}}
 
           @include(backpack_view('inc.sidebar_content'))
 
-          <!-- ======================================= -->
-          <!-- <li class="divider"></li> -->
-          <!-- <li class="nav-title">Entries</li> -->
+          {{-- =======================================  --}}
+          {{-- <li class="divider"></li>  --}}
+          {{-- <li class="nav-title">Entries</li>  --}}
         </ul>
       </nav>
-      <!-- /.sidebar -->
+      {{-- /.sidebar  --}}
     </div>
 @endif
 
@@ -46,36 +46,5 @@
 
 @push('after_scripts')
   <script>
-      // Set active state on menu element
-      var full_url = "{{ Request::fullUrl() }}";
-      var $navLinks = $(".sidebar-nav li a, .app-header li a");
-
-      // First look for an exact match including the search string
-      var $curentPageLink = $navLinks.filter(
-          function() { return $(this).attr('href') === full_url; }
-      );
-
-      // If not found, look for the link that starts with the url
-      if(!$curentPageLink.length > 0){
-          $curentPageLink = $navLinks.filter( function() {
-            if ($(this).attr('href').startsWith(full_url)) {
-              return true;
-            }
-
-            if (full_url.startsWith($(this).attr('href'))) {
-              return true;
-            }
-
-            return false;
-          });
-      }
-
-      // for the found links that can be considered current, make sure 
-      // - the parent item is open
-      $curentPageLink.parents('li').addClass('open');
-      // - the actual element is active
-      $curentPageLink.each(function() {
-        $(this).addClass('active');
-      });
   </script>
 @endpush


### PR DESCRIPTION
While testing https://github.com/Laravel-Backpack/CRUD/pull/3391, I noticed most of the javascript code was not being used, I believe it is replicated somewhere in the bundle.

By removing everything the sidebar still works, links are highlighted with `active` class. And menus are open when submenus are active.