### PR TITLE
Detect suitable column type based on model casts

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -106,9 +106,11 @@ trait ColumnsProtectedMethods
                 case 'encrypted:array':
                 case 'collection':
                 case 'encrypted:collection':
+                    $column['type'] = 'array';
+                    break;
                 case 'json':
                 case 'object':
-                    $column['type'] = 'array';
+                    $column['type'] = 'json';
                     break;
                 case 'bool':
                 case 'boolean':


### PR DESCRIPTION
This PR adds some form of autodetection on casts you placed on your model, so that they automatically have a better suitable column type set.

Note that this potentialy alters the looks of existing admin list interfaces, so should be considered a breaking change (although it shouldn't actually cause any real problems).