### PR TITLE
[4.2.x] Allow to choose whether you show bulk checkbox

### DIFF
--- a/src/resources/views/crud/columns/checkbox.blade.php
+++ b/src/resources/views/crud/columns/checkbox.blade.php
@@ -1,10 +1,12 @@
 {{-- checkbox with loose false/null/0 checking --}}
 <span>
+    @if (!isset($crud->bulkCallback) || !is_callable($crud->bulkCallback) || ($crud->bulkCallback)($entry))
     <input type="checkbox"
     		class="crud_bulk_actions_row_checkbox"
     		data-primary-key-value="{{ $entry->getKey() }}"
     		style="width: 16px; height: 16px; vertical-align: middle; margin-bottom: 2px;"
     		>
+    @endif
 </span>
 
 <script>


### PR DESCRIPTION
## WHY

Perhaps people don't want a checkbox for every item. For example, maybe if you have a bulk delete and there is an active filter for including soft deletes, you don't want to "delete" it again

### BEFORE - What was wrong? What was happening before this PR?

Every entry had a checkbox

### AFTER - What is happening after this PR?

Every entry still has a checkbox, but you can choose to limit which ones should have it


## HOW

### How did you achieve that, in technical terms?

I added an optional callback function that you can create in your setupListOperation: `$this->crud->bulkCallback = function($entry) { return true; }` that should return true or false for each entry



### Is it a breaking change or non-breaking change?

Non-breaking change


### How can we test the before & after?

Add the aforementioned callback that would limit which entries have a checkbox
