### PR TITLE
Fix repeatable name re-indexing on multiple inputs

### DIFF
--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -267,7 +267,6 @@
                 let container = $('[data-repeatable-holder='+$($repeatableElement).attr('data-repeatable-identifier')+']')
 
                 // get existing values
-                //let values = repeatableElementToObj($repeatableElement);
                 let index = $repeatableElement.index();
     
                 index += $(this).is('.move-element-up') ? -1 : 1;
@@ -330,20 +329,28 @@
                 $(repeatable).find('input, select, textarea').each(function(i, el) {
                     if(typeof $(el).attr('data-row-number') !== 'undefined') {
                         let field_name = $(el).attr('data-repeatable-input-name') ?? $(el).attr('name') ?? $(el).parent().find('input[data-repeatable-input-name]').first().attr('data-repeatable-input-name');
+                        let suffix = field_name.endsWith("[]") ? '[]' : '';
                         // if there are more than one "[" character, that means we already have the repeatable name
                         // we need to parse that name to get the "actual" field name. 
                         if(field_name.split('[').length - 1 > 1) {
                             let field_name_position = field_name.lastIndexOf('[');
                             // field name will contain the closing "]" that's why the last slice.
-                            field_name = field_name.substring(field_name_position + 1).slice(0,-1);
+                            field_name = field_name.substring(field_name_position + 1);
+                            if(field_name.endsWith("[]")) {
+                                // remove the last "]" and the array definition from field name "[]"
+                                field_name = field_name.slice(0,-3);
+                                suffix = "[]";
+                            }else{
+                                field_name = field_name.slice(0,-1);
+                            }
                         }
-                        let unprefixed_field_name = field_name.endsWith("[]") ? field_name.substring(0, field_name.length - 2) : field_name;
+                        let unsuffixed_field_name = field_name.endsWith("[]") ? field_name.slice(0,-2) : field_name;
                         if(typeof $(el).attr('data-repeatable-input-name') === 'undefined') {
                             $(el).attr('data-repeatable-input-name', field_name);
                         }
         
-                        let prefix = field_name.endsWith("[]") ? '[]' : '';
-                        $(el).attr('name', container.attr('data-repeatable-holder')+'['+index+']['+unprefixed_field_name+']'+prefix);
+                        
+                        $(el).attr('name', container.attr('data-repeatable-holder')+'['+index+']['+unsuffixed_field_name+']'+suffix);
                     }
                 });
             });

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -329,28 +329,24 @@
                 $(repeatable).find('input, select, textarea').each(function(i, el) {
                     if(typeof $(el).attr('data-row-number') !== 'undefined') {
                         let field_name = $(el).attr('data-repeatable-input-name') ?? $(el).attr('name') ?? $(el).parent().find('input[data-repeatable-input-name]').first().attr('data-repeatable-input-name');
-                        let suffix = field_name.endsWith("[]") ? '[]' : '';
+                        let suffix = '';
                         // if there are more than one "[" character, that means we already have the repeatable name
-                        // we need to parse that name to get the "actual" field name. 
+                        // we need to parse that name to get the "actual" field name.
+                        if(field_name.endsWith("[]")) {
+                            suffix = "[]";
+                            field_name = field_name.slice(0,-2);
+                        }
                         if(field_name.split('[').length - 1 > 1) {
                             let field_name_position = field_name.lastIndexOf('[');
                             // field name will contain the closing "]" that's why the last slice.
-                            field_name = field_name.substring(field_name_position + 1);
-                            if(field_name.endsWith("[]")) {
-                                // remove the last "]" and the array definition from field name "[]"
-                                field_name = field_name.slice(0,-3);
-                                suffix = "[]";
-                            }else{
-                                field_name = field_name.slice(0,-1);
-                            }
+                            field_name = field_name.substring(field_name_position + 1).slice(0,-1);
                         }
-                        let unsuffixed_field_name = field_name.endsWith("[]") ? field_name.slice(0,-2) : field_name;
+
                         if(typeof $(el).attr('data-repeatable-input-name') === 'undefined') {
                             $(el).attr('data-repeatable-input-name', field_name);
                         }
-        
-                        
-                        $(el).attr('name', container.attr('data-repeatable-holder')+'['+index+']['+unsuffixed_field_name+']'+suffix);
+
+                        $(el).attr('name', container.attr('data-repeatable-holder')+'['+index+']['+field_name+']'+suffix);
                     }
                 });
             });


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was a bug in repeatable that was preventing it from properly work with multiple inputs. The new introduced code to deal with the fact that the names are setup in PHP and not JS was not complete was missing this bit to handle cases where name ends with `[]`.

The way it was working to check if the name was already a repeatable name was broken and the field name was not properly generated.

### AFTER - What is happening after this PR?

After this PR it properly parses the name.


## HOW

### How did you achieve that, in technical terms?

Mostly a refactor, moved the suffix handling higher in execution and worked only with non ending `[]`, appending it later if needed.

### Is it a breaking change or non-breaking change?

non


### How can we test the before & after?

Go to dummy, fill one nice dummy (just mandatory and one select multiple for example in the relationships section).
Edit it, and add a new row in that section. 
Check the select multiple name is broke.

Do the same with this PR, names are properly set.
