### PR TITLE
Fix column guessing when translations enabled

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -88,7 +88,7 @@ trait ColumnsProtectedMethods
         // Set text as default column type
         $column['type'] = 'text';
 
-        if($this->model->translationEnabledForModel() && array_key_exists($column['name'], $this->model->getTranslations())) {
+        if(method_exists($this->model, 'translationEnabledForModel') && $this->model->translationEnabledForModel() && array_key_exists($column['name'], $this->model->getTranslations())) {
             return $column;
         }
 

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -88,6 +88,10 @@ trait ColumnsProtectedMethods
         // Set text as default column type
         $column['type'] = 'text';
 
+        if($this->model->translationEnabledForModel() && array_key_exists($column['name'], $this->model->getTranslations())) {
+            return $column;
+        }
+
         $could_be_relation = Arr::get($column, 'entity', false) !== false;
 
         if ($could_be_relation) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Columns that are "translatable" are automatically casted to array in the model making the guessing functionality think that we are going to display an array. 

### AFTER - What is happening after this PR?

The guessing functionality is now aware of this possibility and will use the "old" set to text and return the column method without trying to infer the column type.


## HOW

### How did you achieve that, in technical terms?

Checking if translations are enabled for the model and also check if the column name exists in this translations property.


### Is it a breaking change or non-breaking change?

Non.


### How can we test the before & after?

See #4040 . Just visit product page on demo.
