### PR TITLE
Add number_columns option to checklist field

### DIFF
--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -31,7 +31,7 @@
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)
-            <div class="col-sm-{{ isset($field['number_columns']) ? intval(12/$field['number_columns']) : '4'}}">
+            <div class="col-sm-{{ isset($field['number_of_columns']) ? intval(12/$field['number_of_columns']) : '4'}}">
                 <div class="checkbox">
                   <label class="font-weight-normal">
                     <input type="checkbox" value="{{ $key }}"> {{ $option }}

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -31,7 +31,7 @@
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)
-            <div class="col-sm-4">
+            <div class="col-sm-{{ isset($field['number_columns']) ? intval(12/$field['number_columns']) : '4'}}">
                 <div class="checkbox">
                   <label class="font-weight-normal">
                     <input type="checkbox" value="{{ $key }}"> {{ $option }}


### PR DESCRIPTION
## WHY

To have more option on the checklist field, just like on the checklist_dependency field.

### BEFORE - What was wrong? What was happening before this PR?

By default, checklist field always use `col-md-4` (3 columns) and cannot be changed.

### AFTER - What is happening after this PR?

Add option `number_columns` to set how many columns checklist should be rendered.

## HOW

### How did you achieve that, in technical terms?

I copy the checklist_dependency code:

https://github.com/Laravel-Backpack/CRUD/blob/370531d2fd637b6ce1872f2732438853b96ebc66/src/resources/views/crud/fields/checklist_dependency.blade.php#L94


### Is it a breaking change or non-breaking change?

Non-breaking change.

### How can we test the before & after?

Before:

```php
$this->crud->addField([
    'name' => 'permissions',
    'type' => 'checklist',
    'attribute' => 'full_name',
]);
```

![image](https://user-images.githubusercontent.com/20186786/146405706-a44d2032-b96c-4f14-ad5e-7a0d97e649ef.png)

After:

```php
$this->crud->addField([
    'name' => 'permissions',
    'type' => 'checklist',
    'attribute' => 'full_name',
    'number_columns' => 2,
]);
```

![image](https://user-images.githubusercontent.com/20186786/146405822-0f6502b9-16df-4dd1-a9ca-ba76fe5bac8c.png)
