### PR TITLE
Columns empty value consistency

### DIFF
--- a/src/resources/views/crud/columns/closure.blade.php
+++ b/src/resources/views/crud/columns/closure.blade.php
@@ -1,12 +1,14 @@
 {{-- closure function column type --}}
 @php
+    $value = $column['function']($entry);
+
     $column['escaped'] = $column['escaped'] ?? false;
-    $column['text'] = $column['function']($entry);
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].$value.$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/custom_html.blade.php
+++ b/src/resources/views/crud/columns/custom_html.blade.php
@@ -1,11 +1,13 @@
 @php
-    $column['text'] = $column['value'] ?? '';
+    $value = $column['value'] ?? '';
+
     $column['escaped'] = $column['escaped'] ?? false;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].$value.$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/date.blade.php
+++ b/src/resources/views/crud/columns/date.blade.php
@@ -6,7 +6,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['format'] = $column['format'] ?? config('backpack.base.default_date_format');
-    $column['text'] = '';
+    $column['text'] = '-';
 
     if(!empty($value)) {
         $column['text'] = \Carbon\Carbon::parse($value)

--- a/src/resources/views/crud/columns/datetime.blade.php
+++ b/src/resources/views/crud/columns/datetime.blade.php
@@ -6,7 +6,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['format'] = $column['format'] ?? config('backpack.base.default_datetime_format');
-    $column['text'] = '';
+    $column['text'] = '-';
 
     if(!empty($value)) {
         $column['text'] = \Carbon\Carbon::parse($value)

--- a/src/resources/views/crud/columns/json.blade.php
+++ b/src/resources/views/crud/columns/json.blade.php
@@ -3,14 +3,14 @@
         json_decode($entry->{$column['name']}, true) : 
         $entry->{$column['name']};
 
-    $column['text'] = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['wrapper']['element'] = $column['wrapper']['element'] ?? 'pre';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/markdown.blade.php
+++ b/src/resources/views/crud/columns/markdown.blade.php
@@ -1,11 +1,13 @@
 @php
-    $column['text'] = Illuminate\Mail\Markdown::parse($entry->{$column['name']} ?? '');
+    $value = Illuminate\Mail\Markdown::parse($entry->{$column['name']} ?? '');
+
     $column['escaped'] = $column['escaped'] ?? false;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].$value.$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -6,9 +6,11 @@
     $column['limit']   = $column['limit'] ?? 40;
     $column['prefix']  = $column['prefix'] ?? '';
     $column['suffix']  = $column['suffix'] ?? '';
-    $column['text']    = $column['prefix'].
-                         Str::limit($value, $column['limit'], "[...]").
-                         $column['suffix'];
+    $column['text'] = '-';
+
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], "[...]").$column['suffix'];
+    }
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/model_function_attribute.blade.php
+++ b/src/resources/views/crud/columns/model_function_attribute.blade.php
@@ -4,12 +4,14 @@
     $value = $model_function ? $model_function->{$column['attribute']} : '';
 
     $column['escaped'] = $column['escaped'] ?? false;
-    $column['limit']   = $column['limit'] ?? 40;
-    $column['prefix']  = $column['prefix'] ?? '';
-    $column['suffix']  = $column['suffix'] ?? '';
-    $column['text']    = $column['prefix'].
-                         Str::limit($value, $column['limit'], "[...]").
-                         $column['suffix'];
+    $column['limit'] = $column['limit'] ?? 40;
+    $column['prefix'] = $column['prefix'] ?? '';
+    $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
+
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], "[...]").$column['suffix'];
+    }
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/number.blade.php
+++ b/src/resources/views/crud/columns/number.blade.php
@@ -1,13 +1,14 @@
 {{-- regular object attribute --}}
 @php
     $value = data_get($entry, $column['name']);
+
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['decimals'] = $column['decimals'] ?? 0;
     $column['dec_point'] = $column['dec_point'] ?? '.';
     $column['thousands_sep'] = $column['thousands_sep'] ?? ',';
