### PR TITLE
Fire 'change' event when selecting radio elements

### DIFF
--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -70,8 +70,8 @@
 
             // when one radio input is selected
             element.find('input[type=radio]').change(function(event) {
-                // the value gets updated in the hidden input
-                hiddenInput.val($(this).val());
+                // the value gets updated in the hidden input and the 'change' event is fired
+                hiddenInput.val($(this).val()).change();
                 // all other radios get unchecked
                 element.find('input[type=radio]').not(this).prop('checked', false);
             });


### PR DESCRIPTION
Allows for custom JS such as:
```
var elem = $('input[name="radio_choice"]');
elem.change(function() {
    console.log(this);
});