### PR TITLE
remove process in favor of artisan, remove unused provider

### DIFF
--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -68,22 +68,7 @@ class AddCustomRouteContent extends Command
                 $this->error('Could not write to file: '.$path);
             }
         } else {
-            $command = 'php artisan vendor:publish --provider="Backpack\Base\BaseServiceProvider" --tag=custom_routes';
-
-            $process = new Process($command, null, null, null, 300, null);
-
-            $process->run(function ($type, $buffer) {
-                if (Process::ERR === $type) {
-                    $this->line($buffer);
-                } else {
-                    $this->line($buffer);
-                }
-            });
-
-            // executes after the command finishes
-            if (! $process->isSuccessful()) {
-                throw new ProcessFailedException($process);
-            }
+            Artisan::call('vendor:publish', ['--provider' => 'Backpack\CRUD\BackpackServiceProvider', '--tag' => 'custom_routes']);
 
             $this->handle();
         }

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 
 class AddCustomRouteContent extends Command

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -4,8 +4,6 @@ namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class AddCustomRouteContent extends Command
 {


### PR DESCRIPTION
Backpack\Base is no longer used. 

Also I dunno why we use `Process` here, but `Artisan` can handle this call IMO.

I'v just tested and the file get's correctly published with `Artisan`. Any special reason for not using it here ?

Best,
Pedro