### PR TITLE
Refactor default backpack avatar from an external service to some internal css/img creation feature

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -56,12 +56,12 @@ if (! function_exists('backpack_avatar_url')) {
     function backpack_avatar_url($user)
     {
         $firstLetter = $user->getAttribute('name') ? mb_substr($user->name, 0, 1, 'UTF-8') : 'A';
-        $placeholder = 'https://placehold.it/160x160/00a65a/ffffff/&text='.$firstLetter;
+        $placeholder = 'https://place-hold.it/160x160/00a65a/ffffff/&bold&fontsize=18&text='.$firstLetter;
 
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
                 if (backpack_users_have_email()) {
-                    return Gravatar::fallback('https://placehold.it/160x160/00a65a/ffffff/&text='.$firstLetter)->get($user->email);
+                    return Gravatar::fallback('https://place-hold.it/160x160/00a65a/ffffff/&bold&fontsize=18&text='.$firstLetter)->get($user->email);
                 } else {
                     return $placeholder;
                 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -56,7 +56,7 @@ if (! function_exists('backpack_avatar_url')) {
     function backpack_avatar_url($user)
     {
         $firstLetter = $user->getAttribute('name') ? mb_substr($user->name, 0, 1, 'UTF-8') : 'A';
-        $placeholder = 'https://place-hold.it/160x160/00a65a/ffffff/&bold&fontsize=18&text='.$firstLetter;
+        $placeholder = 'https://place-hold.it/160x160/00a65a/ffffff/&fontsize=40&text='.$firstLetter;
 
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':


### PR DESCRIPTION
refs: #3423 

It's not the first time it happens. `placehold.it` is now `placeholder.com`. Still it's not the first time they let the certificates expire. 

It's certificate is expired since 25th of december this year (even the new service `placeholder.com`

I am switching here for a new placeholder service, but still, I think we might want to have our own image creation process (maybe just css will be enough ? ) and don't rely on external services for something I am pretty sure lots of people leave by default.

Best,
Pedro