### PR TITLE
ShowOperation should not add fields by default

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -79,7 +79,7 @@ trait ShowOperation
 
         // set columns from db
         if ($setFromDb) {
-            $this->crud->setFromDb();
+            $this->crud->setFromDb(false, true);
         }
 
         // cycle through columns

--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -10,29 +10,27 @@ trait AutoSet
      *
      * @return void
      */
-    public function setFromDb()
+    public function setFromDb($setFields = true, $setColumns = true)
     {
         if ($this->driverIsSql()) {
             $this->getDbColumnTypes();
         }
 
-        array_map(function ($field) {
-            $new_field = [
-                'name'       => $field,
-                'label'      => $this->makeLabel($field),
-                'value'      => null,
-                'default'    => isset($this->autoset['db_column_types'][$field]['default']) ? $this->autoset['db_column_types'][$field]['default'] : null,
-                'type'       => $this->inferFieldTypeFromDbColumnType($field),
-                'values'     => [],
-                'attributes' => [],
-                'autoset'    => true,
-            ];
-
-            if (! isset($this->fields()[$field])) {
-                $this->addField($new_field);
+        array_map(function ($field) use ($setFields, $setColumns) {
+            if ($setFields && ! isset($this->fields()[$field])) {
+                $this->addField([
+                    'name'       => $field,
+                    'label'      => $this->makeLabel($field),
+                    'value'      => null,
+                    'default'    => isset($this->autoset['db_column_types'][$field]['default']) ? $this->autoset['db_column_types'][$field]['default'] : null,
+                    'type'       => $this->inferFieldTypeFromDbColumnType($field),
+                    'values'     => [],
+                    'attributes' => [],
+                    'autoset'    => true,
+                ]);
             }
 
-            if (! in_array($field, $this->model->getHidden()) && ! in_array($field, $this->columns())) {
+            if ($setColumns && ! in_array($field, $this->model->getHidden()) && ! isset($this->columns()[$field])) {
                 $this->addColumn([
                     'name'    => $field,
                     'label'   => $this->makeLabel($field),


### PR DESCRIPTION
By default, `setFromDb()` was called inside the SHOW operation, which added both fields and columns. That doesn't really make sense, since Show only uses columns. So I've added parameters to `setFromDb()` so that we can choose to add fields, columns or both.

This also inadvertently fixes https://github.com/Laravel-Backpack/CRUD/issues/3925 for the Show operation, since it was trying to add a Field that was impossible to add.