### PR TITLE
Validation inside CrudController, from array or field definition

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -11,22 +11,46 @@ trait Validation
      *
      * @param array $requiredFields
      */
-    public function setValidationFromArray(array $rules)
+    public function setValidationFromArray(array $rules, array $messages = [])
     {
-        $requiredFields = [];
-
-        if (count($rules)) {
-            foreach ($rules as $key => $rule) {
-                if (
-                    (is_string($rule) && strpos($rule, 'required') !== false && strpos($rule, 'required_') === false) ||
-                    (is_array($rule) && array_search('required', $rule) !== false && array_search('required_', $rule) === false)
-                ) {
-                    $requiredFields[] = $key;
-                }
-            }
-        }
-        $this->setOperationSetting('requiredFields', $requiredFields);
+        $this->setRequiredFields($rules);
         $this->setOperationSetting('validationRules', $rules);
+        $this->setOperationSetting('validationMessages', $messages);
+    }
+
+    /**
+     * Take the rules defined on fields and create a validation
+     * array from them.
+     */
+    public function setValidationFromFields()
+    {
+        $fields = $this->getOperationSetting('fields');
+
+        // construct the validation rules array
+        // (eg. ['name' => 'required|min:2'])
+        $rules = collect($fields)
+                    ->filter(function ($value, $key) {
+                        // only keep fields where 'validationRules' attribute is defined
+                        return array_key_exists('validationRules', $value);
+                    })->map(function ($item, $key) {
+                        // only keep the rules, not the entire field definition
+                        return $item['validationRules'];
+                    })->toArray();
+
+        // construct the validation messages array
+        // (eg. ['title.required' => 'You gotta write smth man.'])
+        $messages = [];
+        collect($fields)
+                    ->filter(function ($value, $key) {
+                        // only keep fields where 'validationMessages' attribute is defined
+                        return array_key_exists('validationMessages', $value);
+                    })->each(function ($item, $key) use (&$messages) {
+                        foreach ($item['validationMessages'] as $rule => $message) {
+                            $messages[$key.'.'.$rule] = $message;
+                        }
+                    });
+
+        $this->setValidationFromArray($rules, $messages);
     }
 
     /**
@@ -35,10 +59,30 @@ trait Validation
      *
      * @param  string  $class  Class that extends FormRequest
      */
-    public function setValidation($class)
+    public function setValidationFromRequest($class)
     {
         $this->setFormRequest($class);
         $this->setRequiredFields($class);
+    }
+
+    /**
+     * Mark a FormRequest file as required for the current operation, in Settings.
+     * Adds the required rules to an array for easy access.
+     *
+     * @param  string|array  $classOrRulesArray  Class that extends FormRequest or array of validation rules
+     * @param  array  $messages  Array of validation messages.
+     */
+    public function setValidation($classOrRulesArray = false, $messages = [])
+    {
+        if (!$classOrRulesArray) {
+            $this->setValidationFromFields();
+        } elseif (is_array($classOrRulesArray)) {
+            $this->setValidationFromArray($classOrRulesArray, $messages);
+        } elseif (is_string($classOrRulesArray) || is_class($classOrRulesArray)) {
+            $this->setValidationFromRequest($classOrRulesArray);
+        } else {
+            abort(500, 'Please pass setValidation() nothing, a rules array or a FormRequest class.');
+        }
     }
 
     /**
@@ -97,7 +141,8 @@ trait Validation
 
             if ($this->hasOperationSetting('validationRules')) {
                 $rules = $this->getOperationSetting('validationRules');
-                $request->validate($rules);
+                $messages = $this->getOperationSetting('validationMessages') ?? [];
+                $request->validate($rules, $messages);
             }
         }
 
@@ -108,13 +153,18 @@ trait Validation
      * Parse a FormRequest class, figure out what inputs are required
      * and store this knowledge in the current object.
      *
-     * @param  string  $class  Class that extends FormRequest
+     * @param  string|array  $classOrRulesArray  Class that extends FormRequest or rules array
      */
