### PR TITLE
[4.2] guess attributes for subfields too (not just fields)

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -127,6 +127,8 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasEntity($field)
     {
+        $model = isset($field['baseModel']) ? app($field['baseModel']) : $this->model;
+
         if (isset($field['entity'])) {
             return $field;
         }
@@ -140,15 +142,15 @@ trait FieldsProtectedMethods
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
             // if it has parameters it's not a relation method.
-            $field['entity'] = $this->modelMethodHasParameters($this->model, $possibleMethodName) ? false : $field['name'];
+            $field['entity'] = $this->modelMethodHasParameters($model, $possibleMethodName) ? false : $field['name'];
 
             return $field;
         }
 
         // if there's a method on the model with this name
-        if (method_exists($this->model, $field['name'])) {
+        if (method_exists($model, $field['name'])) {
             // if it has parameters it's not a relation method.
-            $field['entity'] = $this->modelMethodHasParameters($this->model, $field['name']) ? false : $field['name'];
+            $field['entity'] = $this->modelMethodHasParameters($model, $field['name']) ? false : $field['name'];
 
             return $field;
         }
@@ -158,9 +160,9 @@ trait FieldsProtectedMethods
         if (Str::endsWith($field['name'], '_id')) {
             $possibleMethodName = Str::replaceLast('_id', '', $field['name']);
 
-            if (method_exists($this->model, $possibleMethodName)) {
+            if (method_exists($model, $possibleMethodName)) {
                 // if it has parameters it's not a relation method.
-                $field['entity'] = $this->modelMethodHasParameters($this->model, $possibleMethodName) ? false : $possibleMethodName;
+                $field['entity'] = $this->modelMethodHasParameters($model, $possibleMethodName) ? false : $possibleMethodName;
 
                 return $field;
             }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -17,7 +17,7 @@ trait Relationships
     {
         $entity = $this->getOnlyRelationEntity($field);
         $possible_method = Str::before($entity, '.');
-        $model = $this->model;
+        $model = isset($field['baseModel']) ? app($field['baseModel']) : $this->model;
 
         if (method_exists($model, $possible_method)) {
             $parts = explode('.', $entity);

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -30,7 +30,7 @@ trait Relationships
             return $relation;
         }
 
-        abort(500, "Did not find a matching relationship. Are you sure that ".get_class($model)." has the {$field['entity']}() relationship on it?");
+        abort(500, 'Did not find a matching relationship. Are you sure that '.get_class($model)." has the {$field['entity']}() relationship on it?");
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -29,6 +29,8 @@ trait Relationships
 
             return $relation;
         }
+
+        abort(500, "Did not find a matching relationship. Are you sure that ".get_class($model)." has the {$field['entity']}() relationship on it?");
     }
 
     /**

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -21,11 +21,16 @@
             if (is_string($subfield)) {
                 $subfield = ['name' => $subfield];
             }
-            // if a model was defined on the repeatable field
-            // use that as the baseModel for all subfields
-            // so that guessing of subfield attributes is
-            // done starting from that model
-            if (isset($field['model'])) {
+
+            if (!isset($field['model'])) {
+                // we're inside a simple 'repeatable' with no model/relationship, so
+                // we assume all subfields are supposed to be text fields
+                $subfield['type'] = $subfield['type'] ?? 'text';
+                $subfield['entity'] = $subfield['entity'] ?? false;
+            } else {
+                // we should use 'model' as the `baseModel` for all subfields, so that when
+                // we look if `category()` relationship exists on the model, we look on
+                // the model this repeatable represents, not the main CRUD model
                 $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
             }
             $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -26,7 +26,7 @@
             // so that guessing of subfield attributes is
             // done starting from that model
             if (isset($field['model'])) {
-                $subfield['baseModel'] = $field['model'];
+                $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
             }
             $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -21,9 +21,13 @@
             if (is_string($subfield)) {
                 $subfield = ['name' => $subfield];
             }
-            // all subfields are considered text fields if not otherwise specified
-            $subfield['type'] = $subfield['type'] ?? 'text';
-            $subfield['entity'] = $subfield['entity'] ?? false;
+            // if a model was defined on the repeatable field
+            // use that as the baseModel for all subfields
+            // so that guessing of subfield attributes is
+            // done starting from that model
+            if (isset($field['model'])) {
+                $subfield['baseModel'] = $field['model'];
+            }
             $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
             $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -25,6 +25,7 @@
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
+    $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? get_class($crud->model);
     
     switch ($field['relation_type']) {
         case 'MorphToMany':


### PR DESCRIPTION
## WHY

Note: this points to the relationship refactor branch, which is PR https://github.com/Laravel-Backpack/CRUD/pull/4095

### BEFORE - What was wrong? What was happening before this PR?

For subfields with relationships, we assumed we cannot accurately predict the needed attributes (`entity`, `relation_type`, `model`, `pivot`, `multiple`) because we were trying to predict them from the main CRUD model, which for subfields is super-wrong.

So in 4.2-alpha, we decided for all subfields to default to `text` type and set `entity=>false`. If someone wanted a relationship subfield, they'd have to define ALL the attributes above, manually. Then it would work. Miss just one attribute (eg. `relation_type`), and it would fail.

### AFTER - What is happening after this PR?

Instead of defaulting to `text` type for subfields, and setting `entity=>false` arbitrarily... I fixed the root problem. Instead of looking at the main model to guess attributes, subfields now look at the correct model, the one that is represented by the repeatable field. 


`$field['baseModel']`, if defined. And we can _easily_ define that inside the repeatable... we know that if a repeatable FIELD has a model... then it's actually a relationship field. Soo.... we know we should set `baseModel` on all subfields.

## HOW

### How did you achieve that, in technical terms?

The model was only used in two places in the attribute-guessing logic. There, I used `$field['baseModel']` if defined. That way, we basically allow a field to say "_don't look on the CRUD model, use this as a baseModel instead_".

Then in `repeatable`, we look to see if there's a `model` on the repeatable field. If so... we know it's actually a repeatable for a model. So we know the baseModel... so we just set it for all subfields, so that they use the _proper_ model as their `baseModel`.

### Is it a breaking change or non-breaking change?

Non-breaking to 4.2. It fixes a problem.

Breaking to 4.1. Because it will use the correct model, where previously it wasn't. But... it's a fix. And it's less of a breaking change than the previous setting to text we did 😅

### How can we test the before & after?

Add a relationship subfield without defining stuff. Before, it wouldn't work, it'd show as text. Now, it will work.

If you're using the new Story, Cave and Hero demo branch, you can see in Caves that you can use all the selects - they won't error any more, even if they're not fully-defined on Monster.
