### PR TITLE
add optional details and link to 500 error page

### DIFF
--- a/src/resources/error_views/500.blade.php
+++ b/src/resources/error_views/500.blade.php
@@ -2,15 +2,39 @@
 
 @php
 	$error_number = 500;
+	$title = "It's not you, it's me.";
+	$description = "An internal server error has occurred. If the error persists please contact the development team.";
+
+	if (isset($exception)) {
+		// if a message exists in the error, show that
+		if ($exception->getMessage()) {
+			$description = $exception->getMessage();
+		}
+		// if title and description have been given as headers, show those
+		$title = $exception->getHeaders()['title'] ?? $title;
+		$description = $exception->getHeaders()['description'] ?? $description;
+		$details = $exception->getHeaders()['details'] ?? false;
+		$link = $exception->getHeaders()['link'] ?? false;
+	}
 @endphp
 
 @section('title')
-	It's not you, it's me.
+	{!! $title !!}
 @endsection
 
 @section('description')
-	@php
-	  $default_error_message = "An internal server error has occurred. If the error persists please contact the development team.";
-	@endphp
-	{!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+	<span class="text-danger">{!! $description !!}</span>
+
+	@if ($details || $link)
+	<div class="col-md-10 offset-1">
+		@if ($details)
+			<p class="mt-5"><small>{!! $details !!}</small></p>
+		@endif
+
+		@if ($link)
+			<a target="_blank" href="{{ $link }}" class="btn btn-default"><i class="la la-external-link-alt"></i> Read more</a>
+		@endif
+	</div>
+	@endif
+
 @endsection


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Cannot send more than "description" to a 500 error page.

### AFTER - What is happening after this PR?

You can, by giving it in the headers. For example:

```php
abort(500, null, [
    "title" => "Backpack Field Misconfigured",
    "description" => "The relationship field type does not cover 'One of Many' relationships.",
    "details" => "Those relationship are only meant to be 'read', not 'created' or 'updated'. Please change your <code>{$field['name']}</code> field to use the 1-n relationship towards <code>{$field['model']}</code>, the one that does NOT have latestOfMany() or oldestOfMany().",
    "link" => "https://backpackforlaravel.com/docs/crud-fields#has-one-of-many-1-1-relationship-out-of-1-n-relationship",
]);
```

Will show:

![Screenshot 2022-01-07 at 10 53 25](https://user-images.githubusercontent.com/1032474/148518494-599fc408-e615-4f54-8c3d-98200641a96a.png)


Which is a little prettier than doing:
```php
abort(500, "<strong>The relationship field type does not cover 'One of Many' relationships.</strong><br> Those relationship are only meant to be 'read', not 'created' or 'updated'. Please change your <code>{$field['name']}</code> field to use the 1-n relationship towards <code>{$field['model']}</code>, the one that does NOT have latestOfMany() or oldestOfMany(). See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#has-one-of-many-1-1-relationship-out-of-1-n-relationship'>the docs</a> for more information.");
```

And getting:

![Screenshot 2022-01-07 at 10 54 52](https://user-images.githubusercontent.com/1032474/148518506-6f25f4cf-d0eb-42dc-a4e8-e3fb2fcd5530.png)



## HOW

### How did you achieve that, in technical terms?

That's the problem. I did it by modifying the `500.blade.php` file. Which means it's a breaking change. And I don't think the small improvement is worth the breaking change. Especially since this is NOT a full, long-term solution. In these cases, we _probably_ shouldn't be throwing 500 errors, but throwing custom exceptions. Something like `FieldMisconfiguredException` which would render its own blade file (from the package).

If we did that everywhere, it's possible that we don't even need to publish the error views. Which would also solve [#error ](https://github.com/Laravel-Backpack/ideas/issues/36) 

But I couldn't do that. I couldn't find a good way _for a package_ to render a custom exception with its own view. Not without asking the dev to manually change his `app\Exceptions\Handler.php`, which is obviously not ok, not automatic enough.

So I'm dropping the view here, in this PR, maybe it helps us in the future when we do find a solution to this Exception problem - then we could use this view (or a prettier one). Until then, the ugly view we have now should do.

### Is it a breaking change or non-breaking change?

Breaking


### How can we test the before & after?

Don't. Not gonna merge this.
