### PR TITLE
The endDate format miss an H in format, when the hidden fields value are set in the javascript 

### DIFF
--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -117,7 +117,7 @@
 
                 $visibleInput.on('apply.daterangepicker hide.daterangepicker', function(e, picker){
                     $startInput.val( picker.startDate.format('YYYY-MM-DD HH:mm:ss') );
-                    $endInput.val( picker.endDate.format('YYYY-MM-DD H:mm:ss') );
+                    $endInput.val( picker.endDate.format('YYYY-MM-DD HH:mm:ss') );
                 });
         }
     </script>
@@ -125,4 +125,3 @@
 
 @endif
 {{-- End of Extra CSS and JS --}}
-


### PR DESCRIPTION
On event $visibleInput apply.daterangepicker hide.daterangepicker, on line 120.

Oh I saw that I remove too the end line at the bottom. I didn't search if it's a prerequist in code style of CRUD ? It was a reflex.

Let me know if I need to get it back :)