### PR TITLE
Fix inline create routes in conformity with fetch ones

### DIFF
--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -18,7 +18,7 @@ trait InlineCreateOperation
     protected function setupInlineCreateRoutes($segment, $routeName, $controller)
     {
         $inlineRouteName = Str::kebab(str_replace('_', '-', $routeName));
-        Route::post($segment.'/inline-create/modal', [
+        Route::post($segment.'/inline/create/modal', [
             'as'        => $inlineRouteName.'-inline-create',
             'uses'      => $controller.'@getInlineCreateModal',
             'operation' => 'InlineCreate',

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -23,7 +23,7 @@ trait InlineCreateOperation
             'uses'      => $controller.'@getInlineCreateModal',
             'operation' => 'InlineCreate',
         ]);
-        Route::post($segment.'/inline-create', [
+        Route::post($segment.'/inline/create', [
             'as'        => $inlineRouteName.'-inline-create-save',
             'uses'      => $controller.'@storeInlineCreate',
             'operation' => 'InlineCreate',

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -3,7 +3,9 @@
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use Prologue\Alerts\Facades\Alert;
+
 
 trait InlineCreateOperation
 {
@@ -16,13 +18,14 @@ trait InlineCreateOperation
      */
     protected function setupInlineCreateRoutes($segment, $routeName, $controller)
     {
-        Route::post($segment.'/inline/create/modal', [
-            'as'        => $segment.'-inline-create',
+        $inlineRouteName =  Str::kebab(str_replace('_', '-', $routeName));
+        Route::post($segment.'/inline-create/modal', [
+            'as'        => $inlineRouteName.'-inline-create',
             'uses'      => $controller.'@getInlineCreateModal',
             'operation' => 'InlineCreate',
         ]);
-        Route::post($segment.'/inline/create', [
-            'as'        => $segment.'-inline-create-save',
+        Route::post($segment.'/inline-create', [
+            'as'        => $inlineRouteName.'-inline-create-save',
             'uses'      => $controller.'@storeInlineCreate',
             'operation' => 'InlineCreate',
         ]);

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Prologue\Alerts\Facades\Alert;
 
-
 trait InlineCreateOperation
 {
     /**
@@ -18,7 +17,7 @@ trait InlineCreateOperation
      */
     protected function setupInlineCreateRoutes($segment, $routeName, $controller)
     {
-        $inlineRouteName =  Str::kebab(str_replace('_', '-', $routeName));
+        $inlineRouteName = Str::kebab(str_replace('_', '-', $routeName));
         Route::post($segment.'/inline-create/modal', [
             'as'        => $inlineRouteName.'-inline-create',
             'uses'      => $controller.'@getInlineCreateModal',


### PR DESCRIPTION
## WHY

There was a bug in `FetchOperation` that we are fixing now in #3995 . This operation suffers from the same evil. 

### BEFORE - What was wrong? What was happening before this PR?

Inline create routes would not respect the the `kebabing` of the entity done in `fetch_and_create` and would not match neither the fetch operation routes or the inline modal ones, so developer needed to manually define `entity => smt` in more cases than needed.

### AFTER - What is happening after this PR?

Reduced the cases for when specifying `entity => smt` is needed, probably only needed now when adding Inline create to multiple relations that usually is setup as singular crud (eg: `Route::crud('icon')), and then have a `belongsToMany` (eg: `icons` as a relation name).

## HOW

### How did you achieve that, in technical terms?

Applied the same thing as in #3995 when setting up the routes

### Is it a breaking change or non-breaking change?

It's possible a breaking one for some edge cases, not for the "simpler" ones.


### How can we test the before & after?

??
