### PR TITLE
Show operation add softdeletes support

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -33,7 +33,7 @@ trait ShowOperation
         $this->crud->operation('show', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
 
-            if (!method_exists($this, 'setupShowOperation')) {
+            if (! method_exists($this, 'setupShowOperation')) {
                 $this->autoSetupShowOperation();
             }
         });

--- a/src/config/backpack/operations/show.php
+++ b/src/config/backpack/operations/show.php
@@ -16,4 +16,9 @@ return [
 
     // Automatically add created_at and updated_at columns, if model has timestamps?
     'timestamps' => true,
+
+    // If model has SoftDeletes, allow the admin to access the Show page for
+    // soft deleted items & add a deleted_at column to ShowOperation?
+    'softDeletes' => true,
+
 ];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If your model had SoftDeletes, you couldn't open the Show page for that item, you had to override the `show()` method to get the entry `withTrashed()`.

### AFTER - What is happening after this PR?

If the `show.softDeletes` config doesn't say otherwise, the Show page will be visible for soft deleted items, and a new `deleted_at` column will show up.

## HOW

### How did you achieve that, in technical terms?

Code is super-simple and self-explanatory.

### Is it a breaking change or non-breaking change?

Breaking, because it changes the default behaviour.

### How can we test the before & after?

Inside the CRUD of a model with SoftDeletes, click the "Preview" button on a soft-deleted item (you can probably only do that if you have a "trashed" filter. Otherwise use the address bar to access a deleted ID.

Before - you got a 404 error.
Now - you don't, you see the Show page and a new "deleted_at" column.
