### PR TITLE
bugfix image field not showing old value because of the repeated disk storage URL

### DIFF
--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -1,6 +1,9 @@
 @php
     $prefix = isset($field['prefix']) ? $field['prefix'] : '';
     $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+    if (isset($field['disk'])) {
+        $value = str_replace(Storage::disk($field['disk'])->url(''), '', $value);
+    }
     $value = $value
         ? preg_match('/^data\:image\//', $value)
             ? $value


### PR DESCRIPTION
Proposal to fix image field not showing old value because of the repeated disk storage URL

This is only happening on edit, on create it seems to work fine. Or maybe I missed some edge cases? 😕 

For some reason, I think this PR is not a correct or proper way to fix this bug, maybe because I did not check the origin of the full URL value and fixed it there.

steps to reproduce:
- edit an entity with `image` field
- make the validation check return error(s). In the video below I just removed a value from a `required` field
- image URL is broken

Or just view this short video

https://user-images.githubusercontent.com/13914485/103742060-2e95f380-5035-11eb-890b-61922f89dcac.mp4

Thanks