### PR TITLE
fix table headers on table resize #3833

### DIFF
--- a/src/resources/views/base/inc/sidebar.blade.php
+++ b/src/resources/views/base/inc/sidebar.blade.php
@@ -49,6 +49,14 @@
       document.querySelectorAll('.sidebar-toggler').forEach(function(toggler) {
         toggler.addEventListener('click', function() {
           sessionStorage.setItem('sidebar-collapsed', Number(!document.body.classList.contains(sidebarClass)))
+          // wait for the sidebar animation to end (250ms) and then update the table headers because datatables uses a cached version
+          // and dont update this values if there are dom changes after the table is draw. The sidebar toggling makes
+          // the table change width, so the headers need to be adjusted accordingly.
+          setTimeout(function() {
+            if(typeof crud !== "undefined" && crud.table) {
+              crud.table.fixedHeader.adjust();
+            }
+          }, 300);
         })
       });
       // Set active state on menu element


### PR DESCRIPTION
short: when changing the sidebar state in the List view, the table headers were not updated to match the current table size. 

Image and description on: #3833