### PR TITLE
only enable or disable options that has value in repeatable pivots

### DIFF
--- a/src/resources/views/crud/fields/relationship/select.blade.php
+++ b/src/resources/views/crud/fields/relationship/select.blade.php
@@ -156,11 +156,13 @@
                 $(container).find('select').each(function(i, el) {
                     
                     if(typeof $(el).attr('data-is-pivot-select') !== 'undefined' && $(el).attr('data-is-pivot-select')) {
-                        if(enable) {
-                            $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',false);   
-                        }else{
-                            if($(el).val() !== pivot_selector.val()) {
-                                $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',true);
+                        if(pivot_selector.val()) {
+                            if(enable) {
+                                $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',false);   
+                            }else{
+                                if($(el).val() !== pivot_selector.val()) {
+                                    $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',true);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

JS error when trying to delete an "empty pivot selector" from a repeatable row.

### AFTER - What is happening after this PR?

We can safelly delete it. 

## HOW

### How did you achieve that, in technical terms?

Check if there is value before using it.

### Is it a breaking change or non-breaking change?

Nop.


### How can we test the before & after?

Got to owners, click add `Badge` but dont select or write nothing, try to delete the newly added row from repeatable.
