### PR TITLE
account for base entity when getting relation entity

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -61,7 +61,8 @@ trait Relationships
 
     public function getOnlyRelationEntity($field)
     {
-        $model = $this->getRelationModel($field['entity'], -1);
+        $entity = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$field['entity'] : $field['entity'];
+        $model = $this->getRelationModel($entity, -1);
         $lastSegmentAfterDot = Str::of($field['entity'])->afterLast('.');
 
         if (! method_exists($model, $lastSegmentAfterDot)) {

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -35,7 +35,8 @@
             // TODO: if relationship has `isOneOfMany` on it, load a readonly select; this covers:
             // - has One Of Many - hasOne(Order::class)->latestOfMany()
             // - morph One Of Many - morphOne(Image::class)->latestOfMany()
-            $relationship = CRUD::getModel()->{$field['entity']}();
+            $model = isset($field['baseModel']) ? app($field['baseModel']) : CRUD::getModel();
+            $relationship = $model->{$field['entity']}();
             if ($relationship->isOneOfMany()) {
                 abort(500, "<strong>The relationship field type does not cover 'One of Many' relationships.</strong><br> Those relationship are only meant to be 'read', not 'created' or 'updated'. Please change your <code>{$field['name']}</code> field to use the 1-n relationship towards <code>{$field['model']}</code>, the one that does NOT have latestOfMany() or oldestOfMany(). See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#has-one-of-many-1-1-relationship-out-of-1-n-relationship'>the docs</a> for more information.");
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Stories controller would not display because we were not taking into account the baseEntity for nested relations. Another problem was not accounting for baseModel.

### AFTER - What is happening after this PR?

Stories crud display fine.


## HOW

### How did you achieve that, in technical terms?

accounted for baseEntity and baseModel when needed.



### Is it a breaking change or non-breaking change?

Not in 4.2


### How can we test the before & after?

Go to stories crud -> error
After -> no error


@tabacitu I tested this with your PR #4122 
