### PR TITLE
Use create recursively

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -137,6 +137,7 @@ trait Create
         }
         return false;
     }
+
     /**
      * Get all fields needed for the ADD NEW ENTRY form.
      *
@@ -195,13 +196,12 @@ trait Create
      */
     private function createRelationsForItem($item, $formattedRelations)
     {
-        if (! isset($formattedRelations['relations'])) {
+        // no relations to create
+        if ( empty($formattedRelations)) {
             return false;
         }
-        foreach ($formattedRelations['relations'] as $relationMethod => $relationDetails) {
-            if (! isset($relationDetails['model'])) {
-                continue;
-            }
+
+        foreach ($formattedRelations as $relationMethod => $relationDetails) {
             $relation = $item->{$relationMethod}();
             $relationType = $relationDetails['relation_type'];
 
@@ -227,10 +227,10 @@ trait Create
                 case 'MorphToMany':
                     $values = $relationDetails['values'][$relationMethod] ?? [];
                     $values = is_string($values) ? json_decode($values, true) : $values;
-
+                
                     $relationValues = [];
 
-                    if (is_multidimensional_array($values)) {
+                    if (is_array($values) && is_multidimensional_array($values)) {
                         foreach ($values as $value) {
                             $relationValues[$value[$relationMethod]] = Arr::except($value, $relationMethod);
                         }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -243,8 +243,8 @@ trait Create
      * 
      * @return array
      */
-    private function getParsedInputs($inputs, $relationMethod = false) {
-        return [$this->getDirectParsedInput($inputs), $this->getRelationDetailsFromInput($inputs, $relationMethod)];
+    private function getParsedInputs($inputs, $model = false, $crudFields = []) {
+        return [$this->getDirectParsedInput($inputs, $model, $crudFields), $this->getRelationDetailsFromInput($inputs, $crudFields)];
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -407,18 +407,17 @@ trait Create
 
         $relation_local_key = $relation->getLocalKeyName();
 
-        $relation_local_key_value = $item[$relation_local_key] ?? false;
-
         $relatedItemsSent = [];
 
         foreach ($items as $item) {
+            [$directInputs, $relationInputs] = $this->getParsedInputs($item, $relationDetails, $relationMethod);
             // for each item we get the inputs to create and the relations of it.
-            [$directInputs, $relationInputs] = $this->getParsedInputs($item, $relationDetails['model'], $relationDetails['crudFields']);
+            $relation_local_key_value = $item[$relation_local_key] ?? null;
 
             // we either find the matched entry by local_key (usually `id`)
             // and update the values from the input
             // or create a new item from input
-            $item = $relation->firstOrCreate([$relation_local_key => $relation_local_key_value], $directInputs);
+            $item = $relation->updateOrCreate([$relation_local_key => $relation_local_key_value], $directInputs);
 
             // we store the item local key do we can match them with database and check if any item was deleted 
             $relatedItemsSent[] = $item->{$relation_local_key};

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -500,23 +500,4 @@ trait Create
         return $relationDetails;
     }
 
-    /**
-     * Returns an array of field names, after we keep only what's before the dots.
-     * Field names that use dot notation are considered as being "grouped fields"
-     * eg: address.city, address.postal_code
-     * And for all those fields, this function will only return one field name (what is before the dot).
-     *
-     * @param  array  $fields  - the fields from where the name would be returned.
-     * @return array
-     */
-    private function getFieldNamesBeforeFirstDot($fields)
-    {
-        $field_names_array = [];
-
-        foreach ($fields as $field) {
-            $field_names_array[] = Str::before($field['name'], '.');
-        }
-
-        return array_unique($field_names_array);
-    }
 }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -312,10 +312,9 @@ trait Create
      * @return array
      */
     private function getParsedInputs($inputs, $relationDetails = null, $relationMethod = false) {
-        $crudFields = $relationDetails['crudFields'] ?? $this->getFieldsFromInput($inputs);
+        $crudFields = $relationDetails['crudFields'] ?? [];
         $model = $relationDetails['model'] ?? false;
         return [$this->getDirectParsedInput($inputs, $model, $crudFields, $relationMethod), $this->getRelationDetailsFromInput($inputs, $crudFields, $relationMethod)];
-    }
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -117,6 +117,25 @@ trait Create
         }
 
         return $excludedFields;
+
+    }
+
+    /**
+     * Returns the field name if the relation should be excluded otherwise false.
+     * The relation should be excluded when the belongsTo foreignKey does not match the 
+     * field name, eg: `user_id` would be keept, but `user` (relationName) would be removed
+     * 
+     * @param $array $field
+     * 
+     * @return mixed
+     */
+    private function shouldBelongsToRelationBeRemoved($field) {
+        $name_for_sub = $this->getOverwrittenNameForBelongsTo($field);
+        $belongsToKey = Str::afterLast($field['name'], '.');
+        if ($belongsToKey !== $name_for_sub) {
+            return $field['name'];
+        }
+        return false;
     }
     /**
      * Get all fields needed for the ADD NEW ENTRY form.

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -220,15 +220,22 @@ trait Create
 
                 return null;
             }
-
+            
             // Scenario C (when it's an array inside an array, because it's been added as one item inside a repeatable field)
             if (gettype($relationMethodValue) == 'array' && is_multidimensional_array($relationMethodValue)) {
-                return $relation->updateOrCreate([], current($relationMethodValue));
+                $relationMethodValue = $relationMethodValue[0];          
             }
         }
+        // saving process       
+        [$directInputs, $relationInputs] = $this->getParsedInputs($relationMethodValue ?? $relationDetails['values'], $relationDetails['model'], $relationDetails['crudFields']);
+        
+        $item = $relation->updateOrCreate([], $directInputs);
+        
+        $this->createRelationsForItem($item, $relationInputs);
 
-        // Scenario A or B
-        return $relation->updateOrCreate([], $relationDetails['values']);
+        return $item;
+    }
+
     /**
      * Returns the direct inputs parsed for model and relationship creation
      * 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -310,7 +310,12 @@ trait Create
      * Handle HasMany/MorphMany relations when used as creatable entries in the crud.
      * By using repeatable field, developer can allow the creation of such entries
      * in the crud forms.
-     *
+     * 
+     * @param $entry - eg: story
+     * @param $relation - eg  story HasMany monsters
+     * @param $relationMethod - eg: monsters
+     * @param $relationDetails - eg: info about relation including submited values
+     * 
      * @return void
      */
     private function createManyEntries($entry, $relation, $relationMethod, $relationDetails)

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -294,11 +294,11 @@ trait Create
                 $relationMethodValue = $relationMethodValue[0];          
             }
         }
-        // saving process       
-        [$directInputs, $relationInputs] = $this->getParsedInputs($relationMethodValue ?? $relationDetails['values'], $relationDetails['model'], $relationDetails['crudFields']);
-        
+        // saving process    
+        [$directInputs, $relationInputs] = $this->getParsedInputs($relationMethodValue ?? $relationDetails['values'], $relationDetails, $relationMethod);
+       
         $item = $relation->updateOrCreate([], $directInputs);
-        
+       
         $this->createRelationsForItem($item, $relationInputs);
 
         return $item;
@@ -311,8 +311,11 @@ trait Create
      * 
      * @return array
      */
-    private function getParsedInputs($inputs, $model = false, $crudFields = []) {
-        return [$this->getDirectParsedInput($inputs, $model, $crudFields), $this->getRelationDetailsFromInput($inputs, $crudFields)];
+    private function getParsedInputs($inputs, $relationDetails = null, $relationMethod = false) {
+        $crudFields = $relationDetails['crudFields'] ?? $this->getFieldsFromInput($inputs);
+        $model = $relationDetails['model'] ?? false;
+        return [$this->getDirectParsedInput($inputs, $model, $crudFields, $relationMethod), $this->getRelationDetailsFromInput($inputs, $crudFields, $relationMethod)];
+    }
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -82,11 +82,16 @@ trait Create
     /**
      * Get all fields with relation set (model key set on field).
      *
+     * @param array $fields
+     * 
      * @return array The fields with model key set.
      */
-    public function getRelationFields()
+    public function getRelationFields($fields = [])
     {
-        $fields = $this->getCleanStateFields();
+        if(empty($fields)) {
+            $fields = $this->getCleanStateFields();
+        }
+
         $relationFields = [];
 
         foreach ($fields as $field) {

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -138,17 +138,9 @@ trait Create
             $relationType = $relationDetails['relation_type'];
 
             switch ($relationType) {
-                case 'BelongsTo':
-                    $modelInstance = $relationDetails['model']::find($relationDetails['values'])->first();
-                    if ($modelInstance != null) {
-                        $relation->associate($modelInstance)->save();
-                    } else {
-                        $relation->dissociate()->save();
-                    }
-                    break;
                 case 'HasOne':
                 case 'MorphOne':
-                        $modelInstance = $this->createUpdateOrDeleteOneToOneRelation($relation, $relationMethod, $relationDetails);
+                        $this->createUpdateOrDeleteOneToOneRelation($relation, $relationMethod, $relationDetails);
                     break;
                 case 'HasMany':
                 case 'MorphMany':
@@ -184,10 +176,6 @@ trait Create
 
                     $item->{$relationMethod}()->sync($relationValues);
                     break;
-            }
-
-            if (isset($relationDetails['relations'])) {
-                $this->createRelationsForItem($modelInstance, ['relations' => $relationDetails['relations']]);
             }
         }
     }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -2,11 +2,6 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -260,10 +260,9 @@ trait Fields
      * Decode attributes that are casted as array/object/json in the model.
      * So that they are not json_encoded twice before they are stored in the db
      * (once by Backpack in front-end, once by Laravel Attribute Casting).
-     * 
-     * @param array $input
-     * @param mixed $model
-     * 
+     *
+     * @param  array  $input
+     * @param  mixed  $model
      * @return array
      */
     public function decodeJsonCastedAttributes($input, $model = false)

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -260,11 +260,17 @@ trait Fields
      * Decode attributes that are casted as array/object/json in the model.
      * So that they are not json_encoded twice before they are stored in the db
      * (once by Backpack in front-end, once by Laravel Attribute Casting).
+     * 
+     * @param array $input
+     * @param mixed $model
+     * 
+     * @return array
      */
-    public function decodeJsonCastedAttributes($data)
+    public function decodeJsonCastedAttributes($input, $model = false)
     {
+        $model = $model ? $model : $this->model;
         $fields = $this->getCleanStateFields();
-        $casted_attributes = $this->model->getCastedAttributes();
+        $casted_attributes = $model->getCastedAttributes();
 
         foreach ($fields as $field) {
 
@@ -275,17 +281,17 @@ trait Fields
                 $jsonCastables = ['array', 'object', 'json'];
                 $fieldCasting = $casted_attributes[$field['name']];
 
-                if (in_array($fieldCasting, $jsonCastables) && isset($data[$field['name']]) && ! empty($data[$field['name']]) && ! is_array($data[$field['name']])) {
+                if (in_array($fieldCasting, $jsonCastables) && isset($input[$field['name']]) && ! empty($input[$field['name']]) && ! is_array($input[$field['name']])) {
                     try {
-                        $data[$field['name']] = json_decode($data[$field['name']]);
+                        $input[$field['name']] = json_decode($input[$field['name']]);
                     } catch (\Exception $e) {
-                        $data[$field['name']] = [];
+                        $input[$field['name']] = [];
                     }
                 }
             }
         }
 
-        return $data;
+        return $input;
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -2,8 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait FieldsProtectedMethods
 {
@@ -145,7 +145,7 @@ trait FieldsProtectedMethods
             // if it has parameters it's not a relation method.
             $field['entity'] = $this->modelMethodHasParameters($model, $possibleMethodName) ? false : $field['name'];
 
-            if($field['entity']) {
+            if ($field['entity']) {
                 $field['nestedEntity'] = $possibleMethodName;
             }
 
@@ -250,17 +250,17 @@ trait FieldsProtectedMethods
                 // we look if `category()` relationship exists on the model, we look on
                 // the model this repeatable represents, not the main CRUD model
                 $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
-                
+
                 $currentEntity = $subfield['baseEntity'] ?? $field['entity'];
                 // chain the parent field baseEntity if it exists
-                $subfield['baseEntity'] = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$currentEntity : $currentEntity; 
+                $subfield['baseEntity'] = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$currentEntity : $currentEntity;
             }
 
             $field['subfields'][$key] = $this->makeSureFieldHasNecessaryAttributes($subfield);
         }
 
-        if(isset($field['relation_type'])) {
-            switch($field['relation_type']) {
+        if (isset($field['relation_type'])) {
+            switch ($field['relation_type']) {
                 case 'MorphToMany':
                 case 'BelongsToMany':
                     $pivotSelectorField = static::getPivotFieldStructure($field);

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -160,10 +160,14 @@ trait Relationships
      * 
      * @return array
      */
-    private function changeBelongsToNamesFromRelationshipToForeignKey($input, $belongs_to_fields)
+    private function changeBelongsToNamesFromRelationshipToForeignKey($input, $belongs_to_fields = [])
     {
         if(empty($belongs_to_fields)) {
             $belongs_to_fields = $this->getFieldsWithRelationType('BelongsTo');
+        }else{
+            $belongs_to_fields = array_filter($belongs_to_fields, function($field) {
+                return isset($field['relation_type']) && $field['relation_type'] === 'BelongsTo';
+            });
         }
         foreach ($belongs_to_fields as $relation_field) {
             $name_for_sub = $this->getOverwrittenNameForBelongsTo($relation_field);

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -264,4 +264,29 @@ trait Relationships
 
         return $field['name'];
     }
+    /**
+     * Returns the pivot definition for BelongsToMany/MorphToMany relation provided in $field
+     * 
+     * @param array $field
+     * 
+     * @return array
+     */
+    private static function getPivotFieldStructure($field) {
+        $pivotSelectorField['name'] = $field['name'];
+        $pivotSelectorField['type'] = 'relationship';
+        $pivotSelectorField['is_pivot_select'] = true;
+        $pivotSelectorField['multiple'] = false;
+        $pivotSelectorField['entity'] = $field['name'];
+        $pivotSelectorField['relation_type'] = $field['relation_type'];
+        $pivotSelectorField['model'] = $field['model'];
+       
+        if(isset($field['baseModel'])) {
+            $pivotSelectorField['baseModel'] = $field['baseModel'];
+        }
+        if(isset($field['baseEntity'])) {
+            $pivotSelectorField['baseEntity'] = $field['baseEntity'];
+        }
+
+        return $pivotSelectorField;
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -126,7 +126,7 @@ trait Relationships
      * Gets the relation fields that DON'T contain the provided relations.
      *
      * @param  string|array  $relations  - the relations to exclude
-     * @param  array  $fields 
+     * @param  array  $fields
      */
     private function getRelationFieldsWithoutRelationType($relations, $fields = [])
     {
@@ -134,18 +134,20 @@ trait Relationships
             $relations = [$relations];
         }
 
-        if(empty($fields)) {
+        if (empty($fields)) {
             $fields = $this->getRelationFields();
         }
 
         foreach ($relations as $relation) {
             $fields = array_filter($fields, function ($field) use ($relation) {
-                if(!isset($field['relation_type'])) {
+                if (! isset($field['relation_type'])) {
                     return false;
                 }
+
                 return $field['relation_type'] !== $relation;
             });
         }
+
         return $fields;
     }
 
@@ -154,26 +156,24 @@ trait Relationships
      * When $belongs_to_fields are provided we will use those fields to replace relation names on the provided input.
      *
      * eg: user -> user_id
-     * 
-     * @param array $input
-     * @param array $belongsToFields
-     * 
+     *
+     * @param  array  $input
+     * @param  array  $belongsToFields
      * @return array
      */
     private function changeBelongsToNamesFromRelationshipToForeignKey($input, $belongs_to_fields = [])
     {
-        if(empty($belongs_to_fields)) {
+        if (empty($belongs_to_fields)) {
             $belongs_to_fields = $this->getFieldsWithRelationType('BelongsTo');
-        }else{
-            foreach($belongs_to_fields as $field) {
-                if(isset($field['subfields'])) {
+        } else {
+            foreach ($belongs_to_fields as $field) {
+                if (isset($field['subfields'])) {
                     $belongs_to_fields = array_merge($field['subfields'], $belongs_to_fields);
                 }
             }
-            $belongs_to_fields = array_filter($belongs_to_fields, function($field) {
+            $belongs_to_fields = array_filter($belongs_to_fields, function ($field) {
                 return isset($field['relation_type']) && $field['relation_type'] === 'BelongsTo';
             });
-            
         }
 
         foreach ($belongs_to_fields as $relation_field) {
@@ -184,6 +184,7 @@ trait Relationships
                 Arr::forget($input, $belongsToKey);
             }
         }
+
         return $input;
     }
 
@@ -259,10 +260,9 @@ trait Relationships
 
     /**
      * Return the name for the BelongTo relation making sure it always has the foreign_key instead of relationName
-     * eg: user - user_id
+     * eg: user - user_id.
      *
      * @param  array  $field  The field we want to get the name from
-     * 
      * @return string
      */
     private function getOverwrittenNameForBelongsTo($field)
@@ -277,13 +277,13 @@ trait Relationships
     }
 
     /**
-     * Returns the pivot definition for BelongsToMany/MorphToMany relation provided in $field
-     * 
-     * @param array $field
-     * 
+     * Returns the pivot definition for BelongsToMany/MorphToMany relation provided in $field.
+     *
+     * @param  array  $field
      * @return array
      */
-    private static function getPivotFieldStructure($field) {
+    private static function getPivotFieldStructure($field)
+    {
         $pivotSelectorField['name'] = $field['name'];
         $pivotSelectorField['type'] = 'relationship';
         $pivotSelectorField['is_pivot_select'] = true;
@@ -291,11 +291,11 @@ trait Relationships
         $pivotSelectorField['entity'] = $field['name'];
         $pivotSelectorField['relation_type'] = $field['relation_type'];
         $pivotSelectorField['model'] = $field['model'];
-       
-        if(isset($field['baseModel'])) {
+
+        if (isset($field['baseModel'])) {
             $pivotSelectorField['baseModel'] = $field['baseModel'];
         }
-        if(isset($field['baseEntity'])) {
+        if (isset($field['baseEntity'])) {
             $pivotSelectorField['baseEntity'] = $field['baseEntity'];
         }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -165,10 +165,17 @@ trait Relationships
         if(empty($belongs_to_fields)) {
             $belongs_to_fields = $this->getFieldsWithRelationType('BelongsTo');
         }else{
+            foreach($belongs_to_fields as $field) {
+                if(isset($field['subfields'])) {
+                    $belongs_to_fields = array_merge($field['subfields'], $belongs_to_fields);
+                }
+            }
             $belongs_to_fields = array_filter($belongs_to_fields, function($field) {
                 return isset($field['relation_type']) && $field['relation_type'] === 'BelongsTo';
             });
+            
         }
+
         foreach ($belongs_to_fields as $relation_field) {
             $name_for_sub = $this->getOverwrittenNameForBelongsTo($relation_field);
             $belongsToKey = Str::afterLast($relation_field['name'], '.');
@@ -268,6 +275,7 @@ trait Relationships
 
         return $field['name'];
     }
+
     /**
      * Returns the pivot definition for BelongsToMany/MorphToMany relation provided in $field
      * 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -126,26 +126,26 @@ trait Relationships
      * Gets the relation fields that DON'T contain the provided relations.
      *
      * @param  string|array  $relations  - the relations to exclude
-     * @param  bool  $include_nested  - if the nested relations of the same relations should be excluded too.
+     * @param  array  $fields 
      */
-    private function getRelationFieldsWithoutRelationType($relations, $include_nested = false)
+    private function getRelationFieldsWithoutRelationType($relations, $fields = [])
     {
         if (! is_array($relations)) {
             $relations = [$relations];
         }
 
-        $fields = $this->getRelationFields();
+        if(empty($fields)) {
+            $fields = $this->getRelationFields();
+        }
 
         foreach ($relations as $relation) {
-            $fields = array_filter($fields, function ($field) use ($relation, $include_nested) {
-                if ($include_nested) {
-                    return $field['relation_type'] !== $relation || ($field['relation_type'] === $relation && Str::contains($field['name'], '.'));
+            $fields = array_filter($fields, function ($field) use ($relation) {
+                if(!isset($field['relation_type'])) {
+                    return false;
                 }
-
                 return $field['relation_type'] !== $relation;
             });
         }
-
         return $fields;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -22,20 +22,13 @@ trait Update
      */
     public function update($id, $input)
     {
-        $input = $this->decodeJsonCastedAttributes($input);
-        $input = $this->compactFakeFields($input);
         $item = $this->model->findOrFail($id);
 
-        $input = $this->changeBelongsToNamesFromRelationshipToForeignKey($input);
+        [$directInputs, $relationInputs] = $this->getParsedInputs($input);
 
-        $relation_input = $this->getRelationDetailsFromInput($input);
+        $updated = $item->update($directInputs);
 
-        // handle the creation of the model relations.
-        $this->createRelationsForItem($item, $relation_input);
-
-        $field_names_to_exclude = $this->getFieldNamesBeforeFirstDot($this->getRelationFieldsWithoutRelationType('BelongsTo', true));
-
-        $updated = $item->update(Arr::except($input, $field_names_to_exclude));
+        $this->createRelationsForItem($item, $relationInputs);
 
         return $item;
     }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -90,16 +90,15 @@ trait Update
     /**
      * Returns the value of the given attribute in the relationship.
      * It takes into account nested relationships.
-     * 
-     * @param \Illuminate\Database\Eloquent\Model $model
-     * @param array $field
-     * 
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $field
      * @return mixed
      */
     private function getModelAttributeValueFromRelationship($model, $field)
     {
         [$related_model, $relation_method] = $this->getModelAndMethodFromEntity($model, $field);
-      
+
         if (! method_exists($related_model, $relation_method)) {
             return $related_model->{$relation_method};
         }
@@ -120,7 +119,6 @@ trait Update
                 $related_models = $related_model->{$relation_method};
                 $result = [];
 
-                
                 foreach ($related_models as $related_model) {
                     $item = [];
                     switch ($relation_type) {
@@ -140,7 +138,7 @@ trait Update
                             break;
                     }
                 }
-                
+
                 return $result;
                 break;
             case 'HasOne':
@@ -150,7 +148,7 @@ trait Update
                 }
 
                 $related_entry = $related_model->{$relation_method}->withFakes();
-               
+
                 if (! $related_entry) {
                     return;
                 }
@@ -175,10 +173,9 @@ trait Update
 
     /**
      * Returns the model and the method from the relation string starting from the provided model.
-     * 
-     * @param Illuminate\Database\Eloquent\Model $model
-     * @param array $field
-     * 
+     *
+     * @param  Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $field
      * @return array
      */
     private function getModelAndMethodFromEntity($model, $field)
@@ -201,11 +198,12 @@ trait Update
 
     /**
      * Return the subfields values from the related model.
-     * 
-     * @param array $subfields
-     * @param \Illuminate\Database\Eloquent\Model $relatedModel
+     *
+     * @param  array  $subfields
+     * @param  \Illuminate\Database\Eloquent\Model  $relatedModel
      */
-    private function getSubfieldsValues($subfields, $relatedModel) {
+    private function getSubfieldsValues($subfields, $relatedModel)
+    {
         $result = [];
         foreach ($subfields as $subfield) {
             $name = is_string($subfield) ? $subfield : $subfield['name'];
@@ -214,9 +212,9 @@ trait Update
             if (! Str::contains($name, '.')) {
                 // when subfields are present, $relatedModel->{$name} returns a model instance
                 // otherwise returns the model attribute.
-                if($relatedModel->{$name}) {
+                if ($relatedModel->{$name}) {
                     if (isset($subfield['subfields'])) {
-                        $result[$name] = [$relatedModel->{$name}->only(array_column($subfield['subfields'], 'name'))]; 
+                        $result[$name] = [$relatedModel->{$name}->only(array_column($subfield['subfields'], 'name'))];
                     } else {
                         $result[$name] = $relatedModel->{$name};
                     }
@@ -233,6 +231,7 @@ trait Update
                 Arr::set($result, $name, (! is_string($iterator) ? $iterator->withFakes()->getAttributes() : $iterator));
             }
         }
+
         return $result;
     }
 }

--- a/src/resources/views/crud/fields/inc/repeatable_row.blade.php
+++ b/src/resources/views/crud/fields/inc/repeatable_row.blade.php
@@ -22,11 +22,16 @@
 
             if(isset($row)) {
                 if(!is_array($subfield['name'])) {
-                    // this is a fix for 4.1 repeatable names that when the field was multiple, saved the keys with `[]` in the end. Eg: `tags[]` instead of `tags`
-                    if(isset($row[$subfield['name']]) || isset($row[$subfield['name'].'[]'])) {
-                        $subfield['value'] = $row[$subfield['name']] ?? $row[$subfield['name'].'[]'];
+                    if(!Str::contains($subfield['name'], '.')) {
+                        // this is a fix for 4.1 repeatable names that when the field was multiple, saved the keys with `[]` in the end. Eg: `tags[]` instead of `tags`
+                        if(isset($row[$subfield['name']]) || isset($row[$subfield['name'].'[]'])) {
+                            $subfield['value'] = $row[$subfield['name']] ?? $row[$subfield['name'].'[]'];
+                        }
+                        $subfield['name'] = $field['name'].'['.$repeatable_row_key.']['.$subfield['name'].']';
+                    }else{
+                        $subfield['value'] = \Arr::get($row, $subfield['name']);
+                        $subfield['name'] = $field['name'].'['.$repeatable_row_key.']['.Str::replace('.', '][', $subfield['name']).']';
                     }
-                    $subfield['name'] = $field['name'].'['.$repeatable_row_key.']['.$subfield['name'].']';
                 }else{
                     foreach ($subfield['name'] as $k => $item) {
                         $subfield['name'][$k] = $field['name'].'['.$repeatable_row_key.']['.$item.']';

--- a/src/resources/views/crud/fields/relationship.blade.php
+++ b/src/resources/views/crud/fields/relationship.blade.php
@@ -35,7 +35,8 @@
             // TODO: if relationship has `isOneOfMany` on it, load a readonly select; this covers:
             // - has One Of Many - hasOne(Order::class)->latestOfMany()
             // - morph One Of Many - morphOne(Image::class)->latestOfMany()
-            $relationship = CRUD::getModel()->{$field['entity']}();
+            $model = isset($field['baseModel']) ? app($field['baseModel']) : CRUD::getModel();
+            $relationship = $model->{$field['entity']}();
             if ($relationship->isOneOfMany()) {
                 abort(500, "<strong>The relationship field type does not cover 'One of Many' relationships.</strong><br> Those relationship are only meant to be 'read', not 'created' or 'updated'. Please change your <code>{$field['name']}</code> field to use the 1-n relationship towards <code>{$field['model']}</code>, the one that does NOT have latestOfMany() or oldestOfMany(). See <a target='_blank' href='https://backpackforlaravel.com/docs/crud-fields#has-one-of-many-1-1-relationship-out-of-1-n-relationship'>the docs</a> for more information.");
             }

--- a/src/resources/views/crud/fields/relationship/entries.blade.php
+++ b/src/resources/views/crud/fields/relationship/entries.blade.php
@@ -13,43 +13,22 @@
     $field['subfields'] = $field['subfields'] ?? [];
     $field['reorder'] = $field['reorder'] ?? false;
 
+    // the allowed to override configurations of the pivot selector.
     $pivotSelectorField = $field['pivotSelect'] ?? [];
     $inline_create = !isset($inlineCreate) && isset($pivotSelectorField['inline_create']) ? $pivotSelectorField['inline_create'] : false;
-    $pivotSelectorField['name'] = $field['name'];
-    $pivotSelectorField['type'] = 'relationship';
-    $pivotSelectorField['is_pivot_select'] = true;
-    $pivotSelectorField['multiple'] = false;
-    $pivotSelectorField['entity'] = $field['name'];
-    $pivotSelectorField['label'] = $pivotSelectorField['label'] ?? \Str::of($field['name'])->singular()->ucfirst();
-    $pivotSelectorField['relation_type'] = $field['relation_type'];
-    $pivotSelectorField['model'] = $field['model'];
     $pivotSelectorField['ajax'] = $inline_create !== false ? true : ($pivotSelectorField['ajax'] ?? false);
     $pivotSelectorField['data_source'] = $pivotSelectorField['data_source'] ?? ($pivotSelectorField['ajax'] ? url($crud->route.'/fetch/'.$field['entity']) : 'false');
     $pivotSelectorField['minimum_input_length'] = $pivotSelectorField['minimum_input_length'] ?? 2;
     $pivotSelectorField['delay'] = $pivotSelectorField['delay'] ?? 500;
     $pivotSelectorField['placeholder'] = $pivotSelectorField['placeholder'] ?? trans('backpack::crud.select_entry');
-    if(isset($field['baseModel']) || isset($pivotSelectorField['baseModel'])) {
-        $pivotSelectorField['baseModel'] = $pivotSelectorField['baseModel'] ?? $field['baseModel'];
-    }
-    if(isset($field['baseEntity']) || isset($pivotSelectorField['baseEntity'])) {
-        $pivotSelectorField['baseEntity'] = $pivotSelectorField['baseEntity'] ?? $field['baseEntity'];
-    }
+    $pivotSelectorField['label'] = $pivotSelectorField['label'] ?? \Str::of($field['name'])->singular()->ucfirst();
 
-    switch ($field['relation_type']) {
-        case 'MorphToMany':
-        case 'BelongsToMany':
-            $field['subfields'] = Arr::prepend($field['subfields'], $pivotSelectorField);
-            break;
-        case 'MorphMany':
-        case 'HasMany':
-            if(isset($entry)) {
-                $field['subfields'] = Arr::prepend($field['subfields'], [
-                    'name' => (new $field['model'])->getKeyName(),
-                    'type' => 'hidden',
-                ]);
-            }
-        break;
-    }
+    $field['subfields'] = array_map(function($subfield) use ($pivotSelectorField) {
+        if(isset($subfield['is_pivot_select'])) {
+            $subfield = $subfield + $pivotSelectorField;
+        }
+        return $subfield;
+    },$field['subfields']);
 @endphp
 
 @include('crud::fields.repeatable')

--- a/src/resources/views/crud/fields/relationship/select.blade.php
+++ b/src/resources/views/crud/fields/relationship/select.blade.php
@@ -150,7 +150,7 @@
         var $isPivotSelect = element.data('is-pivot-select');
         
         const changePivotOptionState = function(pivot_selector, enable = true) {
-            let pivots_container = pivot_selector.closest('div[data-repeatable-holder='+pivot_selector.data('repeatable-input-name')+']');
+            let pivots_container = pivot_selector.closest('div[data-repeatable-holder="'+pivot_selector.data('repeatable-input-name')+'"]');
             
             $(pivots_container).children().each(function(i,container) {
                 $(container).find('select').each(function(i, el) {
@@ -158,10 +158,10 @@
                     if(typeof $(el).attr('data-is-pivot-select') !== 'undefined' && $(el).attr('data-is-pivot-select')) {
                         if(pivot_selector.val()) {
                             if(enable) {
-                                $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',false);   
+                                $(el).find('option[value="'+pivot_selector.val()+'"]').prop('disabled',false);   
                             }else{
                                 if($(el).val() !== pivot_selector.val()) {
-                                    $(el).find('option[value='+pivot_selector.val()+']').prop('disabled',true);
+                                    $(el).find('option[value="'+pivot_selector.val()+'"]').prop('disabled',true);
                                 }
                             }
                         }
@@ -171,7 +171,7 @@
         };
 
         const disablePreviouslySelectedPivots = function(pivot_selector) {
-            let pivots_container = pivot_selector.closest('div[data-repeatable-holder='+pivot_selector.data('repeatable-input-name')+']');
+            let pivots_container = pivot_selector.closest('div[data-repeatable-holder="'+pivot_selector.data('repeatable-input-name')+'"]');
             let selected_values = [];
             let select_inputs = [];
             
@@ -189,7 +189,7 @@
             select_inputs.forEach(function(input) {
                 selected_values.forEach(function(value) {
                     if(value !== $(input).val()) {
-                        $(input).find('option[value='+value+']').prop('disabled',true);
+                        $(input).find('option[value="'+value+'"]').prop('disabled',true);
                     }
                 });
             });

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -146,7 +146,7 @@
 
             var field_name = element.attr('name');
 
-            var container_holder = $('[data-repeatable-holder='+field_name+']');
+            var container_holder = $('[data-repeatable-holder="'+field_name+'"]');
 
             var init_rows = Number(container_holder.attr('data-init-rows'));
             var min_rows = Number(container_holder.attr('data-min-rows'));
@@ -155,7 +155,7 @@
             // make a copy of the group of inputs in their default state
             // this way we have a clean element we can clone when the user
             // wants to add a new group of inputs
-            var container = $('[data-repeatable-identifier='+field_name+']').last();
+            var container = $('[data-repeatable-identifier="'+field_name+'"]').last();
             
             // make sure the inputs get the data-repeatable-input-name
             // so we can know that they are inside repeatable
@@ -250,7 +250,7 @@
             delete_button.click(function(){
 
                 let $repeatableElement = $(this).closest('.repeatable-element');
-                let container = $('[data-repeatable-holder='+$($repeatableElement).attr('data-repeatable-identifier')+']')
+                let container = $('[data-repeatable-holder="'+$($repeatableElement).attr('data-repeatable-identifier')+'"]')
 
                 row.find('input, select, textarea').each(function(i, el) {
                     // we trigger this event so fields can intercept when they are beeing deleted from the page
@@ -287,7 +287,7 @@
             reorder_buttons.click(function(e){
                 
                 let $repeatableElement = $(e.target).closest('.repeatable-element');
-                let container = $('[data-repeatable-holder='+$($repeatableElement).attr('data-repeatable-identifier')+']')
+                let container = $('[data-repeatable-holder="'+$($repeatableElement).attr('data-repeatable-identifier')+'"]')
 
                 // get existing values
                 let index = $repeatableElement.index();

--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -34,7 +34,7 @@
                     <optgroup label="{{ $category->{$field['group_by_attribute']} }}">
                         @foreach ($category->{$field['group_by_relationship_back']} as $subEntry)
                             <option value="{{ $subEntry->getKey() }}"
-                                @if ( ( old($field['name']) && old($field['name']) == $subEntry->getKey() ) || (isset($field['value']) && $subEntry->getKey()==$field['value']))
+                                @if ($subEntry->getKey()===$current_value)
                                      selected
                                 @endif
                             >{{ $subEntry->{$field['attribute']} }}</option>

--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -17,7 +17,10 @@
     $field['value'] = old_empty_or_null($field['name'], collect()) ??  $field['value'] ?? $field['default'] ?? collect();
 
     if(!empty($field['value'])) {
-         $field['value'] = $field['options']->whereIn((new $field['model'])->getKeyName(), $field['value']);
+        if ($field['value'] instanceof \Illuminate\Database\Eloquent\Collection) {
+            $field['value'] = ($field['value'])->modelKeys();
+        }
+        $field['value'] = $field['options']->whereIn((new $field['model'])->getKeyName(), $field['value']);
     }
 
 @endphp

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -32,7 +32,7 @@
                     <optgroup label="{{ $category->{$field['group_by_attribute']} }}">
                         @foreach ($category->{$field['group_by_relationship_back']} as $subEntry)
                             <option value="{{ $subEntry->getKey() }}"
-                                @if ( ( old($field['name']) && old($field['name']) == $subEntry->getKey() ) || (isset($field['value']) && $subEntry->getKey()==$field['value']))
+                                @if ($current_value === $subEntry->getKey())
                                      selected
                                 @endif
                             >{{ $subEntry->{$field['attribute']} }}</option>

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -498,11 +498,106 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals('my first article note', $entry->fresh()->superArticles->first()->pivot->notes);
     }
 
+    public function testCreateHasOneWithNestedRelationsRepeatableInterface()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setOperation('create');
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
+        $this->crudPanel->addField(
+            [
+                'name' => 'accountDetails',
+                'subfields' => [
+                    [
+                        'name' => 'nickname',
+                    ],
+                    [
+                        'name' => 'profile_picture',
+                    ],
+                    [
+                        'name' => 'article',
+                    ],
+                    [
+                        'name' => 'addresses',
+                        'subfields' => [
+                            [
+                                'name' => 'city',
+                            ],
+                            [
+                                'name' => 'street',
+                            ],
+                            [
+                                'name' => 'number',
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'bangs',
+                    ],
+                    [
+                        'name' => 'bangsPivot',
+                        'subfields' => [
+                            [
+                                'name' => 'pivot_field',
+                            ],
+                        ],
+                    ],
+                ]
+            ]);
+
+        $faker = Factory::create();
+
+        $inputData = [
+            'name'           => $faker->name,
+            'email'          => $faker->safeEmail,
+            'password'       => bcrypt($faker->password()),
+            'remember_token' => null,
+            'roles'          => [1, 2],
+            'accountDetails' => [
+                [
+                    'nickname' => 'i_have_has_one',
+                    'profile_picture' => 'ohh my picture 1.jpg',
+                    'article' => 1,
+                    'addresses' => [
+                        [
+                            'city' => 'test',
+                            'street' => 'test',
+                            'number' => 1,
+                        ],
+                        [
+                            'city' => 'test2',
+                            'street' => 'test2',
+                            'number' => 2,
+                        ],
+                    ],
+                    'bangs' => [1, 2],
+                    'bangsPivot' => [
+                        ['bangsPivot' => 1, 'pivot_field' => 'test1'],
+                        ['bangsPivot' => 2, 'pivot_field' => 'test2'],
+                    ],
+                ],
+            ]
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+        $account_details = $entry->accountDetails()->first();
+
+        $this->assertEquals($account_details->article, Article::find(1));
+        $this->assertEquals($account_details->addresses->count(), 2);
+        $this->assertEquals($account_details->addresses->first()->city, 'test');
+        $this->assertEquals($account_details->addresses->first()->street, 'test');
+        $this->assertEquals($account_details->addresses->first()->number, 1);
+        $this->assertEquals($account_details->bangs->first()->name, Bang::find(1)->name);
+        $this->assertEquals($account_details->bangsPivot->count(), 2);
+        $this->assertEquals($account_details->bangsPivot->first()->pivot->pivot_field, 'test1');
+
+        
+    }
+
     public function testCreateHasOneWithNestedRelations()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->setOperation('create');
-
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
         $this->crudPanel->addFields([
             [
                 'name' => 'accountDetails.nickname',
@@ -671,9 +766,11 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
             'remember_token' => null,
             'stars'          => [
                 [
+                    'id' => null,
                     'title' => 'this is the star 1 title',
                 ],
                 [
+                    'id' => null,
                     'title' => 'this is the star 2 title',
                 ],
             ],

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -541,7 +541,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                             ],
                         ],
                     ],
-                ]
+                ],
             ]);
 
         $faker = Factory::create();
@@ -575,7 +575,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                         ['bangsPivot' => 2, 'pivot_field' => 'test2'],
                     ],
                 ],
-            ]
+            ],
         ];
 
         $entry = $this->crudPanel->create($inputData);
@@ -589,8 +589,6 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals($account_details->bangs->first()->name, Bang::find(1)->name);
         $this->assertEquals($account_details->bangsPivot->count(), 2);
         $this->assertEquals($account_details->bangsPivot->first()->pivot->pivot_field, 'test1');
-
-        
     }
 
     public function testCreateHasOneWithNestedRelations()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Nested relations were not properly saved nor displayed.

### AFTER - What is happening after this PR?

They save, they display, they work.

## HOW

### How did you achieve that, in technical terms?

This a 100% replacement for https://github.com/Laravel-Backpack/CRUD/pull/4115

Everything is splitted in small commits so we can move them out to new PR's if needed, but they are all related to this PR .. so!

Creating of entries and relations are done recursivelly, so technically any chained relations would work no matter how long the chain, and all of them have the same way of getting direct inputs (parsing) and relations.

Our tests already provide tests for "repeatable inside repeatable", but due to interface issues they are not supported atm just there to show off our relation creations ability. 🥳 


### Is it a breaking change or non-breaking change?

Non breaking in 4.2


### How can we test the before & after?

I've created https://github.com/Laravel-Backpack/demo/pull/348 so this branch can be properly tested, it enables the fake fields and removes the unsuported relations (repeatables inside repeatables).

From my testings:
- Monster works.
- Cave works.
- Story works.
- Fake fields works.
- Tests are passing.

I hope this time is for good after the usual rounds of code review, I think we got this to a pretty working/predictable state.

One of the biggest issues to make all this work together is the fact that we support `dot.notation.relations`. If we didn't support them this PR would be clean as cristal water. But still, I think it's pretty much intuitive. 

Let me know if I let something slip. We talk better about it tomorrow, I want to refactor some variable_names etc etc (in a separate commit).

Pedro

Pedro