### PR TITLE
Field convenience method for easily uploading files

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -165,8 +165,8 @@ class CrudField
     /**
      * Set an event to a certain closure. Will overwrite if existing.
      *
-     * @param  string   $event   Name of Eloquent Model event
-     * @param  \Closure $closure The function aka callback aka closure to run.
+     * @param  string  $event  Name of Eloquent Model event
+     * @param  \Closure  $closure  The function aka callback aka closure to run.
      * @return CrudField
      */
     public function on(string $event, \Closure $closure)
@@ -180,8 +180,8 @@ class CrudField
      * Register a saving event that uploads the file(s) uploaded using
      * the upload or upload_multiple fields.
      *
-     * @param  string $path Path where to save the file.
-     * @param  string $disk Disk to use.
+     * @param  string  $path  Path where to save the file.
+     * @param  string  $disk  Disk to use.
      * @return CrudField
      */
     public function whenSavingUploadTo(string $path, string $disk = 'public')

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -65,6 +65,7 @@ trait Fields
      * Eg. saving, saved, creating, created, updating, updated.
      *
      * @see https://laravel.com/docs/master/eloquent#events
+     *
      * @return void
      */
     public function registerFieldEvents()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

You had to add a mutator to upload files when using `upload` and `upload_multiple` field types. 


### AFTER - What is happening after this PR?

> After [Laravel-Backpack/CRUD#4009](https://github.com/Laravel-Backpack/CRUD/pull/4009) is merged into 4.2, we have the ability to tell fields what needs to be done on model events.
> 
> This is particularly helpful for UPLOAD fields, to move the uploading logic from mutators to the CrudController.
> 
> ```
> // sure, you can do this after the PR is merged
> CRUD::field('upload')->on('saving', function($entry) {
>     $value = request()->file('upload');
> 
>     if (is_null($value)) {
>         return;
>     }
> 
>     $entry->uploadFileToDisk($value, 'upload', 'public', 'uploads/monsters/upload_field');
> });
> ```
> 
> But that PR also opens up the opportunity for us to create a convenience method, that does what MOST people want, MOST of the time:
> 
> ```
> CRUD::field('upload')->onSavingUploadTo('public', 'uploads/monsters/upload_field');
> // or maybe
> CRUD::field('upload')->whenSavingUploadTo('public', 'uploads/monsters/upload_field');
> ```
> 
> 🤯 That's crazy easy, right?!
> 
> _Originally posted by @tabacitu in [Laravel-Backpack/CRUD#3928 (comment)](https://github.com/Laravel-Backpack/CRUD/pull/3928#issuecomment-990652564)_

I ended up coding `whenSavingUploadTo($path, $disk)` where the second parameter is optional (default: `public`), in a way that works for both `upload` and `upload_multiple`. But... it's not without tradeoffs.


## HOW

### How did you achieve that, in technical terms?

Latch on to the `saving` model event, to do the uploading pretty much the same way it would be done in the mutator. https://github.com/Laravel-Backpack/CRUD/pull/4009 is required for this to work, and this PR points to that branch.


### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

In `App\Models\Monster.php` comments out the upload and upload_multiple mutators. Then in `MonsterCrudController::setupCreateOperation()` after adding the fields do:

```php
        \CRUD::field('upload')->whenSavingUploadTo('uploads/monsters/upload_field');
        \CRUD::field('upload_multiple')->whenSavingUploadTo('uploads/monsters/upload_multiple_field');
```

And everything should work exactly the same way. It's the same logic, but moved from the Model to the CrudController.


## WHAT

What needs to be done:
- [ ] test & review
- [ ] talk about this added method - should we really add it? this `whenSavingUploadTo()` method is only used for `upload` and `upload_multiple`, and even has a `switch` statement inside it to do things differently for those two field types; but... it's on the main `CrudField` object... and that's quite ugly; until now, everything on the `CrudField` object was very general; everything was useful to all field types; this one method breaks that pattern; is it worth bloating up the `CrudField` now, or should we wait until each field type has its own class to implement this?