### PR TITLE
[Bug] prevent relationship functionality when column has entity => false

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -379,8 +379,8 @@ trait Columns
 
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name']) 
-            ? ! isset($column['entity']) || $column['entity'] !== false 
+        $could_be_relation = method_exists($this->model, $column['name'])
+            ? ! isset($column['entity']) || $column['entity'] !== false
             : isset($column['entity']) && $column['entity'] !== false;
 
         if (! $column_exists_in_db && $could_be_relation) {

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -370,19 +370,21 @@ trait Columns
         $column = $this->makeSureColumnHasModel($column);
 
         // check if the column exists in the database (as a db column)
-        $columnExistsInDb = $this->hasDatabaseColumn($this->model->getTable(), $column['name']);
+        $column_exists_in_db = $this->hasDatabaseColumn($this->model->getTable(), $column['name']);
 
         // make sure column has tableColumn, orderable and searchLogic
-        $column['tableColumn'] = $column['tableColumn'] ?? $columnExistsInDb;
-        $column['orderable'] = $column['orderable'] ?? $columnExistsInDb;
-        $column['searchLogic'] = $column['searchLogic'] ?? $columnExistsInDb;
+        $column['tableColumn'] = $column['tableColumn'] ?? $column_exists_in_db;
+        $column['orderable'] = $column['orderable'] ?? $column_exists_in_db;
+        $column['searchLogic'] = $column['searchLogic'] ?? $column_exists_in_db;
 
-        // check if it's a method on the model,
-        // that means it's a relationship
-        if (! $columnExistsInDb && method_exists($this->model, $column['name']) && $column['entity'] !== false) {
-            $relatedModel = $this->model->{$column['name']}()->getRelated();
+        // check if method exists in model so it's a possible relation
+        // but exclude possible matches if developer setup entity => false
+        $could_be_relation = method_exists($this->model, $column['name']) ? !isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+
+        if (! $column_exists_in_db && $could_be_relation) {
+            $related_model = $this->model->{$column['name']}()->getRelated();
             $column['entity'] = $column['name'];
-            $column['model'] = get_class($relatedModel);
+            $column['model'] = get_class($related_model);
         }
 
         return $column;

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -379,7 +379,9 @@ trait Columns
 
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name']) ? ! isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+        $could_be_relation = method_exists($this->model, $column['name']) 
+            ? ! isset($column['entity']) || $column['entity'] !== false 
+            : isset($column['entity']) && $column['entity'] !== false;
 
         if (! $column_exists_in_db && $could_be_relation) {
             $related_model = $this->model->{$column['name']}()->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -379,7 +379,7 @@ trait Columns
 
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name']) ? !isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+        $could_be_relation = method_exists($this->model, $column['name']) ? ! isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
 
         if (! $column_exists_in_db && $could_be_relation) {
             $related_model = $this->model->{$column['name']}()->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -253,7 +253,7 @@ trait Columns
         $columns = $this->columns();
 
         return collect($columns)->pluck('entity')->reject(function ($value, $key) {
-            return $value == null || $value == false;
+            return !$value;
         })->toArray();
     }
 

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -253,7 +253,7 @@ trait Columns
         $columns = $this->columns();
 
         return collect($columns)->pluck('entity')->reject(function ($value, $key) {
-            return $value == null;
+            return $value == null || $value == false;
         })->toArray();
     }
 
@@ -379,7 +379,7 @@ trait Columns
 
         // check if it's a method on the model,
         // that means it's a relationship
-        if (! $columnExistsInDb && method_exists($this->model, $column['name'])) {
+        if (! $columnExistsInDb && method_exists($this->model, $column['name']) && $column['entity'] !== false) {
             $relatedModel = $this->model->{$column['name']}()->getRelated();
             $column['entity'] = $column['name'];
             $column['model'] = get_class($relatedModel);

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -82,8 +82,9 @@ trait ColumnsProtectedMethods
     {
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
-
-        $could_be_relation = method_exists($this->model, $column['name']) ? ! isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+        $could_be_relation = method_exists($this->model, $column['name'])
+            ? !isset($column['entity']) || $column['entity'] !== false
+            : isset($column['entity']) && $column['entity'] !== false;
 
         if (! isset($column['type']) && $could_be_relation) {
             $column['type'] = 'relationship';

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -83,7 +83,7 @@ trait ColumnsProtectedMethods
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
 
-        $could_be_relation = method_exists($this->model, $column['name']) ? !isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+        $could_be_relation = method_exists($this->model, $column['name']) ? ! isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
 
         if (! isset($column['type']) && $could_be_relation) {
             $column['type'] = 'relationship';

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -82,7 +82,7 @@ trait ColumnsProtectedMethods
     {
         // if it's got a method on the model with the same name
         // then it should be a relationship
-        if (! isset($column['type']) && method_exists($this->model, $column['name'])) {
+        if (! isset($column['type']) && method_exists($this->model, $column['name']) && $column['entity'] !== false) {
             $column['type'] = 'relationship';
         }
 

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -83,7 +83,7 @@ trait ColumnsProtectedMethods
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
         $could_be_relation = method_exists($this->model, $column['name'])
-            ? !isset($column['entity']) || $column['entity'] !== false
+            ? ! isset($column['entity']) || $column['entity'] !== false
             : isset($column['entity']) && $column['entity'] !== false;
 
         if (! isset($column['type']) && $could_be_relation) {

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -80,9 +80,12 @@ trait ColumnsProtectedMethods
      */
     protected function makeSureColumnHasType($column)
     {
-        // if it's got a method on the model with the same name
-        // then it should be a relationship
-        if (! isset($column['type']) && method_exists($this->model, $column['name']) && $column['entity'] !== false) {
+        // check if method exists in model so it's a possible relation
+        // but exclude possible matches if developer setup entity => false
+
+        $could_be_relation = method_exists($this->model, $column['name']) ? !isset($column['entity']) || $column['entity'] !== false : isset($column['entity']) || $column['entity'] !== false;
+
+        if (! isset($column['type']) && $could_be_relation) {
             $column['type'] = 'relationship';
         }
 


### PR DESCRIPTION
refs: #3442 

problem: with new crud "guessing" abilities, having a field or a column with the same name of a function in the model, we will assume that is just some relationship, so there is `entity => false` to disable that behavior. It's implemented for fields but not for columns. 

solution: check if `entity => false` is present also in columns.



