### PR TITLE
Fix underscore in field name when using fetch operation

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -2,7 +2,7 @@
 
     //in case entity is superNews we want the url friendly super-news
     $entityWithoutAttribute = $crud->getOnlyRelationEntity($field);
-    $routeEntity = Str::kebab($entityWithoutAttribute);
+    $routeEntity = Str::kebab(str_replace('_', '-', $entityWithoutAttribute));
 
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -4,7 +4,7 @@
 
     //in case entity is superNews we want the url friendly super-news
     $entityWithoutAttribute = $crud->getOnlyRelationEntity($field);
-    $routeEntity = Str::kebab($entityWithoutAttribute);
+    $routeEntity = Str::kebab(str_replace('_', '-', $entityWithoutAttribute));
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
 


### PR DESCRIPTION
## WHY

- https://github.com/Laravel-Backpack/CRUD/issues/2874
- https://github.com/Laravel-Backpack/CRUD/pull/2905
- https://github.com/Laravel-Backpack/CRUD/pull/3930

### BEFORE - What was wrong? What was happening before this PR?

When using a `relationship`, `fetch` or `fetch_or_create` field with a name with an underscore (eg. `billing_address`):
- the route generated by the field was `menu-item/fetch/billing_address`
- the route generated by the Fetch operation was `menu-item/fetch/billing-address` (because the dev defined `fetchBillingAddress()`

This mismatch triggered an AJAX error, because in truth the `menu-item/fetch/billing_address` did not exist.

### AFTER - What is happening after this PR?

The `fetch` and `fetch_or_create` properly generate the fetch URL, even if the field name contains an underscore.

## HOW

### How did you achieve that, in technical terms?

A freakin `str_replace('_', '-', $string)` 😅


### Is it a breaking change or non-breaking change?

Non-breaking:
- if you had an underscore in the field name, you HAD to define the `data_source` because it was broken; so this won't affect you;
- if you didn't have an underscore in the field name, you're not affected in any way;


### How can we test the before & after?

Add a `fetch` field with a complex name with underscores and DO NOT define the `data_source`.
