### PR TITLE
Allow validation from rules next to custom Request class

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -11,10 +11,22 @@ trait Validation
      *
      * @param array $requiredFields
      */
-    public function setValidationFromArray(array $requiredFields)
+    public function setValidationFromArray(array $rules)
     {
-        $this->setOperationSetting('requiredFields', array_keys($requiredFields));
-        $this->setOperationSetting('validationRules', $requiredFields);
+        $requiredFields = [];
+
+        if (count($rules)) {
+            foreach ($rules as $key => $rule) {
+                if (
+                    (is_string($rule) && strpos($rule, 'required') !== false && strpos($rule, 'required_') === false) ||
+                    (is_array($rule) && array_search('required', $rule) !== false && array_search('required_', $rule) === false)
+                ) {
+                    $requiredFields[] = $key;
+                }
+            }
+        }
+        $this->setOperationSetting('requiredFields', $requiredFields);
+        $this->setOperationSetting('validationRules', $rules);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -7,6 +7,17 @@ use Illuminate\Foundation\Http\FormRequest;
 trait Validation
 {
     /**
+     * Adds the required rules from an array and allows validation of that array.
+     *
+     * @param array $requiredFields
+     */
+    public function setValidationFromArray(array $requiredFields)
+    {
+        $this->setOperationSetting('requiredFields', array_keys($requiredFields));
+        $this->setOperationSetting('validationRules', $requiredFields);
+    }
+
+    /**
      * Mark a FormRequest file as required for the current operation, in Settings.
      * Adds the required rules to an array for easy access.
      *
@@ -71,6 +82,11 @@ trait Validation
             $request = app($formRequest);
         } else {
             $request = $this->getRequest();
+
+            if ($this->hasOperationSetting('validationRules')) {
+                $rules = $this->getOperationSetting('validationRules');
+                $request->validate($rules);
+            }
         }
 
         return $request;


### PR DESCRIPTION
For me it's annoying - especially in a large project - to write custom FormRequests for the validation of each and every CRUD. Laravel provides already functionality to validate the "default" Request using a set of rules in an array.

This PR adds this functionality to Backpack