### PR TITLE
Multiple order columns in Datatables

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -95,7 +95,7 @@ trait ListOperation
         if (request()->input('order')) {
             // clear any past orderBy rules
             $this->crud->query->getQuery()->orders = null;
-            foreach((array)request()->input('order') as $order) {
+            foreach ((array) request()->input('order') as $order) {
                 $column_number = $order['column'];
                 $column_direction = $order['dir'];
                 $column = $this->crud->findColumnById($column_number);
@@ -109,7 +109,6 @@ trait ListOperation
                     $this->crud->customOrderBy($column, $column_direction);
                 }
             }
-
         }
 
         // show newest items first, by default (if no order has been set for the primary column)

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -93,20 +93,23 @@ trait ListOperation
         }
         // overwrite any order set in the setup() method with the datatables order
         if (request()->input('order')) {
-            $column_number = request()->input('order')[0]['column'];
-            $column_direction = request()->input('order')[0]['dir'];
-            $column = $this->crud->findColumnById($column_number);
-            if ($column['tableColumn']) {
-                // clear any past orderBy rules
-                $this->crud->query->getQuery()->orders = null;
-                // apply the current orderBy rules
-                $this->crud->orderByWithPrefix($column['name'], $column_direction);
+            // clear any past orderBy rules
+            $this->crud->query->getQuery()->orders = null;
+            foreach((array)request()->input('order') as $order) {
+                $column_number = $order['column'];
+                $column_direction = $order['dir'];
+                $column = $this->crud->findColumnById($column_number);
+                if ($column['tableColumn']) {
+                    // apply the current orderBy rules
+                    $this->crud->orderByWithPrefix($column['name'], $column_direction);
+                }
+
+                // check for custom order logic in the column definition
+                if (isset($column['orderLogic'])) {
+                    $this->crud->customOrderBy($column, $column_direction);
+                }
             }
 
-            // check for custom order logic in the column definition
-            if (isset($column['orderLogic'])) {
-                $this->crud->customOrderBy($column, $column_direction);
-            }
         }
 
         // show newest items first, by default (if no order has been set for the primary column)


### PR DESCRIPTION
refs: #3424 

Problem: Datatables allows us to order by multiple columns. In our current code we only get the first order sent by datatables ignoring the others. 

```php
// ...

if (request()->input('order')) {
            $column_number = request()->input('order')[0]['column'];
            $column_direction = request()->input('order')[0]['dir'];

// ...
```

Solution: Iterate all orders and apply them. 

I didn't even know about this datatables functionality, but indeed it works and we could support it without BC. https://datatables.net/examples/basic_init/multi_col_sort.html

To better test it, in Monsters (demo), order first by the `select` column, and then **SHIFT** click in `text` column. 

The expected result is that entries are ordered first by `select` and within that order beeing ordered by `text`. 

From my tests everything still works as expected, no BC. 

Let me know,
Pedro
