### PR TITLE
Make requests modifiable v2

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -242,7 +242,7 @@ class BackpackServiceProvider extends ServiceProvider
         $operationConfigs = scandir(__DIR__.'/config/backpack/operations/');
         $operationConfigs = array_diff($operationConfigs, ['.', '..']);
 
-        if (!count($operationConfigs)) {
+        if (! count($operationConfigs)) {
             return;
         }
 

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -76,7 +76,7 @@ trait CreateOperation
         $request = $this->crud->validateRequest();
 
         // insert item in the db
-        $item = $this->crud->create($this->crud->getStrippedSaveRequest());
+        $item = $this->crud->create($this->crud->getStrippedSaveRequest($request));
         $this->data['entry'] = $this->crud->entry = $item;
 
         // show a success message

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -89,10 +89,11 @@ trait UpdateOperation
 
         // execute the FormRequest authorization and validation, if one is required
         $request = $this->crud->validateRequest();
+
         // update the row in the db
         $item = $this->crud->update(
             $request->get($this->crud->model->getKeyName()),
-            $this->crud->getStrippedSaveRequest()
+            $this->crud->getStrippedSaveRequest($request)
         );
         $this->data['entry'] = $this->crud->entry = $item;
 

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -426,16 +426,19 @@ trait Fields
     /**
      * Returns the request without anything that might have been maliciously inserted.
      * Only specific field names that have been introduced with addField() are kept in the request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return array
      */
-    public function getStrippedSaveRequest()
+    public function getStrippedSaveRequest($request)
     {
         $setting = $this->getOperationSetting('strippedRequest');
 
         if (is_callable($setting)) {
-            return $setting($this->getRequest());
+            return $setting($request);
         }
 
-        return $this->getRequest()->only($this->getAllFieldNames());
+        return $request->only($this->getAllFieldNames());
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -427,7 +427,7 @@ trait Fields
      * Returns the request without anything that might have been maliciously inserted.
      * Only specific field names that have been introduced with addField() are kept in the request.
      *
-     * @param  \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function getStrippedSaveRequest($request)

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Backpack\CRUD preferences
+ * Backpack\CRUD preferences.
  */
 
 return [

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's CreateOperation
+ * Configurations for Backpack's CreateOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-create
  */
@@ -35,14 +35,14 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-    /**
-     * Before saving the entry, how would you like the request to be stripped?
-     * - false - fall back to Backpack's default (ONLY save inputs that have fields)
-     * - closure - process your own request (example removes all inputs that begin with underscode)
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return  array
-     */
+/**
+ * Before saving the entry, how would you like the request to be stripped?
+ * - false - fall back to Backpack's default (ONLY save inputs that have fields)
+ * - closure - process your own request (example removes all inputs that begin with underscode).
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
     // }),

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's ListOperation
+ * Configurations for Backpack's ListOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-list
  */

--- a/src/config/backpack/operations/reorder.php
+++ b/src/config/backpack/operations/reorder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's ReorderOperation
+ * Configurations for Backpack's ReorderOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-reorder
  */

--- a/src/config/backpack/operations/show.php
+++ b/src/config/backpack/operations/show.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's ShowOperation
+ * Configurations for Backpack's ShowOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-show
  */

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's UpdateOperation
+ * Configurations for Backpack's UpdateOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-update
  */
@@ -35,14 +35,14 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-    /**
-     * Before saving the entry, how would you like the request to be stripped?
-     * - false - fall back to Backpack's default (ONLY save inputs that have fields)
-     * - closure - process your own request (example removes all inputs that begin with underscode)
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return  array
-     */
+/**
+ * Before saving the entry, how would you like the request to be stripped?
+ * - false - fall back to Backpack's default (ONLY save inputs that have fields)
+ * - closure - process your own request (example removes all inputs that begin with underscode).
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
     // }),


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in https://github.com/Laravel-Backpack/CRUD/pull/3789, the `FormRequest` wasn't passed to the saving. So if you edited the request there, tough luck.

### AFTER - What is happening after this PR?

The `FormRequest` gets passed to the saving. 

## HOW

### Is it a breaking change or non-breaking change?

BREAKING

### How can we test the before & after?

Do this in your FormRequest:
```php
    protected function prepareForValidation()
    {
        // add something to the request
        $this->request->add(['updated_by' => backpack_user()->id]);
    }
```

BEFORE this PR you'll notice it's ignored, it doesn't reach the saving part (if you `dd()` before it gets saved).
AFTER this PR it does reach it.

Of course, then it will get stripped by `getStrippedSaveRequest()`, but that's a different problem, but you can do something like this then (and add `updated_by` to your validation rules as `nullable`):
```php
    protected function prepareForValidation()
    {
        // tell Backpack to save the validated inputs (instead of all inputs that have fields)
        \CRUD::set('create.strippedRequest', function ($request) {
            return $request->validated();
        });

        // add something to the request
        $this->request->add(['updated_by' => backpack_user()->id]);
    }
```
