### PR TITLE
Better way to find the custom route position

### DIFF
--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -58,8 +58,8 @@ class AddCustomRouteContent extends Command
             }
 
             $end_line_number = $this->customRoutesFileEndLine($file_lines);
-            $file_lines[$end_line_number + 1] = $file_lines[$end_line_number];
-            $file_lines[$end_line_number] = '    '.$code;
+
+            array_splice($file_lines, $end_line_number, 0, '    '.$code);
             $new_file_content = implode(PHP_EOL, $file_lines);
 
             if ($disk->put($path, $new_file_content)) {
@@ -101,7 +101,7 @@ class AddCustomRouteContent extends Command
         // otherwise, in case the last line HAS been modified
         // return the last line that has an ending in it
         $possible_end_lines = array_filter($file_lines, function ($k) {
-            return strpos($k, '});') === 0;
+            return strpos($k, '}') !== false;
         });
 
         if ($possible_end_lines) {


### PR DESCRIPTION
This is related with https://github.com/Laravel-Backpack/CRUD/issues/3528

It's a bullet proof approach to avoid situations where the `custom.php` routes file may have been changed, maybe even by IDE formatter.

It wil lsearch for the last `}` instead of the all last line `});`.