### PR TITLE
Only apply table prefix when query contains joins

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -143,9 +143,17 @@ trait Query
         return $this->query->count();
     }
 
+
+    /**
+     * Apply table prefix in the order clause if the query contains JOINS clauses.
+     *
+     * @param string $column_name
+     * @param string $column_direction
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function orderByWithPrefix($column_name, $column_direction = 'ASC')
     {
-        if ($this->driverIsSql()) {
+        if (null !== $this->query->getQuery()->joins) {
             return $this->query->orderByRaw($this->model->getTableWithPrefix().'.'.$column_name.' '.$column_direction);
         }
 

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -143,7 +143,6 @@ trait Query
         return $this->query->count();
     }
 
-
     /**
      * Apply table prefix in the order clause if the query contains JOINS clauses.
      *

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -152,7 +152,7 @@ trait Query
      */
     public function orderByWithPrefix($column_name, $column_direction = 'ASC')
     {
-        if (null !== $this->query->getQuery()->joins) {
+        if ($this->query->getQuery()->joins !== null) {
             return $this->query->orderByRaw($this->model->getTableWithPrefix().'.'.$column_name.' '.$column_direction);
         }
 


### PR DESCRIPTION
Instead of checking if db is `sql`, we are going to check if the query contains any joins. 

That's because the only reason why we need to use `table.column` notation in the query, is when other table is joined to avoid `ambiguous` column names in the query.

refs: #3555 


Edit: tests did not run but I ran them locally. @tabacitu what should we do to manually trigger online tests ? 

