### PR TITLE
fix inline quirks

### DIFF
--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -31,7 +31,7 @@ trait InlineCreateOperation
     /**
      *  This operation have some known quirks that can only be addressed using this setup instead of `setupInlineCreateDefaults`
      *  1 - InlineCreateOperation must be added AFTER CreateOperation trait.
-     *  2 - setup() in controllers that have the InlineCreateOperations need to be called twice (technically we are re-creating a new crud)
+     *  2 - setup() in controllers that have the InlineCreateOperations need to be called twice (technically we are re-creating a new crud).
      *
      *  Both problems are solved using this setup because it will only be called when InlineCreate route is requested, so even that we need to call
      *  setup again (we are creating a "new" crud panel to show in modal), it will not affect other operation setups.

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -29,10 +29,21 @@ trait InlineCreateOperation
     }
 
     /**
-     * Setup operation default settings. We run setup() and setupCreateOperation() because those are run in middleware
-     * and to get the fields we need them earlier in application lifecycle.
+     *  This operation have some known quirks that can only be addressed using this setup instead of `setupInlineCreateDefaults`
+     *  1 - InlineCreateOperation must be added AFTER CreateOperation trait.
+     *  2 - setup() in controllers that have the InlineCreateOperations need to be called twice (technically we are re-creating a new crud)
+     *
+     *  Both problems are solved using this setup because it will only be called when InlineCreate route is requested, so even that we need to call
+     *  setup again (we are creating a "new" crud panel to show in modal), it will not affect other operation setups.
+     *
+     *  The downside of it, and why we need this explanation note, is that using `setupInlineCreateOperation`
+     *  in your CrudController to override/configure this operation will not have the same behaviour as
+     *  other operations.
+     *
+     *  Usually you would just `setupSomeOperation()` and add your own setup of the operation. In this specific case is a little bit different,
+     *  this code is the minimum needed to run the operation, and should be present if you override this method in your CrudController.
      */
-    protected function setupInlineCreateDefaults()
+    public function setupInlineCreateOperation()
     {
         if (method_exists($this, 'setup')) {
             $this->setup();


### PR DESCRIPTION
@tabacitu I think the only problem here is the fact the we use `setupInlineCreateDefaults` instead of `setupInlineCreateOperation`. 

I think we had a discussion about this and we settled in setting up `setupInlineCreateDefaults` so developers can `setupInlineCreateOperation` to override/add to the defaults (like any other operation). 

The big difference here is that InlineCreate is indeed an Operation that depends on other operation (create). There is no way to have an inline create without having a CreateOperation in the endpoint. (Monster -> Product beeing Product the endpoint, that's going to be created).

In the create part, developers could use only `setup()` to setup (who would have guessed!!!!) other operations using closures: 

```php

public function setup() {
// ...

$this->crud->operation('list', function() {
    $this->crud->addColumn(...);
});

$this->crud->operation(['create', 'update'], function() {
    $this->crud->addField(...);
});
}
```

So yeah, we need to account for that and call `setup()` and also check for the possible `setupCreateOperation`. 

### key part

That all beeing said, using `setupInlineCreateDefaults` is the "standard" way of setting up an operation. The problem here is the fact that the defaults **are applied at the same time to all operations,** no matter what operation you are in (this is ok, and have no issues in any other operations because they don't call other `CrudController` methods like `setup()`). 

When you hit the operation route beeing it `create` or `InlineCreate` is when Backpack will load the `setupSomeOperationOperation`, so if we move our `setupInlineCreateDefaults` into `setupInlineCreateOperation` this bugs are gone, because we will call the `setup()` and/or the `setupCreateOperation` only when needed (when the InlineCreate routes are requested).

Ofcourse there is implications to this. If developers need to configure or override the InlineCreate they need to carry our `backpack code` to theirs `setupInlineCreateOperation` because it's the minimal to make it work. 

At this moment this is a breaking change. :(
