### PR TITLE
Make repeatable subfields `text` by default

### DIFF
--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -18,11 +18,12 @@
     </div>
     @foreach($field['fields'] as $subfield)
         @php
-            // make sure the field is an array
+            // make sure the field definition is an array
             if (is_string($subfield)) {
                 $subfield = ['name' => $subfield];
             }
-            // avoid relationship field type
+            // all subfields are considered text fields if not otherwise specified
+            $subfield['type'] = $subfield['type'] ?? 'text';
             $subfield['entity'] = $subfield['entity'] ?? false;
             $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -14,6 +14,7 @@
     $pivotSelectorField = $field['pivotSelect'] ?? [];
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField['name'] = $field['name'];
+    $pivotSelectorField['type'] = 'relationship';
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
     $pivotSelectorField['entity'] = $field['name'];    


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When adding a subfield to a `repeatable`, if the field name happened to be the same as an attribute or relationship on the same model... the subfield was inferring information from it.

Eg:
```
product
- category
- title
- body
- date
- testimonials
    - title
    - body
    - category
```

In this case, when you added a `testimonial` repeatable:
- `title` became a text
- `body` became a textarea (because it thought you're talking about `body` on the `product`)
- `category` became a select (because it thought you're talking about `category` on the `product`)

### AFTER - What is happening after this PR?

All repeatable fields default to `text`, if you do not explicitly define a field type. 
Like the docs were saying anyway, if you want a subfield to have a certain field type, you have to define it.

## HOW

### How did you achieve that, in technical terms?

Inside `repeatable_row` we explicitly define 
- the `text` field type if none is defined;
- `entity => false` so that it doesn't check if there's a relationship on the model;

### Is it a breaking change or non-breaking change?

Breaking

### How can we test the before & after?

In dummies... a lot of relationships (most of them) should now show up as `text` fields, because they weren't explicitly defined.
