### PR TITLE
fix for 0 key in select from array

### DIFF
--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -17,7 +17,7 @@
 
         @if (count($field['options']))
             @foreach ($field['options'] as $key => $value)
-                @if((old(square_brackets_to_dots($field['name'])) && (
+                @if((old(square_brackets_to_dots($field['name'])) !== null && (
                         $key == old(square_brackets_to_dots($field['name'])) ||
                         (is_array(old(square_brackets_to_dots($field['name']))) &&
                         in_array($key, old(square_brackets_to_dots($field['name'])))))) ||


### PR DESCRIPTION
This fixes https://github.com/Laravel-Backpack/CRUD/issues/3761

When using `0` as array key it would never reselect it from `old()` since the evaluation always return `false` when checked agains 0. So I specifically check fol nullness! 

I don't think is there anything breaking here, but it would help to have another pair of eyes here! 👀 

