### PR TITLE
Update AuthenticatesUsers to use authentication_column config

### DIFF
--- a/src/app/Library/Auth/AuthenticatesUsers.php
+++ b/src/app/Library/Auth/AuthenticatesUsers.php
@@ -153,7 +153,7 @@ trait AuthenticatesUsers
      */
     public function username()
     {
-        return 'email';
+        return config('backpack.base.authentication_column', 'email');
     }
 
     /**


### PR DESCRIPTION
## WHY

To make AuthenticatesUsers trait to respect authentication_column config

### BEFORE - What was wrong? What was happening before this PR?

The AuthenticatesUsers trait only accept email, but there is authentication_column config to set which column to use for authentication

### AFTER - What is happening after this PR?

The AuthenticatesUsers traits now respect authentication_column config for authentication


## HOW

### How did you achieve that, in technical terms?

I use backpack config `base.authentication_column`



### Is it a breaking change or non-breaking change?

No


### How can we test the before & after?

Make a custom login controller that use AuthenticatesUsers trait from backpack
