### PR TITLE
[Bug] Repeatable subfields not getting the correct old() value if there's a field with the same name in the main form

### DIFF
--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -3,6 +3,7 @@
 <div class="d-none">
 @endif
 
+
 <div class="col-md-12 well repeatable-element row m-1 p-2" data-repeatable-identifier="{{ $field['name'] }}">
     @if (isset($field['fields']) && is_array($field['fields']) && count($field['fields']))
     <div class="controls">
@@ -22,6 +23,7 @@
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
             $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
             if(isset($row)) {
+                $subfield['row_key'] = $row_key;
                 if(!is_array($subfield['name'])) {
                     // this is a fix for 4.1 repeatable names that when the field was multiple, saved the keys with `[]` in the end. Eg: `tags[]` instead of `tags`
                     if(isset($row[$subfield['name']]) || isset($row[$subfield['name'].'[]'])) {
@@ -29,10 +31,12 @@
                     }
                 }else{
                     $subfield['value'] = $row;
+                    
                 }
             }                       
         @endphp
-
+@php
+@endphp
         @include($fieldViewPath, ['field' => $subfield])
     @endforeach
 

--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -29,6 +29,14 @@
     if (!empty($current_value) || is_int($current_value)) {
         switch (gettype($current_value)) {
             case 'array':
+                // check if field have `row_key` set, if it has we are in a repeatable
+                // and should get the current row value
+                if(isset($field['row_key'])) { 
+                    if (isset($current_value[$field['row_key']]) && isset($current_value[$field['row_key']][$field['name']])) {
+                        $current_value = array($current_value[$field['row_key']][$field['name']]);
+                    }
+                }
+                
                 $current_value = $connected_entity
                                     ->whereIn($connected_entity_key_name, $current_value)
                                     ->get()

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -15,6 +15,14 @@
     if (!empty($current_value) || is_int($current_value)) {
         switch (gettype($current_value)) {
             case 'array':
+                // check if field have `row_key` set, if it has we are in a repeatable
+                // and should get the current row value
+                if(isset($field['row_key'])) { 
+                    if (isset($current_value[$field['row_key']]) && isset($current_value[$field['row_key']][$field['name']])) {
+                        $current_value = array($current_value[$field['row_key']][$field['name']]);
+                    }
+                }
+                
                 $current_value = $connected_entity
                                     ->whereIn($connected_entity_key_name, $current_value)
                                     ->get()

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -15,10 +15,18 @@
 
     // make sure the $field['value'] takes the proper value
     $current_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? [];
-    
     if (!empty($current_value) || is_int($current_value)) {
         switch (gettype($current_value)) {
             case 'array':
+                // check if field have `row_key` set, if it has we are in a repeatable
+                // and should get the current row value
+                if(isset($field['row_key'])) { 
+                    if (isset($current_value[$field['row_key']]) && isset($current_value[$field['row_key']][$field['name']])) {
+                        $current_value = array($current_value[$field['row_key']][$field['name']]);
+                    }
+                }
+                
+                
                 $current_value = $connected_entity
                                     ->whereIn($connected_entity_key_name, $current_value)
                                     ->get()
@@ -45,6 +53,7 @@
     }
 
     $current_value = !is_array($current_value) ? $current_value->toArray() : $current_value;
+    //dd($current_value);
 
 @endphp
 

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -29,8 +29,8 @@
         data-min-rows="{{ $field['min_rows'] }}"
     >
     @if(!empty($field['value']))
-        @foreach ($field['value'] as $row)
-            @include('crud::fields.inc.repeatable_row')
+        @foreach ($field['value'] as $key => $row)
+            @include('crud::fields.inc.repeatable_row', ['row_key' => $key])
         @endforeach
         @php
             // the $row variable still exists. We don't need it anymore the loop is over, and would have impact in the following code.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in #4027 there seemd to be something wrong with repeatable and old values. 

While testing I found out the culprit of this was the fact that `old($field_name)` returns true in case of `M-M` relationships because the repeatable name itself, it's the name of the pivot field. 

In `M-M` relationships, **or in case your repeatable name have the same name** as some field inside the repeatable when that field gets it's `old()` value from session, it will get the FULL repeatable value and not that specific row value.

### AFTER - What is happening after this PR?

After the PR if the returned from old is not what we expect (a single field value, but the whole repeatable value) we will parse it accordingly.

## HOW

### How did you achieve that, in technical terms?

Introduced `row_key` that are passed through `repeatable_relation` reaching the field. When setting up field value, we check if that row_key is set, if it is, we parse the value accordingly.


### Is it a breaking change or non-breaking change?

4.2


### How can we test the before & after?

Add a belongstomany relation, create 2 or 3 entries. Update the entry making the validation fail and see that ALL the pivots have the same entry selected.

BEFORE UPDATE:
![image](https://user-images.githubusercontent.com/7188159/147131713-853867ab-d915-4265-9dbc-06c91218fc28.png)

ON UPDATE WITH VALIDATION ERRORS:
![image](https://user-images.githubusercontent.com/7188159/147131795-979643b3-aacb-459a-ac29-f7eb0bc2841a.png)

@tabacitu 2 things that I think that are worth talking about:
- this is fixed only for relationship selects, but could happen with any field. This should be fixed in #3054 that when getting the old value should be aware of the `row_key` parameter for repeatable and parse the value there. This would make the fix work for ANY field used inside the repeatable, because the principle it's the same.
- In the images you can see that the field shows red validation, but it shows the "field previous value" not what I've sent to be validate (empty string). This is also fixed in #3054 

Let me know what you think,
Pedro
