### PR TITLE
Fix issue where a nested relation on column would cause an exception on listing

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -364,10 +364,16 @@ trait Columns
     {
         $column = $this->makeSureColumnHasName($column);
         $column = $this->makeSureColumnHasLabel($column);
+        $column = $this->makeSureColumnHasEntity($column);
         $column = $this->makeSureColumnHasType($column);
         $column = $this->makeSureColumnHasKey($column);
         $column = $this->makeSureColumnHasPriority($column);
         $column = $this->makeSureColumnHasModel($column);
+
+        if(isset($column['entity']) && $column['entity'] !== false) {
+            $column['relation_type'] = $this->inferRelationTypeFromRelationship($column);
+        }
+
 
         // check if the column exists in the database (as a db column)
         $column_exists_in_db = $this->hasDatabaseColumn($this->model->getTable(), $column['name']);
@@ -376,16 +382,6 @@ trait Columns
         $column['tableColumn'] = $column['tableColumn'] ?? $column_exists_in_db;
         $column['orderable'] = $column['orderable'] ?? $column_exists_in_db;
         $column['searchLogic'] = $column['searchLogic'] ?? $column_exists_in_db;
-
-        // check if method exists in model so it's a possible relation
-        // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name']) && (Arr::get($column, 'entity') !== false);
-
-        if (! $column_exists_in_db && $could_be_relation) {
-            $related_model = $this->model->{$column['name']}()->getRelated();
-            $column['entity'] = $column['name'];
-            $column['model'] = get_class($related_model);
-        }
 
         return $column;
     }

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -379,9 +379,7 @@ trait Columns
 
         // check if method exists in model so it's a possible relation
         // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name'])
