### PR TITLE
add placeholder field option to select2

### DIFF
--- a/src/resources/views/crud/fields/select2.blade.php
+++ b/src/resources/views/crud/fields/select2.blade.php
@@ -12,6 +12,7 @@
         $options = call_user_func($field['options'], $field['model']::query());
     }
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
+    $field['placeholder'] = $field['placeholder'] ?? '-';
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -27,7 +28,7 @@
         >
 
         @if ($field['allows_null'])
-            <option value="">-</option>
+            <option value="">{{ $field['placeholder'] }}</option>
         @endif
 
         @if (count($options))


### PR DESCRIPTION
by default, when `allows_null => true` we show an `-` as a placeholder.

this PR allow developers to change field placeholder to something they want like `Select a Recipe Ingredient`