### PR TITLE
[4.2] Guess everything again after fluent attribute change

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -209,13 +209,7 @@ class CrudField
      */
     private function save()
     {
-        $key = $this->attributes['name'];
-
-        if ($this->crud()->hasFieldWhere('name', $key)) {
-            $this->crud()->modifyField($key, $this->attributes);
-        } else {
-            $this->crud()->addField($this->attributes);
-        }
+        $this->crud()->addField($this->attributes);
 
         return $this;
     }


### PR DESCRIPTION
## WHY

Fixes https://github.com/Laravel-Backpack/CRUD/pull/4116

### BEFORE - What was wrong? What was happening before this PR?

When using the fluent syntax to add fields, if you defined the `entity` later on, the `model` and all other relationship attributes would not get re-calculated.
 
```
// for example, if you have two relationships, tags() and categoryTags() on the model, 
// pointing to different models, if you did:
$this->field('tags'); // => model is 'Tag'
$this->field('tags')->entity('tags'); // model is 'Tag'
$this->field('tags')->entity('categoryTags'); // model is still 'Tag'
```

### AFTER - What is happening after this PR?

```
$this->field('tags')->entity('categoryTags'); // model is 'CategoryTag'
```

## HOW

### How did you achieve that, in technical terms?

Previously, when the `CrudField` saved its value differently:
- on first save (eg. `CRUD->field('tags')`) it would use `addField()`, which guesses missing attributes;
- on subsequent saves, (eg. `->entity('tags')`) it would use `modifyField()`, which doesn't do that any more;

After this PR, it uses `addField()` in both cases. So upon EACH attribute change, using the fluent syntax... it will re-guess the attributes.

### Is it a breaking change or non-breaking change?

Should be non-breaking.


### How can we test the before & after?

The example above. OR you could test in https://github.com/Laravel-Backpack/CRUD/pull/4116 - with this change, subfields should have their attributes guessed, even if using the fluent syntax.