### PR TITLE
Fix eager load nested relationships

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -84,15 +84,15 @@ trait Read
     {
         $relationships = $this->getColumnsRelationships();
 
-        foreach($relationships as $relation) {
-            if(strpos($relation, '.') !== false) {
-
+        foreach ($relationships as $relation) {
+            if (strpos($relation, '.') !== false) {
                 $relation_parts = explode('.', $relation);
                 $last_relation_part = array_pop($relation_parts);
 
                 $last_valid_relation_method = array_reduce(array_splice($relation_parts, 0, count($relation_parts)), function ($obj, $method) {
                     try {
                         $result = $obj->$method();
+
                         return $result->getRelated();
                     } catch (Exception $e) {
                         return $method;
@@ -101,10 +101,9 @@ trait Read
 
                 // when this keys don't match means the last part of the relation string is the attribute in the relation and
                 // not a nested relation. In that case, we should eager load the relation but not the attribute
-                if($last_valid_relation_method != $last_relation_part) {
+                if ($last_valid_relation_method != $last_relation_part) {
                     // remove the last part of the relation string because it is the attribute in the relationship
-                    $relation = substr($relation, 0, strrpos( $relation, '.') );
-
+                    $relation = substr($relation, 0, strrpos($relation, '.'));
                 }
             }
             $this->with($relation);
@@ -126,6 +125,7 @@ trait Read
         foreach ($entries as $key => $entry) {
             $entry->addFakes($this->getFakeColumnsAsArray());
         }
+
         return $entries;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -87,15 +87,15 @@ trait Read
         foreach ($relationships as $relation) {
             if (strpos($relation, '.') !== false) {
                 $relation_parts = explode('.', $relation);
-                $last_relation_part = array_pop($relation_parts);
+                $last_relation_part = $last_valid_relation_method = end($relation_parts);
 
-                $last_valid_relation_method = array_reduce(array_splice($relation_parts, 0, count($relation_parts)), function ($obj, $method) {
+                array_reduce(array_splice($relation_parts, 0, count($relation_parts)), function ($obj, $method) use (&$last_valid_relation_method) {
                     try {
                         $result = $obj->$method();
-
+                        $last_valid_relation_method = $method;
                         return $result->getRelated();
                     } catch (Exception $e) {
-                        return $method;
+                        return;
                     }
                 }, $this->model);
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -93,6 +93,7 @@ trait Read
                     try {
                         $result = $obj->$method();
                         $last_valid_relation_method = $method;
+
                         return $result->getRelated();
                     } catch (Exception $e) {
                         return;


### PR DESCRIPTION
Reported in https://github.com/Laravel-Backpack/CRUD/issues/3556

Introduced in: https://github.com/Laravel-Backpack/CRUD/pull/3504

This PR aims to keep backward compatibility. 

In a BelongsTo relation, developers are used to: 

```php
$this->crud->addColumn([
    'name' => 'relation.attribute'
]);
```

The problem here is using the `attribute` in the relation name, we were setting the `relation` to be eager loaded with the attribute too, that would fail because attribute is not a relation of relation. 

Developer should be able to just `$this->crud->addColumn('belongs_to_relation_name')`. The attribute is infered from model, or could be specified when needed. 

This PR checks if the relation string contains the attribute and remove it when eager load the relations `with()`. 

There is no performance issue doing `with(relation1, relation2)` vs, unlimited amount of `with(single_relation)` AFAIK. 

