### PR TITLE
Moving the Hint under the Label on the repeatable field

### DIFF
--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -12,6 +12,11 @@
 
 @include('crud::fields.inc.wrapper_start')
   <label>{!! $field['label'] !!}</label>
+    {{-- HINT --}}
+  @if (isset($field['hint']))
+      <p class="help-block text-muted text-sm">{!! $field['hint'] !!}</p>
+  @endif
+
   @include('crud::fields.inc.translatable_icon')
   <input
       type="hidden"
@@ -21,10 +26,6 @@
       @include('crud::fields.inc.attributes')
   >
 
-  {{-- HINT --}}
-  @if (isset($field['hint']))
-      <p class="help-block text-muted text-sm">{!! $field['hint'] !!}</p>
-  @endif
 
 
 


### PR DESCRIPTION
Just moved the hint to it's better location as a user experience .

<img width="822" alt="Screen Shot 2021-03-04 at 6 04 24 PM" src="https://user-images.githubusercontent.com/3064487/109983684-1d572380-7d14-11eb-8b9a-356f049c0e20.png">
