### PR TITLE
Added missing LangFileManager translation links

### DIFF
--- a/src/resources/lang/ar/langfilemanager.php
+++ b/src/resources/lang/ar/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/bg/langfilemanager.php
+++ b/src/resources/lang/bg/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/cs/langfilemanager.php
+++ b/src/resources/lang/cs/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/da-DK/langfilemanager.php
+++ b/src/resources/lang/da-DK/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/da_DK/langfilemanager.php
+++ b/src/resources/lang/da_DK/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/de/langfilemanager.php
+++ b/src/resources/lang/de/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/el/langfilemanager.php
+++ b/src/resources/lang/el/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/en/langfilemanager.php
+++ b/src/resources/lang/en/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/es/langfilemanager.php
+++ b/src/resources/lang/es/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fa/langfilemanager.php
+++ b/src/resources/lang/fa/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr-CA/langfilemanager.php
+++ b/src/resources/lang/fr-CA/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr/langfilemanager.php
+++ b/src/resources/lang/fr/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/langfilemanager.php
+++ b/src/resources/lang/fr_CA/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/gr/langfilemanager.php
+++ b/src/resources/lang/gr/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/hu/langfilemanager.php
+++ b/src/resources/lang/hu/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/id/langfilemanager.php
+++ b/src/resources/lang/id/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/it/langfilemanager.php
+++ b/src/resources/lang/it/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/ja/langfilemanager.php
+++ b/src/resources/lang/ja/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/lo/langfilemanager.php
+++ b/src/resources/lang/lo/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/lv/langfilemanager.php
+++ b/src/resources/lang/lv/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/nl/langfilemanager.php
+++ b/src/resources/lang/nl/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/pt-BR/langfilemanager.php
+++ b/src/resources/lang/pt-BR/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/pt/langfilemanager.php
+++ b/src/resources/lang/pt/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/pt_br/langfilemanager.php
+++ b/src/resources/lang/pt_br/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/ro/langfilemanager.php
+++ b/src/resources/lang/ro/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/ru/langfilemanager.php
+++ b/src/resources/lang/ru/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/sr/langfilemanager.php
+++ b/src/resources/lang/sr/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/tr/langfilemanager.php
+++ b/src/resources/lang/tr/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/uk/langfilemanager.php
+++ b/src/resources/lang/uk/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/zh-Hant/langfilemanager.php
+++ b/src/resources/lang/zh-Hant/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/zh-cn/langfilemanager.php
+++ b/src/resources/lang/zh-cn/langfilemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../langfilemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];


### PR DESCRIPTION
This PR adds the missing [`LangFileManager`](https://github.com/Laravel-Backpack/LangFileManager) translation.
If the user don't publish [`LangFileManager`](https://github.com/Laravel-Backpack/LangFileManager) translations, the translations are not auto loaded. Causing this;

![image](https://user-images.githubusercontent.com/1838187/118855576-cce07280-b8cd-11eb-9fa0-e2f24b6c48e8.png)

@tabacitu is there a reason for this? Was this meant to be like that?

---
**Note** that the installation is correct, it demands the translations to be published. It's just that this translations are the only one missing, avoiding developers to have a clean `resources/lang/vendor` folder.