### PR TITLE
add wrapper end to text field

### DIFF
--- a/src/resources/views/crud/fields/text.blade.php
+++ b/src/resources/views/crud/fields/text.blade.php
@@ -18,4 +18,4 @@
     @if (isset($field['hint']))
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
-</div>
+@include('crud::fields.inc.wrapper_end')


### PR DESCRIPTION
refs #3744 

Something weird happened when merging the branch into master and the `wrapper_end` in text field was lost. 🙃 