### PR TITLE
dont add the orders to table instead of clearing them

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -99,7 +99,7 @@ trait ListOperation
                 $column_number = $order['column'];
                 $column_direction = $order['dir'];
                 $column = $this->crud->findColumnById($column_number);
-                if ($column['tableColumn']) {
+                if ($column['tableColumn'] && !isset($column['orderLogic'])) {
                     // apply the current orderBy rules
                     $this->crud->orderByWithPrefix($column['name'], $column_direction);
                 }

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -99,7 +99,7 @@ trait ListOperation
                 $column_number = $order['column'];
                 $column_direction = $order['dir'];
                 $column = $this->crud->findColumnById($column_number);
-                if ($column['tableColumn'] && !isset($column['orderLogic'])) {
+                if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
                     $this->crud->orderByWithPrefix($column['name'], $column_direction);
                 }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -74,8 +74,6 @@ trait Query
             return $this->query;
         }
 
-        $this->query->getQuery()->orders = null;
-
         $orderLogic = $column['orderLogic'];
 
         if (is_callable($orderLogic)) {


### PR DESCRIPTION
Like reported and merged in https://github.com/Laravel-Backpack/CRUD/pull/3428

Backpack were limiting the ordering of the table to 1 column at a time. That PR allowed to order by multiple columns removing the constraint from backpack. 

Problem is that in `customLogic`, backpack still clears any past orders (assuming there would only be one as before), to add only the custom order by. 

This PR removed that constraint from the `orderLogic` and adds the custom `orderLogic` on top of any orders previously set in crud. 

Also, if you were ordering by a foreign column, eg. for monsters:

```php
$this->crud->addColumns([
            'text',
            'textarea',
            [   // 1-n relationship
                'label'     => 'Select', // Table column heading
                'type'      => 'select',
                'name'      => 'select', // the column that contains the ID of that connected entity;
                'entity'    => 'category', // the method that defines the relationship in your Model
                'attribute' => 'name', // foreign key attribute that is shown to user
                'model'     => "Backpack\NewsCRUD\app\Models\Category", // foreign key model
                'wrapper'   => [
                    'href' => function ($crud, $column, $entry, $related_key) {
                        return backpack_url('category/'.$related_key.'/show');
                    },
                ],
                'orderLogic' => function ($query, $column, $columnDirection) {
                    return $query->leftJoin('categories', 'categories.id', '=', 'monsters.select')->orderBy('categories.name', $columnDirection)->select('monsters.*');
                },
            ],
    ]);

```
`select` is a column that exists in the monsters table, it's like `category_id`, but the ordering would be by `category.name`, not `monsters.category_id`. So when `orderLogic` is set, we don't apply backpack logic. This is not a BC because previously backpack would clear this order in `customLogic()`.
