### PR TITLE
[Bug] Array fields don't show the required red asterisk

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -94,6 +94,16 @@ trait Validation
                     (is_string($rule) && strpos($rule, 'required') !== false && strpos($rule, 'required_') === false) ||
                     (is_array($rule) && array_search('required', $rule) !== false && array_search('required_', $rule) === false)
                 ) {
+                    if (strpos($key, '.') !== false) {
+                        // Convert dot to array notation
+                        $key = \Str::of($key)
+                            ->explode('.')
+                            ->map(function ($value, $key) {
+                                return $key ? "[$value]" : $value;
+                            })
+                            ->join('');
+                    }
+
                     $requiredFields[] = $key;
                 }
             }


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/CRUD/issues/3568.

The problem is;
- On each field setup `overwriteFieldNameFromDotNotationToArray` runs and replaces dot notation if exists (example; `address.street` into `address[street]`)
- `isRequired` method on `Validation.php` receives the key `address.street` and is checking if it exists on the list of required fields (from the EntityRequest rules), but there the syntax is the array and not dot notation.

I thought about some solution, I think this is the lightest.

Another solution would be adding a new attribute on the field; `name` (no change, array notation), `name_dot` (original name in dot notation).
It's even lighter but we're bloating the field

@pxpm let me know what you think about it 👌