### PR TITLE
Replaced `is_callable` with `instanceof \Closure`

### DIFF
--- a/src/resources/views/crud/columns/array.blade.php
+++ b/src/resources/views/crud/columns/array.blade.php
@@ -5,7 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/array_count.blade.php
+++ b/src/resources/views/crud/columns/array_count.blade.php
@@ -6,7 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? ' items';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/boolean.blade.php
+++ b/src/resources/views/crud/columns/boolean.blade.php
@@ -5,7 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/check.blade.php
+++ b/src/resources/views/crud/columns/check.blade.php
@@ -5,7 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/closure.blade.php
+++ b/src/resources/views/crud/columns/closure.blade.php
@@ -6,7 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/custom_html.blade.php
+++ b/src/resources/views/crud/columns/custom_html.blade.php
@@ -5,7 +5,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/date.blade.php
+++ b/src/resources/views/crud/columns/date.blade.php
@@ -7,7 +7,7 @@
     $column['format'] = $column['format'] ?? config('backpack.base.default_date_format');
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/datetime.blade.php
+++ b/src/resources/views/crud/columns/datetime.blade.php
@@ -7,7 +7,7 @@
     $column['format'] = $column['format'] ?? config('backpack.base.default_datetime_format');
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/email.blade.php
+++ b/src/resources/views/crud/columns/email.blade.php
@@ -7,7 +7,7 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/image.blade.php
+++ b/src/resources/views/crud/columns/image.blade.php
@@ -8,7 +8,7 @@
     $column['radius'] = $column['radius'] ?? "3px";
     $column['prefix'] = $column['prefix'] ?? '';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
       $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/inc/wrapper_end.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_end.blade.php
@@ -4,7 +4,7 @@
 
     // define the wrapper element
     $wrapperElement = $column['wrapper']['element'] ?? 'a';
-    if(!is_string($wrapperElement) && is_callable($wrapperElement)) {
+    if(!is_string($wrapperElement) && $wrapperElement instanceof \Closure) {
         $wrapperElement = $wrapperElement($crud, $column, $entry, $related_key);
     }
 @endphp

--- a/src/resources/views/crud/columns/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_start.blade.php
@@ -5,7 +5,7 @@
     // each wrapper attribute can be a callback or a string
     // for those that are callbacks, run the callbacks to get the final string to use
     foreach($column['wrapper'] as $attribute => $value) {
-        $column['wrapper'][$attribute] = !is_string($value) && is_callable($value) ? $value($crud, $column, $entry, $related_key) : $value ?? '';
+        $column['wrapper'][$attribute] = !is_string($value) && $value instanceof \Closure ? $value($crud, $column, $entry, $related_key) : $value ?? '';
     }
 @endphp
 

--- a/src/resources/views/crud/columns/json.blade.php
+++ b/src/resources/views/crud/columns/json.blade.php
@@ -11,7 +11,7 @@
         $column['value'] = json_decode($column['value'], true);
     }
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/markdown.blade.php
+++ b/src/resources/views/crud/columns/markdown.blade.php
@@ -6,7 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/model_function_attribute.blade.php
+++ b/src/resources/views/crud/columns/model_function_attribute.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/multidimensional_array.blade.php
+++ b/src/resources/views/crud/columns/multidimensional_array.blade.php
@@ -3,7 +3,7 @@
     $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
     $list = [];
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/number.blade.php
+++ b/src/resources/views/crud/columns/number.blade.php
@@ -9,7 +9,7 @@
     $column['thousands_sep'] = $column['thousands_sep'] ?? ',';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
     

--- a/src/resources/views/crud/columns/phone.blade.php
+++ b/src/resources/views/crud/columns/phone.blade.php
@@ -7,7 +7,7 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/radio.blade.php
+++ b/src/resources/views/crud/columns/radio.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/relationship_count.blade.php
+++ b/src/resources/views/crud/columns/relationship_count.blade.php
@@ -6,7 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? ' items';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/row_number.blade.php
+++ b/src/resources/views/crud/columns/row_number.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 40;
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -5,7 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -7,7 +7,7 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/table.blade.php
+++ b/src/resources/views/crud/columns/table.blade.php
@@ -2,7 +2,7 @@
 	$column['value'] = $column['value'] ?? data_get($entry, $column['name']);
     $column['columns'] = $column['columns'] ?? ['value' => 'Value'];
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -7,7 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/textarea.blade.php
+++ b/src/resources/views/crud/columns/textarea.blade.php
@@ -6,7 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/columns/upload_multiple.blade.php
+++ b/src/resources/views/crud/columns/upload_multiple.blade.php
@@ -8,7 +8,7 @@
     $column['wrapper']['target'] = $column['wrapper']['target'] ?? '_blank';
     $column_wrapper_href = $column['wrapper']['href'] ?? function($file_path, $disk, $prefix) { return ( !is_null($disk) ?asset(\Storage::disk($disk)->url($file_path)):asset($prefix.$file_path) ); };
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 @endphp
@@ -17,7 +17,7 @@
     @if ($column['value'] && count($column['value']))
         @foreach ($column['value'] as $file_path)
         @php
-            $column['wrapper']['href'] = is_callable($column_wrapper_href) ? $column_wrapper_href($file_path, $column['disk'], $column['prefix']) : $column_wrapper_href;
+            $column['wrapper']['href'] = $column_wrapper_href instanceof \Closure ? $column_wrapper_href($file_path, $column['disk'], $column['prefix']) : $column_wrapper_href;
             $text = $column['prefix'].$file_path.$column['suffix'];
         @endphp
             @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')

--- a/src/resources/views/crud/columns/video.blade.php
+++ b/src/resources/views/crud/columns/video.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
 
-    if(is_callable($column['value'])) {
+    if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -4,7 +4,7 @@
     // each wrapper attribute can be a callback or a string
     // for those that are callbacks, run the callbacks to get the final string to use
     foreach($field['wrapper'] as $attributeKey => $value) {
-        $field['wrapper'][$attributeKey] = !is_string($value) && is_callable($value) ? $value($crud, $field, $entry ?? null) : $value ?? '';
+        $field['wrapper'][$attributeKey] = !is_string($value) && $value instanceof \Closure ? $value($crud, $field, $entry ?? null) : $value ?? '';
     }
 	// if the field is required in the FormRequest, it should have an asterisk
 	$required = (isset($action) && $crud->isRequired($field['name'], $action)) ? ' required' : '';


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/3984.

Basically;
```php
is_callable('logs') // true
```
Because;
```php
$value = 'logs';
$value() // the same as;
logs() // returns an instance of \Illuminate\Log\LogManager
```