### PR TITLE
change default column limit to 32

### DIFF
--- a/src/resources/views/crud/columns/email.blade.php
+++ b/src/resources/views/crud/columns/email.blade.php
@@ -4,7 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $column['value'] ?? $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';

--- a/src/resources/views/crud/columns/model_function_attribute.blade.php
+++ b/src/resources/views/crud/columns/model_function_attribute.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $column['value'] ?? $entry->{$column['function_name']}(...($column['function_parameters'] ?? []))->{$column['attribute']} ?? '';
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';

--- a/src/resources/views/crud/columns/phone.blade.php
+++ b/src/resources/views/crud/columns/phone.blade.php
@@ -4,7 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {

--- a/src/resources/views/crud/columns/row_number.blade.php
+++ b/src/resources/views/crud/columns/row_number.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $column['value'] ?? $rowNumber;
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -5,7 +5,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -4,7 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
 
     if($column['value'] instanceof \Closure) {

--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Issue https://github.com/Laravel-Backpack/CRUD/issues/4118 was happening. The table was too wide on mobile sometimes:

![Screenshot 2022-01-25 at 09 01 56](https://user-images.githubusercontent.com/1032474/150929936-f0d54efb-fc7a-4c0d-b3cc-3b2828df9eb2.png)


### AFTER - What is happening after this PR?

No longer too wide:

![Screenshot 2022-01-25 at 09 02 12](https://user-images.githubusercontent.com/1032474/150929954-e9245f6f-3f9c-45dc-b0d6-47cc9519a838.png)



## HOW

### How did you achieve that, in technical terms?

The culprit was that the column `limit` was too big (40). Changed it to 32 and now it'll look good on most phones. It still won't look good on very small phones like iPhone 5, but I don't think we should optimize for those at this point.


### Is it a breaking change or non-breaking change?

Some would say breaking... I would say non-breaking. It's just a cosmetic change, after all.

### How can we test the before & after?

Browse all CRUDs in the demo on mobile (using Chrome DevTools).