### PR TITLE
fix "Argument #1 ($var) must be of type Countable|array, string given"

### DIFF
--- a/src/resources/views/crud/columns/upload_multiple.blade.php
+++ b/src/resources/views/crud/columns/upload_multiple.blade.php
@@ -1,5 +1,6 @@
 @php
     $value = data_get($entry, $column['name']);
+    if (is_string($value)) $value = json_decode($value); 
     $column['prefix'] = $column['prefix'] ?? '';
     $column['disk'] = $column['disk'] ?? null;
     $column['escaped'] = $column['escaped'] ?? true;


### PR DESCRIPTION
# error 
```
count(): Argument #1 ($var) must be of type Countable|array, string given
```
![image](https://user-images.githubusercontent.com/12745270/135186078-30a6c693-13f9-4fac-b063-1b6ced532af5.png)

# fix
> convert value to array if the value is string 
![image](https://user-images.githubusercontent.com/12745270/135186004-6a57ec80-0cc5-4efa-818a-440c35ba84dd.png)
