### PR TITLE
Easily change RouteKey + Easily generate UUID on Model

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Delete.php
+++ b/src/app/Library/CrudPanel/Traits/Delete.php
@@ -23,7 +23,7 @@ trait Delete
      */
     public function delete($id)
     {
-        return (string) $this->model->findOrFail($id)->delete();
+        return (string) $this->model->where($this->model->getRouteKeyName(),$id)->firstOrFail()->delete();
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -55,7 +55,7 @@ trait Read
     public function getEntry($id)
     {
         if (! $this->entry) {
-            $this->entry = $this->model->findOrFail($id);
+            $this->entry = $this->model->where($this->model->getRouteKeyName(),$id)->firstOrFail();
             $this->entry = $this->entry->withFakes();
         }
 

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -24,7 +24,7 @@ trait Update
     {
         $data = $this->decodeJsonCastedAttributes($data);
         $data = $this->compactFakeFields($data);
-        $item = $this->model->findOrFail($id);
+        $item = $this->model->where($this->model->getRouteKeyName(),$id)->firstOrFail();
 
         $this->createRelations($item, $data);
 

--- a/src/app/Models/Traits/CanChangeRouteKey.php
+++ b/src/app/Models/Traits/CanChangeRouteKey.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Backpack\CRUD\app\Models\Traits;
+/**
+ * Allows the ability to change the exposed route key simply by setting the public $routeKey parameter.
+ * public $routeKey = 'uuid';
+ */
+
+trait CanChangeRouteKey{
+	
+
+		    /**
+	 * Get the route key for the model.
+	 *
+	 * @return string
+	 */
+	public function getRouteKeyName()
+	{
+	  return $this->routeKey ?? parent::getRouteKeyName();
+	}
+
+
+	public function getKey()
+	{	
+		return $this->routeKey ? $this->{$this->getRouteKeyName()} : parent::getKey();	
+	}
+}

--- a/src/app/Models/Traits/CanGenerateUuid.php
+++ b/src/app/Models/Traits/CanGenerateUuid.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Backpack\CRUD\app\Models\Traits;
+
+use Illuminate\Support\Str;
+
+/**
+ * Generates a UUID on model creation accoriding to the public $uuidColumn parameter
+ */
+	
+trait CanGenerateUuid{
+    protected static function bootCanGenerateUuid()
+    {
+        static::creating(function ($model) {
+            if ($model->uuidColumn != null) {
+                $model->{$model->uuidColumn} = (string) Str::uuid();
+            }
+        });
+    }
+
+}

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -10,6 +10,8 @@ trait CrudTrait
     use HasUploadFields;
     use HasFakeFields;
     use HasTranslatableFields;
+    use CanGenerateUuid;
+    use CanChangeRouteKey;
 
     public static function hasCrudTrait()
     {


### PR DESCRIPTION
This is a set of 2 traits.  --- Easier Implementation of Pull #2223 
1. CanGenerateUuid -- which simply generates a UUID for the model in the column identifed by the public property $uuidColumn. Make sure to add the column to migrations.
2. CanChangeRouteKey - changes the route key used from the Primary key to something else by setting public property $routeKey. To use a 'uuid' column use `public $routeKey = 'uuid'`

There are changes to 4 core files to accomplish this. 
1. Add the traits to Backpack\CRUD\app\Models\Traits\CrudTrait
2. Change the way the 'Read' , 'Update', 'Delete' Traits search for the entry.

I ran the included tests and they pass --- I did not write any new ones. I'm not quite there yet. I did however put it in a project of mine and test it. I did not run into any issues. 

Most of the change route key is made possible by overriding Laravel's `getRouteKeyName()` function. 

