### PR TITLE
[4.2] Non-inputs start with underscore

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -47,8 +47,8 @@ trait ShowOperation
                 'redirect' => function ($crud, $request, $itemId = null) {
                     $itemId = $itemId ?: $request->input('id');
                     $redirectUrl = $crud->route.'/'.$itemId.'/show';
-                    if ($request->has('locale')) {
-                        $redirectUrl .= '?locale='.$request->input('locale');
+                    if ($request->has('_locale')) {
+                        $redirectUrl .= '?_locale='.$request->input('_locale');
                     }
 
                     return $redirectUrl;

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -40,9 +40,9 @@ trait UpdateOperation
 
             if ($this->crud->getModel()->translationEnabled()) {
                 $this->crud->addField([
-                    'name' => 'locale',
+                    'name' => '_locale',
                     'type' => 'hidden',
-                    'value' => request()->input('locale') ?? app()->getLocale(),
+                    'value' => request()->input('_locale') ?? app()->getLocale(),
                 ]);
             }
 
@@ -90,8 +90,10 @@ trait UpdateOperation
         // execute the FormRequest authorization and validation, if one is required
         $request = $this->crud->validateRequest();
         // update the row in the db
-        $item = $this->crud->update($request->get($this->crud->model->getKeyName()),
-                            $this->crud->getStrippedSaveRequest());
+        $item = $this->crud->update(
+            $request->get($this->crud->model->getKeyName()),
+            $this->crud->getStrippedSaveRequest()
+        );
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -82,7 +82,7 @@ trait SaveActions
         //check for some mandatory fields
         $saveAction['name'] ?? abort(500, 'Please define save action name.');
         $saveAction['redirect'] = $saveAction['redirect'] ?? function ($crud, $request, $itemId) {
-            return $request->has('http_referrer') ? $request->get('http_referrer') : $crud->route;
+            return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
         };
         $saveAction['visible'] = $saveAction['visible'] ?? true;
         $saveAction['button_text'] = $saveAction['button_text'] ?? $saveAction['name'];
@@ -304,7 +304,7 @@ trait SaveActions
     public function setSaveAction($forceSaveAction = null)
     {
         $saveAction = $forceSaveAction ?:
-            \Request::input('save_action', $this->getFallBackSaveAction());
+            \Request::input('_save_action', $this->getFallBackSaveAction());
 
         $showBubble = $this->getOperationSetting('showSaveActionChange') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.showSaveActionChange') ?? true;
 
@@ -327,7 +327,7 @@ trait SaveActions
     public function performSaveAction($itemId = null)
     {
         $request = \Request::instance();
-        $saveAction = $request->input('save_action', $this->getFallBackSaveAction());
+        $saveAction = $request->input('_save_action', $this->getFallBackSaveAction());
         $itemId = $itemId ?: $request->input('id');
         $actions = $this->getOperationSetting('save_actions');
 
@@ -375,7 +375,7 @@ trait SaveActions
                     return $crud->hasAccess('list');
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    return $request->has('http_referrer') ? $request->get('http_referrer') : $crud->route;
+                    return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
                 },
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
@@ -387,11 +387,11 @@ trait SaveActions
                 'redirect' => function ($crud, $request, $itemId = null) {
                     $itemId = $itemId ?: $request->input('id');
                     $redirectUrl = $crud->route.'/'.$itemId.'/edit';
-                    if ($request->has('locale')) {
-                        $redirectUrl .= '?locale='.$request->input('locale');
+                    if ($request->has('_locale')) {
+                        $redirectUrl .= '?_locale='.$request->input('_locale');
                     }
-                    if ($request->has('current_tab')) {
-                        $redirectUrl = $redirectUrl.'#'.$request->get('current_tab');
+                    if ($request->has('_current_tab')) {
+                        $redirectUrl = $redirectUrl.'#'.$request->get('_current_tab');
                     }
 
                     return $redirectUrl;

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -103,8 +103,8 @@ trait HasTranslations
             return false;
         }
 
-        $locale = $attributes['locale'] ?? \App::getLocale();
-        $attributes = Arr::except($attributes, ['locale']);
+        $locale = $attributes['_locale'] ?? \App::getLocale();
+        $attributes = Arr::except($attributes, ['_locale']);
         $non_translatable = [];
 
         // do the actual saving
@@ -168,7 +168,7 @@ trait HasTranslations
             return $this->locale;
         }
 
-        return \Request::input('locale', \App::getLocale());
+        return \Request::input('_locale', \App::getLocale());
     }
 
     /**
@@ -188,7 +188,7 @@ trait HasTranslations
             case 'findBySlug':
             case 'findBySlugOrFail':
 
-                $translation_locale = \Request::input('locale', \App::getLocale());
+                $translation_locale = \Request::input('_locale', \App::getLocale());
 
                 if ($translation_locale) {
                     $item = parent::__call($method, $parameters);

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -97,7 +97,7 @@ return [
             // - false - ONLY save inputs that have fields (safest)
             // - [x, y, z] - save ALL inputs, EXCEPT the ones given in this array
             'saveAllInputsExcept' => false,
-            // 'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
+            // 'saveAllInputsExcept' => ['_token', '_method', '_http_referrer', '_current_tab', '_save_action'],
         ],
 
         /*
@@ -133,7 +133,7 @@ return [
             // - false - Save ONLY inputs that have a field (safest, default);
             // - [x, y, z] - Save ALL inputs, EXCEPT the ones given in this array;
             'saveAllInputsExcept' => false,
-            // 'saveAllInputsExcept' => ['_token', '_method', 'http_referrer', 'current_tab', 'save_action'],
+            // 'saveAllInputsExcept' => ['_token', '_method', '_http_referrer', '_current_tab', '_save_action'],
         ],
 
         /*

--- a/src/resources/views/crud/buttons/show.blade.php
+++ b/src/resources/views/crud/buttons/show.blade.php
@@ -15,7 +15,7 @@
 	  <ul class="dropdown-menu dropdown-menu-right">
   	    <li class="dropdown-header">{{ trans('backpack::crud.preview') }}:</li>
 	  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
-		  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}?locale={{ $key }}">{{ $locale }}</a>
+		  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}?_locale={{ $key }}">{{ $locale }}</a>
 	  	@endforeach
 	  </ul>
 	</div>

--- a/src/resources/views/crud/buttons/update.blade.php
+++ b/src/resources/views/crud/buttons/update.blade.php
@@ -15,7 +15,7 @@
 	  <ul class="dropdown-menu dropdown-menu-right">
   	    <li class="dropdown-header">{{ trans('backpack::crud.edit_translations') }}:</li>
 	  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
-		  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}?locale={{ $key }}">{{ $locale }}</a>
+		  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}?_locale={{ $key }}">{{ $locale }}</a>
 	  	@endforeach
 	  </ul>
 	</div>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -45,11 +45,11 @@
 		    	<!-- Single button -->
 				<div class="btn-group">
 				  <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('locale')?request()->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
+				    {{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('_locale')?request()->input('_locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
 				  </button>
 				  <ul class="dropdown-menu">
 				  	@foreach ($crud->model->getAvailableLocales() as $key => $locale)
-					  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}?locale={{ $key }}">{{ $locale }}</a>
+					  	<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}?_locale={{ $key }}">{{ $locale }}</a>
 				  	@endforeach
 				  </ul>
 				</div>

--- a/src/resources/views/crud/fields/relationship/form_content.blade.php
+++ b/src/resources/views/crud/fields/relationship/form_content.blade.php
@@ -1,9 +1,9 @@
-<input type="hidden" name="http_referrer" value={{ old('http_referrer') ?? \URL::previous() ?? url($crud->route) }}>
+<input type="hidden" name="_http_referrer" value={{ old('_http_referrer') ?? \URL::previous() ?? url($crud->route) }}>
 
 {{-- See if we're using tabs --}}
 @if ($crud->tabsEnabled() && count($crud->getTabs()))
     @include('crud::fields.relationship.show_tabbed_fields')
-    <input type="hidden" name="current_tab" value="{{ Str::slug($crud->getTabs()[0], "") }}" />
+    <input type="hidden" name="_current_tab" value="{{ Str::slug($crud->getTabs()[0], "") }}" />
 @else
   <div class="card">
     <div class="card-body row">

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -1,9 +1,9 @@
-<input type="hidden" name="http_referrer" value={{ session('referrer_url_override') ?? old('http_referrer') ?? \URL::previous() ?? url($crud->route) }}>
+<input type="hidden" name="_http_referrer" value={{ session('referrer_url_override') ?? old('_http_referrer') ?? \URL::previous() ?? url($crud->route) }}>
 
 {{-- See if we're using tabs --}}
 @if ($crud->tabsEnabled() && count($crud->getTabs()))
     @include('crud::inc.show_tabbed_fields')
-    <input type="hidden" name="current_tab" value="{{ Str::slug($crud->getTabs()[0]) }}" />
+    <input type="hidden" name="_current_tab" value="{{ Str::slug($crud->getTabs()[0]) }}" />
 @else
   <div class="card">
     <div class="card-body row">
@@ -67,7 +67,7 @@
       // Save button has multiple actions: save and exit, save and edit, save and new
       var saveActions = $('#saveActions'),
       crudForm        = saveActions.parents('form'),
-      saveActionField = $('[name="save_action"]');
+      saveActionField = $('[name="_save_action"]');
 
       saveActions.on('click', '.dropdown-menu a', function(){
           var saveAction = $(this).data('value');
@@ -155,11 +155,11 @@
 
       $("a[data-toggle='tab']").click(function(){
           currentTabName = $(this).attr('tab_name');
-          $("input[name='current_tab']").val(currentTabName);
+          $("input[name='_current_tab']").val(currentTabName);
       });
 
       if (window.location.hash) {
-          $("input[name='current_tab']").val(window.location.hash.substr(1));
+          $("input[name='_current_tab']").val(window.location.hash.substr(1));
       }
 
       });

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -1,7 +1,7 @@
 @if(isset($saveAction['active']) && !is_null($saveAction['active']['value']))
     <div id="saveActions" class="form-group">
 
-        <input type="hidden" name="save_action" value="{{ $saveAction['active']['value'] }}">
+        <input type="hidden" name="_save_action" value="{{ $saveAction['active']['value'] }}">
         @if(!empty($saveAction['options']))
             <div class="btn-group" role="group">
         @endif

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -36,11 +36,11 @@
 					<!-- Change translation button group -->
 					<div class="btn-group float-right">
 					<button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('locale')?request()->input('locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
+						{{trans('backpack::crud.language')}}: {{ $crud->model->getAvailableLocales()[request()->input('_locale')?request()->input('_locale'):App::getLocale()] }} &nbsp; <span class="caret"></span>
 					</button>
 					<ul class="dropdown-menu">
 						@foreach ($crud->model->getAvailableLocales() as $key => $locale)
-							<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}?locale={{ $key }}">{{ $locale }}</a>
+							<a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}?_locale={{ $key }}">{{ $locale }}</a>
 						@endforeach
 					</ul>
 					</div>


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/ideas/issues/9

Renames all system GET/POST parameters to be prefixed by underscore. That way there's less chance of a conflict with any db columns, and easier to spot that an input belongs to Backpack, not the form itself.