### PR TITLE
Add `relationship.entry` subfield for single HasOne/MorphOne

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -174,7 +174,7 @@ trait Create
                     $relation->dissociate()->save();
                 }
             } elseif ($relation instanceof HasOne || $relation instanceof MorphOne) {
-                $relation_values = $relationDetails['values'][$relationMethod] ??  $relationDetails['values'] ?? null;
+                $relation_values = $relationDetails['values'][$relationMethod] ?? $relationDetails['values'] ?? null;
 
                 if ($relation_values === null) {
                     $relation->delete();

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -174,7 +174,17 @@ trait Create
                     $relation->dissociate()->save();
                 }
             } elseif ($relation instanceof HasOne || $relation instanceof MorphOne) {
-                $modelInstance = $relation->updateOrCreate([], $relationDetails['values']);
+                $relation_values = $relationDetails['values'][$relationMethod];
+
+                if ($relation_values === null) {
+                    $relation->delete();
+                    continue;
+                }
+                // if the values are not single dimension array, we want only the first entry of the array sent (repeatable row)
+                if (count($relation_values) != count($relation_values, COUNT_RECURSIVE)) {
+                    $relation_values = $relation_values[0];  
+                }
+                $modelInstance = $relation->updateOrCreate([], $relation_values);
             } elseif ($relation instanceof HasMany || $relation instanceof MorphMany) {
                 $relation_values = $relationDetails['values'][$relationMethod];
                 // if relation values are null we can only attach, also we check if we sent a single dimensional array [1,2,3], or an array of arrays: [[1][2][3]]

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -174,7 +174,7 @@ trait Create
                     $relation->dissociate()->save();
                 }
             } elseif ($relation instanceof HasOne || $relation instanceof MorphOne) {
-                $relation_values = $relationDetails['values'][$relationMethod];
+                $relation_values = $relationDetails['values'][$relationMethod] ??  $relationDetails['values'] ?? null;
 
                 if ($relation_values === null) {
                     $relation->delete();

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -164,24 +164,26 @@ trait Update
                     return;
                 }
 
-                if (Str::contains($field['entity'], '.')) {
-                    return $related_model->{$relation_method}->{Str::afterLast($field['entity'], '.')};
+                $related_entry = $related_model->{$relation_method};
+
+                if (! $related_entry) {
+                    return;
                 }
 
-                if (! $related_model->{$relation_method}) {
-                    return;
+                if (Str::contains($field['entity'], '.')) {
+                    return $related_entry->{Str::afterLast($field['entity'], '.')};
                 }
 
                 if ($field['fields']) {
                     $result = [];
                     foreach ($field['fields'] as $subfield) {
-                        $result[$subfield['name']] = $related_model->{$relation_method}->{$subfield['name']};
+                        $result[$subfield['name']] = $related_entry->{$subfield['name']};
                     }
 
                     return [$result];
                 }
 
-                return $related_model->{$relation_method};
+                return $related_entry;
 
                 break;
             default:

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -160,13 +160,29 @@ trait Update
             break;
             case 'HasOne':
             case 'MorphOne':
-                if (! $related_model->{$relation_method}) {
+                if(!method_exists($related_model, $relation_method)) {
                     return;
                 }
 
-                return $related_model->{$relation_method}->{Str::afterLast($field['entity'], '.')};
+                if(Str::contains($field['entity'], '.')) {
+                    return $related_model->{$relation_method}->{Str::afterLast($field['entity'], '.')};
+                }
 
-            break;
+                if(!$related_model->{$relation_method}) {
+                    return;
+                }
+
+                if($field['fields']) {
+                    $result = [];
+                    foreach($field['fields'] as $subfield) {  
+                        $result[$subfield['name']] = $related_model->{$relation_method}->{$subfield['name']};
+                    }
+                    return [$result];
+                }
+                
+                return $related_model->{$relation_method};
+
+                break;
             default:
                 return $related_model->{$relation_method};
         }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -157,7 +157,7 @@ trait Update
 
                 return $result;
 
-            break;
+                break;
             case 'HasOne':
             case 'MorphOne':
                 if (! method_exists($related_model, $relation_method)) {

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -31,11 +31,6 @@
                 break;
             }
 
-            if(isset($field['fields'])) {
-                $field['type'] = 'relationship.entry';
-                break;
-            }
-
             // TODO: if relationship has `isOneOfMany` on it, load a readonly select; this covers:
             // - has One Of Many - hasOne(Order::class)->latestOfMany()
             // - morph One Of Many - morphOne(Image::class)->latestOfMany()
@@ -45,10 +40,15 @@
             }
 
 
-            // the dev is trying to create a field for the ENTIRE hasOne/morphOne relationship
-            abort(500, "<strong>The relationship field does not support <code>{$field['relation_type']}</code> that way.</strong><br> Please change your <code>{$field['name']}</code> field so that its <i>name</i> also includes the editable attribute on the related model, using dot notation (eg. <code>address.postal_code</code>). If you need to edit more attributes, add a new field for each one (eg. <code>address.postal_code</code>). See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#hasone-1-1-relationship'>the docs</a> for more information.");
-            // TODO: if "fields" is not defined, tell the dev to define it (+ link to docs)
-            // TODO: if "fields" is defined, load a repeatable field with one entry (and 1 entry max)
+            // -----
+            // The dev is trying to create a field for the ENTIRE hasOne/morphOne relationship
+            // -----
+            // if "subfields" is not defined, tell the dev to define it (+ link to docs)
+            if (!isset($field['fields'])) {
+                abort(500, "<strong>Please define <code>subfields</code> on your <code>{$field['model']}</code> field.</strong><br>That way, you can allow the admin to edit the attributes on that related entry (through the hasOne relationship).<br>See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#crud-how-to#hasone-1-1-relationship'>the docs</a> for more information.");
+            }
+            // if "subfields" is defined, load a repeatable field with one entry (and 1 entry max)
+            $field['type'] = 'relationship.entry';
             break;
         case 'BelongsTo':
         case 'BelongsToMany':

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -31,6 +31,11 @@
                 break;
             }
 
+            if(isset($field['fields'])) {
+                $field['type'] = 'relationship.entry';
+                break;
+            }
+
             // TODO: if relationship has `isOneOfMany` on it, load a readonly select; this covers:
             // - has One Of Many - hasOne(Order::class)->latestOfMany()
             // - morph One Of Many - morphOne(Image::class)->latestOfMany()

--- a/src/resources/views/crud/fields/relationship/entry.blade.php
+++ b/src/resources/views/crud/fields/relationship/entry.blade.php
@@ -1,0 +1,17 @@
+{{--
+    This field is a switchboard for the "real" field that is a repeatable
+    Based on developer preferences and the relation type we "guess" the best solution
+    we can provide for the user and setup some defaults for them.
+    One of the things that we take care, is adding the "pivot selector field", that is the link with
+    the current crud and pivot entries, in this scenario is used with other pivot fields in a repeatable container.
+--}}
+
+@php
+    $field['type'] = 'repeatable';
+    //each row represent a related entry in a database table. We should not "auto-add" one relationship if it's not the user intention.
+    $field['init_rows'] = 0;
+    $field['max_rows'] = 1;
+    $field['reorder'] = $field['reorder'] ?? false;
+@endphp
+
+@include('crud::fields.repeatable')

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -156,6 +156,37 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals($account_details->nickname, $account_details_nickname);
     }
 
