### PR TITLE
Dont call identifiable attribute in models that dont use crud trait

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -197,10 +197,8 @@ trait FieldsProtectedMethods
     {
         // if there's a model defined, but no attribute
         // guess an attribute using the indentifiableAttribute functionality in CrudTrait
-        if (isset($field['model']) && ! isset($field['attribute'])) {
-            if (method_exists($field['model'], 'identifiableAttribute')) {
-                $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
-            }
+        if (isset($field['model']) && ! isset($field['attribute']) && method_exists($field['model'], 'identifiableAttribute')) {
+            $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
         }
 
         return $field;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -198,7 +198,9 @@ trait FieldsProtectedMethods
         // if there's a model defined, but no attribute
         // guess an attribute using the indentifiableAttribute functionality in CrudTrait
         if (isset($field['model']) && ! isset($field['attribute'])) {
-            $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
+            if(method_exists($field['model'], 'identifiableAttribute')) {
+                $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
+            }
         }
 
         return $field;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -198,7 +198,7 @@ trait FieldsProtectedMethods
         // if there's a model defined, but no attribute
         // guess an attribute using the indentifiableAttribute functionality in CrudTrait
         if (isset($field['model']) && ! isset($field['attribute'])) {
-            if(method_exists($field['model'], 'identifiableAttribute')) {
+            if (method_exists($field['model'], 'identifiableAttribute')) {
                 $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
             }
         }


### PR DESCRIPTION
refs #3635 

If the related model does not use CrudTrait, `identifiableAttribute` will not be available to call. It's developer responsability to setup `attribute` or return the predefined options.

This is just a small change, __it would error anyway if method don't exist on model__.
