### PR TITLE
Fix checklist with reselection from old values

### DIFF
--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -201,57 +201,65 @@
           var unique_name = element.data('entity');
           var dependencyJson = window[unique_name];
           var thisField = element;
+          var handleCheckInput = function(el, field, dependencyJson) {
+            let idCurrent = el.data('id');
+            //add hidden field with this value
+            let nameInput = field.find('.hidden_fields_primary').data('name');
+            let inputToAdd = $('<input type="hidden" class="primary_hidden" name="'+nameInput+'[]" value="'+idCurrent+'">');
 
-          thisField.find('.primary_list').change(function(){
+            field.find('.hidden_fields_primary').append(inputToAdd);
 
-            var idCurrent = $(this).data('id');
-            if($(this).is(':checked')){
+            $.each(dependencyJson[idCurrent], function(key, value){
+              //check and disable secondies checkbox
+              field.find('input.secondary_list[value="'+value+'"]').prop( "checked", true );
+              field.find('input.secondary_list[value="'+value+'"]').prop( "disabled", true );
+              //remove hidden fields with secondary dependency if was set
+              var hidden = field.find('input.secondary_hidden[value="'+value+'"]');
+              if(hidden)
+                hidden.remove();
+            });
+          };
 
-              //add hidden field with this value
-              var nameInput = thisField.find('.hidden_fields_primary').data('name');
-              var inputToAdd = $('<input type="hidden" class="primary_hidden" name="'+nameInput+'[]" value="'+idCurrent+'">');
+          thisField.find('.primary_list').each(function() {
+            var checkbox = $(this);
+            // re-check the secondary boxes in case the primary is re-checked from old.
+            if(checkbox.is(':checked')){
+               handleCheckInput(checkbox, thisField, dependencyJson);
+            }
+            // register the change event to handle subsquent checkbox state changes.
+            checkbox.change(function(){
+              if(checkbox.is(':checked')){
+                handleCheckInput(checkbox, thisField, dependencyJson);
+              }else{
+                let idCurrent = checkbox.data('id');
+                //remove hidden field with this value.
+                thisField.find('input.primary_hidden[value="'+idCurrent+'"]').remove();
 
-              thisField.find('.hidden_fields_primary').append(inputToAdd);
+                // uncheck and active secondary checkboxs if are not in other selected primary.
+                var secondary = dependencyJson[idCurrent];
 
-              $.each(dependencyJson[idCurrent], function(key, value){
-                //check and disable secondies checkbox
-                thisField.find('input.secondary_list[value="'+value+'"]').prop( "checked", true );
-                thisField.find('input.secondary_list[value="'+value+'"]').prop( "disabled", true );
-                //remove hidden fields with secondary dependency if was set
-                var hidden = thisField.find('input.secondary_hidden[value="'+value+'"]');
-                if(hidden)
-                  hidden.remove();
-              });
+                var selected = [];
+                thisField.find('input.primary_hidden').each(function (index, input){
+                  selected.push( $(this).val() );
+                });
 
-            }else{
-              //remove hidden field with this value
-              thisField.find('input.primary_hidden[value="'+idCurrent+'"]').remove();
+                $.each(secondary, function(index, secondaryItem){
+                  var ok = 1;
 
-              // uncheck and active secondary checkboxs if are not in other selected primary.
+                  $.each(selected, function(index2, selectedItem){
+                    if( dependencyJson[selectedItem].indexOf(secondaryItem) != -1 ){
+                      ok =0;
+                    }
+                  });
 
-              var secondary = dependencyJson[idCurrent];
-
-              var selected = [];
-              thisField.find('input.primary_hidden').each(function (index, input){
-                selected.push( $(this).val() );
-              });
-
-              $.each(secondary, function(index, secondaryItem){
-                var ok = 1;
-
-                $.each(selected, function(index2, selectedItem){
-                  if( dependencyJson[selectedItem].indexOf(secondaryItem) != -1 ){
-                    ok =0;
+                  if(ok){
+                    thisField.find('input.secondary_list[value="'+secondaryItem+'"]').prop('checked', false);
+                    thisField.find('input.secondary_list[value="'+secondaryItem+'"]').prop('disabled', false);
                   }
                 });
 
-                if(ok){
-                  thisField.find('input.secondary_list[value="'+secondaryItem+'"]').prop('checked', false);
-                  thisField.find('input.secondary_list[value="'+secondaryItem+'"]').prop('disabled', false);
-                }
+              }
               });
-
-            }
           });
 
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

https://github.com/Laravel-Backpack/CRUD/issues/4056 - i just wrote it the :|

### AFTER - What is happening after this PR?

checkboxes get reselected.


## HOW

### How did you achieve that, in technical terms?

the JS was only registering the change event for the checkboxes and it was the only place where the checking process would run (after a change). 

I refactored the JS a bit so we could still run the code on change, but also on field initialization we check if any of the checkboxes are checked, it they are we trigger we manually trigger the "auto-checking" for them. 


### Is it a breaking change or non-breaking change?

Non breaking, probably it could go into 4.1 too ?


### How can we test the before & after?

Before: Go to user create in demo, select superadmin and notice the permissions get automatically selected. If you don't fill any more fields you will get a validation error, and will notice that the role was still selected but all permissions are gone. 

In this PR, the permissions are re-selected. 
