### PR TITLE
Non breaking fix for avatar dependency

### DIFF
--- a/src/resources/views/base/inc/menu_user_dropdown.blade.php
+++ b/src/resources/views/base/inc/menu_user_dropdown.blade.php
@@ -1,6 +1,9 @@
 <li class="nav-item dropdown pr-4">
-  <a class="nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-    <img class="img-avatar" src="{{ backpack_avatar_url(backpack_auth()->user()) }}" alt="{{ backpack_auth()->user()->name }}">
+  <a class="nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" style="position: relative;width: 35px;height: 35px;margin: 0 10px;">
+    <img class="img-avatar" src="{{ backpack_avatar_url(backpack_auth()->user()) }}" alt="{{ backpack_auth()->user()->name }}" onerror="this.style.display='none'" style="margin: 0;position: absolute;left: 0;z-index: 1;">
+    <span class="backpack-avatar-menu-container" style="position: absolute;left: 0;width: 100%;background-color: #00a65a;border-radius: 50%;color: #FFF;line-height: 35px;">
+      {{backpack_user()->getAttribute('name') ? mb_substr(backpack_user()->name, 0, 1, 'UTF-8') : 'A'}}
+    </span>
   </a>
   <div class="dropdown-menu {{ config('backpack.base.html_direction') == 'rtl' ? 'dropdown-menu-left' : 'dropdown-menu-right' }} mr-4 pb-1 pt-1">
     <a class="dropdown-item" href="{{ route('backpack.account.info') }}"><i class="la la-user"></i> {{ trans('backpack::base.my_account') }}</a>


### PR DESCRIPTION
Related with https://github.com/Laravel-Backpack/CRUD/pull/3425.

This is super ugly with all the CSS inline 🙃
Anyway, it works, and I think it's non breaking, am I wrong?

Basically it places a CSS solution below the image, and if the image has any error, it is hidden.