### PR TITLE
infer ajax from data_source if no ajax specified

### DIFF
--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -5,7 +5,7 @@
         $field['inline_create'] = [true];
     }
     $field['multiple'] = $field['multiple'] ?? $crud->relationAllowsMultiple($field['relation_type']);
-    $field['ajax'] = $field['ajax'] ?? false;
+    $field['ajax'] = $field['ajax'] ?? isset($field['data_source']) ? true : false;
     $field['placeholder'] = $field['placeholder'] ?? ($field['multiple'] ? trans('backpack::crud.select_entries') : trans('backpack::crud.select_entry'));
     $field['attribute'] = $field['attribute'] ?? (new $field['model'])->identifiableAttribute();
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -5,7 +5,7 @@
         $field['inline_create'] = [true];
     }
     $field['multiple'] = $field['multiple'] ?? $crud->relationAllowsMultiple($field['relation_type']);
-    $field['ajax'] = $field['ajax'] ?? isset($field['data_source']) ? true : false;
+    $field['ajax'] = $field['ajax'] ?? isset($field['data_source']);
     $field['placeholder'] = $field['placeholder'] ?? ($field['multiple'] ? trans('backpack::crud.select_entries') : trans('backpack::crud.select_entry'));
     $field['attribute'] = $field['attribute'] ?? (new $field['model'])->identifiableAttribute();
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
@@ -37,4 +37,3 @@
 @endphp
 
 @include('crud::fields.relationship.'.$field['type'])
-


### PR DESCRIPTION
In relationship field, if you define `data_source` but don't define `ajax => true`, field would not be an ajax field ignoring `data_source` definition. 

When developer define `data_source`, ajax should be true if not otherwise specified .

This:

- If `ajax => true` you need `data_source` **ONLY** if your `name` does not match `fetchName` or **not using fetch operation**, otherwise you are good to go.

- if you specify `data_source => smt`, even if smt is a fetch url, at the present moment the field would not be `ajax` unless you specify `ajax => true` plus `data_source`.

Like I said, I don't think people define `data_source` if they don't want an ajax field. It's the only use of it 👍 😺
 