### PR TITLE
[4.2][Feature] Toggle Field Visibility

### DIFF
--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -33,7 +33,7 @@
             <div class="form-check {{ isset($field['inline']) && $field['inline'] ? 'form-check-inline' : '' }}">
                 <input  type="radio"
                         class="form-check-input"
-                        @if ($field['toggle'])
+                        @if ($field['toggle'] ?? false)
                         data-field-name="{{$field['name']}}"
                         data-field-toggle="{{ json_encode($field['hide_when'][$value] ?? []) }}"
                         @endif

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -33,6 +33,10 @@
             <div class="form-check {{ isset($field['inline']) && $field['inline'] ? 'form-check-inline' : '' }}">
                 <input  type="radio"
                         class="form-check-input"
+                        @if ($field['toggle'])
+                        data-field-name="{{$field['name']}}"
+                        data-field-toggle="{{ json_encode($field['hide_when'][$value] ?? []) }}"
+                        @endif
                         value="{{$value}}"
                         @include('crud::fields.inc.attributes')
                         >
@@ -79,6 +83,43 @@
 
             // select the right radios
             element.find('input[type=radio][value="'+value+'"]').prop('checked', true);
+
+            // If this is a toggleable radio element, then we want to hide/show whatever should be hidden/shown
+            window.hiddenFields = window.hiddenFields || {};
+            var toggle = function( $radio ){
+                let hideWhen = $radio.data('field-toggle'),
+                fieldName = $radio.data('field-name');
+                hiddenFields[ fieldName ] = hiddenFields[ fieldName ] || [];
+                if( Object.keys(hiddenFields[ fieldName ]).length ){
+                    $.each(hiddenFields[ fieldName ], function(idx, field){
+                        field.data('hide_count', field.data('hide_count') - 1);
+                        if (field.data('hide_count') == 0) {
+                            field.show();
+                        }
+                    });
+                    hiddenFields[ fieldName ] = [];
+                }
+                if( hideWhen.length ){
+                    $.each(hideWhen, function(idx, name){
+                        var f = $('[name="'+name+'"]').parents('.form-group');
+                        if( f.length ){
+                            if (f.data('hide_count')) {
+                                f.data('hide_count', f.data('hide_count') + 1);
+                            } else {
+                                f.data('hide_count', 1);
+                            }
+                            hiddenFields[ fieldName ].push(f);
+                            f.hide();
+                        }
+                    });
+                }
+            };
+            $('input[data-field-toggle]').on('change', function(){
+                return toggle( $(this) );
+            });
+            $('input[data-field-toggle]:checked').each(function(){
+                return toggle( $(this) );
+            });
         }
     </script>
     @endpush


### PR DESCRIPTION
I was looking at https://github.com/Laravel-Backpack/CRUD/pull/165 by https://github.com/OwenMelbz and I wanted to update it to bring it into line with the current schema for Backpack. In the process, I realized all you need to do is add a few lines to the radio field. You can just add a parameter that this field can be a toggle. The rest of the usage is the same as in that PR. Additionally, one thing that bothered me is that you couldn't hide a field from two toggle fields. Now, I've added functionality that allows two toggle fields choose to hide another field, and then the only way it becomes visible if both toggles allow it to be visible

**Usage**

```
//Controller->setUp()
$this->crud->addField([
    'label' => 'Is this a featured article?',
    'name' => 'featured', // can be a real db field, or unique name
    'type' => 'radio',
    'toggle' => true,
    'options' => [ // same as radio, these act as the options, the key is the radio value
        0 => 'Not Featured',
        1 => 'Yes Featured'
    ],
    'hide_when' => [ // these fields hide (by name) when the key matches the radio value
        0 => ['featured_image', 'featured_title'],
        1 => ['basic_title']
    ],
    'default' => 0 // which option to select by default
]);
```