### PR TITLE
Get all pivot attributes in one go

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -118,16 +118,6 @@ trait Update
                     return $field['name'] != $item['name'];
                 });
 
-                switch (gettype($field['reorder'] ?? false)) {
-                    case 'string':
-                        $pivot_fields[] = ['name' => $field['reorder']];
-
-                    break;
-                    case 'array':
-                        $pivot_fields[] = $field['reorder'];
-
-                }
-
                 $related_models = $related_model->{$relation_method};
                 $result = [];
 
@@ -135,24 +125,14 @@ trait Update
                 foreach ($related_models as $related_model) {
                     $item = [];
                     switch ($relation_type) {
-
                         case 'HasMany':
                         case 'MorphMany':
-                            // for any given related model, we get the value from pivot fields
-                            foreach ($pivot_fields as $pivot_field) {
-                                $item[$pivot_field['name']] = $related_model->{$pivot_field['name']};
-                            }
-                            $item[$related_model->getKeyName()] = $related_model->getKey();
-                            $result[] = $item;
+                            $result[] = $related_model->getAttributes();
                             break;
 
                         case 'BelongsToMany':
                         case 'MorphToMany':
-                            // for any given related model, we get the pivot fields.
-                            foreach ($pivot_fields as $pivot_field) {
-                                $item[$pivot_field['name']] = $related_model->pivot->{$pivot_field['name']};
-                            }
-
+                            $item = $related_model->pivot->getAttributes();
                             $item[$field['name']] = $related_model->getKey();
                             $result[] = $item;
                             break;


### PR DESCRIPTION
## WHY

Points to https://github.com/Laravel-Backpack/CRUD/pull/4084 because it's a proposal for that PR.

### BEFORE - What was wrong? What was happening before this PR?

In PR #4084 we're forced to add support for `reorder` inside the Backpack CORE, for one field that would use it (`repeatable`). Why? Because at that point the `order` field would not be in `subfields`, and **Backpack only gets the pivot_table attributes that have subfields**.

I don't think that's needed. I think Backpack should get ALL attributes on the pivot_table. That would not only fix the problem at hand, but it would also take up fewer lines of code.

### AFTER - What is happening after this PR?

Instead of going through all subfields and for each one getting the pivot table attribute, we do `->getAttributes()` on the pivot.


## HOW

### How did you achieve that, in technical terms?

`->getAttributes()` on the pivot.


### Is it a breaking change or non-breaking change?

Non-breaking


### How can we test the before & after?

HasMany, MorphMany, BelongsToMany, MorphToMany fields should work the same.
