### PR TITLE
DevTools Require - Add `auth.json` to `.gitignore`

### DIFF
--- a/src/app/Console/Commands/RequireDevTools.php
+++ b/src/app/Console/Commands/RequireDevTools.php
@@ -193,6 +193,14 @@ class RequireDevTools extends Command
                 $this->progressBar->advance();
             });
         }
+
+        // Add auth.json to gitignore
+        if (File::exists('auth.json')) {
+            $gitignore = Str::of(File::get('.gitignore'));
+            if (!$gitignore->contains('auth.json')) {
+                File::put('.gitignore', $gitignore->finish("\n")->append('auth.json'));
+            }
+        }
     }
 
     public function requireDevTools()

--- a/src/app/Console/Commands/RequireDevTools.php
+++ b/src/app/Console/Commands/RequireDevTools.php
@@ -197,7 +197,7 @@ class RequireDevTools extends Command
         // Add auth.json to gitignore
         if (File::exists('auth.json')) {
             $gitignore = Str::of(File::get('.gitignore'));
-            if (!$gitignore->contains('auth.json')) {
+            if (! $gitignore->contains('auth.json')) {
                 File::put('.gitignore', $gitignore->finish("\n")->append('auth.json'));
             }
         }


### PR DESCRIPTION
We should enforce `auth.json` to be on `.gitignore` right?
I'm not 100% sure about it, because we are enforcing it, but credencial shouldn't be on git repos right!?

@tabacitu @pxpm let me know what you think ✌

This PR points to #3843.