### PR TITLE
[v12] Refactor fetch route - fix for when there's an underscore in the field name

### DIFF
--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -22,7 +22,7 @@ trait FetchOperation
 
         if (count($matches[1])) {
             foreach ($matches[1] as $methodName) {
-                Route::post($segment.'/fetch/'.Str::kebab($methodName), [
+                Route::post($segment.'/fetch/'.$methodName, [
                     'as'        => $segment.'.fetch'.Str::studly($methodName),
                     'uses'      => $controller.'@fetch'.$methodName,
                     'operation' => 'FetchOperation',

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Str;
 
 trait FetchOperation
 {

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -22,8 +22,8 @@ trait FetchOperation
 
         if (count($matches[1])) {
             foreach ($matches[1] as $methodName) {
-                Route::post($segment.'/fetch/'.$methodName, [
-                    'as'        => $segment.'.fetch'.Str::studly($methodName),
+                Route::post($segment.'/fetch/'.lcfirst($methodName), [
+                    'as'        => $segment.'.fetch'.$methodName,
                     'uses'      => $controller.'@fetch'.$methodName,
                     'operation' => 'FetchOperation',
                 ]);

--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -1,8 +1,6 @@
 @php
 
-    //in case entity is superNews we want the url friendly super-news
-    $entityWithoutAttribute = $crud->getOnlyRelationEntity($field);
-    $routeEntity = Str::kebab($entityWithoutAttribute);
+    $routeEntity = $crud->getOnlyRelationEntity($field);
 
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -2,9 +2,7 @@
 
 @php
 
-    //in case entity is superNews we want the url friendly super-news
-    $entityWithoutAttribute = $crud->getOnlyRelationEntity($field);
-    $routeEntity = Str::kebab($entityWithoutAttribute);
+    $routeEntity = $crud->getOnlyRelationEntity($field);
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
 


### PR DESCRIPTION
This was discussed in #2905 

I still think we should do it, there is no need for us to have this inconsistency in the code.

It's a breaking change, but if we don't do it now, we would be carrying this bug for the next version. 

The BC in developer perspective does not change much, if they were using `data_source` to overcome the problem of using `camelEntity` it's just a matter of deleting the `data_source` from the field and let Backpack automatically pick it. 