### PR TITLE
fix required repeatable fields

### DIFF
--- a/src/public/packages/backpack/crud/css/form.css
+++ b/src/public/packages/backpack/crud/css/form.css
@@ -4,7 +4,7 @@
 *
 */
 
-.form-group.required label:not(:empty):not(.form-check-label)::after {
+.form-group.required > label:not(:empty):not(.form-check-label)::after {
     content: ' *';
     color: #ff0000;
 }

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -8,11 +8,11 @@
     }
 	// if the field is required in the FormRequest, it should have an asterisk
 	$required = (isset($action) && $crud->isRequired($field['name'], $action)) ? ' required' : '';
-
+	
 	// if the developer has intentionally set the required attribute on the field
 	// forget whatever is in the FormRequest, do what the developer wants
-	$required = (isset($field['showAsterisk'])) ? ($field['showAsterisk'] ? ' required' : '') : $required;
-
+	$required = isset($field['showAsterisk']) ? ($field['showAsterisk'] ? ' required' : '') : $required;
+	
 	$field['wrapper']['class'] = $field['wrapper']['class'] ?? "form-group col-sm-12";
 	$field['wrapper']['class'] = $field['wrapper']['class'].$required;
 	$field['wrapper']['element'] = $field['wrapper']['element'] ?? 'div';

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -45,7 +45,6 @@
               $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
               $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
               $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
-              $subfield['showAsterisk'] = false;
           @endphp
 
           @include($fieldViewPath, ['field' => $subfield])

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -22,6 +22,17 @@
 
     <!-- CRUD FORM CONTENT - crud_fields_styles stack -->
     @stack('crud_fields_styles')
+
+    {{-- Temporary fix on 4.1 --}}
+    <style>
+      .form-group.required label:not(:empty):not(.form-check-label)::after {
+        content: '';
+      }
+      .form-group.required > label:not(:empty):not(.form-check-label)::after {
+        content: ' *';
+        color: #ff0000;
+      }
+    </style>
 @endsection
 
 @section('after_scripts')


### PR DESCRIPTION
I was trying to figure out why would we specifically setup the `showAsterisk => false` in repeatable and find out that it might be to solve an issue when the `parent` (the repeatable field itself) is required. 

From my tests I find out that it does not solve the issue and the issue still persists, so if the parent repeatable is required, all the fields inside the repeatable field show the red asterisk.

![image](https://user-images.githubusercontent.com/7188159/124350137-cb071000-dbea-11eb-8acf-d482f887bb2b.png)

Even setting up `showAsterisk => false` would not make the asterisks go away from the repeatable fields. 

I found out that is due to a CSS rule not beeing correctly applied. 

This would require re-publishing Backpack CSS to work.