### PR TITLE
Move subfield attribute guessing and change `CrudField::save()`

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -209,13 +209,7 @@ class CrudField
      */
     private function save()
     {
-        $key = $this->attributes['name'];
-
-        if ($this->crud()->hasFieldWhere('name', $key)) {
-            $this->crud()->modifyField($key, $this->attributes);
-        } else {
-            $this->crud()->addField($this->attributes);
-        }
+        $this->crud()->addField($this->attributes);
 
         return $this;
     }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -56,6 +56,7 @@ trait Fields
         }
 
         $field = $this->makeSureFieldHasType($field);
+        $field = $this->makeSureSubfieldsHaveNecessaryAttributes($field);
 
         return $field;
     }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -220,12 +220,12 @@ trait FieldsProtectedMethods
      * If a field has subfields, go through each subfield and guess
      * its attribute, filling in whatever is missing.
      *
-     * @param  array $field Field definition array.
-     * @return array        The improved definition of that field (a better 'subfields' array)
+     * @param  array  $field  Field definition array.
+     * @return array The improved definition of that field (a better 'subfields' array)
      */
     protected function makeSureSubfieldsHaveNecessaryAttributes($field)
     {
-        if (!isset($field['subfields'])) {
+        if (! isset($field['subfields'])) {
             return $field;
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -217,6 +217,44 @@ trait FieldsProtectedMethods
     }
 
     /**
+     * If a field has subfields, go through each subfield and guess
+     * its attribute, filling in whatever is missing.
+     *
+     * @param  array $field Field definition array.
+     * @return array        The improved definition of that field (a better 'subfields' array)
+     */
+    protected function makeSureSubfieldsHaveNecessaryAttributes($field)
+    {
+        if (!isset($field['subfields'])) {
+            return $field;
+        }
+
+        foreach ($field['subfields'] as $key => $subfield) {
+            // make sure the field definition is an array
+            if (is_string($subfield)) {
+                $subfield = ['name' => $subfield];
+            }
+
+            if (! isset($field['model'])) {
+                // we're inside a simple 'repeatable' with no model/relationship, so
+                // we assume all subfields are supposed to be text fields
+                $subfield['type'] = $subfield['type'] ?? 'text';
+                $subfield['entity'] = $subfield['entity'] ?? false;
+            } else {
+                // we should use 'model' as the `baseModel` for all subfields, so that when
+                // we look if `category()` relationship exists on the model, we look on
+                // the model this repeatable represents, not the main CRUD model
+                $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
+                $subfield['baseEntity'] = $subfield['baseEntity'] ?? $field['entity'];
+            }
+
+            $field['subfields'][$key] = $this->makeSureFieldHasNecessaryAttributes($subfield);
+        }
+
+        return $field;
+    }
+
+    /**
      * Enable the tabs functionality, if a field has a tab defined.
      *
      * @param  array  $field  Field definition array.

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -17,23 +17,6 @@
     </div>
     @foreach($field['subfields'] as $subfield)
         @php
-            // make sure the field definition is an array
-            if (is_string($subfield)) {
-                $subfield = ['name' => $subfield];
-            }
-
-            if (!isset($field['model'])) {
-                // we're inside a simple 'repeatable' with no model/relationship, so
-                // we assume all subfields are supposed to be text fields
-                $subfield['type'] = $subfield['type'] ?? 'text';
-                $subfield['entity'] = $subfield['entity'] ?? false;
-            } else {
-                // we should use 'model' as the `baseModel` for all subfields, so that when
-                // we look if `category()` relationship exists on the model, we look on
-                // the model this repeatable represents, not the main CRUD model
-                $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
-            }
-            $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
             $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
 

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -12,21 +12,29 @@
     $field['init_rows'] = 0;
     $field['subfields'] = $field['subfields'] ?? [];
     $field['reorder'] = $field['reorder'] ?? false;
-    
+
     $pivotSelectorField = $field['pivotSelect'] ?? [];
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField['name'] = $field['name'];
     $pivotSelectorField['type'] = 'relationship';
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
-    $pivotSelectorField['entity'] = $field['name'];    
+    $pivotSelectorField['entity'] = $field['name'];
+    $pivotSelectorField['label'] = $pivotSelectorField['label'] ?? \Str::of($field['name'])->singular()->ucfirst();
+    $pivotSelectorField['relation_type'] = $field['relation_type'];
+    $pivotSelectorField['model'] = $field['model'];
     $pivotSelectorField['ajax'] = $inline_create !== false ? true : ($pivotSelectorField['ajax'] ?? false);
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? ($pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false');
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
-    $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? get_class($crud->model);
-    
+    if(isset($field['baseModel']) || isset($pivotSelectorField['baseModel'])) {
+        $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? $field['baseModel'];
+    }
+    if(isset($field['baseEntity']) || isset($pivotSelectorField['baseEntity'])) {
+        $pivotSelectorField['baseEntity'] = $pivotSelectorField['baseEntity'] ?? $field['baseEntity'];
+    }
+
     switch ($field['relation_type']) {
         case 'MorphToMany':
         case 'BelongsToMany':
@@ -36,7 +44,7 @@
         case 'HasMany':
             if(isset($entry)) {
                 $field['subfields'] = Arr::prepend($field['subfields'], [
-                    'name' => $entry->{$field['name']}()->getLocalKeyName(),
+                    'name' => (new $field['model'])->getKeyName(),
                     'type' => 'hidden',
                 ]);
             }


### PR DESCRIPTION
## WHY

This is an alternative to https://github.com/Laravel-Backpack/CRUD/pull/4116 , which points to 4.2 instead.

### BEFORE - What was wrong? What was happening before this PR?

The subfield attributes were being guessed in the blade file (`repeatable_row.blade.php`). This presented two problems:
1) when there was an error, it was HELL to pinpoint what the problem is; because blade errors suck, in comparison with regular PHP errors;
2) because the subfields attributes were finalized in the blade file (upon presentation), this meant that nowhere in PHP could we work with `subfields` reliably:
- in PHP we were working with the subfields that the user defined
- in the blade files we were then working with the subfields after the attributes were guessed 

This was messy and unexpected for us Backpack maintainers. We wanted to know that we can trust the subfield definition, as much as we can trust a field definition.

### AFTER - What is happening after this PR?

Subfields attributes are guessed upon the `addField()` or `field()->subfields()` call.

## HOW

### How did you achieve that, in technical terms?

Created a new function, where I moved that bit of the code.

### Is it a breaking change or non-breaking change?

Non-breaking.

### How can we test the before & after?

Merge & test. All CRUDs that use `subfields` should work just as well as before.

---

Notes:
- This points to #4120 because it depends on that to be merged into `4.2` first.
- Without the PR above, this will only work for `addField()`, it will not work for `->subfields()` (fluent syntax)