### PR TITLE
Use the validated method of FormRequest for store and update

### DIFF
--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -76,7 +76,11 @@ trait CreateOperation
         $request = $this->crud->validateRequest();
 
         // insert item in the db
-        $item = $this->crud->create($this->crud->getStrippedSaveRequest());
+        if ($request instanceof \Illuminate\Foundation\Http\FormRequest && $this->crud->isEnableApproachFormRequest()) {
+            $item = $this->crud->create($request->validated());
+        } else {
+            $item = $this->crud->create($this->crud->getStrippedSaveRequest());
+        }
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -91,8 +91,13 @@ trait UpdateOperation
         // execute the FormRequest authorization and validation, if one is required
         $request = $this->crud->validateRequest();
         // update the row in the db
-        $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $this->crud->getStrippedSaveRequest());
+        if ($request instanceof \Illuminate\Foundation\Http\FormRequest && $this->crud->isEnableApproachFormRequest()) {
+            $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
+                $request->validated());
+        } else {
+            $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
+                $this->crud->getStrippedSaveRequest());
+        }
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -57,6 +57,7 @@ class CrudPanel
 
     protected $request;
 
+    private $enableApproachFormRequest;
     // The following methods are used in CrudController or your EntityCrudController to manipulate the variables above.
 
     public function __construct()
@@ -491,5 +492,21 @@ class CrudPanel
         }
 
         return $results;
+    }
+
+    /**
+     *  Enables use of the FormRequest Laravel class, completely.
+     */
+    public function enableApproachFormRequest()
+    {
+        $this->enableApproachFormRequest = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnableApproachFormRequest()
+    {
+        return $this->enableApproachFormRequest;
     }
 }


### PR DESCRIPTION
My suggestion would be to use the validated method of the FormRequest class, this method makes it possible to modify the data after validation and before persisting the data in the database, in addition to giving us the possibility to use the prepareForValidation method that is executed before validation, in case need to unmask data before validating.

To make use of this approach, it would be enough to have a data validation in a form request class and use $this->crud->enableApproachFormRequest() in the controller setup.

Sorry for my English from google translator. ^^