### PR TITLE
Table column - allow for values to be set from code

### DIFF
--- a/src/resources/views/crud/columns/table.blade.php
+++ b/src/resources/views/crud/columns/table.blade.php
@@ -1,5 +1,12 @@
 @php
-	$value = data_get($entry, $column['name']);
+	if(!isset($column['value']))
+    {
+        $value = data_get($entry, $column['name']);
+    }
+    else
+    {
+        $value = $column['value'];
+    }
 
     // make sure columns are defined
     if (!isset($column['columns'])) {


### PR DESCRIPTION
This change allow the developer to specify the data,  as an array, that should be displayed in the table.

if no 'value' is provided, fetch from DB as normal.