### PR TITLE
[Pivot Relations] Pivot Selector should not allow to re-select the same.

### DIFF
--- a/src/resources/views/crud/fields/relationship/fetch.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch.blade.php
@@ -197,7 +197,7 @@
                     processResults: function (data, params) {
                         params.page = params.page || 1;
                         
-                        // if field is a pivot selector we are gona get other pivot values so we can disable them from selection.
+                        // if field is a pivot select we are gona get other pivot values so we can disable them from selection.
                         if($isPivotSelect) {
                             let pivots_container = $(element).closest('div[data-repeatable-holder='+$(element).data('repeatable-input-name')+']');
                             var selected_values = [];

--- a/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
+++ b/src/resources/views/crud/fields/relationship/fetch_or_create.blade.php
@@ -50,7 +50,7 @@
     // this is the time we wait before send the query to the search endpoint, after the user as stopped typing.
     $field['delay'] = $field['delay'] ?? 500;
 
-    // this field can be used as a pivot selector for n-n relationships
+    // this field can be used as a pivot select for n-n relationships
     $field['is_pivot_select'] = $field['is_pivot_select'] ?? false;
 
 
@@ -544,7 +544,7 @@
             processResults: function (data, params) {
                 params.page = params.page || 1;
 
-                // if field is a pivot selector we are gona get other pivot values so we can disable them from selection.
+                // if field is a pivot select we are gona get other pivot values so we can disable them from selection.
                 if($isPivotSelect) {
                     let pivots_container = $(element).closest('div[data-repeatable-holder='+$(element).data('repeatable-input-name')+']');
                     var selected_values = [];

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -7,7 +7,7 @@
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
     // Note: isColumnNullable returns true if column is nullable in database, also true if column does not exist.
 
-    // this field can be used as a pivot selector for n-n relationships
+    // this field can be used as a pivot select for n-n relationships
     $field['is_pivot_select'] = $field['is_pivot_select'] ?? false;
 
     if (!isset($field['options'])) {

--- a/src/resources/views/crud/fields/relationship/relationship_select.blade.php
+++ b/src/resources/views/crud/fields/relationship/relationship_select.blade.php
@@ -7,6 +7,9 @@
     $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
     // Note: isColumnNullable returns true if column is nullable in database, also true if column does not exist.
 
+    // this field can be used as a pivot selector for n-n relationships
+    $field['is_pivot_selector'] = $field['is_pivot_selector'] ?? false;
+
     if (!isset($field['options'])) {
             $field['options'] = $connected_entity::all()->pluck($field['attribute'],$connected_entity_key_name);
         } else {
@@ -63,6 +66,7 @@
         data-placeholder="{{ $field['placeholder'] }}"
         data-field-multiple="{{var_export($field['multiple'])}}"
         data-language="{{ str_replace('_', '-', app()->getLocale()) }}"
+        data-is-pivot-selector={{var_export($field['is_pivot_selector'])}}
 
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control'])
 
@@ -143,6 +147,54 @@
         var $allows_null = (element.attr('data-column-nullable') == 'true') ? true : false;
         var $allowClear = $allows_null;
         var $isFieldInline = element.data('field-is-inline');
+        var $isPivotSelector = element.data('is-pivot-selector');
+        
+        const changePivotOptionState = function(pivot_selector, enable = true) {
+            let pivots_container = pivot_selector.closest('div[data-repeatable-holder='+pivot_selector.data('repeatable-input-name')+']');
+            
+            $(pivots_container).children().each(function(i,container) {
+                $(container).find('select').each(function(i, el) {
+                    
+                    if(typeof $(el).attr('data-is-pivot-selector') !== 'undefined' && $(el).attr('data-is-pivot-selector')) {
+                        if(enable ) {
+                            console.log('HEY!!!!!!!!!');
+                            console.log(pivot_selector.val())
+                            $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',false);   
+                        }else{
+                            if($(el).val() !== pivot_selector.val()) {
+                                console.log('here');
+                                $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',true);
+                            }
+                        }
+                    }
+                });
+            });
+        };
+
+        const disablePreviouslySelectedPivots = function(pivot_selector) {
+            let pivots_container = pivot_selector.closest('div[data-repeatable-holder='+pivot_selector.data('repeatable-input-name')+']');
+            let selected_values = [];
+            
+            $(pivots_container).children().each(function(i,container) {
+                $(container).find('select').each(function(i, el) {
+                    if(typeof $(el).attr('data-is-pivot-selector') !== 'undefined' && $(el).attr('data-is-pivot-selector') && $(el).val()) {
+                        selected_values.push($(el).val());
+                    }
+                });
+            });
+
+            $(pivots_container).children().each(function(i,container) {
+                $(container).find('select').each(function(i, el) {
+                    if(typeof $(el).attr('data-is-pivot-selector') !== 'undefined' && $(el).attr('data-is-pivot-selector')) {
+                        selected_values.forEach(function(value) {
+                            if(value !== $(el).val()) {
+                                $(el).find('option[value='+value+']').prop('disabled',true);
+                            }
+                        });
+                    }
+                });
+            });
+        };
 
         var $select2Settings = {
                 theme: 'bootstrap',
@@ -154,7 +206,23 @@
         if (!$(element).hasClass("select2-hidden-accessible"))
         {
             $(element).select2($select2Settings);
+            disablePreviouslySelectedPivots($(element));
         }
+
+        if($isPivotSelector) {
+            $(element).on('select2:selecting', function(e) {
+                if($(this).val()) {
+                    changePivotOptionState($(this)); 
+                }
+                return true;
+            });
+
+            $(element).on('select2:select', function(e) {
+                changePivotOptionState($(this), false);
+                return true;
+            });
+        }
+
     }
 </script>
 @endpush

--- a/src/resources/views/crud/fields/relationship/repeatable_relation.blade.php
+++ b/src/resources/views/crud/fields/relationship/repeatable_relation.blade.php
@@ -13,9 +13,9 @@
     $field['fields'] = $field['pivotFields'];
     $field['reorder'] = $field['reorder'] ?? false;
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
-    $pivotSelectorField = $field['pivot_selector'] ?? [];
+    $pivotSelectorField = $field['pivotSelect'] ?? [];
     $pivotSelectorField['name'] = $field['name'];
-    $pivotSelectorField['is_pivot_selector'] = true;
+    $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
     $pivotSelectorField['ajax'] = $pivotSelectorField['ajax'] ?? false;
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? isset($pivotSelectorField['ajax']) && $pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false';

--- a/src/resources/views/crud/fields/relationship/repeatable_relation.blade.php
+++ b/src/resources/views/crud/fields/relationship/repeatable_relation.blade.php
@@ -15,6 +15,7 @@
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField = $field['pivot_selector'] ?? [];
     $pivotSelectorField['name'] = $field['name'];
+    $pivotSelectorField['is_pivot_selector'] = true;
     $pivotSelectorField['multiple'] = false;
     $pivotSelectorField['ajax'] = $pivotSelectorField['ajax'] ?? false;
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? isset($pivotSelectorField['ajax']) && $pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false';


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In relations that work with the pivot field `BelongsToMany/MorphToMany` the user could select twice the same pivot entry without noticing and only the last choise of the same entry would get persisted in the database. This could have disastrous consequences if allowed to happen.

### AFTER - What is happening after this PR?

The already selected pivot entries gets disabled in the other pivot selectors preventing them from beeing selected twice.


## HOW

### How did you achieve that, in technical terms?

Using JS :| Not a fan, but it works. 

When the field initialize we check for other pivots and get all their values, then we disable those options on all other selects.
When value change we re-enable the "free" option and disable the selected one.

### Is it a breaking change or non-breaking change?
Noo

### How can we test the before & after?

Just see `Dummyproducts` in Demo before & after this PR.
