### PR TITLE
remove asterisks from radio options

### DIFF
--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -4,7 +4,7 @@
 *
 */
 
-.form-group.required label:not(:empty)::after {
+.form-group.required label:not(:empty):not(.form-check-label)::after {
     content: ' *';
     color: #ff0000;
 }


### PR DESCRIPTION
refs: #3467 

When using radio field that is required, all the options were beeing added `*` (the red asterisk), leading to confusion.

This PR keeps the asterisk in field label, but removes it from options.

BEFORE:
![image](https://user-images.githubusercontent.com/7188159/104913538-a6ddac80-5985-11eb-9bbd-12bc026c1322.png)


AFTER:
![image](https://user-images.githubusercontent.com/7188159/104913457-86155700-5985-11eb-9b69-2df408b78ca2.png)
