### PR TITLE
Fix select2_nested in 4.2 - account for a model being returned

### DIFF
--- a/src/resources/views/crud/fields/select2_nested.blade.php
+++ b/src/resources/views/crud/fields/select2_nested.blade.php
@@ -8,7 +8,9 @@
 
 @php
     $current_value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
-
+    if (!empty($current_value)) {
+        $current_value = is_object($current_value) ? $current_value->getKey() : $current_value;
+    }
     if (!function_exists('echoSelect2NestedEntry')) {
         function echoSelect2NestedEntry($entry, $field, $current_value) {
             if ($current_value == $entry->getKey()) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Before 4.2, some relations didn't return the related entry when getting the value. In 4.2 they return the entry, and this field was expecting a single `id` instead of the full entry. 

### AFTER - What is happening after this PR?

The field accounts for the presence of an entry and gets they key from there. 


## HOW

### How did you achieve that, in technical terms?

added a check for the presence of an object.



### Is it a breaking change or non-breaking change?

Non breaking, but it's 4.2 anyway.


### How can we test the before & after?

@tabacitu already tested the before here #4053 and can test the after in this branch.

NOTES:
- Should we keep supporting the old integer, or just assume that we will get the model everytime here since that's what will happen? 
```php
$current_value = $current_value->getKey(); //without needing for the ternary.
```

This field is ... mehh... in a lot of ways but this one stands out:

![image](https://user-images.githubusercontent.com/7188159/148374569-c831dceb-ad1b-4830-9b54-45f87e79a431.png)

God forbbid you to have houndreds or thousands of categories. I just wish some fields were not "core" fields. They are so niche.

Sorry for the rant, I would be an happy person if they are gone! 🙃 😈 

Pedro