### PR TITLE
[4.2][Fix] Reorder operation fix for more than 200 items

### DIFF
--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -80,7 +80,7 @@ trait ReorderOperation
     {
         $this->crud->hasAccessOrFail('reorder');
 
-        $all_entries = \Request::input('tree');
+        $all_entries = json_decode(\Request::input('tree'), true);
 
         if (count($all_entries)) {
             $count = $this->crud->updateTreeOrder($all_entries);

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -265,7 +265,7 @@ function tree_element($entry, $key, $all_entries, $crud)
         $.ajax({
             url: '{{ url(Request::path()) }}',
             type: 'POST',
-            data: { tree: arraied },
+            data: { tree: JSON.stringify(arraied) },
         })
         .done(function() {
             new Noty({


### PR DESCRIPTION
This is a fix for https://github.com/Laravel-Backpack/CRUD/issues/3722
**NOTE**: As pointed out by @tabacitu, it could break custom implementations so it could be merged as part of version 4.2.