### PR TITLE
fix unit test coverage report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit --testdox",
-        "test-failing": "vendor/bin/phpunit --order-by=defects --stop-on-failure"
+        "test-failing": "vendor/bin/phpunit --order-by=defects --stop-on-failure",
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,16 +16,13 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/PanelTraits/</directory>
-            <file>./src/CrudPanel.php</file>
+            <directory suffix=".php">./src/app/Library/CrudPanel/Traits/</directory>
+            <directory suffix=".php">./src/app/Library/CrudPanel/</directory>
+            <directory suffix=".php">./src/app/Models/Traits/</directory>
+            <file>./src/app/Library/Widget.php</file>
+            <file>./src/app/Http/Controllers//CrudController.php</file>
             <exclude>
-                <file>./src/PanelTraits/AutoFocus.php</file>
-                <file>./src/PanelTraits/Errors.php</file>
-                <file>./src/PanelTraits/Filters.php</file>
-                <file>./src/PanelTraits/Query.php</file>
-                <file>./src/PanelTraits/Reorder.php</file>
-                <file>./src/PanelTraits/Views.php</file>
-                <file>./src/PanelTraits/ViewsAndRestoresRevisions.php</file>
+                <directory suffix=".php">./src/app/Models/Traits/SpatieTranslatable/</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,7 +20,7 @@
             <directory suffix=".php">./src/app/Library/CrudPanel/</directory>
             <directory suffix=".php">./src/app/Models/Traits/</directory>
             <file>./src/app/Library/Widget.php</file>
-            <file>./src/app/Http/Controllers//CrudController.php</file>
+            <file>./src/app/Http/Controllers/CrudController.php</file>
             <exclude>
                 <directory suffix=".php">./src/app/Models/Traits/SpatieTranslatable/</directory>
             </exclude>

