### PR TITLE
Fix for select2 dropdownParent inside inline create modals

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -65,6 +65,7 @@
         style="width:100%"
         name="{{ $field['name'].($field['multiple']?'[]':'') }}"
         data-init-function="bpFieldInitFetchElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-column-nullable="{{ var_export($field['allows_null']) }}"
         data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-model-local-key="{{$crud->model->getKeyName()}}"
@@ -193,6 +194,7 @@
         var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
         var $multiple = element.prop('multiple');
         var $ajaxDelay = element.attr('data-ajax-delay');
+        var $isFieldInline = element.data('field-is-inline');
 
         var FetchAjaxFetchSelectedEntry = function (element) {
             return new Promise(function (resolve, reject) {
@@ -283,6 +285,7 @@
                 placeholder: $placeholder,
                 minimumInputLength: $minimumInputLength,
                 allowClear: $allows_null,
+                dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body,
                 ajax: {
                     url: $dataSource,
                     type: $method,

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -104,11 +104,11 @@ if($activeInlineCreate) {
         @endif
 <select
         name="{{ $field['name'].($field['multiple']?'[]':'') }}"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-original-name="{{ $field['name'] }}"
         style="width: 100%"
         data-force-select="{{ var_export($field['inline_create']['force_select']) }}"
         data-init-function="bpFieldInitFetchOrCreateElement"
-        data-is-inline="{{ $inlineCreate ?? 'false' }}"
         data-allows-null="{{var_export($field['allows_null'])}}"
         data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-model-local-key="{{$crud->model->getKeyName()}}"
@@ -504,7 +504,7 @@ function selectOption(element, option) {
 
 function bpFieldInitFetchOrCreateElement(element) {
     var form = element.closest('form');
-    var $inlineField = element.attr('data-is-inline');
+    var $isFieldInline = element.data('field-is-inline');
     var $ajax = element.attr('data-field-ajax') == 'true' ? true : false;
     var $placeholder = element.attr('data-placeholder');
     var $minimumInputLength = element.attr('data-minimum-input-length');
@@ -597,7 +597,7 @@ function bpFieldInitFetchOrCreateElement(element) {
     }
 
     //Checks if field is not beeing inserted in one inline create modal and setup buttons
-    if($inlineField == "false") {
+    if(!$isFieldInline) {
         setupInlineCreateButtons(element);
     }
 
@@ -610,6 +610,7 @@ function bpFieldInitFetchOrCreateElement(element) {
         allowClear: $allows_null,
         ajax: {
         url: $dataSource,
+        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body,
         type: $method,
         dataType: 'json',
         delay: $ajaxDelay,

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -59,6 +59,7 @@
         style="width:100%"
         name="{{ $field['name'].($field['multiple']?'[]':'') }}"
         data-init-function="bpFieldInitRelationshipSelectElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-column-nullable="{{ var_export($field['allows_null']) }}"
         data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-model-local-key="{{$crud->model->getKeyName()}}"
@@ -146,6 +147,7 @@
         var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
         var $allows_null = (element.attr('data-column-nullable') == 'true') ? true : false;
         var $allowClear = $allows_null;
+        var $isFieldInline = element.data('field-is-inline');
 
         var $item = false;
 
@@ -175,6 +177,7 @@
                 multiple: $multiple,
                 placeholder: $placeholder,
                 allowClear: $allowClear,
+                dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
             };
         if (!$(element).hasClass("select2-hidden-accessible"))
         {

--- a/src/resources/views/crud/fields/select2.blade.php
+++ b/src/resources/views/crud/fields/select2.blade.php
@@ -22,6 +22,7 @@
     <select
         name="{{ $field['name'] }}"
         style="width: 100%"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-init-function="bpFieldInitSelect2Element"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_field'])
@@ -73,9 +74,13 @@
         <script>
             function bpFieldInitSelect2Element(element) {
                 // element will be a jQuery wrapped DOM node
-                if (!element.hasClass("select2-hidden-accessible")) {
+                if (!element.hasClass("select2-hidden-accessible")) 
+                {
+                    let $isFieldInline = element.data('field-is-inline');
+                    
                     element.select2({
-                        theme: "bootstrap"
+                        theme: "bootstrap",
+                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
                     });
                 }
             }

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -15,6 +15,7 @@
         name="{{ $field['name'] }}"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2FromAjaxElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-column-nullable="{{ var_export($field['allows_null']) }}"
         data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-placeholder="{{ $field['placeholder'] }}"
@@ -109,6 +110,7 @@
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
         var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse(null);
+        var $isFieldInline = element.data('field-is-inline');
 
         var select2AjaxFetchSelectedEntry = function (element) {
             return new Promise(function (resolve, reject) {
@@ -141,6 +143,7 @@
             placeholder: $placeholder,
             minimumInputLength: $minimumInputLength,
             allowClear: $allowClear,
+            dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body,
             ajax: {
                 url: $dataSource,
                 type: $method,

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -16,6 +16,7 @@
         name="{{ $field['name'] }}[]"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2FromAjaxMultipleElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-dependencies="{{ isset($field['dependencies'])?json_encode(Arr::wrap($field['dependencies'])): json_encode([]) }}"
         data-placeholder="{{ $field['placeholder'] }}"
         data-minimum-input-length="{{ $field['minimum_input_length'] }}"
@@ -94,6 +95,7 @@
         var $dependencies = JSON.parse(element.attr('data-dependencies'));
         var $ajaxDelay = element.attr('data-ajax-delay');
         var $selectedOptions = typeof element.attr('data-selected-options') === 'string' ? JSON.parse(element.attr('data-selected-options')) : JSON.parse("[]");
+        var $isFieldInline = element.data('field-is-inline');
 
         var select2AjaxMultipleFetchSelectedEntries = function (element) {
             return new Promise(function (resolve, reject) {
@@ -121,6 +123,7 @@
                 multiple: true,
                 placeholder: $placeholder,
                 minimumInputLength: $minimumInputLength,
+                dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body,
                 ajax: {
                     url: $dataSource,
                     type: $method,

--- a/src/resources/views/crud/fields/select2_from_array.blade.php
+++ b/src/resources/views/crud/fields/select2_from_array.blade.php
@@ -8,6 +8,7 @@
         name="{{ $field['name'] }}@if (isset($field['allows_multiple']) && $field['allows_multiple']==true)[]@endif"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2FromArrayElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_from_array'])
         @if (isset($field['allows_multiple']) && $field['allows_multiple']==true)multiple @endif
@@ -78,8 +79,11 @@
         function bpFieldInitSelect2FromArrayElement(element) {
             if (!element.hasClass("select2-hidden-accessible"))
                 {
+                    let $isFieldInline = element.data('field-is-inline');
+
                     element.select2({
-                        theme: "bootstrap"
+                        theme: "bootstrap",
+                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
                     }).on('select2:unselect', function(e) {
                         if ($(this).attr('multiple') && $(this).val().length == 0) {
                             $(this).val(null).trigger('change');

--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -20,6 +20,7 @@
         name="{{ $field['name'] }}"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2GroupedElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_field'])
         >
@@ -87,9 +88,12 @@
         <script>
             function bpFieldInitSelect2GroupedElement(element) {
                 if (!element.hasClass("select2-hidden-accessible"))
-                {
+                {   
+                    let $isFieldInline = element.data('field-is-inline');
+
                     element.select2({
-                        theme: "bootstrap"
+                        theme: "bootstrap",
+                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
                     });
                 }
             }

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -21,6 +21,7 @@
         name="{{ $field['name'] }}[]"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2MultipleElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-select-all="{{ var_export($field['select_all'] ?? false)}}"
         data-options-for-js="{{json_encode(array_values($options_ids_array))}}"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
@@ -81,23 +82,26 @@
 
                 var $select_all = element.attr('data-select-all');
                 if (!element.hasClass("select2-hidden-accessible"))
-                    {
-                        var $obj = element.select2({
-                            theme: "bootstrap"
+                {
+                    let $isFieldInline = element.data('field-is-inline');
+
+                    var $obj = element.select2({
+                        theme: "bootstrap",
+                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
+                    });
+
+                    //get options ids stored in the field.
+                    var options = JSON.parse(element.attr('data-options-for-js'));
+
+                    if($select_all) {
+                        element.parent().find('.clear').on("click", function () {
+                            $obj.val([]).trigger("change");
                         });
-
-                        //get options ids stored in the field.
-                        var options = JSON.parse(element.attr('data-options-for-js'));
-
-                        if($select_all) {
-                            element.parent().find('.clear').on("click", function () {
-                                $obj.val([]).trigger("change");
-                            });
-                            element.parent().find('.select_all').on("click", function () {
-                                $obj.val(options).trigger("change");
-                            });
-                        }
+                        element.parent().find('.select_all').on("click", function () {
+                            $obj.val(options).trigger("change");
+                        });
                     }
+                }
             }
         </script>
     @endpush

--- a/src/resources/views/crud/fields/select2_nested.blade.php
+++ b/src/resources/views/crud/fields/select2_nested.blade.php
@@ -46,6 +46,7 @@
         name="{{ $field['name'] }}"
         style="width: 100%"
         data-init-function="bpFieldInitSelect2NestedElement"
+        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_field'])
         >
@@ -101,8 +102,11 @@
             function bpFieldInitSelect2NestedElement(element) {
                 if (!element.hasClass("select2-hidden-accessible"))
                 {
+                    let $isFieldInline = element.data('field-is-inline');
+
                     element.select2({
-                        theme: "bootstrap"
+                        theme: "bootstrap",
+                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
                     });
                 }
             }


### PR DESCRIPTION
This fixes #3838 

As described in the issue thread there is a problem introduced by jQuery I think that affects the select2 in some breaking way. 

The problem is that the dropdown does not work inside inline create modals unless the correct parent is specified on the select2 initialization. 

Note: this will probably be fixed in some future version of select2/jquery, or we migth take other direction that does not rely on this dependencies. 

@tabacitu can you please take a look at this and give it a try in your browsers ? I tested in latest chrome for win. 

Best,
Pedro