### PR TITLE
fix 4.1 select2_from_array using 0 as key.

### DIFF
--- a/src/resources/views/crud/fields/select2_from_array.blade.php
+++ b/src/resources/views/crud/fields/select2_from_array.blade.php
@@ -20,7 +20,7 @@
 
         @if (count($field['options']))
             @foreach ($field['options'] as $key => $value)
-                @if((old(square_brackets_to_dots($field['name'])) && (
+                @if((old(square_brackets_to_dots($field['name'])) !== null && (
                         $key == old(square_brackets_to_dots($field['name'])) ||
                         (is_array(old(square_brackets_to_dots($field['name']))) &&
                         in_array($key, old(square_brackets_to_dots($field['name'])))))) ||


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If you use `0` as key for `select2_from_array` field the current code checking for `old(field)` would not work properly so the value with key `0` would not be reselected when validation fails as reported in #4099 

### AFTER - What is happening after this PR?

It works as expected.


## HOW

### How did you achieve that, in technical terms?

We had already solved this for `select_from_array` in #3816 . This ports the same fix for this field. 



### Is it a breaking change or non-breaking change?

Non


### How can we test the before & after?

Add a select2_from_array that contains the key `'0' => 'some value'`, select it and force the validation error to trigger you will notice that the value you selected is no longer selected.

After it is.

Note @tabacitu this is fixed in 4.2 no need to port this fix there, our `old()` wrapper solves this.
