### PR TITLE
Replace belongs relation names with foreign key

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -25,11 +25,10 @@ trait Create
     {
         $data = $this->decodeJsonCastedAttributes($data);
         $data = $this->compactFakeFields($data);
+        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data);
 
         // omit the n-n relationships when updating the eloquent item
         $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
-
-        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data, $this->getFields());
 
         $item = $this->model->create(Arr::except($data, $nn_relationships));
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -28,6 +28,9 @@ trait Create
 
         // omit the n-n relationships when updating the eloquent item
         $nn_relationships = Arr::pluck($this->getRelationFieldsWithPivot(), 'name');
+
+        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data, $this->getFields());
+
         $item = $this->model->create(Arr::except($data, $nn_relationships));
 
         // if there are any relationships available, also sync those
@@ -236,26 +239,5 @@ trait Create
         }
 
         return $relationData;
-    }
-
-    public function getOnlyRelationEntity($relation_field)
-    {
-        $entity_array = explode('.', $relation_field['entity']);
-
-        $relation_model = $this->getRelationModel($relation_field['entity'], -1);
-
-        $related_method = Arr::last($entity_array);
-
-        if (! method_exists($relation_model, $related_method)) {
-            if (count($entity_array) <= 1) {
-                return $relation_field['entity'];
-            } else {
-                array_pop($entity_array);
-            }
-
-            return implode('.', $entity_array);
-        }
-
-        return $relation_field['entity'];
     }
 }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -151,24 +151,6 @@ trait FieldsProtectedMethods
         return $field;
     }
 
-    protected function makeSureFieldHasRelationshipData($field)
-    {
-        // only do this if "entity" is defined on the field
-        if (! isset($field['entity'])) {
-            return $field;
-        }
-
-        $extraFieldAttributes = $this->inferFieldAttributesFromRelationship($field);
-
-        if (! empty($extraFieldAttributes)) {
-            $field = array_merge($field, $extraFieldAttributes);
-        } else {
-            abort(500, 'Unable to process relationship data: '.$field['name']);
-        }
-
-        return $field;
-    }
-
     protected function overwriteFieldNameFromEntity($field)
     {
         // if the entity doesn't have a dot, it means we don't need to overwrite the name

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -22,7 +22,6 @@ trait Relationships
         if (method_exists($model, $possible_method)) {
             $parts = explode('.', $entity);
             // here we are going to iterate through all relation parts to check
-            // if the attribute is present in the relation string.
             foreach ($parts as $i => $part) {
                 $relation = $model->$part();
                 $model = $relation->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -119,16 +119,18 @@ trait Relationships
         return $fields;
     }
 
-    protected function changeBelongsToNamesFromRelationshipToForeignKey($data) {
+    protected function changeBelongsToNamesFromRelationshipToForeignKey($data)
+    {
         $belongs_to_fields = $this->getFieldsWithRelationType('BelongsTo');
 
         foreach ($belongs_to_fields as $relation_field) {
             $relation = $this->getRelationInstance($relation_field);
-            if(Arr::has($data, $relation->getRelationName())) {
+            if (Arr::has($data, $relation->getRelationName())) {
                 $data[$relation->getForeignKeyName()] = Arr::get($data, $relation->getRelationName());
                 unset($data[$relation->getRelationName()]);
             }
         }
+
         return $data;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -26,6 +26,8 @@ trait Update
         $data = $this->compactFakeFields($data);
         $item = $this->model->findOrFail($id);
 
+        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data, $this->getFields());
+
         $this->createRelations($item, $data);
 
         // omit the n-n relationships when updating the eloquent item

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -26,7 +26,7 @@ trait Update
         $data = $this->compactFakeFields($data);
         $item = $this->model->findOrFail($id);
 
-        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data, $this->getFields());
+        $data = $this->changeBelongsToNamesFromRelationshipToForeignKey($data);
 
         $this->createRelations($item, $data);
 

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -106,6 +106,12 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         ],
     ];
 
+    private $articleInputBelongsToRelationName = [
+        [
+            'name' => 'user',
+        ]
+    ];
+
     public function testCreate()
     {
         $this->crudPanel->setModel(User::class);
@@ -124,26 +130,51 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEmpty($entry->articles);
     }
 
-    /**
-     * @group failing
-     */
     public function testCreateWithOneToOneRelationship()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
         $this->crudPanel->addFields($this->userInputHasOneRelation);
         $faker = Factory::create();
+        $account_details_nickname = $faker->name;
         $inputData = [
             'name'     => $faker->name,
             'email'    => $faker->safeEmail,
             'password' => bcrypt($faker->password()),
             'accountDetails' => [
-                'nickname' => $faker->name,
+                'nickname' => $account_details_nickname,
                 'profile_picture' => 'test.jpg',
             ],
         ];
         $entry = $this->crudPanel->create($inputData);
-        $this->markTestIncomplete('Has one relation is not created in tests.');
+        $account_details = $entry->accountDetails()->first();
+
+        $this->assertEquals($account_details->nickname, $account_details_nickname);
+        
+    }
+
+    public function testCreateBelongsToWithRelationName()
+    {
+        $this->crudPanel->setModel(Article::class);
+        $this->crudPanel->addFields($this->articleInputFieldsOneToMany);
+        $this->crudPanel->removeField('user_id');
+        $this->crudPanel->addFields($this->articleInputBelongsToRelationName);
+        $faker = Factory::create();
+        $inputData = [
+            'content'     => $faker->text(),
+            'tags'        => $faker->words(3, true),
+            'user'     => 1,
+            'metas'       => null,
+            'extras'      => null,
+            'cast_metas'  => null,
+            'cast_tags'   => null,
+            'cast_extras' => null,
+        ];
+        $entry = $this->crudPanel->create($inputData);
+        $userEntry = User::find(1);
+        $article = Article::where('user_id', 1)->with('user')->get()->last();
+        $this->assertEquals($article->user_id, $entry->user_id);
+        $this->assertEquals($article->id, $entry->id);
     }
 
     public function testCreateWithOneToManyRelationship()

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -109,7 +109,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
     private $articleInputBelongsToRelationName = [
         [
             'name' => 'user',
-        ]
+        ],
     ];
 
     public function testCreate()
@@ -150,7 +150,6 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $account_details = $entry->accountDetails()->first();
 
         $this->assertEquals($account_details->nickname, $account_details_nickname);
-        
     }
 
     public function testCreateBelongsToWithRelationName()


### PR DESCRIPTION
This closes #3796 .

I remember we talked about changing names, but If I remember correctly we were trying to do it upstream, in the field "infering" part, and we decided for renaming only the `HasOne` relations. 

This solution works as expected I think, so far I am testing with:
```php
        $this->crud->addField('icon');

        $this->crud->addField('address.icon');

        $this->crud->addField('address.street');

        $this->crud->addField('address.postalBox.postal_name');
        $this->crud->addField('address.postalBox.monster');
```

I'm testing this out, and adding a test to it, I just need to pull it in another project so WIP here!