### PR TITLE
Show operation add timestamps by default

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -95,6 +95,11 @@ trait ShowOperation
             $this->crud->setFromDb(false, true);
         }
 
+        // if the model has timestamps, add columns for created_at and updated_at
+        if ($this->crud->get('show.timestamps') && $this->crud->model->usesTimestamps()) {
+            $this->crud->column($this->crud->model->getCreatedAtColumn())->type('datetime');
+            $this->crud->column($this->crud->model->getUpdatedAtColumn())->type('datetime');
+        }
         // remove the columns that usually don't make sense inside the Show operation
         $this->removeColumnsThatDontBelongInsideShowOperation();
 

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -33,7 +33,7 @@ trait ShowOperation
         $this->crud->operation('show', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
 
-            if (!method_exists($this, 'setupShowOperation')) {
+            if (! method_exists($this, 'setupShowOperation')) {
                 $this->autoSetupShowOperation();
             }
         });

--- a/src/config/backpack/operations/show.php
+++ b/src/config/backpack/operations/show.php
@@ -10,4 +10,10 @@ return [
     // Define the size/looks of the content div for all CRUDs
     // To override per Controller use $this->crud->setShowContentClass('class-string')
     'contentClass' => 'col-md-8',
+
+    // Automatically add all columns from the db table?
+    'setFromDb'  => true,
+
+    // Automatically add created_at and updated_at columns, if model has timestamps?
+    'timestamps' => true,
 ];


### PR DESCRIPTION
## WHY

Refs:
- https://github.com/Laravel-Backpack/devtools-issues/issues/19
- https://github.com/Laravel-Backpack/CRUD/issues/3991

### BEFORE - What was wrong? What was happening before this PR?

When the model had timestamps, there were no `created_at` and `updated_at` columns in the ShowOperation, by default, despite the fact that you _probably_ want them. 

The principle with ShowOperation auto-setup/guessing is to show as many columns as possible _by default_. `created_at` and `updated_at` are simple columns, we can definitely add them.

### AFTER - What is happening after this PR?

If timestamps on the model, those 2 columns will be added automatically, unless the config value says we shouldn't.

## HOW

### How did you achieve that, in technical terms?

Code is self-explanatory.


### Is it a breaking change or non-breaking change?

Breaking, as it is a change in default behaviour.


### How can we test the before & after?

Go to a CRUD where there the model has timestamps, take a look at the before & after, if you've done nothing in setupShowOperation to add timestamp columns. 

Before - no `created_at` and `updated_at` columns.
After - yes `created_at` and `updated_at` columns.


Fixes https://github.com/Laravel-Backpack/CRUD/issues/3991