### PR TITLE
fix AutoSet never taking into account previously added columns

### DIFF
--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -32,7 +32,7 @@ trait AutoSet
                 $this->addField($new_field);
             }
 
-            if (! in_array($field, $this->model->getHidden()) && ! in_array($field, $this->columns())) {
+            if (! in_array($field, $this->model->getHidden()) && ! isset($this->columns()[$field])) {
                 $this->addColumn([
                     'name'    => $field,
                     'label'   => $this->makeLabel($field),


### PR DESCRIPTION
I've noticed that AutoSet, at some point, because of using `in_array()` instead of `isset()`, basically overwrote previously defined columns.

If you did
```php
$this->crud->field('name')->entity(false);
$this->crud->column('name')->entity(false);
$this->crud->setFromDb();
```

Then:
- for fields it would remember the previous definition
- for columns it would NOT remember the previous definition

This PR makes it work the same way for both fields and columns - what the dev defined before running `setFromDb()` is king. We don't overwrite those things - no way Jose.