### PR TITLE
fix: creating translatable models with multiple languages

### DIFF
--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -81,9 +81,7 @@ trait HasTranslations
         foreach ($attributes as $attribute => $value) {
             if ($model->isTranslatableAttribute($attribute)) { // the attribute is translatable
                 if (is_array($value)) {
-                    foreach ($value as $lang => $val) {
-                        $model->setTranslation($attribute, $lang, $val);
-                    }
+                    $model->setTranslations($attribute, $value);
                 } else {
                     $model->setTranslation($attribute, $locale, $value);
                 }

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -80,7 +80,13 @@ trait HasTranslations
         // do the actual saving
         foreach ($attributes as $attribute => $value) {
             if ($model->isTranslatableAttribute($attribute)) { // the attribute is translatable
-                $model->setTranslation($attribute, $locale, $value);
+                if (is_array($value)) {
+                    foreach ($value as $lang => $val) {
+                        $model->setTranslation($attribute, $lang, $val);
+                    }
+                } else {
+                    $model->setTranslation($attribute, $locale, $value);
+                }
             } else { // the attribute is NOT translatable
                 $non_translatable[$attribute] = $value;
             }


### PR DESCRIPTION
This PR fixes doing something like this with a translatable model:

```php
Category::create(['title' => ['de' => 'Maschinenbau', 'en' => 'Mechanical Engineering']]);
```

[Spatie's docs](https://github.com/spatie/laravel-translatable#creating-models) say that's how it is supposed to work. However, with the backpack trait instead of Spatie's, I found this would create the following json for the `title` attribute in the database:

```json
{"en":{"de":"Maschinenbau","en":"Mechanical Engineering"}}
```
where it should be this:

```json
{"de":"Maschinenbau","en":"Mechanical Engineering"}
```

I'm not quite sure if my fix is the optimal way to do it since spatie does not seem to override eloquent's create method at all and it works without issues.