### PR TITLE
Move subfield attribute guessing and add `CrudField::subfields()`

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -186,7 +186,7 @@ class CrudField
     public function subfields($subfields)
     {
         $this->attributes['subfields'] = $subfields;
-        $this->attributes = $this->crud()->makeSureSubfieldsHaveNecessaryAttributes($this->attributes);
+        $this->attributes = $this->crud()->makeSureFieldHasNecessaryAttributes($this->attributes);
 
         return $this->save();
     }

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -209,13 +209,7 @@ class CrudField
      */
     private function save()
     {
-        $key = $this->attributes['name'];
-
-        if ($this->crud()->hasFieldWhere('name', $key)) {
-            $this->crud()->modifyField($key, $this->attributes);
-        } else {
-            $this->crud()->addField($this->attributes);
-        }
+        $this->crud()->addField($this->attributes);
 
         return $this;
     }

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -176,6 +176,21 @@ class CrudField
         return $this->save();
     }
 
+    /**
+     * When subfields are defined, pass them through the guessing function
+     * so that they have label, relationship attributes, etc.
+     *
+     * @param  array $subfields Subfield definition array
+     * @return self
+     */
+    public function subfields($subfields)
+    {
+        $this->attributes['subfields'] = $subfields;
+        $this->attributes = $this->crud()->makeSureSubfieldsHaveNecessaryAttributes($this->attributes);
+
+        return $this->save();
+    }
+
     // ---------------
     // PRIVATE METHODS
     // ---------------
@@ -209,7 +224,13 @@ class CrudField
      */
     private function save()
     {
-        $this->crud()->addField($this->attributes);
+        $key = $this->attributes['name'];
+
+        if ($this->crud()->hasFieldWhere('name', $key)) {
+            $this->crud()->modifyField($key, $this->attributes);
+        } else {
+            $this->crud()->addField($this->attributes);
+        }
 
         return $this;
     }

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -180,7 +180,7 @@ class CrudField
      * When subfields are defined, pass them through the guessing function
      * so that they have label, relationship attributes, etc.
      *
-     * @param  array $subfields Subfield definition array
+     * @param  array  $subfields  Subfield definition array
      * @return self
      */
     public function subfields($subfields)

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -56,6 +56,7 @@ trait Fields
         }
 
         $field = $this->makeSureFieldHasType($field);
+        $field = $this->makeSureSubfieldsHaveNecessaryAttributes($field);
 
         return $field;
     }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -220,12 +220,12 @@ trait FieldsProtectedMethods
      * If a field has subfields, go through each subfield and guess
      * its attribute, filling in whatever is missing.
      *
