### PR TITLE
Prevent 500 return code on empty post request to bulk routes

### DIFF
--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -50,7 +50,7 @@ trait BulkCloneOperation
     {
         $this->crud->hasAccessOrFail('bulkClone');
 
-        $entries = request()->input('entries');
+        $entries = request()->input('entries', []);
         $clonedEntries = [];
 
         foreach ($entries as $key => $id) {

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -48,7 +48,7 @@ trait BulkDeleteOperation
     {
         $this->crud->hasAccessOrFail('bulkDelete');
 
-        $entries = request()->input('entries');
+        $entries = request()->input('entries', []);
         $deletedEntries = [];
 
         foreach ($entries as $key => $id) {


### PR DESCRIPTION
When posting with empty body to bulk routes, a 500 HTTP code is returned as `$entries` will be null, hence cannot be called in a foreach loop.

Other POST (and PUT/DELETE) routes return a 302 / 200 HTTP code on empty bodies. I think this is a better default response to aim for, as it allows for easier feature testing on accessibility of routes.