### PR TITLE
change placeholder URL

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -99,12 +99,12 @@ if (! function_exists('backpack_avatar_url')) {
     function backpack_avatar_url($user)
     {
         $firstLetter = $user->getAttribute('name') ? mb_substr($user->name, 0, 1, 'UTF-8') : 'A';
-        $placeholder = 'https://placehold.it/160x160/00a65a/ffffff/&text='.$firstLetter;
+        $placeholder = 'https://via.placeholder.com/160x160/00a65a/ffffff/&text='.$firstLetter;
 
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
                 if (backpack_users_have_email()) {
-                    return Gravatar::fallback('https://placehold.it/160x160/00a65a/ffffff/&text='.$firstLetter)->get($user->email);
+                    return Gravatar::fallback('https://via.placeholder.com/160x160/00a65a/ffffff/&text='.$firstLetter)->get($user->email);
                 } else {
                     return $placeholder;
                 }


### PR DESCRIPTION
Guys... I know I just merged https://github.com/Laravel-Backpack/CRUD/pull/3681

But... I just noticed the `placehold.it` links will not work if using HTTPS because... the proper domain was changed to `via.placeholder.com`...

Shouldn't we also do this?

😅