-    $column['text'] = '';
+    $column['text'] = '-';
 
     if (!is_null($value)) {
         $value = number_format($value, $column['decimals'], $column['dec_point'], $column['thousands_sep']);

--- a/src/resources/views/crud/columns/phone.blade.php
+++ b/src/resources/views/crud/columns/phone.blade.php
@@ -1,13 +1,14 @@
 {{-- telephone link --}}
 @php
     $value = data_get($entry, $column['name']);
+
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 40;
     $column['wrapper']['element'] = $column['wrapper']['element'] ?? 'a';
     $column['wrapper']['href'] = $column['wrapper']['href'] ?? 'tel:'.$value;
-    $column['text'] = '';
+    $column['text'] = '-';
 
     if(!empty($value)) {
         $column['text'] = $column['prefix'].Str::limit(strip_tags($value), $column['limit'], "[...]").$column['suffix'];

--- a/src/resources/views/crud/columns/radio.blade.php
+++ b/src/resources/views/crud/columns/radio.blade.php
@@ -1,12 +1,14 @@
 @php
+    $value = $column['options'][data_get($entry, $column['key'])] ?? '';
+
 	$column['key'] = $column['key'] ?? $column['name'];
-    $column['text'] = $column['options'][data_get($entry, $column['key'])] ?? '';
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if(!empty($value)) {
+        $column['text'] = $column['prefix'].$value.$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/relationship_count.blade.php
+++ b/src/resources/views/crud/columns/relationship_count.blade.php
@@ -5,7 +5,7 @@
     $column['escaped'] = $column['escaped'] ?? false;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? ' items';
-    $column['text'] = '';
+    $column['text'] = '-';
 
     if($value) {
         $column['text'] = $column['prefix'].$value.$column['suffix'];

--- a/src/resources/views/crud/columns/row_number.blade.php
+++ b/src/resources/views/crud/columns/row_number.blade.php
@@ -4,9 +4,7 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-	$column['text'] = 	$column['prefix'].
-						Str::limit(strip_tags($rowNumber), $column['limit'], "[...]").
-						$column['suffix'];
+    $column['text'] = $column['prefix'].$rowNumber.$column['suffix'];
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/table.blade.php
+++ b/src/resources/views/crud/columns/table.blade.php
@@ -1,56 +1,52 @@
 @php
-	$value = data_get($entry, $column['name']);
+    $value = data_get($entry, $column['name']);
 
     // make sure columns are defined
     if (!isset($column['columns'])) {
         $column['columns'] = ['value' => "Value"];
     }
 
-	$columns = $column['columns'];
-
-	// if this attribute isn't using attribute casting, decode it
-	if (is_string($value)) {
-	    $value = json_decode($value);
+    // if this attribute isn't using attribute casting, decode it
+    if (is_string($value)) {
+        $value = json_decode($value);
     }
 @endphp
 
 <span>
-    @if ($value && count($columns))
+    @if ($value && count($column['columns']))
+        @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
 
-    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+        <table class="table table-bordered table-condensed table-striped m-b-0">
+            <thead>
+                <tr>
+                    @foreach($column['columns'] as $tableColumnKey => $tableColumnLabel)
+                    <th>{{ $tableColumnLabel }}</th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($value as $tableRow)
+                <tr>
+                    @foreach($column['columns'] as $tableColumnKey => $tableColumnLabel)
+                        <td>
+                            @if(is_array($tableRow) && isset($tableRow[$tableColumnKey]))
 
-    <table class="table table-bordered table-condensed table-striped m-b-0">
-		<thead>
-			<tr>
-				@foreach($columns as $tableColumnKey => $tableColumnLabel)
-				<th>{{ $tableColumnLabel }}</th>
-				@endforeach
-			</tr>
-		</thead>
-		<tbody>
-			@foreach ($value as $tableRow)
-			<tr>
-				@foreach($columns as $tableColumnKey => $tableColumnLabel)
-					<td>
+                                {{ $tableRow[$tableColumnKey] }}
 
-						@if( is_array($tableRow) && isset($tableRow[$tableColumnKey]) )
+                            @elseif(is_object($tableRow) && property_exists($tableRow, $tableColumnKey))
 
-                            {{ $tableRow[$tableColumnKey] }}
+                                {{ $tableRow->{$tableColumnKey} }}
 
-                        @elseif( is_object($tableRow) && property_exists($tableRow, $tableColumnKey) )
+                            @endif
+                        </td>
+                    @endforeach
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
 
-                            {{ $tableRow->{$tableColumnKey} }}
-
-                        @endif
-
-					</td>
-				@endforeach
-			</tr>
-			@endforeach
-		</tbody>
-    </table>
-
-    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-
-	@endif
+        @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+    @else
+        -
+    @endif
 </span>

--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -7,7 +7,11 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], '[...]').$column['suffix'];
+    $column['text'] = '-';
+
+    if($value) {
+        $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], '[...]').$column['suffix'];
+    }
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/textarea.blade.php
+++ b/src/resources/views/crud/columns/textarea.blade.php
@@ -1,13 +1,15 @@
 {{-- regular object attribute --}}
 @php
     $value = data_get($entry, $column['name']);
-    $column['text'] = is_string($value) ? $value : '';
+    $value = is_string($value) ? $value : '';
+
     $column['escaped'] = $column['escaped'] ?? false;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = '-';
 
-    if(!empty($column['text'])) {
-        $column['text'] = $column['prefix'].$column['text'].$column['suffix'];
+    if($value) {
+        $column['text'] = $column['prefix'].$value.$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/upload_multiple.blade.php
+++ b/src/resources/views/crud/columns/upload_multiple.blade.php
@@ -1,5 +1,6 @@
 @php
     $value = data_get($entry, $column['name']);
+
     $column['prefix'] = $column['prefix'] ?? '';
     $column['disk'] = $column['disk'] ?? null;
     $column['escaped'] = $column['escaped'] ?? true;


### PR DESCRIPTION
Depends on https://github.com/Laravel-Backpack/CRUD/pull/3435.
Breaking change on v4.1.

This adds consistency to columns empty (default) values
When there's no value, the fallback is always `'-'`.

Question;
Should it be a config? Or let's just assume no one wants an empty space `''`?
