### PR TITLE
Add option to warn user before leaving create or edit page

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -28,6 +28,7 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\Tabs;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Update;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Validation;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Views;
+use Backpack\CRUD\app\Library\CrudPanel\Traits\WarnBeforeLeaving;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -37,7 +38,7 @@ use Illuminate\Support\Arr;
 class CrudPanel
 {
     // load all the default CrudPanel features
-    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships;
+    use Create, Read, Search, Update, Delete, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships, WarnBeforeLeaving;
     // allow developers to add their own closures to this object
     use Macroable;
 

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -417,26 +417,4 @@ trait SaveActions
 
         $this->addSaveActions($defaultSaveActions);
     }
-
-    /**
-     * Here we check if user should be warned before leaving the page.
-     *
-     * @return bool
-     */
-    public function getWarnBeforeLeave(): bool
-    {
-        return $this->getOperationSetting('warnBeforeLeave') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.warnBeforeLeave') ?? false;
-    }
-
-    /**
-     * Change the variable that determines if user should be warned before leaving the page.
-     *
-     * @param bool $value
-     *
-     * @return void
-     */
-    public function setWarnBeforeLeave(bool $value = true)
-    {
-        $this->setOperationSetting('warnBeforeLeave', $value);
-    }
 }

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -417,4 +417,26 @@ trait SaveActions
 
         $this->addSaveActions($defaultSaveActions);
     }
+
+    /**
+     * Here we check if user should be warned before leaving the page.
+     *
+     * @return bool
+     */
+    public function getWarnBeforeLeave(): bool
+    {
+        return $this->getOperationSetting('warnBeforeLeave') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.warnBeforeLeave') ?? false;
+    }
+
+    /**
+     * Change the variable that determines if user should be warned before leaving the page.
+     *
+     * @param bool $value
+     *
+     * @return void
+     */
+    public function setWarnBeforeLeave(bool $value = true)
+    {
+        $this->setOperationSetting('warnBeforeLeave', $value);
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/WarnBeforeLeaving.php
+++ b/src/app/Library/CrudPanel/Traits/WarnBeforeLeaving.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
+
+trait WarnBeforeLeaving
+{
+    /**
+     * Here we check if user should be warned before leaving the page.
+     *
+     * @return bool
+     */
+    public function getWarnBeforeLeaving(): bool
+    {
+        return $this->getOperationSetting('warnBeforeLeaving') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.warnBeforeLeaving') ?? false;
+    }
+
+    /**
+     * Change the variable that determines if user should be warned before leaving the page.
+     *
+     * @param bool $value
+     * @return void
+     */
+    public function setWarnBeforeLeaving(bool $value = true): void
+    {
+        $this->setOperationSetting('warnBeforeLeaving', $value);
+    }
+}

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -94,7 +94,7 @@ return [
             'showCancelButton' => true,
 
             // Should we warn a user before leaving the page with unsaved changes?
-            'warnBeforeLeave' => false,
+            'warnBeforeLeaving' => false,
 
             // Before saving the entry, how would you like the request to be stripped?
             // - false - ONLY save inputs that have fields (safest)
@@ -133,7 +133,7 @@ return [
             'showCancelButton' => true,
 
             // Should we warn a user before leaving the page with unsaved changes?
-            'warnBeforeLeave' => false,
+            'warnBeforeLeaving' => false,
 
             // Before saving the entry, how would you like the request to be stripped?
             // - false - Save ONLY inputs that have a field (safest, default);

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -93,6 +93,9 @@ return [
             // Should we show a cancel button to the user?
             'showCancelButton' => true,
 
+            // Should we warn a user before leaving the page with unsaved changes?
+            'warnBeforeLeave' => false,
+
             // Before saving the entry, how would you like the request to be stripped?
             // - false - ONLY save inputs that have fields (safest)
             // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
@@ -128,6 +131,9 @@ return [
 
             // Should we show a cancel button to the user?
             'showCancelButton' => true,
+
+            // Should we warn a user before leaving the page with unsaved changes?
+            'warnBeforeLeave' => false,
 
             // Before saving the entry, how would you like the request to be stripped?
             // - false - Save ONLY inputs that have a field (safest, default);

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -53,19 +53,28 @@
       });
     }
 
-    function preventUnload(event) {
-      // Cancel the event as stated by the standard.
-      event.preventDefault();
-      // Older browsers supported custom message
-      event.returnValue = '';
-    }
-
     jQuery('document').ready(function($){
 
       // trigger the javascript for all fields that have their js defined in a separate method
       initializeFieldsWithJavascript('form');
 
+      // Retrieves the current form data
+      function getFormData() {
+        return new URLSearchParams(new FormData(document.querySelector("main form"))).toString();
+      }
+
+      // Prevents unloading of page if form data was changed
+      function preventUnload(event) {
+        if (initData !== getFormData()) {
+          // Cancel the event as stated by the standard.
+          event.preventDefault();
+          // Older browsers supported custom message
+          event.returnValue = '';
+        }
+      }
+
       @if($crud->getWarnBeforeLeaving())
+      const initData = getFormData();
       window.addEventListener('beforeunload', preventUnload);
       @endif
 

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -65,7 +65,7 @@
       // trigger the javascript for all fields that have their js defined in a separate method
       initializeFieldsWithJavascript('form');
 
-      @if($crud->getWarnBeforeLeave())
+      @if($crud->getWarnBeforeLeaving())
       window.addEventListener('beforeunload', preventUnload);
       @endif
 

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -53,11 +53,21 @@
       });
     }
 
+    function preventUnload(event) {
+      // Cancel the event as stated by the standard.
+      event.preventDefault();
+      // Older browsers supported custom message
+      event.returnValue = '';
+    }
+
     jQuery('document').ready(function($){
 
       // trigger the javascript for all fields that have their js defined in a separate method
       initializeFieldsWithJavascript('form');
 
+      @if($crud->getWarnBeforeLeave())
+      window.addEventListener('beforeunload', preventUnload);
+      @endif
 
       // Save button has multiple actions: save and exit, save and edit, save and new
       var saveActions = $('#saveActions'),
@@ -83,6 +93,7 @@
 
       // prevent duplicate entries on double-clicking the submit form
       crudForm.submit(function (event) {
+        window.removeEventListener('beforeunload', preventUnload);
         $("button[type=submit]").prop('disabled', true);
       });
 


### PR DESCRIPTION
Sometimes, especially on CRUD entries that take a long time to create or edit, it is useful to warn users if they attempt to leave the page by other means then the save button, to prevent accidental loss of input. 

This PR adds a warnBeforeLeave config option that can be set both globally (in the config file) or per crud operation (with the `setWarnBeforeLeave` method).