### PR TITLE
Added Backpack fallback route

### DIFF
--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -42,4 +42,14 @@ class AdminController extends Controller
         // The '/admin' route is not to be used as a page, because it breaks the menu's active state.
         return redirect(backpack_url('dashboard'));
     }
+
+    /**
+     * Show the 404 error page.
+     *
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    public function notFound()
+    {
+        return view('errors.404');
+    }
 }

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -48,7 +48,7 @@ class AdminController extends Controller
      *
      * @return \Illuminate\View\View
      */
-    public function notFound()
+    public function backpackHttpNotFoundView()
     {
         return view('errors.404');
     }

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -42,14 +42,4 @@ class AdminController extends Controller
         // The '/admin' route is not to be used as a page, because it breaks the menu's active state.
         return redirect(backpack_url('dashboard'));
     }
-
-    /**
-     * Show the 404 error page.
-     *
-     * @return \Illuminate\View\View
-     */
-    public function backpackHttpNotFoundView()
-    {
-        return view('errors.404');
-    }
 }

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -46,7 +46,7 @@ class AdminController extends Controller
     /**
      * Show the 404 error page.
      *
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\Response
      */
     public function notFound()
     {

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -46,7 +46,7 @@ class AdminController extends Controller
     /**
      * Show the 404 error page.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function notFound()
     {

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -51,6 +51,7 @@ function () {
         Route::post('change-password', 'MyAccountController@postChangePasswordForm')->name('backpack.account.password');
     }
 
-    // Backpack fallback route
-    Route::fallback('AdminController@notFound');
+    // This defines the fallback route when no matching route is found, is responsible for showing the 404 page.
+    // NOTE: this should be the last registered route in this file. 
+    Route::fallback('AdminController@backpackHttpNotFoundView');
 });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -50,4 +50,7 @@ function () {
         Route::post('edit-account-info', 'MyAccountController@postAccountInfoForm')->name('backpack.account.info.store');
         Route::post('change-password', 'MyAccountController@postChangePasswordForm')->name('backpack.account.password');
     }
+
+    // Backpack fallback route
+    Route::fallback('AdminController@notFound');
 });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -54,6 +54,6 @@ function () {
     // This defines the fallback route when no matching route is found, is responsible for showing the 404 page.
     // NOTE: this should be the last registered route in this file.
     Route::fallback(function () {
-        return abort('404');
+        abort('404');
     });
 });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -51,8 +51,9 @@ function () {
         Route::post('change-password', 'MyAccountController@postChangePasswordForm')->name('backpack.account.password');
     }
 
-    // This defines the fallback route when no matching route is found, is responsible for showing the 404 page.
-    // NOTE: this should be the last registered route in this file.
+    // NOTE: The fallback should be the last command in this file.
+    
+    // When no matching route is found, show the 404 page.
     Route::fallback(function () {
         abort('404');
     });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -52,6 +52,6 @@ function () {
     }
 
     // This defines the fallback route when no matching route is found, is responsible for showing the 404 page.
-    // NOTE: this should be the last registered route in this file. 
+    // NOTE: this should be the last registered route in this file.
     Route::fallback('AdminController@backpackHttpNotFoundView');
 });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -53,5 +53,7 @@ function () {
 
     // This defines the fallback route when no matching route is found, is responsible for showing the 404 page.
     // NOTE: this should be the last registered route in this file.
-    Route::fallback('AdminController@backpackHttpNotFoundView');
+    Route::fallback(function () {
+        return abort('404');
+    });
 });

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -52,7 +52,7 @@ function () {
     }
 
     // NOTE: The fallback should be the last command in this file.
-    
+
     // When no matching route is found, show the 404 page.
     Route::fallback(function () {
         abort('404');


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/3446.

By using the `Route::fallback`, any non existing route will be rendered as 404 with backpack navbar and sidebar.

![image](https://user-images.githubusercontent.com/1838187/103812103-e3d8a380-5055-11eb-95c2-38a2ce791063.png)
