### PR TITLE
[Bug] Unable to modify the wrapper classes of upload field

### DIFF
--- a/src/resources/views/crud/fields/address_algolia.blade.php
+++ b/src/resources/views/crud/fields/address_algolia.blade.php
@@ -2,6 +2,8 @@
 
 <?php
     $field['store_as_json'] = $field['store_as_json'] ?? false;
+
+    $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
     $field['wrapper']['algolia-wrapper'] = $field['wrapper']['algolia-wrapper'] ?? 'true';
     $field['config'] = [
         'field' => $field['name'],

--- a/src/resources/views/crud/fields/browse_multiple.blade.php
+++ b/src/resources/views/crud/fields/browse_multiple.blade.php
@@ -7,7 +7,7 @@ if (!$multiple && is_array($value)) {
     $value = Arr::first($value);
 }
 
-$field['wrapper'] = $field['wrapperAttributes'] ?? [];
+$field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
 $field['wrapper']['data-init-function'] = $field['wrapper']['data-init-function'] ?? 'bpFieldInitBrowseMultipleElement';
 $field['wrapper']['data-elfinder-trigger-url'] = $field['wrapper']['data-elfinder-trigger-url'] ?? url(config('elfinder.route.prefix').'/popup/'.$field['name'].'?multiple=1');
 

--- a/src/resources/views/crud/fields/hidden.blade.php
+++ b/src/resources/views/crud/fields/hidden.blade.php
@@ -1,6 +1,7 @@
 @php
 	// if not otherwise specified, the hidden input should take up no space in the form
-  $field['wrapper']['class'] = $field['wrapper']['class'] ?? $field['wrapperAttributes']['class'] ?? "hidden";
+  $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
+  $field['wrapper']['class'] = $field['wrapper']['class'] ?? "hidden";
 @endphp
 
 <!-- hidden input -->

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -13,6 +13,7 @@
         $field['attributes']['class'] = 'radio';
     }
 
+    $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
     $field['wrapper']['data-init-function'] = $field['wrapper']['data-init-function'] ?? 'bpFieldInitRadioElement';
 @endphp
 

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -1,11 +1,7 @@
 @php
-   if (!isset($field['wrapper']) || !isset($field['wrapper']['data-init-function'])){
-        $field['wrapper']['data-init-function'] = 'bpFieldInitUploadElement';
-    }
-
-    if (!isset($field['wrapper']) || !isset($field['wrapper']['data-field-name'])) {
-        $field['wrapper']['data-field-name'] = $field['name'];
-    }
+    $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
+    $field['wrapper']['data-init-function'] = 'bpFieldInitUploadElement';
+    $field['wrapper']['data-field-name'] = $field['name'];
 @endphp
 
 <!-- text input -->

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -1,7 +1,7 @@
 @php
     $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
-    $field['wrapper']['data-init-function'] = 'bpFieldInitUploadElement';
-    $field['wrapper']['data-field-name'] = $field['name'];
+    $field['wrapper']['data-init-function'] = $field['wrapper']['data-init-function'] ?? 'bpFieldInitUploadElement';
+    $field['wrapper']['data-field-name'] = $field['wrapper']['data-field-name'] ?? $field['name'];
 @endphp
 
 <!-- text input -->

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -1,7 +1,7 @@
 @php
     $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
-    $field['wrapper']['data-init-function'] = 'bpFieldInitUploadMultipleElement';
-    $field['wrapper']['data-field-name'] = $field['name'];
+    $field['wrapper']['data-init-function'] = $field['wrapper']['data-init-function'] ?? 'bpFieldInitUploadMultipleElement';
+    $field['wrapper']['data-field-name'] = $field['wrapper']['data-field-name'] ?? $field['name'];
 @endphp
 
 <!-- upload multiple input -->

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -1,12 +1,7 @@
 @php
-    if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-init-function'])){
-        $field['wrapperAttributes']['data-init-function'] = 'bpFieldInitUploadMultipleElement';
-    }
-
-    if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-field-name'])) {
-        $field['wrapperAttributes']['data-field-name'] = $field['name'];
-    }
-
+    $field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];
+    $field['wrapper']['data-init-function'] = 'bpFieldInitUploadMultipleElement';
+    $field['wrapper']['data-field-name'] = $field['name'];
 @endphp
 
 <!-- upload multiple input -->


### PR DESCRIPTION
This is a fix for #3593.

Upload field was not considering `wrapperAttributes` as an option for the `wrapper` as other fields do.
This PR fixes that, and I also checked every field and fixed some issues similar to this one other fields;

- address_algolia
- browse_multiple
- hidden
- radio
- upload
- upload_multiple

All this fields were not consistent with the standard of `$field['wrapper'] = $field['wrapper'] ?? $field['wrapperAttributes'] ?? [];` 