### PR TITLE
Bug] prevent relationship functionality when field has entity => false

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -86,7 +86,7 @@ trait Update
      */
     private function getModelAttributeValue($model, $field)
     {
-        if (isset($field['entity'])) {
+        if ($field['entity'] ?? false) {
             $relational_entity = $this->parseRelationFieldNamesFromHtml([$field])[0]['name'];
 
             $relation_array = explode('.', $relational_entity);


### PR DESCRIPTION
Fix for #3442 - field part
Related with; https://github.com/Laravel-Backpack/CRUD/pull/3445 which fixes the column part.

I was able to reproduce what user described while adding the field.

This bit of code should be, not only checking if `$field['entity']` is set, but also not falsy.