### PR TITLE
Replace null coalescing operator with ternary, fixes #3639

### DIFF
--- a/src/resources/views/base/inc/alerts.blade.php
+++ b/src/resources/views/base/inc/alerts.blade.php
@@ -15,7 +15,8 @@
             var $alerts_from_php = JSON.parse('@json(\Alert::getMessages())');
 
             // get the alerts from the localstorage
-            var $alerts_from_localstorage = JSON.parse(localStorage.getItem('backpack_alerts')) ?? {};
+            var $alerts_from_localstorage = JSON.parse(localStorage.getItem('backpack_alerts'))
+                ? JSON.parse(localStorage.getItem('backpack_alerts')) : {};
 
             // merge both php alerts and localstorage alerts
             Object.entries($alerts_from_php).forEach(([type, messages]) => {

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -18,7 +18,8 @@
     // datatables caches the ajax responses with pageLength in LocalStorage so when changing this
     // settings in controller users get unexpected results. To avoid that we will reset
     // the table cache when both lengths don't match.
-    let $dtCachedInfo = JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}')) ?? [];
+    let $dtCachedInfo = JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}'))
+        ? JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}')) : [];
     var $dtDefaultPageLength = {{ $crud->getDefaultPageLength() }};
     let $dtStoredPageLength = localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength');
 
@@ -28,7 +29,8 @@
 
     // in this page we allways pass the alerts to localStorage because we can be redirected with
     // persistent table, and this way we guarantee non-duplicate alerts.
-    $oldAlerts = JSON.parse(localStorage.getItem('backpack_alerts')) ?? {};
+    $oldAlerts = JSON.parse(localStorage.getItem('backpack_alerts'))
+        ? JSON.parse(localStorage.getItem('backpack_alerts')) : {};
     $newAlerts = @json($backpack_alerts);
 
     Object.entries($newAlerts).forEach(([type, messages]) => {


### PR DESCRIPTION
Fixes #3639, which prevents using Backpack on Chrome versions prior to version 80.