### PR TITLE
Use modern \Composer\InstalledVersions

### DIFF
--- a/src/Stats.php
+++ b/src/Stats.php
@@ -63,7 +63,7 @@ trait Stats
             'SERVER_SOFTWARE'       => $_SERVER['SERVER_SOFTWARE'] ?? false,
             'DB_CONNECTION'         => $_SERVER['DB_CONNECTION'] ?? false,
             'LARAVEL_VERSION'       => $this->app->version() ?? false,
-            'BACKPACK_CRUD_VERSION' => \PackageVersions\Versions::getVersion('backpack/crud') ?? false,
+            'BACKPACK_CRUD_VERSION' => \Composer\InstalledVersions::getVersion('backpack/crud') ?? false,
             'BACKPACK_LICENSE'      => config('backpack.base.license_code') ?? false,
             'BACKPACK_URL'          => backpack_url('') ?? false,
         ];

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -33,11 +33,11 @@ class Version extends Command
         $this->runConsoleCommand(['php', '-v']);
 
         $this->comment('### LARAVEL VERSION:');
-        $this->line(\PackageVersions\Versions::getVersion('laravel/framework'));
+        $this->line(\Composer\InstalledVersions::getVersion('laravel/framework'));
         $this->line('');
 
         $this->comment('### BACKPACK VERSION:');
-        $this->line(\PackageVersions\Versions::getVersion('backpack/crud'));
+        $this->line(\Composer\InstalledVersions::getVersion('backpack/crud'));
         $this->line('');
     }
 

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -149,7 +149,7 @@ return [
     // All JS and CSS assets defined above have this string appended as query string (?v=string).
     // If you want to manually trigger cachebusting for all styles and scripts,
     // append or prepend something to the string below, so that it's different.
-    'cachebusting_string' => \PackageVersions\Versions::getVersion('backpack/crud'),
+    'cachebusting_string' => \Composer\InstalledVersions::getVersion('backpack/crud'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
My IDE is complaing that \PackageVersions\Versions is deprecated and to use the native \Composer\InstalledVersions instead

![image](https://user-images.githubusercontent.com/1624261/111254138-55137480-860c-11eb-9b32-de541d037e47.png)

This wasn't working in one of my CI environments and I can only assume it was down to composer 2