-            ? ! isset($column['entity']) || $column['entity'] !== false
-            : isset($column['entity']) && $column['entity'] !== false;
+        $could_be_relation = method_exists($this->model, $column['name']) && (Arr::get($column, 'entity') !== false);
 
         if (! $column_exists_in_db && $could_be_relation) {
             $related_model = $this->model->{$column['name']}()->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -370,10 +370,9 @@ trait Columns
         $column = $this->makeSureColumnHasPriority($column);
         $column = $this->makeSureColumnHasModel($column);
 
-        if(isset($column['entity']) && $column['entity'] !== false) {
+        if (isset($column['entity']) && $column['entity'] !== false) {
             $column['relation_type'] = $this->inferRelationTypeFromRelationship($column);
         }
-
 
         // check if the column exists in the database (as a db column)
         $column_exists_in_db = $this->hasDatabaseColumn($this->model->getTable(), $column['name']);

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -139,11 +139,17 @@ trait ColumnsProtectedMethods
             return $column;
         }
 
-        //if the name is dot notation we are sure it's a relationship
+        // if the name is dot notation it might be a relationship
         if (strpos($column['name'], '.') !== false) {
-            $column['entity'] = $column['name'];
+            $possibleMethodName = Str::before($column['name'], '.');
 
-            return $column;
+            // if the first part of the string exists as method,
+            // it is a relationship
+            if (method_exists($this->model, $possibleMethodName)) {
+                $column['entity'] = $column['name'];
+
+                return $column;
+            }
         }
 
         // if there's a method on the model with this name

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -80,7 +80,7 @@ trait ColumnsProtectedMethods
      */
     protected function makeSureColumnHasType($column)
     {
-        $could_be_relation = isset($column['entity']) && $column['entity'] !== false ? true : false;
+        $could_be_relation = isset($column['entity']) && $column['entity'] !== false;
 
         if (! isset($column['type']) && $could_be_relation) {
             $column['type'] = 'relationship';

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -80,11 +80,7 @@ trait ColumnsProtectedMethods
      */
     protected function makeSureColumnHasType($column)
     {
-        // check if method exists in model so it's a possible relation
-        // but exclude possible matches if developer setup entity => false
-        $could_be_relation = method_exists($this->model, $column['name'])
-            ? ! isset($column['entity']) || $column['entity'] !== false
-            : isset($column['entity']) && $column['entity'] !== false;
+        $could_be_relation = isset($column['entity']) && $column['entity'] !== false ? true : false;
 
         if (! isset($column['type']) && $could_be_relation) {
             $column['type'] = 'relationship';
@@ -132,6 +128,45 @@ trait ColumnsProtectedMethods
         return $column;
     }
 
+    protected function makeSureColumnHasEntity($column) {
+        if (isset($column['entity'])) {
+            return $column;
+        }
+
+        // if the name is an array it's definitely not a relationship
+        if (is_array($column['name'])) {
+            return $column;
+        }
+
+        //if the name is dot notation we are sure it's a relationship
+        if (strpos($column['name'], '.') !== false) {
+            $column['entity'] = $column['name'];
+
+            return $column;
+        }
+
+        // if there's a method on the model with this name
+        if (method_exists($this->model, $column['name'])) {
+            $column['entity'] = $column['name'];
+
+            return $column;
+        }
+
+        // if the name ends with _id and that method exists,
+        // we can probably use it as an entity
+        if (Str::endsWith($column['name'], '_id')) {
+            $possibleMethodName = Str::replaceLast('_id', '', $column['name']);
+
+            if (method_exists($this->model, $possibleMethodName)) {
+                $column['entity'] = $possibleMethodName;
+
+                return $column;
+            }
+        }
+
+        return $column;
+    }
+
     /**
      * If an entity has been defined for the column, but no model,
      * determine the model from that relationship.
@@ -143,7 +178,7 @@ trait ColumnsProtectedMethods
     {
         // if this is a relation type field and no corresponding model was specified,
         // get it from the relation method defined in the main model
-        if (isset($column['entity']) && ! isset($column['model'])) {
+        if (isset($column['entity']) && $column['entity'] !== false && ! isset($column['model'])) {
             $column['model'] = $this->getRelationModel($column['entity']);
         }
 

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -128,7 +128,8 @@ trait ColumnsProtectedMethods
         return $column;
     }
 
-    protected function makeSureColumnHasEntity($column) {
+    protected function makeSureColumnHasEntity($column)
+    {
         if (isset($column['entity'])) {
             return $column;
         }

--- a/src/resources/views/crud/columns/relationship.blade.php
+++ b/src/resources/views/crud/columns/relationship.blade.php
@@ -1,8 +1,6 @@
 {{-- relationships (switchboard; supports both single and multiple: 1-1, 1-n, n-n) --}}
 @php
-   $relationshipType = new ReflectionClass($entry->{$column['name']}());
-   $relationshipType = $relationshipType->getShortName();
-   $allows_multiple = $crud->guessIfFieldHasMultipleFromRelationType($relationshipType);
+   $allows_multiple = $crud->guessIfFieldHasMultipleFromRelationType($column['relation_type']);
 @endphp
 
 @if ($allows_multiple)

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -125,26 +125,33 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'searchLogic' => false,
             'entity'      => 'accountDetails',
             'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
+            'relation_type' => 'HasOne'
         ],
         'accountDetails__nickname' => [
             'name'        => 'accountDetails.nickname',
             'label'       => 'AccountDetails.nickname',
-            'type'        => 'text',
+            'type'        => 'relationship',
             'key'         => 'accountDetails__nickname',
             'priority'    => 1,
             'tableColumn' => false,
             'orderable'   => false,
             'searchLogic' => false,
+            'relation_type' => 'HasOne',
+            'entity' => 'accountDetails.nickname',
+            'model' => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails'
         ],
         'accountDetails__user' => [
             'name'        => 'accountDetails.user',
             'label'       => 'AccountDetails.user',
-            'type'        => 'text',
+            'type'        => 'relationship',
             'key'         => 'accountDetails__user',
             'priority'    => 2,
             'tableColumn' => false,
             'orderable'   => false,
             'searchLogic' => false,
+            'relation_type' => 'BelongsTo',
+            'entity' => 'accountDetails.user',
+            'model' => 'Backpack\CRUD\Tests\Unit\Models\User'
         ],
     ];
 
@@ -168,29 +175,47 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'orderable'   => false,
             'searchLogic' => false,
             'priority'    => 0,
+            'relation_type' => 'HasOne'
         ],
     ];
 
     private $nestedRelationColumnArray = [
-        'name'      => 'nickname',
-        'type'      => 'select',
-        'entity'    => 'user.accountDetails',
-        'attribute' => 'nickname',
+        'name'      => 'accountDetails.article',
+    ];
+
+    private $secondNestedRelationColumnArray = [
+        'name'      => 'accountDetails.article',
+        'attribute' => 'content',
+        'key'       => 'ac_article_content'
     ];
 
     private $expectedNestedRelationColumnArray = [
-        'nickname' => [
-            'name'        => 'nickname',
-            'type'        => 'select',
-            'entity'      => 'user.accountDetails',
-            'attribute'   => 'nickname',
-            'label'       => 'Nickname',
-            'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
-            'key'         => 'nickname',
+        'accountDetails__article' => [
+            'name'        => 'accountDetails.article',
+            'type'        => 'relationship',
+            'entity'      => 'accountDetails.article',
+            'label'       => 'AccountDetails.article',
+            'model'       => 'Backpack\CRUD\Tests\Unit\Models\Article',
+            'key'         => 'accountDetails__article',
             'tableColumn' => false,
             'orderable'   => false,
             'searchLogic' => false,
             'priority'    => 0,
+            'relation_type' => 'BelongsTo'
+        ],
+        'ac_article_content' => [
+            'name'        => 'accountDetails.article',
+            'type'        => 'relationship',
+            'entity'      => 'accountDetails.article',
+            'label'       => 'AccountDetails.article',
+            'model'       => 'Backpack\CRUD\Tests\Unit\Models\Article',
+            'key'         => 'ac_article_content',
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+            'priority'    => 1,
+            'relation_type' => 'BelongsTo',
+            'attribute' => 'content'
         ],
     ];
 
@@ -260,11 +285,17 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
 
         $this->assertEquals($this->expectedRelationColumnArray, $this->crudPanel->columns());
     }
-
+    /**
+     * Undocumented function
+     *
+     * @group failing
+     */
     public function testAddNestedRelationColumn()
     {
-        $this->crudPanel->setModel(Article::class);
+        $this->crudPanel->setModel(User::class);
         $this->crudPanel->addColumn($this->nestedRelationColumnArray);
+
+        $this->crudPanel->addColumn($this->secondNestedRelationColumnArray);
 
         $this->assertEquals($this->expectedNestedRelationColumnArray, $this->crudPanel->columns());
     }

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -2,6 +2,9 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
+use Backpack\CRUD\Tests\Unit\Models\Article;
+use Backpack\CRUD\Tests\Unit\Models\User;
+
 class CrudPanelColumnsTest extends BaseDBCrudPanelTest
 {
     private $oneColumnArray = [
@@ -110,6 +113,87 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
         ],
     ];
 
+    private $expectedRelationColumnsArray = [
+        'accountDetails' => [
+            'name'        => 'accountDetails',
+            'label'       => 'AccountDetails',
+            'type'        => 'relationship',
+            'key'         => 'accountDetails',
+            'priority'    => 0,
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+            'entity'      => 'accountDetails',
+            'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
+        ],
+        'accountDetails__nickname' => [
+            'name'        => 'accountDetails.nickname',
+            'label'       => 'AccountDetails.nickname',
+            'type'        => 'text',
+            'key'         => 'accountDetails__nickname',
+            'priority'    => 1,
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+        ],
+        'accountDetails__user' => [
+            'name'        => 'accountDetails.user',
+            'label'       => 'AccountDetails.user',
+            'type'        => 'text',
+            'key'         => 'accountDetails__user',
+            'priority'    => 2,
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+        ],
+    ];
+
+    private $relationColumnArray = [
+        'name'      => 'nickname',
+        'type'      => 'select',
+        'entity'    => 'accountDetails',
+        'attribute' => 'nickname',
+    ];
+
+    private $expectedRelationColumnArray = [
+        'nickname' => [
+            'name'        => 'nickname',
+            'type'        => 'select',
+            'entity'      => 'accountDetails',
+            'attribute'   => 'nickname',
+            'label'       => 'Nickname',
+            'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
+            'key'         => 'nickname',
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+            'priority'    => 0,
+        ],
+    ];
+
+    private $nestedRelationColumnArray = [
+        'name'      => 'nickname',
+        'type'      => 'select',
+        'entity'    => 'user.accountDetails',
+        'attribute' => 'nickname',
+    ];
+
+    private $expectedNestedRelationColumnArray = [
+        'nickname' => [
+            'name'        => 'nickname',
+            'type'        => 'select',
+            'entity'      => 'user.accountDetails',
+            'attribute'   => 'nickname',
+            'label'       => 'Nickname',
+            'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
+            'key'         => 'nickname',
+            'tableColumn' => false,
+            'orderable'   => false,
+            'searchLogic' => false,
+            'priority'    => 0,
+        ],
+    ];
+
     /**
      * Setup the test environment.
      *
@@ -157,6 +241,32 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
         $this->expectException(\ErrorException::class);
 
         $this->crudPanel->addColumns('column1');
+    }
+
+    public function testAddRelationsByName()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addColumn('accountDetails');
+        $this->crudPanel->addColumn('accountDetails.nickname');
+        $this->crudPanel->addColumn('accountDetails.user');
+
+        $this->assertEquals($this->expectedRelationColumnsArray, $this->crudPanel->columns());
+    }
+
+    public function testAddRelationColumn()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addColumn($this->relationColumnArray);
+
+        $this->assertEquals($this->expectedRelationColumnArray, $this->crudPanel->columns());
+    }
+
+    public function testAddNestedRelationColumn()
+    {
+        $this->crudPanel->setModel(Article::class);
+        $this->crudPanel->addColumn($this->nestedRelationColumnArray);
+
+        $this->assertEquals($this->expectedNestedRelationColumnArray, $this->crudPanel->columns());
     }
 
     public function testMoveColumnBefore()

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
-use Backpack\CRUD\Tests\Unit\Models\Article;
 use Backpack\CRUD\Tests\Unit\Models\User;
 
 class CrudPanelColumnsTest extends BaseDBCrudPanelTest
@@ -125,7 +124,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'searchLogic' => false,
             'entity'      => 'accountDetails',
             'model'       => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
-            'relation_type' => 'HasOne'
+            'relation_type' => 'HasOne',
         ],
         'accountDetails__nickname' => [
             'name'        => 'accountDetails.nickname',
@@ -138,7 +137,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'searchLogic' => false,
             'relation_type' => 'HasOne',
             'entity' => 'accountDetails.nickname',
-            'model' => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails'
+            'model' => 'Backpack\CRUD\Tests\Unit\Models\AccountDetails',
         ],
         'accountDetails__user' => [
             'name'        => 'accountDetails.user',
@@ -151,7 +150,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'searchLogic' => false,
             'relation_type' => 'BelongsTo',
             'entity' => 'accountDetails.user',
-            'model' => 'Backpack\CRUD\Tests\Unit\Models\User'
+            'model' => 'Backpack\CRUD\Tests\Unit\Models\User',
         ],
     ];
 
@@ -175,7 +174,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'orderable'   => false,
             'searchLogic' => false,
             'priority'    => 0,
-            'relation_type' => 'HasOne'
+            'relation_type' => 'HasOne',
         ],
     ];
 
@@ -186,7 +185,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
     private $secondNestedRelationColumnArray = [
         'name'      => 'accountDetails.article',
         'attribute' => 'content',
-        'key'       => 'ac_article_content'
+        'key'       => 'ac_article_content',
     ];
 
     private $expectedNestedRelationColumnArray = [
@@ -201,7 +200,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'orderable'   => false,
             'searchLogic' => false,
             'priority'    => 0,
-            'relation_type' => 'BelongsTo'
+            'relation_type' => 'BelongsTo',
         ],
         'ac_article_content' => [
             'name'        => 'accountDetails.article',
@@ -215,7 +214,7 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
             'searchLogic' => false,
             'priority'    => 1,
             'relation_type' => 'BelongsTo',
-            'attribute' => 'content'
+            'attribute' => 'content',
         ],
     ];
 
@@ -285,8 +284,9 @@ class CrudPanelColumnsTest extends BaseDBCrudPanelTest
 
         $this->assertEquals($this->expectedRelationColumnArray, $this->crudPanel->columns());
     }
+
     /**
-     * Undocumented function
+     * Undocumented function.
      *
      * @group failing
      */

--- a/tests/Unit/Models/AccountDetails.php
+++ b/tests/Unit/Models/AccountDetails.php
@@ -10,7 +10,7 @@ class AccountDetails extends Model
     use CrudTrait;
 
     protected $table = 'account_details';
-    protected $fillable = ['user_id', 'nickname', 'profile_picture'];
+    protected $fillable = ['user_id', 'nickname', 'profile_picture', 'article_id'];
 
     /**
      * Get the user for the account details.
@@ -29,4 +29,10 @@ class AccountDetails extends Model
     {
         return $this->nickname.'++';
     }
+
+    public function article() {
+        return $this->belongsTo('Backpack\CRUD\Tests\Unit\Models\Article');
+    }
+
+
 }

--- a/tests/Unit/Models/AccountDetails.php
+++ b/tests/Unit/Models/AccountDetails.php
@@ -30,9 +30,8 @@ class AccountDetails extends Model
         return $this->nickname.'++';
     }
 
-    public function article() {
+    public function article()
+    {
         return $this->belongsTo('Backpack\CRUD\Tests\Unit\Models\Article');
     }
-
-
 }

--- a/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
+++ b/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
@@ -26,12 +26,11 @@ class CreateAccountDetailsTable extends Migration
                 ->on('users')
                 ->onDelete('cascade');
 
-                $table->foreign('article_id')
+            $table->foreign('article_id')
                 ->references('id')
                 ->on('articles')
                 ->onDelete('cascade');
-
-            });
+        });
     }
 
     /**

--- a/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
+++ b/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
@@ -18,13 +18,20 @@ class CreateAccountDetailsTable extends Migration
             $table->integer('user_id')->length(10)->unsigned();
             $table->string('nickname');
             $table->string('profile_picture');
+            $table->bigInteger('article_id')->nullable();
             $table->timestamps();
 
             $table->foreign('user_id')
                 ->references('id')
                 ->on('users')
                 ->onDelete('cascade');
-        });
+
+                $table->foreign('article_id')
+                ->references('id')
+                ->on('articles')
+                ->onDelete('cascade');
+
+            });
     }
 
     /**


### PR DESCRIPTION
In commit a7aa59b269e73b0dc5a1929487b49680add2c154 the `makeSureColumnHasNeededAttributes` method was refactored, to have more situations in which `$could_be_relation` is considered true.

However this raises a weird bug with the next if clause: if `method_exists($this->model, $column['name'])` is equal to false, the call `$this->model->{$column['name']}()->getRelated();` below will _always_ raise a `BadMethodCallException`, since the boolean just showed that `$this->model` has no method named `$column['name']`.

I adjusted the code so that it now correctly excludes the `entity === false` case, but ignores the column if no method exists.

See also issue https://github.com/Laravel-Backpack/CRUD/issues/3503.