### PR TITLE
Add support for Laravel 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Alternatively, if you don't have 20 minutes right now, subscribe to our [drip em
 ## Install
 
 Installation guides:
-- [Install Backpack 4.1 on Laravel 6, 7 or 8](https://backpackforlaravel.com/docs/4.1/installation) - recommended;
+- [Install Backpack 4.2 on Laravel 9 or 8](https://backpackforlaravel.com/docs/4.2/installation) - recommended;
+- [Install Backpack 4.1 on Laravel 6, 7 or 8](https://backpackforlaravel.com/docs/4.1/installation);
 - [Install Backpack 4.0 on Laravel 5.8, 6 or 7](https://backpackforlaravel.com/docs/4.0/installation) - last feature update was 21st Apr 2020;
 - [Install Backpack 3.6 on Laravel 5.8 or 6.x](https://backpackforlaravel.com/docs/3.6/installation) - last feature update was 17th Sep 2019;
 - [Install Backpack 3.5 on Laravel 5.5, 5.6, 5.7](https://backpackforlaravel.com/docs/3.5/installation) - last feature update was 27th Feb 2019;
@@ -84,7 +85,7 @@ Installation guides:
 
 ## Change Log
 
-For the current release (4.1.x) please see [the Releases tab](https://github.com/Laravel-Backpack/CRUD/releases). For previous versions (Backpack <=4.0.x), please see our old [CHANGELOG](CHANGELOG.md) file.
+For the current release (4.2.x) please see [the Releases tab](https://github.com/Laravel-Backpack/CRUD/releases). For previous versions (Backpack <=4.0.x), please see our old [CHANGELOG](CHANGELOG.md) file.
 
 ## Contributing Guidelines
 
@@ -123,7 +124,7 @@ Please see the [License File](LICENSE.md) and [Pricing](https://backpackforlarav
 <a name="versioning"></a>
 ## Versioning
 
-When installing Backpack, require its minor version (currently ```4.1.*```). For us, this is what ```major.minor.patch``` means:
+When installing Backpack, require its minor version (currently ```4.2.*```). For us, this is what ```major.minor.patch``` means:
 
 - ```major``` - **PAID upgrade; MAJOR breaking changes;** historically every 2-3 years; upgrading may take even 2-3 hours; includes major new features, major changes in how the whole system works, and complete rewrites; it allows us to _considerably_ improve the product, and add features that were previously impossible;
 - ```minor``` - **FREE upgrade; MINOR breaking changes**; historically every 6-12 months; upgrading takes less than 30 minutes; it allows us to add big new features, for free;

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         }
     ],
     "require": {
-        "laravel/framework": "^8.0",
-        "prologue/alerts": "^0.4.1",
+        "laravel/framework": "^9.0|^8.0",
+        "prologue/alerts": "^1.0|^0.4",
         "digitallyhappy/assets": "^2.0.1",
         "creativeorange/gravatar": "~1.0",
         "composer/package-versions-deprecated": "^1.8",

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -107,7 +107,7 @@ class BackpackServiceProvider extends ServiceProvider
         $error_views = [__DIR__.'/resources/error_views' => resource_path('views/errors')];
         $backpack_views = [__DIR__.'/resources/views' => resource_path('views/vendor/backpack')];
         $backpack_public_assets = [__DIR__.'/public' => public_path()];
-        $backpack_lang_files = [__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')];
+        $backpack_lang_files = [__DIR__.'/resources/lang' => app()->langPath().'/vendor/backpack'];
         $backpack_config_files = [__DIR__.'/config' => config_path()];
 
         // sidebar content views, which are the only views most people need to overwrite


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Could not install Backpack on Laravel 9.

### AFTER - What is happening after this PR?

Can install, but only Backpack 4.2. I think this is a good way to proceed, because if you have the time to upgrade Laravel, you should also have the time to upgrade Backpack.

## HOW

### How did you achieve that, in technical terms?

Bumped `composer.json` requirements.


### Is it a breaking change or non-breaking change?

Non-breaking for 4.2.

### How can we test the before & after?

Try installing without - shouldn't work. Try installing with - should work.
