### PR TITLE
This adds consistency between messages on generators

### DIFF
--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -55,6 +55,7 @@ class AddCustomRouteContent extends Command
             // if the code already exists in the file, abort
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
                 $this->error('Route already exists!');
+
                 return;
             }
 

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -54,7 +54,7 @@ class AddCustomRouteContent extends Command
 
             // if the code already exists in the file, abort
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
-                return $this->info('Route already exists!');
+                return $this->error('Route already exists!');
             }
 
             $end_line_number = $this->customRoutesFileEndLine($file_lines);

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -54,7 +54,8 @@ class AddCustomRouteContent extends Command
 
             // if the code already exists in the file, abort
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
-                return $this->error('Route already exists!');
+                $this->error('Route already exists!');
+                return;
             }
 
             $end_line_number = $this->customRoutesFileEndLine($file_lines);

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -49,7 +49,8 @@ class AddSidebarContent extends Command
             $file_lines = file($disk->path($path), FILE_IGNORE_NEW_LINES);
 
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
-                return $this->error('Sidebar item already exists!');
+                $this->error('Sidebar item already exists!');
+                return;
             }
 
             if ($disk->put($path, $contents.PHP_EOL.$code)) {

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -49,7 +49,7 @@ class AddSidebarContent extends Command
             $file_lines = file($disk->path($path), FILE_IGNORE_NEW_LINES);
 
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
-                return $this->info('Sidebar item already exists!');
+                return $this->error('Sidebar item already exists!');
             }
 
             if ($disk->put($path, $contents.PHP_EOL.$code)) {

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -50,6 +50,7 @@ class AddSidebarContent extends Command
 
             if ($this->getLastLineNumberThatContains($code, $file_lines)) {
                 $this->error('Sidebar item already exists!');
+
                 return;
             }
 


### PR DESCRIPTION
Dependes on https://github.com/Laravel-Backpack/Generators/pull/102.

By changing `Artisan::call()` to `$this->call()` messages are now highlighted.

So this PR turns this;
![image](https://user-images.githubusercontent.com/1838187/104067692-88e0b100-51fb-11eb-84d3-8ca73397e0db.png)

into this;
![image](https://user-images.githubusercontent.com/1838187/104067681-841bfd00-51fb-11eb-957e-f4636b1a4517.png)

