### PR TITLE
[v12] Use str helper to render markdown

### DIFF
--- a/src/resources/views/crud/columns/markdown.blade.php
+++ b/src/resources/views/crud/columns/markdown.blade.php
@@ -1,5 +1,5 @@
 @php
-    $column['text'] = Illuminate\Mail\Markdown::parse($entry->{$column['name']} ?? '');
+    $column['text'] = Illuminate\Support\Str::markdown($entry->{$column['name']} ?? '');
     $column['escaped'] = $column['escaped'] ?? false;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';


### PR DESCRIPTION
As shown in this old tweet https://twitter.com/taylorotwell/status/1355188002818035713, taylor otwell introducing `Str::markdown` use within laravel. This PR change markdown renderer from Maillable to Str class helper. 

The helper was introduced here https://github.com/laravel/framework/pull/36171 and released here https://github.com/laravel/framework/releases/tag/v8.26.0.