### PR TITLE
[Relationships] Hasone and morphone

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -204,7 +204,7 @@ trait Create
 
         $relationDetails = [];
         foreach ($relation_fields as $relation_field) {
-            $attributeKey = $relation_field['name'];           
+            $attributeKey = $relation_field['name'];
             $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));
             $fieldData = Arr::get($relationDetails, 'relations.'.$key, []);
             if (! array_key_exists('model', $fieldData)) {
@@ -216,8 +216,9 @@ trait Create
             $relatedAttribute = Arr::last(explode('.', $attributeKey));
             $fieldData['values'][$relatedAttribute] = Arr::get($input, $attributeKey);
 
-            Arr::set($relationDetails, 'relations.'.$key, $fieldData);         
+            Arr::set($relationDetails, 'relations.'.$key, $fieldData);
         }
+
         return $relationDetails;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -204,19 +204,26 @@ trait Create
 
         $relationDetails = [];
         foreach ($relation_fields as $relation_field) {
+            // use the field name as a search parameter 
             $attributeKey = $relation_field['name'];
-            $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));
-            $fieldData = Arr::get($relationDetails, 'relations.'.$key, []);
-            if (! array_key_exists('model', $fieldData)) {
-                $fieldData['model'] = $relation_field['model'];
-            }
-            if (! array_key_exists('parent', $fieldData)) {
-                $fieldData['parent'] = $this->getRelationModel($attributeKey, -1);
-            }
-            $relatedAttribute = Arr::last(explode('.', $attributeKey));
-            $fieldData['values'][$relatedAttribute] = Arr::get($input, $attributeKey);
 
-            Arr::set($relationDetails, 'relations.'.$key, $fieldData);
+            // we split the entity into relations, eg: user.accountDetails.address (user -> HasOne accountDetails -> BelongsTo address).
+            // we specifically use only the relation entity because relations like HasOne and MorphOne use the attribute in the relation string
+            $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));
+
+            // since we can have for example 3 fields for address relation, we make sure that atleast once we set the relation details.
+            $fieldDetails = Arr::get($relationDetails, 'relations.'.$key, []);
+            
+            $fieldDetails['model'] = $fieldDetails['model'] ?? $relation_field['model'];
+            
+            $fieldDetails['parent'] = $fieldDetails['parent'] ?? $this->getRelationModel($attributeKey, -1);
+            
+            // this relations have the attribute as a last parameter, use it to create the array of details, eg: address.name
+            $relatedAttribute = Arr::last(explode('.', $attributeKey));
+
+            $fieldDetails['values'][$relatedAttribute] = Arr::get($input, $attributeKey);
+
+            Arr::set($relationDetails, 'relations.'.$key, $fieldDetails);
         }
 
         return $relationDetails;

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -204,7 +204,7 @@ trait Create
 
         $relationDetails = [];
         foreach ($relation_fields as $relation_field) {
-            // use the field name as a search parameter 
+            // use the field name as a search parameter
             $attributeKey = $relation_field['name'];
 
             // we split the entity into relations, eg: user.accountDetails.address (user -> HasOne accountDetails -> BelongsTo address).
@@ -213,11 +213,11 @@ trait Create
 
             // since we can have for example 3 fields for address relation, we make sure that atleast once we set the relation details.
             $fieldDetails = Arr::get($relationDetails, 'relations.'.$key, []);
-            
+
             $fieldDetails['model'] = $fieldDetails['model'] ?? $relation_field['model'];
-            
+
             $fieldDetails['parent'] = $fieldDetails['parent'] ?? $this->getRelationModel($attributeKey, -1);
-            
+
             // this relations have the attribute as a last parameter, use it to create the array of details, eg: address.name
             $relatedAttribute = Arr::last(explode('.', $attributeKey));
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -213,9 +213,7 @@ trait Create
 
             // since we can have for example 3 fields for address relation, we make sure that at least once we set the relation details.
             $fieldDetails = Arr::get($relationDetails, 'relations.'.$key, []);
-
             $fieldDetails['model'] = $fieldDetails['model'] ?? $relation_field['model'];
-
             $fieldDetails['parent'] = $fieldDetails['parent'] ?? $this->getRelationModel($attributeKey, -1);
 
             // this relations have the attribute as a last parameter, use it to create the array of details, eg: address.name

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -211,7 +211,7 @@ trait Create
             // we specifically use only the relation entity because relations like HasOne and MorphOne use the attribute in the relation string
             $key = implode('.relations.', explode('.', $this->getOnlyRelationEntity($relation_field)));
 
-            // since we can have for example 3 fields for address relation, we make sure that atleast once we set the relation details.
+            // since we can have for example 3 fields for address relation, we make sure that at least once we set the relation details.
             $fieldDetails = Arr::get($relationDetails, 'relations.'.$key, []);
 
             $fieldDetails['model'] = $fieldDetails['model'] ?? $relation_field['model'];

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -189,11 +189,40 @@ trait Relationships
             case 'BelongsToMany':
             case 'HasManyThrough':
             case 'MorphMany':
-            case 'MorphOneOrMany':
             case 'MorphToMany':
+            case 'HasMany':
                 return true;
+            break;
             default:
                 return false;
         }
