### PR TITLE
bugfix browse_multiple field using backslash in Windows machine

### DIFF
--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -77,7 +77,7 @@ if($sortable){
     @endphp
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
-    @push('crud_fields_styles')        
+    @push('crud_fields_styles')
         <link href="{{ asset('packages/jquery-colorbox/example2/colorbox.css') }}" rel="stylesheet" type="text/css" />
         <style>
             #cboxContent, #cboxLoadedContent, .cboxIframe {
@@ -87,7 +87,7 @@ if($sortable){
     @endpush
 
     @push('crud_fields_scripts')
-        
+
         <script src="{{ asset('packages/jquery-ui-dist/jquery-ui.min.js') }}"></script>
         <script src="{{ asset('packages/jquery-colorbox/jquery.colorbox-min.js') }}"></script>
         <script>
@@ -97,7 +97,11 @@ if($sortable){
 
             // function to use the files selected inside elfinder
             function processSelectedMultipleFiles(files, requestingField) {
-                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);                
+                files = files.map(function(file){
+                    file.path = file.path.replace(/\\/g,"/");
+                    return file;
+                });
+                elfinderTarget.trigger('createInputsForItemsSelectedWithElfinder', [files]);
                 elfinderTarget = false;
             }
 
@@ -109,7 +113,7 @@ if($sortable){
                 var $multiple = element.attr('data-multiple');
                 var $sortable = element.attr('sortable');
 
-                // show existing items - display visible inputs for each stored path  
+                // show existing items - display visible inputs for each stored path
                 if ($input.val() != '' && $input.val() != null && $multiple === 'true') {
                     $paths = JSON.parse($input.val());
                     if (Array.isArray($paths) && $paths.length) {


### PR DESCRIPTION
a couple of years ago this commit https://github.com/Laravel-Backpack/CRUD/commit/d3c4e84a3dae2c65a732dc9bae7889f00cefa3f4 (originating from https://github.com/Laravel-Backpack/CRUD/issues/496) is used to work around this issue, however it's only applied in the `browse` field, not `browse_multiple`

this PR add the same fixes to the `browse_multiple` field