-     * @param  array $field Field definition array.
-     * @return array        The improved definition of that field (a better 'subfields' array)
+     * @param  array  $field  Field definition array.
+     * @return array The improved definition of that field (a better 'subfields' array)
      */
     protected function makeSureSubfieldsHaveNecessaryAttributes($field)
     {
-        if (!isset($field['subfields'])) {
+        if (! isset($field['subfields'])) {
             return $field;
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -217,6 +217,44 @@ trait FieldsProtectedMethods
     }
 
     /**
+     * If a field has subfields, go through each subfield and guess
+     * its attribute, filling in whatever is missing.
+     *
+     * @param  array $field Field definition array.
+     * @return array        The improved definition of that field (a better 'subfields' array)
+     */
+    protected function makeSureSubfieldsHaveNecessaryAttributes($field)
+    {
+        if (!isset($field['subfields'])) {
+            return $field;
+        }
+
+        foreach ($field['subfields'] as $key => $subfield) {
+            // make sure the field definition is an array
+            if (is_string($subfield)) {
+                $subfield = ['name' => $subfield];
+            }
+
+            if (! isset($field['model'])) {
+                // we're inside a simple 'repeatable' with no model/relationship, so
+                // we assume all subfields are supposed to be text fields
+                $subfield['type'] = $subfield['type'] ?? 'text';
+                $subfield['entity'] = $subfield['entity'] ?? false;
+            } else {
+                // we should use 'model' as the `baseModel` for all subfields, so that when
+                // we look if `category()` relationship exists on the model, we look on
+                // the model this repeatable represents, not the main CRUD model
+                $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
+                $subfield['baseEntity'] = $subfield['baseEntity'] ?? $field['entity'];
+            }
+
+            $field['subfields'][$key] = $this->makeSureFieldHasNecessaryAttributes($subfield);
+        }
+
+        return $field;
+    }
+
+    /**
      * Enable the tabs functionality, if a field has a tab defined.
      *
      * @param  array  $field  Field definition array.

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -223,7 +223,7 @@ trait FieldsProtectedMethods
      * @param  array  $field  Field definition array.
      * @return array The improved definition of that field (a better 'subfields' array)
      */
-    protected function makeSureSubfieldsHaveNecessaryAttributes($field)
+    public function makeSureSubfieldsHaveNecessaryAttributes($field)
     {
         if (! isset($field['subfields'])) {
             return $field;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -223,7 +223,7 @@ trait FieldsProtectedMethods
      * @param  array  $field  Field definition array.
      * @return array The improved definition of that field (a better 'subfields' array)
      */
-    public function makeSureSubfieldsHaveNecessaryAttributes($field)
+    protected function makeSureSubfieldsHaveNecessaryAttributes($field)
     {
         if (! isset($field['subfields'])) {
             return $field;

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -17,23 +17,6 @@
     </div>
     @foreach($field['subfields'] as $subfield)
         @php
-            // make sure the field definition is an array
-            if (is_string($subfield)) {
-                $subfield = ['name' => $subfield];
-            }
-
-            if (!isset($field['model'])) {
-                // we're inside a simple 'repeatable' with no model/relationship, so
-                // we assume all subfields are supposed to be text fields
-                $subfield['type'] = $subfield['type'] ?? 'text';
-                $subfield['entity'] = $subfield['entity'] ?? false;
-            } else {
-                // we should use 'model' as the `baseModel` for all subfields, so that when
-                // we look if `category()` relationship exists on the model, we look on
-                // the model this repeatable represents, not the main CRUD model
-                $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
-            }
-            $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
             $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
             $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
 

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -12,21 +12,29 @@
     $field['init_rows'] = 0;
     $field['subfields'] = $field['subfields'] ?? [];
     $field['reorder'] = $field['reorder'] ?? false;
-    
+
     $pivotSelectorField = $field['pivotSelect'] ?? [];
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
     $pivotSelectorField['name'] = $field['name'];
     $pivotSelectorField['type'] = 'relationship';
     $pivotSelectorField['is_pivot_select'] = true;
     $pivotSelectorField['multiple'] = false;
-    $pivotSelectorField['entity'] = $field['name'];    
+    $pivotSelectorField['entity'] = $field['name'];
+    $pivotSelectorField['label'] = $pivotSelectorField['label'] ?? \Str::of($field['name'])->singular()->ucfirst();
+    $pivotSelectorField['relation_type'] = $field['relation_type'];
+    $pivotSelectorField['model'] = $field['model'];
     $pivotSelectorField['ajax'] = $inline_create !== false ? true : ($pivotSelectorField['ajax'] ?? false);
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? ($pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false');
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
-    $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? get_class($crud->model);
-    
+    if(isset($field['baseModel']) || isset($pivotSelectorField['baseModel'])) {
+        $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? $field['baseModel'];
+    }
+    if(isset($field['baseEntity']) || isset($pivotSelectorField['baseEntity'])) {
+        $pivotSelectorField['baseEntity'] = $pivotSelectorField['baseEntity'] ?? $field['baseEntity'];
+    }
+
     switch ($field['relation_type']) {
         case 'MorphToMany':
         case 'BelongsToMany':
@@ -36,7 +44,7 @@
         case 'HasMany':
             if(isset($entry)) {
                 $field['subfields'] = Arr::prepend($field['subfields'], [
-                    'name' => $entry->{$field['name']}()->getLocalKeyName(),
+                    'name' => (new $field['model'])->getKeyName(),
                     'type' => 'hidden',
                 ]);
             }


### PR DESCRIPTION
## WHY

Alternative to https://github.com/Laravel-Backpack/CRUD/pull/4121 that does NOT need https://github.com/Laravel-Backpack/CRUD/pull/4120 - notice it points to 4.2 directly.

### BEFORE - What was wrong? What was happening before this PR?

Subfields attributes were guessed in blade. Which was bad for reasons 😅

### AFTER - What is happening after this PR?

Subfields attributes are guessed:
- if you're using array syntax, when you do `addField()` 
- if you're using fluent syntax, when you do `->subfields()`


## HOW

### How did you achieve that, in technical terms?

Moved logic from blade to PHP. Then added a `subfields()` convenience method on `CrudField` so that it also guesses missing attributes. Otherwise the fluent syntax wouldn't guess subfield attributes, because it only does `addField()` once, at the beginning, all modifications are done using `modifyField()`.


### Is it a breaking change or non-breaking change?

Non-breaking to 4.2.


### How can we test the before & after?

Both with this and without it, you should be able to add subfields. Both with fluent and array syntax. 
