### PR TITLE
remove fields that are not in the request

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -198,7 +198,7 @@ trait Create
         }
     }
 
-        /**
+    /**
      * When using the HasMany/MorphMany relations as selectable elements we use this function to sync those relations.
      * Here we allow for different functionality than when creating. Developer could use this relation as a
      * selectable list of items that can belong to one/none entity at any given time.
@@ -303,6 +303,7 @@ trait Create
                 Arr::set($relationData, 'relations.'.$key, $fieldData);
             }
         }
+
         return $relationData;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -214,10 +214,19 @@ trait Create
      */
     private function getRelationDataFromFormData($data)
     {
+
         $relation_fields = $this->getRelationFields();
+
+        $relation_fields = $this->parseRelationFieldNamesFromHtml($relation_fields);
+
+        //remove fields that are not in the submitted form.
+        $relation_fields = array_filter($relation_fields, function($item) use ($data) {
+            return Arr::has($data, $item['name']);
+        });
+
         $relationData = [];
         foreach ($relation_fields as $relation_field) {
-            $attributeKey = $this->parseRelationFieldNamesFromHtml([$relation_field])[0]['name'];
+            $attributeKey = $relation_field['name'];
 
             if (isset($relation_field['pivot']) && $relation_field['pivot'] !== true) {
                 $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -214,13 +214,12 @@ trait Create
      */
     private function getRelationDataFromFormData($data)
     {
-
         $relation_fields = $this->getRelationFields();
 
         $relation_fields = $this->parseRelationFieldNamesFromHtml($relation_fields);
 
         //remove fields that are not in the submitted form.
-        $relation_fields = array_filter($relation_fields, function($item) use ($data) {
+        $relation_fields = array_filter($relation_fields, function ($item) use ($data) {
             return Arr::has($data, $item['name']);
         });
 


### PR DESCRIPTION
refs: #3713 

When we get the relation fields from a crud panel, we get ALL of them. The problem relies in the fact that if field is `disabled` or not present in the form at all, we don't make that exclusion from relation fields and assume that `null` is sent for that field, removing the relationship between the entities as it would happen if the field is in form and you `allow_null`. 

Example: We add a `belongs to` relation field `user_id` to the crud. In the update form you use the same relationship field but add the `disabled` attribute, when you update the entry, as the `user` relation is a field we get from `getRelationFields` but it's not in the `request form`, we assume that the field is `null`, so we clear the relationship if any. 

**NOTE**: this is usefull behavior in case of `select multiple`, because if empty they don't post their value, so we assume developer cleared the select and clear the relationship. 

If we merge this PR, and I think we should first settle in a way of posting the `select multiple` values:
- there is already a PR #3284 that proposes that the select changed between `multiple` and `single` based in the selected values (when empty we setup a `single` select that post the empty value).
- use a hidden field for multiple selects that gets posted when the select multiple is empty or not present (not suitable for repeatable, but we can change repeatable names into `array` names instead of stripping the name?)

We should not merge this until we settle in a way to handle the select multiple inputs, otherwise they could not be cleared. 
