### PR TITLE
Fix for DOMContentLoaded event using onDomReady helper

### DIFF
--- a/src/resources/views/base/inc/alerts.blade.php
+++ b/src/resources/views/base/inc/alerts.blade.php
@@ -2,7 +2,7 @@
 <script type="text/javascript">
     // This is intentionaly run after dom loads so this way we can avoid showing duplicate alerts
     // when the user is beeing redirected by persistent table, that happens before this event triggers.
-    window.addEventListener('DOMContentLoaded', function() {
+    onDomReady().then(() => {
         Noty.overrideDefaults({
             layout: 'topRight',
             theme: 'backstrap',

--- a/src/resources/views/base/inc/scripts.blade.php
+++ b/src/resources/views/base/inc/scripts.blade.php
@@ -10,9 +10,7 @@
     @endforeach
 @endif
 
-@include('backpack::inc.alerts')
-
-<!-- page script -->
+{{-- page script --}}
 <script type="text/javascript">
     // To make Pace works on Ajax calls
     $(document).ajaxStart(function() { Pace.restart(); });
@@ -30,4 +28,15 @@
     $('.nav-tabs a').on('shown.bs.tab', function (e) {
         location.hash = e.target.hash.replace("#tab_", "#");
     });
+
+    // On DOM Ready promise helper
+    function onDomReady() {
+        return new Promise(resolve => {
+            document.readyState === 'loading'
+                ? document.addEventListener('DOMContentLoaded', resolve)
+                : resolve();
+        });
+    }
 </script>
+
+@include('backpack::inc.alerts')

--- a/src/resources/views/base/inc/scripts.blade.php
+++ b/src/resources/views/base/inc/scripts.blade.php
@@ -22,14 +22,15 @@
         }
     });
 
-    {{-- Enable deep link to tab --}}
+    // Enable deep link to tab
     var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');
     location.hash && activeTab && activeTab.tab('show');
     $('.nav-tabs a').on('shown.bs.tab', function (e) {
         location.hash = e.target.hash.replace("#tab_", "#");
     });
 
-    // On DOM Ready promise helper
+    // On DOM Ready promise helper, used to to avoid conflicts when DOMContentLoad is needed and some page optimizers
+    // like Cloudflare Rocket Load defers the initialization of Javascript to after the content load.
     function onDomReady() {
         return new Promise(resolve => {
             document.readyState === 'loading'


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/CRUD/issues/3540.

With this `onDomReady` promise helper, we may use it everywhere we need a `DOMContentLoaded` event and we avoid future similar problems.

EDIT:
I know we're bloating the DOM a little 😬
But this is a really useful helper, I use it everywhere, and now that I know about cloud flare messing-with-loading-order thing, this makes even more sense.

@tabacitu let me know if we shouldn't use it for any reason.