### PR TITLE
[Bug] DataTables resetting to first page on bulk actions

### DIFF
--- a/src/resources/views/crud/buttons/bulk_clone.blade.php
+++ b/src/resources/views/crud/buttons/bulk_clone.blade.php
@@ -58,7 +58,7 @@
 				          }).show();
 
 						  crud.checkedItems = [];
-						  crud.table.ajax.reload();
+						  crud.table.draw(false);
 						},
 						error: function(result) {
 						  // Show an alert with the result

--- a/src/resources/views/crud/buttons/bulk_delete.blade.php
+++ b/src/resources/views/crud/buttons/bulk_delete.blade.php
@@ -80,8 +80,13 @@
 								  }			          	  
 							}
 
-						  	crud.checkedItems = [];
-							  	crud.table.ajax.reload();
+							// Move to previous page in case of deleting all the items in table
+							if(crud.table.rows().count() === crud.checkedItems.length) {
+								crud.table.page("previous");
+							}
+
+							crud.checkedItems = [];
+							crud.table.draw(false);
 						},
 						error: function(result) {
 							// Show an alert with the result

--- a/src/resources/views/crud/buttons/clone.blade.php
+++ b/src/resources/views/crud/buttons/clone.blade.php
@@ -30,7 +30,7 @@
                   $('.modal').modal('hide');
 
                   if (typeof crud !== 'undefined') {
-                    crud.table.ajax.reload();
+                    crud.table.draw(false);
                   }
               },
               error: function(result) {

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -31,6 +31,11 @@
 			          if (result == 1) {
 						  // Redraw the table
 						  if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+							  // Move to previous page in case of deleting the only item in table
+							  if(crud.table.rows().count() === 1) {
+							    crud.table.page("previous");
+							  }
+
 							  crud.table.draw(false);
 						  }
 


### PR DESCRIPTION
As @gthu96 reported on #3524, Data tables are reloading resetting to first page on bulk actions clone/delete.
This PR fix that behavior, keeping the user on the current page.

This fix also validates if while deleting the remaining rows on the last page, data tables would move the previous page.