+    public function testCreateWithOneToOneRelationshipUsingRepeatableInterface()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
+        $this->crudPanel->addField([
+            'name' => 'accountDetails',
+            'fields' => [
+                [
+                    'name' => 'nickname',
+                ],
+                [
+                    'name' => 'profile_picture'
+                ]
+            ]
+        ]);
+        $faker = Factory::create();
+        $account_details_nickname = $faker->name;
+        $inputData = [
+            'name'     => $faker->name,
+            'email'    => $faker->safeEmail,
+            'password' => bcrypt($faker->password()),
+            'accountDetails' => [
+                ['nickname' => $account_details_nickname, 'profile_picture' => 'test.jpg'],
+            ],
+        ];
+        $entry = $this->crudPanel->create($inputData);
+        $account_details = $entry->accountDetails()->first();
+
+        $this->assertEquals($account_details->nickname, $account_details_nickname);
+    }
+
     public function testCreateBelongsToWithRelationName()
     {
         $this->crudPanel->setModel(Article::class);

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -167,9 +167,9 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                     'name' => 'nickname',
                 ],
                 [
-                    'name' => 'profile_picture'
-                ]
-            ]
+                    'name' => 'profile_picture',
+                ],
+            ],
         ]);
         $faker = Factory::create();
         $account_details_nickname = $faker->name;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The HasOne/MorphOne relations could not be deleted from the entry only edited. It makes sense in some scenarios, but in others completely deleting the relation is the desired behaviour.

### AFTER - What is happening after this PR?

User can add a single `entry` field that represent the `HasOne/MorphOne` relation, allowing also for complete deletion of the relation.

## HOW

### How did you achieve that, in technical terms?

Introduced the new `entry.blade.php` file and updated the saving process to accomodate this new relationship field definition.

### Is it a breaking change or non-breaking change?

non in 4.2


### How can we test the before & after?

Can't test the before as this is new functionality. But testing the mentioned problem should be done in demo where `Monster` has a HasOne relation with `Address` and after the Monster is created there is no way to delete the address relation from Monster.


