### PR TITLE
Disabled the animation during page load

### DIFF
--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -25,7 +25,7 @@
   <script type="text/javascript">
     // Save default sidebar class
     let sidebarClass = (document.body.className.match(/sidebar-(sm|md|lg|xl)-show/) || ['sidebar-lg-show'])[0];
-    let sidebarTransition = value => document.querySelector('.sidebar').style.transition = value || '';
+    let sidebarTransition = value => document.querySelector('.app-body > .sidebar').style.transition = value || '';
 
     // Recover sidebar state
     let sessionState = sessionStorage.getItem('sidebar-collapsed');

--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -25,10 +25,18 @@
   <script type="text/javascript">
     // Save default sidebar class
     let sidebarClass = (document.body.className.match(/sidebar-(sm|md|lg|xl)-show/) || ['sidebar-lg-show'])[0];
+    let sidebarTransition = value => document.querySelector('.sidebar').style.transition = value || '';
 
     // Recover sidebar state
     let sessionState = sessionStorage.getItem('sidebar-collapsed');
-    if(sessionState) document.body.classList.toggle(sidebarClass, sessionState === '1');
+    if(sessionState) {
+      // disable the transition animation temporarly
+      sidebarTransition("none");
+      document.body.classList.toggle(sidebarClass, sessionState === '1');
+
+      // re-enable the transition
+      setTimeout(sidebarTransition, 100);
+    }
   </script>
 @endpush
 


### PR DESCRIPTION
I can think about two ways of fixing this;
- Adding an ajax request to tell the backend if the sidebar is closed or not (kind of heavy)
- Disabling the animation during that first sidebar close.

I went for the second one.

https://user-images.githubusercontent.com/1838187/105838832-8d151880-5fc8-11eb-8ea0-ce64cfdcd0f1.mp4