--- a/tests/Unit/CrudPanel/CrudPanelAccessTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAccessTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\app\Exceptions\AccessDeniedException;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Access
+ */
 class CrudPanelAccessTest extends BaseCrudPanelTest
 {
     private $unknownPermission = 'unknownPermission';

--- a/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
@@ -10,6 +10,9 @@ class MyColumnTypeWithOtherConnection extends ColumnType
     protected $connection = 'testing_2';
 }
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Autoset
+ */
 class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
 {
     private $expectedUnknownFieldType = 'text';

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\app\Library\CrudPanel\CrudButton;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Buttons
+ */
 class CrudPanelButtonsTest extends BaseCrudPanelTest
 {
     private $defaultButtonNames = [];

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\User;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Columns
+ */
 class CrudPanelColumnsTest extends BaseDBCrudPanelTest
 {
     private $oneColumnArray = [

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -7,6 +7,9 @@ use Backpack\CRUD\Tests\Unit\Models\User;
 use Faker\Factory;
 use Illuminate\Support\Arr;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Create
+ */
 class CrudPanelCreateTest extends BaseDBCrudPanelTest
 {
     private $nonRelationshipField = [

--- a/tests/Unit/CrudPanel/CrudPanelDeleteTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelDeleteTest.php
@@ -6,6 +6,9 @@ use Backpack\CRUD\Tests\Unit\Models\Article;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Delete
+ */
 class CrudPanelDeleteTest extends BaseDBCrudPanelTest
 {
     public function testDelete()

--- a/tests/Unit/CrudPanel/CrudPanelFakeColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFakeColumnsTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\Article;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\FakeColumns
+ */
 class CrudPanelFakeColumnsTest extends BaseDBCrudPanelTest
 {
     private $emptyFakeColumnsArray = ['extras'];

--- a/tests/Unit/CrudPanel/CrudPanelFakeFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFakeFieldsTest.php
@@ -5,6 +5,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 use Backpack\CRUD\Tests\Unit\Models\Article;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\FakeFields
+ */
 class CrudPanelFakeFieldsTest extends BaseDBCrudPanelTest
 {
     private $fakeFieldsArray = [

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\User;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Fields
+ */
 class CrudPanelFieldsTest extends BaseDBCrudPanelTest
 {
     private $oneTextFieldArray = [

--- a/tests/Unit/CrudPanel/CrudPanelReadTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReadTest.php
@@ -9,6 +9,9 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Read
+ */
 class CrudPanelReadTest extends BaseDBCrudPanelTest
 {
     private $relationshipColumn = [

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -2,6 +2,9 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\SaveActions
+ */
 class CrudPanelSaveActionsTest extends BaseDBCrudPanelTest
 {
     private $singleSaveAction;

--- a/tests/Unit/CrudPanel/CrudPanelTablePrefixedTests.php
+++ b/tests/Unit/CrudPanel/CrudPanelTablePrefixedTests.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\Tests\Unit\Models\User;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\CrudPanel
+ */
 class CrudPanelTablePrefixedTests extends BasePrefixedDBCrudPanelTest
 {
     public function testGetColumnTypeFromColumnNameWithPrefixedDatabase()

--- a/tests/Unit/CrudPanel/CrudPanelTabsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelTabsTest.php
@@ -6,6 +6,9 @@ use Backpack\CRUD\Tests\Unit\Models\Article;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Tabs
+ */
 class CrudPanelTabsTest extends BaseDBCrudPanelTest
 {
     private $horizontalTabsType = 'horizontal';

--- a/tests/Unit/CrudPanel/CrudPanelTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelTest.php
@@ -5,6 +5,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 use Backpack\CRUD\Tests\Unit\Models\TestModel;
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\CrudPanel
+ */
 class CrudPanelTest extends BaseCrudPanelTest
 {
     public function testSetModelFromModelClass()

--- a/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
@@ -7,6 +7,9 @@ use Faker\Factory;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Update
+ */
 class CrudPanelUpdateTest extends BaseDBCrudPanelTest
 {
     private $userInputFields = [

--- a/tests/Unit/CrudPanel/CrudPanelViewsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelViewsTest.php
@@ -4,6 +4,9 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Config;
 
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Views
+ */
 class CrudPanelViewsTest extends BaseCrudPanelTest
 {
     private $customView = 'path/to/custom/view';

--- a/tests/Unit/CrudTrait/CrudTraitFakeFieldsTest.php
+++ b/tests/Unit/CrudTrait/CrudTraitFakeFieldsTest.php
@@ -8,6 +8,7 @@ use Unit\CrudPanel\Models\FakeColumnsModel;
  * Class CrudTraitFakeFieldsTest.
  *
  * @group CrudTraitFakeFields
+ * @covers Backpack\CRUD\app\Models\Traits\HasFakeFields
  */
 class CrudTraitFakeFieldsTest extends BaseCrudTraitTest
 {

--- a/tests/Unit/Http/CrudControllerTest.php
+++ b/tests/Unit/Http/CrudControllerTest.php
@@ -5,6 +5,9 @@ namespace Backpack\CRUD\Tests\Unit\Http;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Backpack\CRUD\Tests\BaseTest;
 
+/**
+ * @covers Backpack\CRUD\app\Http\Controllers\CrudController
+ */
 class CrudControllerTest extends BaseTest
 {
     private $crudPanel;


### PR DESCRIPTION
Bad news - we've been lying to ourselves 😅 Apparently our 59% unit test coverage in 4.1 is not at all accurate, it's closer to 30% actually. In Backpack 4.1 we've moved things around, without changing the PHPUnit configuration file, so the test coverage results were off... by a lot. 

This PR:
- fixes the bad coverage report;
- adds a new `composer test-coverage` command, that we maintainers can run to see the coverage on our machines;

After installing Xdebug on mine and running `composer test-coverage` here's what I see:
![Screenshot 2021-05-10 at 10 39 46](https://user-images.githubusercontent.com/1032474/117623166-2208df80-b17c-11eb-8465-1919ac48d0eb.png)
![Screenshot 2021-05-10 at 10 40 10](https://user-images.githubusercontent.com/1032474/117623190-27662a00-b17c-11eb-9a58-f56ff47ffee5.png)

So... we're a long way off from our goal of 75% test coverage. 

Writing more unit tests is not a priority _right now_, BUT. From now on, if we discover and fix bugs in the main PHP classes (`CrudPanel`, the `CrudPanel` traits and `CrudTrait`), let's also take the time to write unit tests for that PHP class. So that, little by little, this number goes up. 

This will become more important when we start working on the next Backpack version. The more methods we have tested, the more we can be sure that our changes and refactors don't break stuff.