### PR TITLE
WIP: Create `backpack_upload` validator and refactor upload to send value when no change is made

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -5,10 +5,13 @@ namespace Backpack\CRUD;
 use Backpack\CRUD\app\Http\Middleware\ThrottlePasswordRecovery;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 class BackpackServiceProvider extends ServiceProvider
 {
@@ -48,6 +51,55 @@ class BackpackServiceProvider extends ServiceProvider
         $this->publishFiles();
         $this->checkLicenseCodeExists();
         $this->sendUsageStats();
+
+        Validator::extend('backpack_upload_validator', function ($attribute, $value, $parameters, $validator) {
+            // we use ";" to distinguish between Laravel Validator parameters separated by "," from the inner rule parameters that developer 
+            // may provide to validate the file. Example: "unique:table;id" would be translated into Laravel validation "unique:table,id"
+            $parameters = collect($parameters)->map(function($parameter) {
+                return Str::replace(';', ',', $parameter);
+            })->implode('|');
+
+            $validating_model = app('crud')->getCurrentEntry();
+
+            // if value is a string it means that nothing has changed in field, we just make sure that both values match
+            if(is_string($value)) {
+                //if there is a previous entry in database
+                if($validating_model) {
+                    // check if it's not an array attribute and we can access the previous model value
+                    if(strpos($attribute,'.') === false) {
+                        return $value === $validating_model->{$attribute};
+                    }else{
+                        // if we are validating arrays, we make sure that this value exists in the array of previous values
+                        $array_attribute = Str::afterLast($attribute, '.');
+                        $model_attribute = Str::before($attribute, '.');
+                        return in_array($value, array_column($validating_model->{$model_attribute}, $array_attribute));
+                    }
+                    
+                }
+                // it can't be a string when creating
+                return false;
+            }
+
+            // build the 
+            $attribute_for_validation = strpos($attribute,'.') === false ? $attribute : Str::before($attribute, '.').'.*.'.Str::afterLast($attribute, '.');
+
+            // transform dot notation attribute into a data array for validation 
+            if(strpos($attribute,'.') !== false) {
+                $validation_input_array = [Str::before($attribute, '.') => [
+                    [
+                        Str::afterLast($attribute, '.') => $value,
+                    ]
+                ]];
+            // just build the validation input
+            }else{
+                $validation_input_array = [Str::before($attribute, '.') => $value];
+            }
+            
+            // we check if the validator fails(), that's why our response to the validation is the negation of this operation result.
+            // so if the `fails()` return `true`, means that this validator is failing, so we return `false` to the main validation instance
+            return !Validator::make($validation_input_array, [$attribute_for_validation => $parameters])->fails();
+            
+        });
     }
 
     /**

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -23,6 +23,7 @@
         @endif
             {{ $field['value'] }}
         </a>
+        <input type="hidden" value="{{$field['value']}}" name="{{$field['name']}}" />
     	<a href="#" class="file_clear_button btn btn-light btn-sm float-right" title="Clear file"><i class="la la-remove"></i></a>
     	<div class="clearfix"></div>
     </div>
@@ -34,7 +35,7 @@
             type="file"
             name="{{ $field['name'] }}"
             value="{{ old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '' }}"
-            @include('crud::fields.inc.attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'file_input backstrap-file-input':'file_input backstrap-file-input'])
+            @include('crud::fields.inc.attributes', ['default_class' =>  'file_input backstrap-file-input'])
         >
         <label class="backstrap-file-label" for="customFile"></label>
     </div>
@@ -157,9 +158,8 @@
 
                     // redo the selector, so we can use the same fileInput variable going forward
                     fileInput = element.find(".file_input");
-
                     // add a hidden input with the same name, so that the setXAttribute method is triggered
-                    $("<input type='hidden' name='"+fieldName+"' value=''>").insertAfter(fileInput);
+                    $("<input type='hidden' name='"+fileInput.attr('name')+"' value=''>").insertAfter(fileInput);
                 });
 
                 fileInput.change(function() {


### PR DESCRIPTION
This changes upload field behaviour by sending the field value when there is no changes in field. Previously it would not send the field at all in the request. 

It introduces a validation helper that should be used to validate file inputs.

It accepts the same rules as laravel, but should be separated by `,` comma instead of pipe `|`. 
`'your_input' => 'backpack_upload:required,file'`

