### PR TITLE
Removed change trigger from select2 ajax in repeatable prepopulation

### DIFF
--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -203,7 +203,6 @@
 
                 // set the option keys as selected.
                 $(element).val(optionsForSelect);
-                $(element).trigger('change');
             });
         }
 

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -176,7 +176,6 @@
 
                 // set the option keys as selected.
                 $(element).val(optionsForSelect);
-                $(element).trigger('change');
             });
         }
 


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/CRUD/issues/3561.
I applied the fix both for `select2_from_ajax` and `select2_from_ajax_multiple`.

In an overview, when the page initially loads the ajax data loads and then the event is fired, which causes the depending field to reset. This change fixes it.