-    public function setRequiredFields($class)
+    public function setRequiredFields($classOrRulesArray)
     {
-        $formRequest = new $class();
-        $rules = $formRequest->rules();
         $requiredFields = [];
+
+        if (is_array($classOrRulesArray)) {
+            $rules = $classOrRulesArray;
+        } else {
+            $formRequest = new $classOrRulesArray();
+            $rules = $formRequest->rules();
+        }
 
         if (count($rules)) {
             foreach ($rules as $key => $rule) {

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -9,7 +9,7 @@ trait Validation
     /**
      * Adds the required rules from an array and allows validation of that array.
      *
-     * @param array $requiredFields
+     * @param  array  $requiredFields
      */
     public function setValidationFromArray(array $rules, array $messages = [])
     {
@@ -74,7 +74,7 @@ trait Validation
      */
     public function setValidation($classOrRulesArray = false, $messages = [])
     {
-        if (!$classOrRulesArray) {
+        if (! $classOrRulesArray) {
             $this->setValidationFromFields();
         } elseif (is_array($classOrRulesArray)) {
             $this->setValidationFromArray($classOrRulesArray, $messages);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

You could validate the Create & Update forms in just one way - by defining a `FormRequest`. But for simple entities... that's overkill. Think of `tags`... do you really need a `TagRequest`?

What you _could_ do in that case was to create your own validator, manually. But that's cumbersome. You have to ask yourself "when will this be run?". So it's gotta be inside a conditional. Bleah.

### AFTER - What is happening after this PR?

You can pass more than one thing to the validate function, in your `setupCreateOperation()` and `setupUpdateOperation()`:

```php
// validating using a FormRequest will work just as before
$this->crud->setValidation(TagRequest::class); 
// or
$this->crud->setValidation('App\Http\Requests\TagRequest');

// ----------------------------------
// NEW - validate using a rules array
// ----------------------------------

// just pass a rules array to the same method
$rules = [
    'name' => 'required|min:2',
];
$this->crud->setValidation($rules);

// and you can use the second parameter for custom validation messages
$messages = [
    'name.required' => 'You gotta give it a name, man.',
    'name.min' => 'You came up short. Try more than 2 characters.',
];
$this->crud->setValidation($rules, $messages);

// --------------------------------------
// NEW - define validation rules on fields
// --------------------------------------
$this->crud->addField([
    'name' => 'content',
    'label' => 'Content',
    'type' => 'ckeditor',
    'placeholder' => 'Your textarea text here',
    'validationRules' => 'required|min:10',
    'validationMessages' => [
        'required' => 'You gotta write smth man.',
        'min' => 'More than 10 characters, bro. Wtf... You can do this!',
    ]
]);
$this->crud->setValidation(); // This MUST be called AFTER the fields are defined, NEVER BEFORE
```

Alternatively, instead of calling the one method for everything, you can call each individual method:

```php
$this->crud->setValidationFromRequest(TagRequest::class);
$this->crud->setValidationFromRequest('App\Http\Requests\TagRequest');
$this->crud->setValidationFromArray($rules);
$this->crud->setValidationFromArray($rules, $messages);
$this->crud->setValidationFromFields();
```

I'm not sure what we should be recommending - the individual methods or the general polymorphic one.

## HOW

### How did you achieve that, in technical terms?

`setValidation()` now accepts three things:
- a `class` or `string` => validate that FormRequest
- an `array` => validate that rules array
- nothing => parse field definitions and create rules and messages array from that

For the `class` option, nothing changes in how the validation is done.
For `array` and `field` options, we store the rules and messages in a CRUD setting, as `validationRules` and `validationMessages`.

### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

The before doesn't need to be tested. The "after" will work with the examples above in your `setupCreateOperation()` and `setupUpdateOperation()`.


## WHAT

What's left to be done:
- [x] review & test this;
- [x] decide on attribute names on fields (`validationRules` & `validationMessages`? `rules` & `messages`?);
- [x] decide whether to recommend using the general polymorphic method, or each individual method; 
- [x] write docs for this - https://github.com/Laravel-Backpack/docs/commit/e1628c75a58d522454235bf3cb13b7bbc854c21b
- [x] mention in release notes - https://github.com/Laravel-Backpack/docs/commit/e1628c75a58d522454235bf3cb13b7bbc854c21b