### PR TITLE
Add all select option on checklist field

### DIFF
--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -25,11 +25,18 @@
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
+    <div class="row">
+        <div class="col-sm-4">
+            <label class="font-weight-normal">
+                <input type="checkbox"  id="select-all" {{ count($field['options']) == count($field['value']) ? 'checked' : '' }}> <strong> Select all </strong>
+            </label>
+        </div>
+    </div>
     @include('crud::fields.inc.translatable_icon')
 
     <input type="hidden" value='@json($field['value'])' name="{{ $field['name'] }}">
 
-    <div class="row">
+    <div class="row" id="checkbox-wrapper">
         @foreach ($field['options'] as $key => $option)
             <div class="col-sm-4">
                 <div class="checkbox">
@@ -59,37 +66,68 @@
     @push('crud_fields_scripts')
         <script>
             function bpFieldInitChecklist(element) {
+                console.log('element', element);
                 var hidden_input = element.find('input[type=hidden]');
                 var selected_options = JSON.parse(hidden_input.val() || '[]');
-                var checkboxes = element.find('input[type=checkbox]');
+                var checkboxes = element.find('#checkbox-wrapper :input[type=checkbox]');
                 var container = element.find('.row');
 
                 // set the default checked/unchecked states on checklist options
                 checkboxes.each(function(key, option) {
-                  var id = $(this).val();
+                    var id = $(this).val();
 
-                  if (selected_options.map(String).includes(id)) {
-                    $(this).prop('checked', 'checked');
-                  } else {
-                    $(this).prop('checked', false);
-                  }
+                    if (selected_options.map(String).includes(id)) {
+                        $(this).prop('checked', 'checked');
+                    } else {
+                        $(this).prop('checked', false);
+                    }
                 });
 
                 // when a checkbox is clicked
                 // set the correct value on the hidden input
                 checkboxes.click(function() {
-                  var newValue = [];
+                    var newValue = [];
 
-                  checkboxes.each(function() {
-                    if ($(this).is(':checked')) {
-                      var id = $(this).val();
-                      newValue.push(id);
-                    }
-                  });
+                    checkboxes.each(function() {
+                        if ($(this).is(':checked')) {
+                            var id = $(this).val();
+                            newValue.push(id);
+                        }
+                    });
 
                   hidden_input.val(JSON.stringify(newValue));
 
+                  toggleAllSelectCheckbox();
                 });
+            }
+
+            document.getElementById("select-all").addEventListener("click", selectAll);
+
+            function selectAll() {
+                var allCheckbox = $('#checkbox-wrapper :input[type=checkbox]');
+
+                if ($("#select-all").is(':checked')) {
+                    allCheckbox.each(function(){
+                        if ($(this).is(':checked') == false) {
+                            $(this).click();
+                        }
+                    });
+                } else {
+                    allCheckbox.each(function(){
+                        $(this).click();
+                    });
+                }
+            };
+
+            function toggleAllSelectCheckbox() {
+                var selectedItems = JSON.parse(document.getElementsByName("{{ $field['name'] }}")['0'].value);
+                var allItems = "{{ count($field['options']) }}";
+
+                if(selectedItems.length == allItems) {
+                    $('#select-all').prop('checked', 'checked');
+                } else {
+                    $('#select-all').prop('checked', false);
+                }
             }
         </script>
     @endpush

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -28,7 +28,8 @@
     <div class="row">
         <div class="col-sm-4">
             <label class="font-weight-normal">
-                <input type="checkbox"  id="select-all" {{ count($field['options']) == count($field['value']) ? 'checked' : '' }}> <strong> Select all </strong>
+                <input type="checkbox"  id="select-all" {{ count($field['options']) == count($field['value']) ? 'checked' : '' }}> 
+                <strong> Select all </strong>
             </label>
         </div>
     </div>
@@ -74,26 +75,26 @@
 
                 // set the default checked/unchecked states on checklist options
                 checkboxes.each(function(key, option) {
-                    var id = $(this).val();
+                  var id = $(this).val();
 
-                    if (selected_options.map(String).includes(id)) {
-                        $(this).prop('checked', 'checked');
-                    } else {
-                        $(this).prop('checked', false);
-                    }
+                  if (selected_options.map(String).includes(id)) {
+                    $(this).prop('checked', 'checked');
+                  } else {
+                    $(this).prop('checked', false);
+                  }
                 });
 
                 // when a checkbox is clicked
                 // set the correct value on the hidden input
                 checkboxes.click(function() {
-                    var newValue = [];
+                  var newValue = [];
 
-                    checkboxes.each(function() {
-                        if ($(this).is(':checked')) {
-                            var id = $(this).val();
-                            newValue.push(id);
-                        }
-                    });
+                  checkboxes.each(function() {
+                    if ($(this).is(':checked')) {
+                      var id = $(this).val();
+                      newValue.push(id);
+                    }
+                  });
 
                   hidden_input.val(JSON.stringify(newValue));
 
@@ -107,27 +108,27 @@
                 var allCheckbox = $('#checkbox-wrapper :input[type=checkbox]');
 
                 if ($("#select-all").is(':checked')) {
-                    allCheckbox.each(function(){
-                        if ($(this).is(':checked') == false) {
-                            $(this).click();
-                        }
-                    });
+                  allCheckbox.each(function(){
+                    if ($(this).is(':checked') == false) {
+                      $(this).click();
+                    }
+                  });
                 } else {
-                    allCheckbox.each(function(){
-                        $(this).click();
-                    });
+                  allCheckbox.each(function(){
+                    $(this).click();
+                  });
                 }
             };
 
             function toggleAllSelectCheckbox() {
-                var selectedItems = JSON.parse(document.getElementsByName("{{ $field['name'] }}")['0'].value);
-                var allItems = "{{ count($field['options']) }}";
+              var selectedItems = JSON.parse(document.getElementsByName("{{ $field['name'] }}")['0'].value);
+              var allItems = "{{ count($field['options']) }}";
 
-                if(selectedItems.length == allItems) {
-                    $('#select-all').prop('checked', 'checked');
-                } else {
-                    $('#select-all').prop('checked', false);
-                }
+              if(selectedItems.length == allItems) {
+                $('#select-all').prop('checked', 'checked');
+              } else {
+                $('#select-all').prop('checked', false);
+              }
             }
         </script>
     @endpush


### PR DESCRIPTION
## There is no all select option in checklist type field. I have added this option.

### BEFORE - What was wrong? What was happening before this PR?

There was no all select option in checklist type field. that's why user could not select all of checkbox in one click. 

### AFTER - What is happening after this PR?

User can easily select all checkbox by one click on "Select all" checkbox.


### Is it a breaking change or non-breaking change?

Non-breaking change


### How can we test the before & after?

Use input type 'checklist' and check it on view. It show an extra 'Select all' checkbox option on top. Check and uncheck this. You will see the effect.
