### PR TITLE
select2_from_array fix when multiple and X clicked twice - fixes #1224

### DIFF
--- a/src/resources/views/crud/fields/select2_from_array.blade.php
+++ b/src/resources/views/crud/fields/select2_from_array.blade.php
@@ -1,21 +1,27 @@
 <!-- select2 from array -->
 @php
+    $field['placeholder'] = $field['placeholder'] ?? '-';
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
+    $field['allows_multiple'] = $field['allows_multiple'] ?? false;
+
 @endphp
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     <select
-        name="{{ $field['name'] }}@if (isset($field['allows_multiple']) && $field['allows_multiple']==true)[]@endif"
+        name="{{ $field['name'] }}@if ($field['allows_multiple'])[]@endif"
         style="width: 100%"
+        data-real-name="{{ $field['name'] }}"
+        data-field-placeholder="{{$field['placeholder']}}"
+        data-allows-null="{{var_export($field['allows_null'])}}"
         data-init-function="bpFieldInitSelect2FromArrayElement"
-        data-field-is-inline="{{var_export($inlineCreate ?? false)}}"
-        data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
+        data-language="{{str_replace('_', '-', app()->getLocale()) }}"
+        data-field-multiple="{{var_export($field['allows_multiple'])}}"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control select2_from_array'])
-        @if (isset($field['allows_multiple']) && $field['allows_multiple']==true)multiple @endif
+        @if ($field['allows_multiple'])multiple @endif
         >
 
-        @if ($field['allows_null'])
-            <option value="">-</option>
+        @if($field['allows_null'])
+            <option value="">{{$field['placeholder']}}</option>
         @endif
 
         @if (count($field['options']))
@@ -76,19 +82,133 @@
     <script src="{{ asset('packages/select2/dist/js/i18n/' . str_replace('_', '-', app()->getLocale()) . '.js') }}"></script>
     @endif
     <script>
+         
         function bpFieldInitSelect2FromArrayElement(element) {
-            if (!element.hasClass("select2-hidden-accessible"))
-                {
-                    let $isFieldInline = element.data('field-is-inline');
+            var $placeholder = element.attr('data-field-placeholder');
+            var $allows_null = element.attr('data-allows-null') == 'true' ? true : false;
+            var $multiple = element.attr('data-field-multiple') == 'true' ? true : false;
+            var $real_name = element.attr('data-real-name');
+            var $attr_multiple_name = $real_name+'[]';
+
+            //this variable checks if there are any options selected in the multi-select field
+            //if there is no options the field will initialize as a single select.
+            var $multiple_init = (Array.isArray(element.val()) && element.val().length > 0 && $multiple) ? true : false;
+
+            if (!element.hasClass("select2-hidden-accessible")) {
+                    //if we determined that the field has no value, is multiple and allows null
+                    //we create the placeholder option
+                    if(!$multiple_init && $multiple) {
+                        element.append('<option value="" selected></option>');
+                    }
 
                     element.select2({
                         theme: "bootstrap",
-                        dropdownParent: $isFieldInline ? $('#inline-create-dialog .modal-content') : document.body
-                    }).on('select2:unselect', function(e) {
-                        if ($(this).attr('multiple') && $(this).val().length == 0) {
-                            $(this).val(null).trigger('change');
+                        placeholder: $placeholder,
+                        allowClear: $allows_null,
+                        multiple: $multiple_init
+                    }).on('select2:unselect', function (e) {
+
+                        if ($multiple && Array.isArray(element.val()) && element.val().length == 0) {
+                            //if there are no options selected we make sure the field name is reverted to single selection
+                            //this way browser will send the empty value, otherwise it will omit the multiple input when empty
+                            //we only change the name if the element attr name is present to avoid messing with repeatable
+                            if(typeof element.attr('name') !== typeof undefined) {
+                                element.attr('name', $real_name);
+                            }
+
+                            //we also change the multiple attribute from field
+                            element.attr('multiple',false);
+
+                            //we destroy the current select
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+                            //we reinitialize the select as a single select
+                            setTimeout(function() {
+                                element.select2({
+                                    theme: "bootstrap",
+                                    placeholder: $placeholder,
+                                    allowClear: false,
+                                    multiple: false
+                                });
+                                
+                                element.val('').trigger('change');
+                            });
+                        }
+                    }).on('select2:opening', function() {
+                            //this prevents the selection from opening upon clearing the field
+                            if (element.data('unselecting') === true) {
+                                element.data('unselecting', false);
+                                return false;
+                            }
+                            return true;
+                    }).on('select2:unselecting', function(e) {
+                        //we set a variable in the field that indicates that an unselecting operation is running
+                        //we will read this variable in the opening event to determine if we should open the options
+                        element.data('unselecting',true);
+                        return true;
+                    }).on('select2:selecting', function(e) {
+                        //when we select an option, if the element does not have the multiple attribute
+                        //but is indeed a multiple field, we know that this happened because we setup a single select while there is no selection
+                        //and now that user selected atleast one option we will make it multiple again.
+                        //the reason for this is because multiple selects are not sent by browser in request when empty
+                        //making it a single select when empty, will, send the value empty in request.
+                        if(typeof element.attr('multiple') === typeof undefined && $multiple) {
+                            //set the element attribute multiple back to true
+                            element.attr('multiple',true);
+
+                            //revert the name to array
+                            if(typeof element.attr('name') !== typeof undefined && element.attr('name') !== false && element.attr('name') !== $attr_multiple_name) {
+                                element.attr('name', $attr_multiple_name);
+                            }
+
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+
+                            //we remove the placeholder option
+                            $(element.find('option[value=""]')).remove();
+
+                            setTimeout(function() {
+                                element.select2({
+                                    theme: "bootstrap",
+                                    placeholder: $placeholder,
+                                    allowClear: true,
+                                    multiple: true
+                                });
+                            });
+                        }
+                    }).on('select2:clear', function(e) {
+                        //when clearing the selection we revert the field back to a "select single" state if it's multiple.
+                        if($multiple) {
+
+                            if(typeof element.attr('name') !== typeof undefined && element.attr('name') !== false) {
+                                element.attr('name', $real_name);
+                            }
+
+                            element.attr('multiple',false);
+
+                            setTimeout(function() {
+                                element.select2('destroy');
+                            });
+
+                            setTimeout(function() {
+                                element.select2({
+                                    theme: "bootstrap",
+                                    placeholder: $placeholder,
+                                    allowClear: false,
+                                    multiple: false
+                                });
+
+                                element.append('<option value=""></option>');
+                                element.val('').trigger('change');
+
+                            });
+
                         }
                     });
+
+
                 }
         }
     </script>


### PR DESCRIPTION
Created this PR instead of #3284 . That PR had 70+ StyleCI docs changes that didn't make sense and made it difficult to review. So let's use this PR instead.

I'll copy-paste the text from there:

----

Fixes #1224 by basically doing #3243 all over again. That PR #3243 has been merged by mistake, then reverted, so it couldn't be merged again. This PR, if merged, will do the exact same thing as that one.

Here's a copy-paste from @pxpm 's #3243 :

----

This is a fix for #1224

It's an old issue, and I think it's a problem that persists with all select2 that allows the clear of all options.

The main problem is that a select multiple without selected value does not get posted by the browser.

We need to send an empty value (so laravel will convert empty to null with ConvertEmptyStringsToNull) thus updating the value in the database accordingly.

The easiest solution would be to have an hidden input that gets sent in case nothing is selected in the multiple select, but that does not work for us because of repeatable.

This solution might be applicable to all select2 inputs.