### PR TITLE
use filter key instead of name in range filter

### DIFF
--- a/src/resources/views/crud/filters/range.blade.php
+++ b/src/resources/views/crud/filters/range.blade.php
@@ -120,7 +120,7 @@ END OF FILTER JAVSCRIPT CHECKLIST --}}
 			$(".range-filter-{{ $filter->key }}-clear-button").click(function(e) {
 				e.preventDefault();
 
-				$('li[filter-name={{ $filter->key }}]').trigger('filter:clear');
+				$('li[filter-key={{ $filter->key }}]').trigger('filter:clear');
 			})
 
 		});


### PR DESCRIPTION
This have been reported in #3492 

It slipped us while refactoring the filters to use `key`.