### PR TITLE
[Idea] Skip `ConvertEmptyStringsToNull` middleware when we feel like it

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -225,7 +225,7 @@ class BackpackServiceProvider extends ServiceProvider
      * Used to be used inside CreateOperation and UpdateOperation, but can be used
      * by any other operation too, if they need it.
      *
-     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Routing\Route  $route
      * @return void
      */
     public function skipConvertingEmptyStringsToNull($route)

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -220,6 +220,29 @@ class BackpackServiceProvider extends ServiceProvider
         });
     }
 
+    /**
+     * Add a rule to ConvertEmptyStringsToNull to not run itself for a specific route.
+     * Used to be used inside CreateOperation and UpdateOperation, but can be used
+     * by any other operation too, if they need it.
+     *
+     * @param  \Illuminate\Routing\Route $route
+     * @return void
+     */
+    public function skipConvertingEmptyStringsToNull($route)
+    {
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::skipWhen(
+            function ($request) use ($route) {
+                // Unfortunately inside this closure we don't have access to the current route,
+                // both request()->route() and Route::getCurrent() will return null,
+                // so we have to rely on manual matching
+                $routeUriMatches = $request->is(str_replace('{id}', '*', $route->uri));
+                $routeMethodMatches = in_array($request->method(), $route->methods);
+
+                return ($routeUriMatches && $routeMethodMatches) ? true : false;
+            }
+        );
+    }
+
     public function loadViewsWithFallbacks()
     {
         $customBaseFolder = resource_path('views/vendor/backpack/base');

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
+use Backpack\CRUD\BackpackServiceProvider;
 use Illuminate\Support\Facades\Route;
 
 trait CreateOperation
@@ -21,11 +22,13 @@ trait CreateOperation
             'operation' => 'create',
         ]);
 
-        Route::post($segment, [
+        $storeRoute = Route::post($segment, [
             'as'        => $routeName.'.store',
             'uses'      => $controller.'@store',
             'operation' => 'create',
         ]);
+
+        BackpackServiceProvider::skipConvertingEmptyStringsToNull($storeRoute);
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
+use Backpack\CRUD\BackpackServiceProvider;
 use Illuminate\Support\Facades\Route;
 
 trait UpdateOperation
@@ -21,11 +22,13 @@ trait UpdateOperation
             'operation' => 'update',
         ]);
 
-        Route::put($segment.'/{id}', [
+        $updateRoute = Route::put($segment.'/{id}', [
             'as'        => $routeName.'.update',
             'uses'      => $controller.'@update',
             'operation' => 'update',
         ]);
+
+        BackpackServiceProvider::skipConvertingEmptyStringsToNull($updateRoute);
     }
 
     /**
@@ -90,8 +93,10 @@ trait UpdateOperation
         // execute the FormRequest authorization and validation, if one is required
         $request = $this->crud->validateRequest();
         // update the row in the db
-        $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $this->crud->getStrippedSaveRequest());
+        $item = $this->crud->update(
+            $request->get($this->crud->model->getKeyName()),
+            $this->crud->getStrippedSaveRequest()
+        );
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message


### PR DESCRIPTION
Note: works only on Laravel 8.36+ - that's when `skipWhen()` was introduced to this middleware.

This PR excludes a few routes from the `ConvertEmptyStringsToNull` middleware:
- `UpdateOperation::update()`
- `CreateOperation::store()`

Here's the before&after for a request that reaches `update()`:

![Screenshot 2021-11-22 at 12 37 15](https://user-images.githubusercontent.com/1032474/142846826-9d413bf2-dd9e-41dc-a44e-ac5bf82b6d48.png)

**I'm not sure this is a good idea**, but yeah, if we decide to do it, this is how we can do that. Tried it A BUNCH of ways but this is the only one I could make work.

---

@pxpm **what do you think about this idea - good/bad?** Would it help us or not? Do we have _enough reasons_ to do something so invasive/unexpected to the request? The way I see it:

PROs:
- would fix https://github.com/Laravel-Backpack/CRUD/issues/3944
- I know we have other problems due to `ConvertEmptyStringsToNull` that would probably be fixed by this (@pxpm can you please tell me which ones in particular?)

CONs:
- we'll probably need to turn empty values to `null` ourselves somewhere in the saving process, to prevent saving empty strings to the database;
- possible performance implications? if you have 10 CRUDs, each with both Create and Update, this will basically add 20 closures that `ConvertEmptyStringsToNull` will have to run; and that's done _upon each request_, so _every pageload_; the logic inside it is basic, just string manipulation and comparison, but still... might slow down all pageloads? I dunno 🤷‍♂️
- what else? let's be careful about the implications here 👀

CONs we can/have overcome:
- ~~what happens with the FormRequest validation - will empty string still be picked up by the `nullable` validation?~~ I checked, empty string works as expected in validation, `required` doesn't like them one bit 😀

But if we _do_ decide to do it, this is the moment. Before we tag 4.2. I'll put it as a MUST just so we see it, even though... it might not be a MUST.

Let me know what you think @pxpm .

----

Implementation note to self: We cannot "_just exclude the middleware_" from that route using `Route::get('bla-bla')->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class)` because `ConvertEmptyStringsToNull` is defined as **global middleware** and Laravel doesn't let you exclude those. See:
- https://github.com/laravel/framework/issues/32384
- https://github.com/laravel/framework/pull/32404