### PR TITLE
[Bug] Radio field on a boolean attribute interprets old value incorrectly

### DIFF
--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -5,7 +5,7 @@
 
     // check if attribute is casted, if it is, we get back un-casted values
     if(Arr::get($crud->model->getCasts(), $field['name']) === 'boolean') {
-        $optionValue = $optionValue === true ? 1 : 0;
+        $optionValue = (int) $optionValue;
     }
 
     // if the class isn't overwritten, use 'radio'


### PR DESCRIPTION
Related with https://github.com/Laravel-Backpack/CRUD/issues/3554.

The previous code was only checking if the `value === true` this works on load, when attribute is casted to boolean.
But when validation error happens, the value is not casted, so it may be "0" or "1".

By doing the `(int) $option` we assure it works with `"1"` or `true`.