### PR TITLE
Fix pivot field in repeatable

### DIFF
--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -16,18 +16,17 @@
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
     $pivotSelectorField['allows_null'] = false;
-    $pivotSelectorField['entity'] = $field['entity'];
+    $pivotSelectorField['entity'] = $field['name'];
     $pivotSelectorField['model'] = $field['model'];
     
-    $pivotSelectorField['ajax'] = $pivotSelectorField['ajax'] ?? false;
-    $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? isset($pivotSelectorField['ajax']) && $pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false';
+    $pivotSelectorField['ajax'] = $inline_create !== false ? true : ($pivotSelectorField['ajax'] ?? false);
+    $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? ($pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false');
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
     $pivotSelectorField['type'] = $inline_create !== false ? 'fetch_or_create' : ($pivotSelectorField['ajax'] ? 'fetch' : 'select');
     $pivotSelectorField['view_namespace'] = 'crud::fields.relationship';
-    $pivotSelectorField['attribute'] = $pivotSelectorField['attribute'] ?? (new $field['model'])->identifiableAttribute();
-    
+    $pivotSelectorField['attribute'] = $pivotSelectorField['attribute'] ?? (new $field['model'])->identifiableAttribute();    
     
     if($inline_create) {
         $field['inline_create'] = $inline_create;

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -8,21 +8,27 @@
 
 @php
     $field['type'] = 'repeatable';
-    //each row represent a related entry in a database table. We should not "auto-add" one relationship if it's not the user intention.
-    $field['init_rows'] = 0;
     $field['fields'] = $field['pivotFields'];
     $field['reorder'] = $field['reorder'] ?? false;
-    $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField = $field['pivotSelect'] ?? [];
+    $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField['name'] = $field['name'];
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
+    $pivotSelectorField['allows_null'] = false;
+    $pivotSelectorField['entity'] = $field['entity'];
+    $pivotSelectorField['model'] = $field['model'];
+    
     $pivotSelectorField['ajax'] = $pivotSelectorField['ajax'] ?? false;
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? isset($pivotSelectorField['ajax']) && $pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false';
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
-
+    $pivotSelectorField['type'] = $inline_create !== false ? 'fetch_or_create' : ($pivotSelectorField['ajax'] ? 'fetch' : 'select');
+    $pivotSelectorField['view_namespace'] = 'crud::fields.relationship';
+    $pivotSelectorField['attribute'] = $pivotSelectorField['attribute'] ?? (new $field['model'])->identifiableAttribute();
+    
+    
     if($inline_create) {
         $field['inline_create'] = $inline_create;
     }

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -10,27 +10,19 @@
     $field['type'] = 'repeatable';
     $field['fields'] = $field['pivotFields'];
     $field['reorder'] = $field['reorder'] ?? false;
+    
     $pivotSelectorField = $field['pivotSelect'] ?? [];
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField['name'] = $field['name'];
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
-    $pivotSelectorField['allows_null'] = false;
-    $pivotSelectorField['entity'] = $field['name'];
-    $pivotSelectorField['model'] = $field['model'];
-    
+    $pivotSelectorField['entity'] = $field['name'];    
     $pivotSelectorField['ajax'] = $inline_create !== false ? true : ($pivotSelectorField['ajax'] ?? false);
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? ($pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false');
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
-    $pivotSelectorField['type'] = $inline_create !== false ? 'fetch_or_create' : ($pivotSelectorField['ajax'] ? 'fetch' : 'select');
-    $pivotSelectorField['view_namespace'] = 'crud::fields.relationship';
-    $pivotSelectorField['attribute'] = $pivotSelectorField['attribute'] ?? (new $field['model'])->identifiableAttribute();    
     
-    if($inline_create) {
-        $field['inline_create'] = $inline_create;
-    }
     switch ($field['relation_type']) {
         case 'MorphToMany':
         case 'BelongsToMany':


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

After #4077 merge the pivot field would not work properly if everything is not properly defined by us!

### AFTER - What is happening after this PR?

The pivot field is correctly setup and it's working again.


## HOW

### How did you achieve that, in technical terms?

Added the manual configurations to the field.


### Is it a breaking change or non-breaking change?

non


### How can we test the before & after?

Check any `BelongsToMany` or `MorphMany` with pivot relations before and after this PR.
