### PR TITLE
Fix search when devs use prefixed database tables

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -335,6 +335,6 @@ trait Search
      */
     public function getColumnWithTableNamePrefixed($query, $column)
     {
-        return $query->getModel()->getTableWithPrefix().'.'.$column;
+        return $query->getModel()->getTable().'.'.$column;
     }
 }


### PR DESCRIPTION
Fix for #3620.

We were forcing the prefix on the table and Eloquent does that part for us, hence the double prefix.