### PR TITLE
add hidden field for relationship select

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -203,11 +203,12 @@ trait Create
         $model_instance = $relation->getRelated();
         $relation_foreign_key = $relation->getForeignKeyName();
         $relation_local_key = $relation->getLocalKeyName();
-        
+
         if ($relation_values === null) {
             // the developer cleared the selection
             // we gonna clear all related values by setting up the value to the fallback id, to null or delete.
             $removed_entries = $model_instance->where($relation_foreign_key, $item->{$relation_local_key});
+
             return $this->handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key);
         }
         // we add the new values into the relation

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -196,33 +196,32 @@ trait Create
      * - `force_delete` is configurable in the field, it's `true` by default. When false, if connecting column is nullable instead of deleting the row we set the column to null.
      * - `fallback_id` could be provided. In this case instead of deleting we set the connecting key to whatever developer gives us.
      *
-     * @return void
+     * @return mixed
      */
     private function attachManyRelation($item, $relation, $relationDetails, $relation_values)
     {
         $model_instance = $relation->getRelated();
         $relation_foreign_key = $relation->getForeignKeyName();
         $relation_local_key = $relation->getLocalKeyName();
-
-        if ($relation_values !== null) {
-            // we add the new values into the relation
-            $model_instance->whereIn($model_instance->getKeyName(), $relation_values)
-                ->update([$relation_foreign_key => $item->{$relation_local_key}]);
-
-            // we clear up any values that were removed from model relation.
-            // if developer provided a fallback id, we use it
-            // if column is nullable we set it to null if developer didn't specify `force_delete => true`
-            // if none of the above we delete the model from database
-            $removed_entries = $model_instance->whereNotIn($model_instance->getKeyName(), $relation_values)
-                                ->where($relation_foreign_key, $item->{$relation_local_key});
-
-            $this->handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key);
-        } else {
+        
+        if ($relation_values === null) {
             // the developer cleared the selection
             // we gonna clear all related values by setting up the value to the fallback id, to null or delete.
             $removed_entries = $model_instance->where($relation_foreign_key, $item->{$relation_local_key});
-            $this->handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key);
+            return $this->handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key);
         }
+        // we add the new values into the relation
+        $model_instance->whereIn($model_instance->getKeyName(), $relation_values)
+            ->update([$relation_foreign_key => $item->{$relation_local_key}]);
+
+        // we clear up any values that were removed from model relation.
+        // if developer provided a fallback id, we use it
+        // if column is nullable we set it to null if developer didn't specify `force_delete => true`
+        // if none of the above we delete the model from database
+        $removed_entries = $model_instance->whereNotIn($model_instance->getKeyName(), $relation_values)
+                            ->where($relation_foreign_key, $item->{$relation_local_key});
+
+        return $this->handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key);
     }
 
     private function handleManyRelationItemRemoval($model_instance, $removed_entries, $relationDetails, $relation_foreign_key)

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -50,6 +50,7 @@
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
+    <input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />
     <select
         style="width:100%"
         name="{{ $field['name'].($field['multiple']?'[]':'') }}"
@@ -71,7 +72,7 @@
         multiple
         @endif
         >
-        @if ($field['allows_null'])
+        @if ($field['allows_null'] && !$field['multiple'])
             <option value="">-</option>
         @endif
 

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -50,6 +50,7 @@
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
+    {{-- To make sure a value gets submitted even if the "select multiple" is empty, we need a hidden input --}}
     <input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />
     <select
         style="width:100%"


### PR DESCRIPTION
## WHY

Shortstory: 
- multiple fields don't post value when empty.
- we should not assume that when not posted we should clear them, otherwise people can't use disabled fields for displaying purposes.

### BEFORE - What was wrong? What was happening before this PR?

They don't post the value

### AFTER - What is happening after this PR?

They post the value

## HOW

### How did you achieve that, in technical terms?

Adding an hidden input.

### Is it a breaking change or non-breaking change?

I guess a breaking one but ... 


### How can we test the before & after?

@tabacitu tested the before already, he can now test the after!
