### PR TITLE
Add some defaults for easier field setup

### DIFF
--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -1,12 +1,12 @@
 <!-- checklist -->
 @php
-  $model = new $field['model'];
-  $key_attribute = $model->getKeyName();
-  $identifiable_attribute = $field['attribute'];
+  $key_attribute = $field['model']->getKeyName();
+  $field['attribute'] = $field['attribute'] ?? (new $field['model'])->identifiableAttribute();
+  $field['number_of_columns'] = $field['number_of_columns'] ?? 3;
 
   // calculate the checklist options
   if (!isset($field['options'])) {
-      $field['options'] = $field['model']::all()->pluck($identifiable_attribute, $key_attribute)->toArray();
+      $field['options'] = $field['model']::all()->pluck($field['attribute'], $key_attribute)->toArray();
   } else {
       $field['options'] = call_user_func($field['options'], $field['model']::query());
   }
@@ -31,7 +31,7 @@
 
     <div class="row">
         @foreach ($field['options'] as $key => $option)
-            <div class="col-sm-{{ isset($field['number_of_columns']) ? intval(12/$field['number_of_columns']) : '4'}}">
+            <div class="col-sm-{{ intval(12/$field['number_of_columns']) }}">
                 <div class="checkbox">
                   <label class="font-weight-normal">
                     <input type="checkbox" value="{{ $key }}"> {{ $option }}

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -1,6 +1,6 @@
 <!-- checklist -->
 @php
-  $key_attribute = $field['model']->getKeyName();
+  $key_attribute = (new $field['model'])->getKeyName();
   $field['attribute'] = $field['attribute'] ?? (new $field['model'])->identifiableAttribute();
   $field['number_of_columns'] = $field['number_of_columns'] ?? 3;
 

--- a/src/resources/views/crud/fields/select2_from_ajax.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax.blade.php
@@ -7,6 +7,9 @@
     // this is the time we wait before send the query to the search endpoint, after the user as stopped typing.
     $field['delay'] = $field['delay'] ?? 500;
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
+    $field['placeholder'] = $field['placeholder'] ?? trans('backpack::crud.select_entry');
+    $field['attribute'] = $field['attribute'] ?? $connected_entity->identifiableAttribute();
+    $field['minimum_input_length'] = $field['minimum_input_length'] ?? 2;
 @endphp
 
 @include('crud::fields.inc.wrapper_start')

--- a/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_from_ajax_multiple.blade.php
@@ -3,6 +3,9 @@
     $connected_entity = new $field['model'];
     $connected_entity_key_name = $connected_entity->getKeyName();
     $old_value = old(square_brackets_to_dots($field['name'])) ?? $field['value'] ?? $field['default'] ?? false;
+    $field['placeholder'] = $field['placeholder'] ?? trans('backpack::crud.select_entry');
+    $field['attribute'] = $field['attribute'] ?? $connected_entity->identifiableAttribute();
+    $field['minimum_input_length'] = $field['minimum_input_length'] ?? 2;
 
     // by default set ajax query delay to 500ms
     // this is the time we wait before send the query to the search endpoint, after the user as stopped typing.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

For example, setting up a `select_from_ajax` field required you to manually provide `attribute` and `placeholder`. 
At this time we already have a very good way of guessing the `identifiableAttribute` and setting up a default placeholder. 

### AFTER - What is happening after this PR?

You can ommit some of those configurations that Backpack can easily guess or setup a reasonable default value.


## HOW

### How did you achieve that, in technical terms?

Adding defaults in the fields.


### Is it a breaking change or non-breaking change?

I don't think so. 


### How can we test the before & after?

Try to setup a `select_from_ajax` without providing any of: `placeholder`, `minimum_input_length`, `attribute` and the field will error. 

After this PR you can ommit those 3 parameters from field configuration and Backpack will guess them or use sensible defaults.
