### PR TITLE
Refactor last pivotFields instance, refactor tests

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -121,7 +121,7 @@ trait Create
             }
 
             $relation_data = [];
-            if (isset($field['pivotFields'])) {
+            if (isset($field['subfields'])) {
                 foreach ($values as $pivot_row) {
                     $relation_data[$pivot_row[$field['name']]] = Arr::except($pivot_row, $field['name']);
                 }

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -471,7 +471,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
-        $this->crudPanel->addField(['name' => 'recommends', 'pivotFields' => [
+        $this->crudPanel->addField(['name' => 'recommends', 'subfields' => [
             [
                 'name' => 'text',
             ],
@@ -519,7 +519,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
         $this->crudPanel->addField([
             'name' => 'superArticles',
-            'pivotFields' => [
+            'subfields' => [
                 [
                     'name' => 'notes',
                 ],
@@ -628,7 +628,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
         $this->crudPanel->addField([
             'name'    => 'stars',
-            'pivotFields' => [
+            'subfields' => [
                 [
                     'name' => 'title',
                 ],
@@ -678,7 +678,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
         $this->crudPanel->addField([
             'name'    => 'universes',
-            'pivotFields' => [
+            'subfields' => [
                 [
                     'name' => 'title',
                 ],


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

A leftover of pivotFields in the core. Is now subfields and the tests are also updated. Since our change from yesterday, this was missing for save, basically on update we didn't account for pivotFields and they didn't show up, in create we were not accounting for subfields so they didn't create the entry. 

### AFTER - What is happening after this PR?

Both create and update uses `subfields`

## HOW

### How did you achieve that, in technical terms?

refactored



### Is it a breaking change or non-breaking change?

non


### How can we test the before & after?

try to create a belongsToMany relation in current 4.2 using `->subfields()` instead of `pivotFields`. 

do the same in this branch and everything will work.
