### PR TITLE
Fix color_picker field.

### DIFF
--- a/src/resources/views/crud/fields/color_picker.blade.php
+++ b/src/resources/views/crud/fields/color_picker.blade.php
@@ -11,9 +11,9 @@
             data-init-function="bpFieldInitColorPickerElement"
             @include('crud::fields.inc.attributes')
         	>
-            <span class="input-group-append">
-                <span class="input-group-text colorpicker-input-addon"><i></i></span>
-            </span>
+        <span class="input-group-append">
+            <span class="input-group-text colorpicker-input-addon"><i></i></span>
+        </span>
     </div>
 
     {{-- HINT --}}

--- a/src/resources/views/crud/fields/color_picker.blade.php
+++ b/src/resources/views/crud/fields/color_picker.blade.php
@@ -4,17 +4,16 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
     <div class="input-group colorpicker-component">
-
         <input
         	type="text"
         	name="{{ $field['name'] }}"
             value="{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}"
             data-init-function="bpFieldInitColorPickerElement"
             @include('crud::fields.inc.attributes')
-        	>
-        <div class="input-group-addon">
-            <i class="color-preview-{{ $field['name'] }}"></i>
-        </div>
+			>
+		<span class="input-group-append">
+			<span class="input-group-text colorpicker-input-addon"><i></i></span>
+		</span>
     </div>
 
     {{-- HINT --}}
@@ -33,7 +32,17 @@
 
     {{-- FIELD CSS - will be loaded in the after_styles section --}}
     @push('crud_fields_styles')
-        <link rel="stylesheet" href="{{ asset('packages/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css') }}" />
+		<link rel="stylesheet" href="{{ asset('packages/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css') }}" />
+		<style>
+			.input-group>.input-group-append>.input-group-text{
+				border: 1px solid rgba(0,40,100,.12);
+			}
+			.input-group>.input-group-append>.input-group-text:focus{
+				border-color: #9080f1;
+				outline: 0;
+				box-shadow: 0 0 0 2px #e1dcfb;
+			}
+		</style>
     @endpush
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
@@ -41,7 +50,7 @@
     <script type="text/javascript" src="{{ asset('packages/bootstrap-colorpicker/dist/js/bootstrap-colorpicker.min.js') }}"></script>
     <script>
         function bpFieldInitColorPickerElement(element) {
-            // https://itsjaviaguilar.com/bootstrap-colorpicker/
+            // https://itsjavi.com/bootstrap-colorpicker/
             var config = jQuery.extend({}, {!! isset($field['color_picker_options']) ? json_encode($field['color_picker_options']) : '{}' !!});
             var picker = element.parents('.colorpicker-component').colorpicker(config);
 

--- a/src/resources/views/crud/fields/color_picker.blade.php
+++ b/src/resources/views/crud/fields/color_picker.blade.php
@@ -10,10 +10,10 @@
             value="{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}"
             data-init-function="bpFieldInitColorPickerElement"
             @include('crud::fields.inc.attributes')
-			>
-		<span class="input-group-append">
-			<span class="input-group-text colorpicker-input-addon"><i></i></span>
-		</span>
+        	>
+            <span class="input-group-append">
+                <span class="input-group-text colorpicker-input-addon"><i></i></span>
+            </span>
     </div>
 
     {{-- HINT --}}
@@ -34,12 +34,12 @@
     @push('crud_fields_styles')
 		<link rel="stylesheet" href="{{ asset('packages/bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css') }}" />
 		<style>
-			.input-group>.input-group-append>.input-group-text{
+			.input-group>.input-group-append>.input-group-text {
 				border: 1px solid rgba(0,40,100,.12);
 			}
-			.input-group>.input-group-append>.input-group-text:focus{
-				border-color: #9080f1;
+			.input-group>.input-group-append>.input-group-text:focus {
 				outline: 0;
+				border-color: #9080f1;
 				box-shadow: 0 0 0 2px #e1dcfb;
 			}
 		</style>


### PR DESCRIPTION
Color picker preview is not working as expected. Example from [demo.backpackforlaravel.com](https://demo.backpackforlaravel.com/admin/monster/create#miscellaneous):
![image](https://user-images.githubusercontent.com/17077712/106618479-2b305200-6578-11eb-9746-ec6f74a24215.png)

Added proper html markup and styling to fit in the theme. Example of the fixed version which includes extra options to create swatches and use of horizontal line-up:
![image](https://user-images.githubusercontent.com/17077712/106618784-87937180-6578-11eb-8d1b-9ab99e48f580.png)

In the docs, options of this field are misleading, I'll be giving a touch there too.