### PR TITLE
Improve `upload_multiple` field validation

### DIFF
--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -35,12 +35,12 @@
     @endif
     @endif
 	{{-- Show the file picker on CREATE form. --}}
-	<input name="{{ $field['name'] }}[]" type="hidden" value="">
+	
 	<div class="backstrap-file mt-2">
 		<input
 	        type="file"
 	        name="{{ $field['name'] }}[]"
-	        @include('crud::fields.inc.attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'file_input backstrap-file-input':'file_input backstrap-file-input'])
+	        @include('crud::fields.inc.attributes', ['default_class' => 'file_input backstrap-file-input'])
 	        multiple
 	    >
         <label class="backstrap-file-label" for="customFile"></label>
@@ -72,6 +72,7 @@
 		        	parent.remove();
 		        	// if the file container is empty, remove it
 		        	if ($.trim(container.html())=='') {
+						$('<input type="hidden" name="'+fieldName+'[]" value="">').insertBefore(fileInput);
 		        		container.remove();
 		        	}
 		        	$("<input type='hidden' name='clear_"+fieldName+"[]' value='"+$(this).data('filename')+"'>").insertAfter(fileInput);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

See https://github.com/Laravel-Backpack/CRUD/issues/4073 - it was clunky to validate the `upload_multiple` field.

### AFTER - What is happening after this PR?

??


## HOW

### How did you achieve that, in technical terms?

Added a hidden input (using JS).


### Is it a breaking change or non-breaking change?

??


### How can we test the before & after?

??
