### PR TITLE
Corrected by passing parameter by reference

### DIFF
--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -7,7 +7,7 @@
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
 
     $attributes = $crud->getRelatedEntriesAttributes($entry, $column['entity'], $column['attribute']);
-    foreach ($attributes as $key => $text) {
+    foreach ($attributes as $key => &$text) {
         $text = Str::limit($text, $column['limit'], '[...]');
     }
 @endphp


### PR DESCRIPTION
```
    foreach ($attributes as $key => $text) {
        $text = Str::limit($text, $column['limit'], '[...]');
    }
```
The above for loop has no effect as the values are not updated in the array, changed that to update by passing parameter by reference.
