### PR TITLE
Don't re-associate belongs to relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -205,6 +205,11 @@ trait Create
             return Arr::has($input, $item['name']);
         });
 
+        // exclude the already attached belongs to relations in the main entry but include nested belongs to.
+        $relationFields = Arr::where($relationFields, function ($field, $key) {
+            return $field['relation_type'] !== 'BelongsTo' || ($field['relation_type'] === 'BelongsTo' && Str::contains($field['name'], '.'));
+        });
+
         $relationDetails = [];
         foreach ($relationFields as $field) {
             // we split the entity into relations, eg: user.accountDetails.address


### PR DESCRIPTION
## WHY

As discussed in #4009 some events were triggered twice. The BelongsTo relations were beeing "re-attached" in the relationship creation.

### BEFORE - What was wrong? What was happening before this PR?

We would associate the belongs to relations after they are already saved in the main entry, triggering multiple events for each relation.

### AFTER - What is happening after this PR?

We don't trigger multiple events.


## HOW

### How did you achieve that, in technical terms?

Removing the already attached belongsTo relations from the relations that should be saved after the main entry is created.


### How can we test the before & after?

Before in the mentioned PR #4009 . After in this PR. 


@tabacitu this PR is pointing to the `create-and-update-model-events` branch!