+    }
+
+    /**
+     * Get all relation fields that don't have pivot set
+     *
+     * @return array The fields with model key set.
+     */
+    public function getRelationFieldsWithoutPivot()
+    {
+        $all_relation_fields = $this->getRelationFields();
+
+        return Arr::where($all_relation_fields, function ($value, $key) {
+            return isset($value['pivot']) && !$value['pivot'];
+        });
+    }
+
+    /**
+     * Get all fields with n-n relation set (pivot table is true).
+     *
+     * @return array The fields with n-n relationships.
+     */
+    public function getRelationFieldsWithPivot()
+    {
+        $all_relation_fields = $this->getRelationFields();
+
+        return Arr::where($all_relation_fields, function ($value, $key) {
+            return isset($value['pivot']) && $value['pivot'];
+        });
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -199,7 +199,7 @@ trait Relationships
     }
 
     /**
-     * Get all relation fields that don't have pivot set
+     * Get all relation fields that don't have pivot set.
      *
      * @return array The fields with model key set.
      */
@@ -208,7 +208,7 @@ trait Relationships
         $all_relation_fields = $this->getRelationFields();
 
         return Arr::where($all_relation_fields, function ($value, $key) {
-            return isset($value['pivot']) && !$value['pivot'];
+            return isset($value['pivot']) && ! $value['pivot'];
         });
     }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -57,16 +57,16 @@ trait Relationships
         return Arr::last(explode('\\', get_class($relation)));
     }
 
-    public function getOnlyRelationEntity($relation_field)
+    public function getOnlyRelationEntity($field)
     {
-        $relation_model = $this->getRelationModel($relation_field['entity'], -1);
-        $related_method = Str::afterLast($relation_field['entity'], '.');
+        $model = $this->getRelationModel($field['entity'], -1);
+        $lastSegmentAfterDot = Str::of($field['entity'])->afterLast('.');
 
-        if (! method_exists($relation_model, $related_method)) {
-            return Str::beforeLast($relation_field['entity'], '.');
+        if (! method_exists($model, $lastSegmentAfterDot)) {
+            return (string) Str::of($field['entity'])->beforeLast('.');
         }
 
-        return $relation_field['entity'];
+        return $field['entity'];
     }
 
     /**

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -14,10 +14,8 @@
     }
 
     // make sure the $field['value'] takes the proper value
-    // and format it to JSON, so that select2 can parse it
-    $current_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? '';
-
-
+    $current_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? [];
+    
     if (!empty($current_value) || is_int($current_value)) {
         switch (gettype($current_value)) {
             case 'array':
@@ -45,6 +43,9 @@
                 break;
         }
     }
+
+    $current_value = !is_array($current_value) ? $current_value->toArray() : $current_value;
+
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -80,7 +81,7 @@
             @php
                 $selected = '';
                 if(!empty($current_value)) {
-                    if(in_array($key, array_keys($current_value->toArray()))) {
+                    if(in_array($key, array_keys($current_value))) {
                         $selected = 'selected';
                     }
                 }


### PR DESCRIPTION
## WHY

Make `HasOne` and `MorphOne` relations consistent without any difference on the setup, cause there should be no difference, the only difference is at database level, and that should be handled by Laravel as part of the relations.

### BEFORE - What was wrong? What was happening before this PR?

`HasOne` was working almost fine, it was just impossible to clear a value from a `BelongsTo` relation **nested** in an `HasOne` and the field would not auto-set as a select for the relation. 
MorphOne partially worked, needed to add some more configs to the field, `'morphs' => true` but didn't support relations like HasOne supports. 

### AFTER - What is happening after this PR?

- Setting up` HasOne` or `MorphOne` relation in CrudPanel is exactly the same, Backpack takes care of saving the correct relation. 
- `BelongsTo` relations can be properlly cleared.


## HOW

### How did you achieve that, in technical terms?

I didn't pursue the `morphs` configuration scenario since `HasOne` was working in other part of the panel, and `MorphOne` should be exactly the same as `HasOne` in terms of saving process. I didn't remove the `morphs` part from `syncPivot()` function for Backwards compatibility, but we should be aware that people using the new relationships will never reach that part of the code. 



### Is it a breaking change or non-breaking change?

I don't think it's breaking, but to be safe this is pointing to 4.2


### How can we test the before & after?

This relationships are setup in branch 4.2 of demo project. Also there are tests in the test suit to test the saving process. 

There are failing scenarios that I will be adding into #4012 

