### PR TITLE
add json as text column type

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -81,7 +81,7 @@ trait FetchOperation
             $config['query']->get();
         }
 
-        $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array'];
+        $textColumnTypes = ['string', 'json_string', 'text', 'longText', 'json_array', 'json'];
 
         // if the query builder brings any where clause already defined by the user we must
         // ensure that the where prevails and we should only use our search as a complement to the query constraints.


### PR DESCRIPTION
Our `FetchOperation` is broken for `json` columns since `dbal` deprecated `array_json`.

This adds back `json` column support (as text column) to the FetchOperation.

I didn't remove the deprecated yet, as they are not hurting us, and some people might still using them even if deprecated. 