### PR TITLE
prefixes in repeatable fields that need them

### DIFF
--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -89,7 +89,7 @@
     <div class="btn-group">
         <div class="btn btn-light btn-sm btn-file">
             {{ trans('backpack::crud.choose_file') }} <input type="file" accept="image/*" data-handle="uploadImage"  @include('crud::fields.inc.attributes')>
-            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" value="{{ $value }}">
+            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" data-value-prefix="{{$field['prefix']}}" value="{{ $value }}">
         </div>
         @if(isset($field['crop']) && $field['crop'])
         <button class="btn btn-light btn-sm" data-handle="rotateLeft" type="button" style="display: none;"><i class="la la-rotate-left"></i></button>

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -89,7 +89,7 @@
     <div class="btn-group">
         <div class="btn btn-light btn-sm btn-file">
             {{ trans('backpack::crud.choose_file') }} <input type="file" accept="image/*" data-handle="uploadImage"  @include('crud::fields.inc.attributes')>
-            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" data-value-prefix="{{$field['prefix']}}" value="{{ $value }}">
+            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" data-value-prefix="{{ $field['prefix'] }}" value="{{ $value }}">
         </div>
         @if(isset($field['crop']) && $field['crop'])
         <button class="btn btn-light btn-sm" data-handle="rotateLeft" type="button" style="display: none;"><i class="la la-rotate-left"></i></button>

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -217,7 +217,15 @@
                 // set the value on field inputs, based on the JSON in the hidden input
                 new_field_group.find('input, select, textarea').each(function () {
                     if ($(this).data('repeatable-input-name')) {
-                        $(this).val(values[$(this).data('repeatable-input-name')]);
+
+                        // if the field provides a `data-value-prefix` attribute, we should respect that and add that prefix to the value.
+                        // this is different than using prefix in fields like text, number etc. In those cases the prefix is used
+                        // only for displaying purposes, when is set as `data-value-prefix` is when it is part of the value
+                        // like image field.
+
+                        let valuePrefix = $(this).data('value-prefix') ?? '';
+
+                        $(this).val(valuePrefix+values[$(this).data('repeatable-input-name')]);
 
                         // if it's a Select input with no options, also attach the values as a data attribute;
                         // this is done because the above val() call will do nothing if the options aren't there

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -222,7 +222,6 @@
                         // this is different than using prefix in fields like text, number etc. In those cases the prefix is used
                         // only for displaying purposes, when is set as `data-value-prefix` is when it is part of the value
                         // like image field.
-
                         let valuePrefix = $(this).data('value-prefix') ?? '';
 
                         $(this).val(valuePrefix+values[$(this).data('repeatable-input-name')]);


### PR DESCRIPTION
refs: #3500 

Summary: as image field required the `prefix` to be added to the value when displaying the image, in repeatable we set the value directly from DB with js, so no prefix added to value.

This change allows ANY field that setup `data-value-prefix` in it's definition, to have a prefix added into the value that we store in database. 

I am not sure this is the best solution, hope we can come up with something together @promatik 