### PR TITLE
Fix to allow enter key to select an option from address_google list of options without submitting the form.

### DIFF
--- a/src/resources/views/crud/fields/address_google.blade.php
+++ b/src/resources/views/crud/fields/address_google.blade.php
@@ -130,6 +130,13 @@
                         }
                     }
                 });
+                
+                element.keydown(function(e) {
+                    if ($('.pac-container').is(':visible') && e.keyCode == 13) {
+                        e.preventDefault();
+                        return false;
+                    }
+                });
 
                 // Make sure pac container is closed on modals (inline create)
                 let modal = document.querySelector('.modal-dialog');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fixes #4003

Pressing the enter key while navigating the options of address_google would submit the form instead of choosing an option from the list.

### AFTER - What is happening after this PR?

The form is only submitted if the .pac-container is not being displayed


## HOW

### How did you achieve that, in technical terms?

Checks the jQuery selector for visibility attached to keydown event



### Is it a breaking change or non-breaking change?

Don't think so.


### How can we test the before & after?

??
