### PR TITLE
fix sql vector in order by clauses

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -96,8 +96,12 @@ trait ListOperation
             // clear any past orderBy rules
             $this->crud->query->getQuery()->orders = null;
             foreach ((array) request()->input('order') as $order) {
-                $column_number = $order['column'];
+                $column_number = (int)$order['column'];
                 $column_direction = $order['dir'];
+
+                if(!in_array(strtolower($order['dir']), ['asc', 'desc'])) {
+                    $column_direction = 'asc';
+                }
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn']) {
                     // apply the current orderBy rules

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -97,7 +97,7 @@ trait ListOperation
             $this->crud->query->getQuery()->orders = null;
             foreach ((array) request()->input('order') as $order) {
                 $column_number = (int) $order['column'];
-                $column_direction = (string)$order['dir'];
+                $column_direction = (string) $order['dir'];
 
                 if (! in_array(strtolower($order['dir']), ['asc', 'desc'])) {
                     $column_direction = 'asc';

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -97,11 +97,7 @@ trait ListOperation
             $this->crud->query->getQuery()->orders = null;
             foreach ((array) request()->input('order') as $order) {
                 $column_number = (int) $order['column'];
-                $column_direction = (string) $order['dir'];
-
-                if (! in_array(strtolower($order['dir']), ['asc', 'desc'])) {
-                    $column_direction = 'asc';
-                }
+                $column_direction = (strtolower((string) $order['dir']) == 'asc' ? 'ASC' : 'DESC');
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn']) {
                     // apply the current orderBy rules

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -96,10 +96,10 @@ trait ListOperation
             // clear any past orderBy rules
             $this->crud->query->getQuery()->orders = null;
             foreach ((array) request()->input('order') as $order) {
-                $column_number = (int)$order['column'];
+                $column_number = (int) $order['column'];
                 $column_direction = $order['dir'];
 
-                if(!in_array(strtolower($order['dir']), ['asc', 'desc'])) {
+                if (! in_array(strtolower($order['dir']), ['asc', 'desc'])) {
                     $column_direction = 'asc';
                 }
                 $column = $this->crud->findColumnById($column_number);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -97,7 +97,7 @@ trait ListOperation
             $this->crud->query->getQuery()->orders = null;
             foreach ((array) request()->input('order') as $order) {
                 $column_number = (int) $order['column'];
-                $column_direction = $order['dir'];
+                $column_direction = (string)$order['dir'];
 
                 if (! in_array(strtolower($order['dir']), ['asc', 'desc'])) {
                     $column_direction = 'asc';


### PR DESCRIPTION
The only injectable parameter was `dir`.

Whitelisting the `dir` closes the vector. 

For sake of future us, also casting to `int` the column number. 

ping @tabacitu 

