### PR TITLE
[4.2] Send database value when image dont change instead of url

### DIFF
--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -52,7 +52,7 @@
 
         // generate URL
         $value_url = $field['disk']
-            ? getDiskUrl($field['disk'], $value)
+            ? getDiskUrl($field['disk'], $value_url)
             : url($value_url);
     }
 

--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -2,6 +2,7 @@
     $field['prefix'] = $field['prefix'] ?? '';
     $field['disk'] = $field['disk'] ?? null;
     $value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
+    $value_url = '';
 
     if (! function_exists('getDiskUrl')) {
         function getDiskUrl($disk, $path) {
@@ -47,12 +48,12 @@
     // if value isn't a base 64 image, generate URL
     if($value && !preg_match('/^data\:image\//', $value)) {
         // make sure to append prefix once to value
-        $value = Str::start($value, $field['prefix']);
+        $value_url = Str::start($value, $field['prefix']);
 
         // generate URL
-        $value = $field['disk']
+        $value_url = $field['disk']
             ? getDiskUrl($field['disk'], $value)
-            : url($value);
+            : url($value_url);
     }
 
     $max_image_size_in_bytes = $field['max_file_size'] ?? (int)maximumServerUploadSizeInBytes();
@@ -89,7 +90,7 @@
     <div class="btn-group">
         <div class="btn btn-light btn-sm btn-file">
             {{ trans('backpack::crud.choose_file') }} <input type="file" accept="image/*" data-handle="uploadImage"  @include('crud::fields.inc.attributes')>
-            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" data-value-prefix="{{ $field['prefix'] }}" value="{{ $value }}">
+            <input type="hidden" data-handle="hiddenImage" name="{{ $field['name'] }}" data-value-prefix="{{ $field['prefix'] }}" data-value-url="{{$value_url}}" value="{{ $value }}">
         </div>
         @if(isset($field['crop']) && $field['crop'])
         <button class="btn btn-light btn-sm" data-handle="rotateLeft" type="button" style="display: none;"><i class="la la-rotate-left"></i></button>
@@ -196,8 +197,8 @@
                         $previews.hide();
                         $remove.hide();
                     }
-                    // Make the main image show the image in the hidden input
-                    $mainImage.attr('src', $hiddenImage.val());
+                    // Make the main image show the image in the hidden input url (image loaded from database) or show the preview data
+                    $mainImage.attr('src', $hiddenImage.data('value-url').length > 0 ? $hiddenImage.data('value-url') : $hiddenImage.val());
 
 
                     // Only initialize cropper plugin if crop is set to true


### PR DESCRIPTION
When using an `image` field I hope developers would not follow our documentation, otherwise they could had some headaches.

The last `else` is breaking their apps (we don't use it in our demo, but still have it in the docs, some leftover from previous versions 😞 ) I've sent a PR to remove it in 4.1: https://github.com/Laravel-Backpack/docs/pull/279

This else would make images save as full url `https://something.com/uploads/image.jpg` when you expect to save the relative paths in the database `uploads/image.jpg`. 

The problem is the fact that when you don't change the image and submit the form, the value in the hidden input is sent, and contains the full url because we mutated the value in the begining of `image` file.

This PR aims to send the database value when there is no image changes, so that `else` would not be a breaking one (because we send the database value when no changes are made in image), and also is a necessary feature to handle images inside repeatable, otherwise developer would need to strip `https://something.com` from the sent information when no image is changed and decide how he would want to save it, with or without the `domain url`.

I expect alot of people didn't notice it because the way `url()` is implemented, the field just works:

![image](https://user-images.githubusercontent.com/7188159/142771787-4a009999-c6c5-44fe-902f-629051f44e87.png)

Let me know what you think,
Pedro

