### PR TITLE
[4.2] Make relationship field treat ALL relationship types

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -214,10 +214,12 @@ trait FieldsProtectedMethods
 
         if (isset($field['relation_type'])) {
             $field['type'] = 'relationship';
+
             return $field;
         }
 
         $field['type'] = $this->inferFieldTypeFromDbColumnType($field['name']);
+
         return $field;
     }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -208,7 +208,7 @@ trait FieldsProtectedMethods
     protected function makeSureFieldHasType($field)
     {
         if (! isset($field['type'])) {
-            $field['type'] = isset($field['relation_type']) ? $this->inferFieldTypeFromFieldRelation($field) : $this->inferFieldTypeFromDbColumnType($field['name']);
+            $field['type'] = isset($field['relation_type']) ? 'relationship' : $this->inferFieldTypeFromDbColumnType($field['name']);
         }
 
         return $field;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -207,18 +207,9 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasType($field)
     {
-        // if a type is already set, do nothing
-        if (isset($field['type'])) {
-            return $field;
+        if (! isset($field['type'])) {
+            $field['type'] = isset($field['relation_type']) ? $this->inferFieldTypeFromFieldRelation($field) : $this->inferFieldTypeFromDbColumnType($field['name']);
         }
-
-        if (isset($field['relation_type'])) {
-            $field['type'] = 'relationship';
-
-            return $field;
-        }
-
-        $field['type'] = $this->inferFieldTypeFromDbColumnType($field['name']);
 
         return $field;
     }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -174,7 +174,7 @@ trait FieldsProtectedMethods
         // if there's a model defined, but no attribute
         // guess an attribute using the identifiableAttribute functionality in CrudTrait
         if (isset($field['model']) && ! isset($field['attribute']) && method_exists($field['model'], 'identifiableAttribute')) {
-            $field['attribute'] = call_user_func([(new $field['model']), 'identifiableAttribute']);
+            $field['attribute'] = call_user_func([(new $field['model']()), 'identifiableAttribute']);
         }
 
         return $field;
@@ -207,10 +207,17 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasType($field)
     {
-        if (! isset($field['type'])) {
-            $field['type'] = isset($field['relation_type']) ? $this->inferFieldTypeFromFieldRelation($field) : $this->inferFieldTypeFromDbColumnType($field['name']);
+        // if a type is already set, do nothing
+        if (isset($field['type'])) {
+            return $field;
         }
 
+        if (isset($field['relation_type'])) {
+            $field['type'] = 'relationship';
+            return $field;
+        }
+
+        $field['type'] = $this->inferFieldTypeFromDbColumnType($field['name']);
         return $field;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -133,28 +133,6 @@ trait Relationships
     }
 
     /**
-     * Based on relation type returns the default field type.
-     *
-     * @param  string  $relation_type
-     * @return bool
-     */
-    public function inferFieldTypeFromFieldRelation($field)
-    {
-        switch ($field['relation_type']) {
-            case 'BelongsToMany':
-            case 'HasMany':
-            case 'HasManyThrough':
-            case 'MorphMany':
-            case 'MorphToMany':
-            case 'BelongsTo':
-                return 'relationship';
-
-            default:
-                return 'text';
-        }
-    }
-
-    /**
      * Based on relation type returns if relation allows multiple entities.
      *
      * @param  string  $relation_type

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -133,6 +133,28 @@ trait Relationships
     }
 
     /**
+     * Based on relation type returns the default field type.
+     *
+     * @param  string  $relation_type
+     * @return bool
+     */
+    public function inferFieldTypeFromFieldRelation($field)
+    {
+        switch ($field['relation_type']) {
+            case 'BelongsToMany':
+            case 'HasMany':
+            case 'HasManyThrough':
+            case 'MorphMany':
+            case 'MorphToMany':
+            case 'BelongsTo':
+                return 'relationship';
+
+            default:
+                return 'text';
+        }
+    }
+
+    /**
      * Based on relation type returns if relation allows multiple entities.
      *
      * @param  string  $relation_type

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -20,7 +20,16 @@
     // if field is not ajax but user wants to use InlineCreate
     // we make minimum_input_length = 0 so when user open we show the entries like a regular select
     $field['minimum_input_length'] = ($field['ajax'] !== true) ? 0 : ($field['minimum_input_length'] ?? 2);
+
     switch($field['relation_type']) {
+        case 'HasOne':
+        case 'MorphOne':
+            abort("The relationship field does not support {$field['relation_type']} at the moment. Please add a text/number/textarea/etc field, but use dot notation for its name. This will allow you to have a field that edits information directly on the related entry (eg. phone.number). See https://backpackforlaravel.com/docs/crud-fields#hasone-1-1-relationship for more information.");
+            // TODO: if relationship has `isOneOfMany` on it, load a readonly select
+            // TODO: if "fields" is not defined, tell the dev to define it (+ link to docs)
+            // TODO: if "fields" is defined, load a repeatable field with one entry (and 1 entry max)
+            // TODO: remove the ugly abort from above
+            break;
         case 'BelongsTo':
         case 'BelongsToMany':
         case 'MorphToMany':
@@ -29,18 +38,18 @@
                 $field['type'] = 'repeatable_relation';
                 break;
             }
-    
+
             if(!isset($field['inline_create'])) {
                 $field['type'] = $field['ajax'] ? 'fetch' : 'relationship_select';
                 break;
             }
-    
+
             // the field is beeing inserted in an inline create modal case $inlineCreate is set.
             if(! isset($inlineCreate)) {
                 $field['type'] = 'fetch_or_create';
                 break;
             }
-                
+
     		$field['type'] = $field['ajax'] ? 'fetch' : 'relationship_select';
             break;
         case 'MorphMany':
@@ -57,7 +66,15 @@
                 // we show a regular/ajax select
                 $field['type'] = $field['ajax'] ? 'fetch' : 'relationship_select';
             }
-        break;
+            break;
+        case 'HasOneThrough':
+        case 'HasManyThrough':
+            abort("The relationship field does not support {$field['relation_type']} at the moment. This is a 'readonly' relationship type. When we do add support for it, it the field only SHOW the related entries, NOT allow you to select/edit them.");
+            // TODO: load a readonly select for that chained relationship, and remove the abort above
+            break;
+        default:
+            abort("Unknown relationship type used with the 'relationship' field. Please let the Backpack team know of this new Laravel relationship, so they add support for it.");
+            break;
     }
 @endphp
 

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -24,7 +24,7 @@
     switch($field['relation_type']) {
         case 'HasOne':
         case 'MorphOne':
-            abort("The relationship field does not support {$field['relation_type']} at the moment. Please add a text/number/textarea/etc field, but use dot notation for its name. This will allow you to have a field that edits information directly on the related entry (eg. phone.number). See https://backpackforlaravel.com/docs/crud-fields#hasone-1-1-relationship for more information.");
+            abort(500, "The relationship field does not support {$field['relation_type']} at the moment. Please add a text/number/textarea/etc field, but use dot notation for its name. This will allow you to have a field that edits information directly on the related entry (eg. phone.number). See https://backpackforlaravel.com/docs/crud-fields#hasone-1-1-relationship for more information.");
             // TODO: if relationship has `isOneOfMany` on it, load a readonly select
             // TODO: if "fields" is not defined, tell the dev to define it (+ link to docs)
             // TODO: if "fields" is defined, load a repeatable field with one entry (and 1 entry max)
@@ -69,11 +69,11 @@
             break;
         case 'HasOneThrough':
         case 'HasManyThrough':
-            abort("The relationship field does not support {$field['relation_type']} at the moment. This is a 'readonly' relationship type. When we do add support for it, it the field only SHOW the related entries, NOT allow you to select/edit them.");
+            abort(500, "The relationship field does not support {$field['relation_type']} at the moment. This is a 'readonly' relationship type. When we do add support for it, it the field only SHOW the related entries, NOT allow you to select/edit them.");
             // TODO: load a readonly select for that chained relationship, and remove the abort above
             break;
         default:
-            abort("Unknown relationship type used with the 'relationship' field. Please let the Backpack team know of this new Laravel relationship, so they add support for it.");
+            abort(500, "Unknown relationship type used with the 'relationship' field. Please let the Backpack team know of this new Laravel relationship, so they add support for it.");
             break;
     }
 @endphp


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I could not understand what relationships are supported by the `relationship` field and which are not. I had to look:
- in the docs, inside the `relationship` field
- in the docs, at the bottom, where all relationships are explained
- in the code, inside the switchboard

### AFTER - What is happening after this PR?

The relationship field does _something_ for ALL relationship types:
- if it can properly help, it does;
- if it cannot help, it'll show an ugly error and point the developer to the docs;

That way, there should be less confusion. You can use the `relationship` field on whatever you want. If it won't work, it'll tell you why.

## HOW

### How did you achieve that, in technical terms?

Added the missing relationships to the `switch` statement. Plus TODOs with what we're supposed to do next, to complete the "full vision" of the `relationship` field (more on that in another issue).

### Is it a breaking change or non-breaking change?

Non-breaking, I think. It just throws explicit errors instead of the old ones, which didn't explain anything.

### How can we test the before & after?

Add a `relationship` field for one of the unsupported relationships - `HasOne`, `MorphOne`, `HasOneThrough`, `HasManyThrough`. Previously, it would crack (I think). Now, it'll show an explicit error which should help the dev understand what they need to do.
