### PR TITLE
Fix old checklistdependency

### DIFF
--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -29,7 +29,7 @@
                 $dependencyArray[$primary->id][] = $secondary->id;
             }
         }
-      
+
         $old_primary_dependency = old_empty_or_null($primary_dependency['name'], false) ?? false;
         $old_secondary_dependency = old_empty_or_null($secondary_dependency['name'], false) ?? false;
 

--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -29,6 +29,9 @@
                 $dependencyArray[$primary->id][] = $secondary->id;
             }
         }
+      
+        $old_primary_dependency = old_empty_or_null($primary_dependency['name'], false) ?? false;
+        $old_secondary_dependency = old_empty_or_null($secondary_dependency['name'], false) ?? false;
 
       //for update form, get initial state of the entity
       if (isset($id) && $id) {
@@ -44,10 +47,6 @@
           $primary_array = $entity_dependencies->{$primary_dependency['entity']}->toArray();
 
           $secondary_ids = [];
-
-          $old_primary_dependency = old_empty_or_null($primary_dependency['name'], false) ?? false;
-          $old_secondary_dependency = old_empty_or_null($secondary_dependency['name'], false) ?? false;
-
           //create secondary dependency from primary relation, used to check what checkbox must be checked from second checklist
           if ($old_primary_dependency) {
               foreach ($old_primary_dependency as $primary_item) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

To avoid using so many issets I just set the "old" by default (if not it will be false) and instead of using issets I just check for trueness of the variable. It needs to be defined in a higher scope that I set it up first.

### AFTER - What is happening after this PR?

The old value is allways populated, but when `false` is not taken into account instead of issets everywhere.


## HOW

### How did you achieve that, in technical terms?

Moved the variable definition higher in scope. 



### Is it a breaking change or non-breaking change?

nope, 4.2

### How can we test the before & after?

It would error as reported in #4051 
