### PR TITLE
do not add column prefix in the query

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -66,7 +66,7 @@ trait Search
                 case 'email':
                 case 'text':
                 case 'textarea':
-                    $query->orWhere($this->model->getTable() .'.'. $column['name'], 'like', '%'.$searchTerm.'%');
+                    $query->orWhere($this->model->getTable().'.'.$column['name'], 'like', '%'.$searchTerm.'%');
                     break;
 
                 case 'date':
@@ -77,13 +77,13 @@ trait Search
                         break;
                     }
 
-                    $query->orWhereDate($this->model->getTable() .'.'. $column['name'], Carbon::parse($searchTerm));
+                    $query->orWhereDate($this->model->getTable().'.'.$column['name'], Carbon::parse($searchTerm));
                     break;
 
                 case 'select':
                 case 'select_multiple':
                     $query->orWhereHas($column['entity'], function ($q) use ($column, $searchTerm) {
-                        $q->where($q->getModel()->getTable() .'.'. $column['attribute'], 'like', '%'.$searchTerm.'%');
+                        $q->where($q->getModel()->getTable().'.'.$column['attribute'], 'like', '%'.$searchTerm.'%');
                     });
                     break;
 

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -66,7 +66,7 @@ trait Search
                 case 'email':
                 case 'text':
                 case 'textarea':
-                    $query->orWhere($this->getColumnWithTableNamePrefixed($query, $column['name']), 'like', '%'.$searchTerm.'%');
+                    $query->orWhere($this->model->getTable() .'.'. $column['name'], 'like', '%'.$searchTerm.'%');
                     break;
 
                 case 'date':
@@ -77,13 +77,13 @@ trait Search
                         break;
                     }
 
-                    $query->orWhereDate($this->getColumnWithTableNamePrefixed($query, $column['name']), Carbon::parse($searchTerm));
+                    $query->orWhereDate($this->model->getTable() .'.'. $column['name'], Carbon::parse($searchTerm));
                     break;
 
                 case 'select':
                 case 'select_multiple':
                     $query->orWhereHas($column['entity'], function ($q) use ($column, $searchTerm) {
-                        $q->where($this->getColumnWithTableNamePrefixed($q, $column['attribute']), 'like', '%'.$searchTerm.'%');
+                        $q->where($q->getModel()->getTable() .'.'. $column['attribute'], 'like', '%'.$searchTerm.'%');
                     });
                     break;
 
@@ -324,17 +324,5 @@ trait Search
             'recordsFiltered' => $filteredRows,
             'data'            => $rows,
         ];
-    }
-
-    /**
-     * Return the column attribute (column in database) prefixed with table to use in search.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $column
-     * @return string
-     */
-    public function getColumnWithTableNamePrefixed($query, $column)
-    {
-        return $query->getModel()->getTableWithPrefix().'.'.$column;
     }
 }


### PR DESCRIPTION
refs: #3620 

When building the query, the _table prefix_ is automatically added, and the changes we did in https://github.com/Laravel-Backpack/CRUD/commit/8aef333c86e958c3132e4826ba0184e6ec742953 broke this part of the functionality because we get the _table name with prefix_ and then it gets prefixed again.

This ensures we keep fixing what we fixed in the mentioned commit __(adding table name prefix in queries)__, but when using global prefixes they will be added, no need to add it there. 



