### PR TITLE
Rename fields to subfields inside `repeatable` and `relationship` field types

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -66,11 +66,18 @@ trait Create
                 array_push($relationFields, $field);
             }
 
-            if (isset($field['subfields']) &&
+            // if a field has an array name AND subfields
+            // then take those fields into account (check if they have relationships);
+            // this is done in particular for the checklist_dependency field,
+            // but other fields could use it too, in the future;
+            if (is_array($field['name']) &&
+                isset($field['subfields']) &&
                 is_array($field['subfields']) &&
                 count($field['subfields'])) {
                 foreach ($field['subfields'] as $subfield) {
-                    array_push($relationFields, $subfield);
+                    if (isset($subfield['model']) && $subfield['model'] !== false) {
+                        array_push($relationFields, $subfield);
+                    }
                 }
             }
         }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -109,11 +109,12 @@ trait Update
             case 'HasMany':
             case 'BelongsToMany':
             case 'MorphToMany':
-                if (! isset($field['pivotFields'])) {
+                // use subfields aka. pivotFields
+                if (! isset($field['subfields'])) {
                     return $related_model->{$relation_method};
                 }
                 // we want to exclude the "self pivot field" since we already have it.
-                $pivot_fields = Arr::where($field['pivotFields'], function ($item) use ($field) {
+                $pivot_fields = Arr::where($field['subfields'], function ($item) use ($field) {
                     return $field['name'] != $item['name'];
                 });
                 $related_models = $related_model->{$relation_method};
@@ -164,9 +165,9 @@ trait Update
                     return $related_entry->{Str::afterLast($field['entity'], '.')};
                 }
 
-                if ($field['fields']) {
+                if ($field['subfields']) {
                     $result = [];
-                    foreach ($field['fields'] as $subfield) {
+                    foreach ($field['subfields'] as $subfield) {
                         $name = is_string($subfield) ? $subfield : $subfield['name'];
                         $result[$name] = $related_entry->{$name};
                     }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -52,17 +52,7 @@ trait Update
         $entry = ($id != false) ? $this->getEntry($id) : $this->getCurrentEntry();
 
         foreach ($fields as &$field) {
-            // set the value
-            if (! isset($field['value'])) {
-                if (isset($field['subfields'])) {
-                    $field['value'] = [];
-                    foreach ($field['subfields'] as $subfield) {
-                        $field['value'][] = $entry->{$subfield['name']};
-                    }
-                } else {
-                    $field['value'] = $this->getModelAttributeValue($entry, $field);
-                }
-            }
+            $field['value'] = $field['value'] ?? $this->getModelAttributeValue($entry, $field);
         }
 
         // always have a hidden input for the entry id
@@ -96,8 +86,8 @@ trait Update
 
         if (is_array($field['name'])) {
             $result = [];
-            foreach ($field['name'] as $key => $value) {
-                $result = $model->{$value};
+            foreach ($field['name'] as $name) {
+                $result[] = $model->{$name};
             }
 
             return $result;

--- a/src/resources/views/crud/fields/date_range.blade.php
+++ b/src/resources/views/crud/fields/date_range.blade.php
@@ -19,13 +19,14 @@
             return $formattedDate;
         }
     }
+
     if (isset($field['value'])) {
         if (isset($entry) && ! is_array($field['value'])) {
             $start_value = formatDate($entry, $field['name'][0]);
             $end_value = formatDate($entry, $field['name'][1]);
-        } elseif (is_array($field['value'])) {
-            $start_value = $field['value'][$field['name'][0]];
-            $end_value = $field['value'][$field['name'][1]];
+        } elseif (is_array($field['value'])) { // gets here when inside repeatable
+            $start_value = current($field['value']); // first array item
+            $end_value = next($field['value']); // second array item
         }
     }
 

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -4,7 +4,7 @@
 @endif
 
 <div class="col-md-12 well repeatable-element row m-1 p-2" data-repeatable-identifier="{{ $field['name'] }}">
-    @if (isset($field['fields']) && is_array($field['fields']) && count($field['fields']))
+    @if (isset($field['subfields']) && is_array($field['subfields']) && count($field['subfields']))
     <div class="controls">
         <button type="button" class="close delete-element"><span aria-hidden="true">×</span></button>
         @if ($field['reorder'])
@@ -16,7 +16,7 @@
         </button>
         @endif
     </div>
-    @foreach($field['fields'] as $subfield)
+    @foreach($field['subfields'] as $subfield)
         @php
             // make sure the field is an array
             if (is_string($subfield)) {

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -20,6 +20,7 @@
     // if field is not ajax but user wants to use InlineCreate
     // we make minimum_input_length = 0 so when user open we show the entries like a regular select
     $field['minimum_input_length'] = ($field['ajax'] !== true) ? 0 : ($field['minimum_input_length'] ?? 2);
+    $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivotFields'] ?? false;
 
     switch($field['relation_type']) {
         case 'HasOne':
@@ -44,7 +45,7 @@
             // The dev is trying to create a field for the ENTIRE hasOne/morphOne relationship
             // -----
             // if "subfields" is not defined, tell the dev to define it (+ link to docs)
-            if (!isset($field['fields'])) {
+            if (!is_array($field['subfields'])) {
                 abort(500, "<strong>Please define <code>subfields</code> on your <code>{$field['model']}</code> field.</strong><br>That way, you can allow the admin to edit the attributes on that related entry (through the hasOne relationship).<br>See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#crud-how-to#hasone-1-1-relationship'>the docs</a> for more information.");
             }
             // if "subfields" is defined, load a repeatable field with one entry (and 1 entry max)
@@ -54,7 +55,7 @@
         case 'BelongsToMany':
         case 'MorphToMany':
             // if there are pivot fields we show the repeatable field
-            if(isset($field['pivotFields'])) {
+            if(is_array($field['subfields'])) {
                 $field['type'] = 'relationship.entries';
                 break;
             }
@@ -80,7 +81,7 @@
             $field['force_delete'] = $field['force_delete'] ?? false;
 
             // if there are pivot fields we show the repeatable field
-            if(isset($field['pivotFields'])) {
+            if(is_array($field['subfields'])) {
                 $field['type'] = 'relationship.entries';
             } else {
                 // we show a regular/ajax select

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -20,7 +20,7 @@
     // if field is not ajax but user wants to use InlineCreate
     // we make minimum_input_length = 0 so when user open we show the entries like a regular select
     $field['minimum_input_length'] = ($field['ajax'] !== true) ? 0 : ($field['minimum_input_length'] ?? 2);
-    $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivotFields'] ?? false;
+    $field['subfields'] = $field['subfields'] ?? false;
 
     switch($field['relation_type']) {
         case 'HasOne':

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -10,7 +10,7 @@
     $field['type'] = 'repeatable';
     //each row represent a related entry in a database table. We should not "auto-add" one relationship if it's not the user intention.
     $field['init_rows'] = 0;
-    $field['fields'] = $field['pivotFields'];
+    $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivotFields'];
     $field['reorder'] = $field['reorder'] ?? false;
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField = $field['pivotSelect'] ?? [];
@@ -29,12 +29,12 @@
     switch ($field['relation_type']) {
         case 'MorphToMany':
         case 'BelongsToMany':
-            $field['fields'] = Arr::prepend($field['fields'], $pivotSelectorField);
+            $field['subfields'] = Arr::prepend($field['subfields'], $pivotSelectorField);
             break;
         case 'MorphMany':
         case 'HasMany':
             if(isset($entry)) {
-                $field['fields'] = Arr::prepend($field['fields'], [
+                $field['subfields'] = Arr::prepend($field['subfields'], [
                     'name' => $entry->{$field['name']}()->getLocalKeyName(),
                     'type' => 'hidden',
                 ]);

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -10,7 +10,7 @@
     $field['type'] = 'repeatable';
     //each row represent a related entry in a database table. We should not "auto-add" one relationship if it's not the user intention.
     $field['init_rows'] = 0;
-    $field['subfields'] = $field['fields'];
+    $field['subfields'] = $field['subfields'] ?? [];
     $field['reorder'] = $field['reorder'] ?? false;
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField = $field['pivotSelect'] ?? [];

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -10,7 +10,7 @@
     $field['type'] = 'repeatable';
     //each row represent a related entry in a database table. We should not "auto-add" one relationship if it's not the user intention.
     $field['init_rows'] = 0;
-    $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivotFields'];
+    $field['subfields'] = $field['fields'];
     $field['reorder'] = $field['reorder'] ?? false;
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField = $field['pivotSelect'] ?? [];

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -9,7 +9,7 @@
   $field['max_rows'] = $field['max_rows'] ?? 0;
   $field['min_rows'] =  $field['min_rows'] ?? 0;
   $field['reorder'] = $field['reorder'] ?? true;
-  $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivot_fields'] ?? [];
+  $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? [];
 @endphp
 
 @include('crud::fields.inc.wrapper_start')

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -9,6 +9,7 @@
   $field['max_rows'] = $field['max_rows'] ?? 0;
   $field['min_rows'] =  $field['min_rows'] ?? 0;
   $field['reorder'] = $field['reorder'] ?? true;
+  $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? $field['pivot_fields'] ?? [];
 @endphp
 
 @include('crud::fields.inc.wrapper_start')


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some fields wanted `fields`, others wanted `subfields`, others wanted `pivotFields`.

### AFTER - What is happening after this PR?

Everything that has subfields... works with `subfields`.


## HOW

### How did you achieve that, in technical terms?

Both the `repeatable` and the `relationship` fields turn `fields` and `pivotFields` into `subfields`.

### Is it a breaking change or non-breaking change?

Non-breaking. But it depends on https://github.com/Laravel-Backpack/CRUD/pull/4069 to be merged (this branch points to that one). Heads-up, for some reason the Github Diff also show the changes in that one. So please review that one first.

### How can we test the before & after?

Before - use `subfields` in your `repeatable` and `relationship` fields and it won't work.

After - it will.
