### PR TITLE
customize delete button redirect action

### DIFF
--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -37,6 +37,8 @@
 							  }
 
 							  crud.table.draw(false);
+						  }else{
+							  window.location.href = '{{url()->previous()}}';
 						  }
 
 			          	  // Show a success notification bubble


### PR DESCRIPTION
refs #3762 

When deleting an entry from the `show` operation, although the entry is indeed deleted the browser stays in the entry show page. Refreshing the page would cause 404 error as the entry is already deleted from database. 

This PR adds a fallback for when no `crudTable` is present on page and the entry is deleted we redirect to previous page. 


