### PR TITLE
[WIP] Don't include CSS&JS assets in ZIP file (use `export-ignore` in git)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitattributes.html
+# Add export-ignore to reduce package download size
+# See https://php.watch/articles/composer-gitattributes
+
+src/public/         export-ignore


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The ZIP that got downloaded by `composer install` was 40.3 MB. 
Details in https://github.com/Laravel-Backpack/ideas/issues/116

### AFTER - What is happening after this PR?

The ZIP is 0.9 MB.

## HOW

### How did you achieve that, in technical terms?

Telling git (and github) to not include `src/public/` in the downloaded ZIP.


### Is it a breaking change or non-breaking change?

Super-breaking.

### How can we test the before & after?

Don't. This is WIP.
