### PR TITLE
[4.2] make default min_rows in repeatable zero

### DIFF
--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -5,7 +5,7 @@
   // make sure the value is always an array, even if stored as JSON in database
   $field['value'] = is_string($field['value']) ? json_decode($field['value'], true) : $field['value'];
 
-  $field['init_rows'] = $field['init_rows'] ?? $field['min_rows'] ?? 1;
+  $field['init_rows'] = $field['init_rows'] ?? $field['min_rows'] ?? 0;
   $field['max_rows'] = $field['max_rows'] ?? 0;
   $field['min_rows'] =  $field['min_rows'] ?? 0;
   $field['reorder'] = $field['reorder'] ?? true;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The admin goes to add an entry that has a `repeatable` field. But that repeatable field isn't so important, so they don't fill it in. In fact, they remove that one "empty" entry from the repeatable, click "Save and Edit".

My expectation as an admin is to get to a form that looks the same way I submitted it. But no, an item appears again inside `repeatable` - an empty one.

### AFTER - What is happening after this PR?

No more empty `repeatable` item after submitting an empty `repeatable`.

## HOW

### How did you achieve that, in technical terms?

Set the `min_rows` default to `0`.


### Is it a breaking change or non-breaking change?

Breaking, because it's a change in default behaviour.


### How can we test the before & after?

Before: Go to Dummies in the demo, remove everything but the required. Click submit. Afterwards you'll have an empty entry inside each `repeatable` again.

After: You won't. You'll see the form exactly like you submitted it.
