### PR TITLE
Make fake fields work when used as subfields

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait FakeFields
 {
@@ -12,26 +13,51 @@ trait FakeFields
      * plus the '_token' and 'redirect_after_save' variables.
      *
      * @param  array  $requestInput  The request input.
-     * @param  string  $form  The CRUD form. Can be 'create' or 'update' . Default is 'create'.
-     * @param  int|bool  $id  The CRUD entry id in the case of the 'update' form.
+     * @param  array $fields 
      *
      * @see \Illuminate\Http\Request::all() For an example on how to get the request input.
      *
      * @return array The updated request input.
      */
-    public function compactFakeFields($requestInput)
+    public function compactFakeFields($requestInput, $model = false, $fields = [])
     {
         // get the right fields according to the form type (create/update)
-        $fields = $this->fields();
+        if(empty($fields)) {
+            $fields = $this->fields();
+        }
+
+        $model = $model ? (is_string($model) ? app($model) : $model)  : $this->model;
 
         $compactedFakeFields = [];
+       
         foreach ($fields as $field) {
             // compact fake fields
             // cast the field name to array first, to account for array field names
             // in fields that send multiple inputs and want them all saved to the database
             foreach ((array) $field['name'] as $fieldName) {
-                if (isset($field['fake']) && $field['fake'] == true && array_key_exists($fieldName, $requestInput)) {
-                    $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
+
+                $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
+                $isFakeField = $field['fake'] ?? false;
+               
+                // field is represented by the subfields
+                if(isset($field['subfields']) && $field['model'] === get_class($model)) {
+                    foreach($field['subfields'] as $subfield) {
+                        $subfieldName = Str::afterLast($subfield['name'],'.');
+                        $isSubfieldFake = $subfield['fake'] ?? false;
+                        $subFakeFieldKey = isset($subfield['store_in']) ? $subfield['store_in'] : 'extras';
+                        
+                        if (array_key_exists($subfieldName, $requestInput) && $isSubfieldFake) {
+                            $this->addCompactedField($requestInput, $subfieldName, $subFakeFieldKey);
+
+                            if (! in_array($subFakeFieldKey, $compactedFakeFields)) {
+                                $compactedFakeFields[] = $subFakeFieldKey;
+                            }
+                        }
+                    }
+                    continue; 
+                }
+
+                if (array_key_exists($fieldName, $requestInput) && $isFakeField) {
                     $this->addCompactedField($requestInput, $fieldName, $fakeFieldKey);
 
                     if (! in_array($fakeFieldKey, $compactedFakeFields)) {
@@ -43,7 +69,7 @@ trait FakeFields
 
         // json_encode all fake_value columns if applicable in the database, so they can be properly stored and interpreted
         foreach ($compactedFakeFields as $value) {
-            if (! (property_exists($this->model, 'translatable') && in_array($value, $this->model->getTranslatableAttributes(), true)) && $this->model->shouldEncodeFake($value)) {
+            if (! (property_exists($model, 'translatable') && in_array($value, $model->getTranslatableAttributes(), true)) && $model->shouldEncodeFake($value)) {
                 $requestInput[$value] = json_encode($requestInput[$value]);
             }
         }

--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -13,7 +13,7 @@ trait FakeFields
      * plus the '_token' and 'redirect_after_save' variables.
      *
      * @param  array  $requestInput  The request input.
-     * @param  array $fields 
+     * @param  array  $fields
      *
      * @see \Illuminate\Http\Request::all() For an example on how to get the request input.
      *
@@ -22,30 +22,29 @@ trait FakeFields
     public function compactFakeFields($requestInput, $model = false, $fields = [])
     {
         // get the right fields according to the form type (create/update)
-        if(empty($fields)) {
+        if (empty($fields)) {
             $fields = $this->fields();
         }
 
-        $model = $model ? (is_string($model) ? app($model) : $model)  : $this->model;
+        $model = $model ? (is_string($model) ? app($model) : $model) : $this->model;
 
         $compactedFakeFields = [];
-       
+
         foreach ($fields as $field) {
             // compact fake fields
             // cast the field name to array first, to account for array field names
             // in fields that send multiple inputs and want them all saved to the database
             foreach ((array) $field['name'] as $fieldName) {
-
                 $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
                 $isFakeField = $field['fake'] ?? false;
-               
+
                 // field is represented by the subfields
-                if(isset($field['subfields']) && $field['model'] === get_class($model)) {
-                    foreach($field['subfields'] as $subfield) {
-                        $subfieldName = Str::afterLast($subfield['name'],'.');
+                if (isset($field['subfields']) && $field['model'] === get_class($model)) {
+                    foreach ($field['subfields'] as $subfield) {
+                        $subfieldName = Str::afterLast($subfield['name'], '.');
                         $isSubfieldFake = $subfield['fake'] ?? false;
                         $subFakeFieldKey = isset($subfield['store_in']) ? $subfield['store_in'] : 'extras';
-                        
+
                         if (array_key_exists($subfieldName, $requestInput) && $isSubfieldFake) {
                             $this->addCompactedField($requestInput, $subfieldName, $subFakeFieldKey);
 
@@ -54,7 +53,7 @@ trait FakeFields
                             }
                         }
                     }
-                    continue; 
+                    continue;
                 }
 
                 if (array_key_exists($fieldName, $requestInput) && $isFakeField) {

--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -48,7 +48,7 @@ trait Input
         $model = $model ? (is_string($model) ? app($model) : $model) : $this->model;
 
         $input = $this->decodeJsonCastedAttributes($input, $model);
-        $input = $this->compactFakeFields($input);
+        $input = $this->compactFakeFields($input, $model, $fields);
         $input = $this->excludeRelationFieldsExceptBelongsTo($input, $fields, $relationMethod);
         $input = $this->changeBelongsToNamesFromRelationshipToForeignKey($input, $fields);
 

--- a/src/resources/views/crud/fields/select2_grouped.blade.php
+++ b/src/resources/views/crud/fields/select2_grouped.blade.php
@@ -1,11 +1,6 @@
 <!-- select2 -->
 @php
     $current_value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
-    if(!empty($current_value)) {
-        if (is_a($current_value, \Illuminate\Support\Collection::class)) {
-           $current_value = ($current_value)->pluck((new $field['model'])->getKeyName(), $field['attribute']);
-        }
-    }
     $field['allows_null'] = $field['allows_null'] ?? $field['model']::isColumnNullable($field['name']);
 @endphp
 

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -1,15 +1,21 @@
 <!-- select2 -->
 @php
     $current_value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
-    $field['allows_null'] = $field['allows_null'] ?? $crud->model::isColumnNullable($field['name']);
+    
+    if(!empty($current_value)) {
+        if (is_a($current_value, \Illuminate\Support\Collection::class)) {
+           $current_value = ($current_value)->pluck((new $field['model'])->getKeyName(), $field['attribute']);
+        }
+    }
+
+    $field['allows_null'] = $field['allows_null'] ?? $field['model']::isColumnNullable($field['name']);
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
     @php
-        $entity_model = $crud->model;
-        $related_model = $crud->getRelationModel($field['entity']);
+        $related_model = $field['model'];
         $group_by_model = (new $related_model)->{$field['group_by']}()->getRelated();
         $categories = $group_by_model::with($field['group_by_relationship_back'])->get();
 

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -1,13 +1,6 @@
 <!-- select2 -->
 @php
     $current_value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
-    
-    if(!empty($current_value)) {
-        if (is_a($current_value, \Illuminate\Support\Collection::class)) {
-           $current_value = ($current_value)->pluck((new $field['model'])->getKeyName(), $field['attribute']);
-        }
-    }
-
     $field['allows_null'] = $field['allows_null'] ?? $field['model']::isColumnNullable($field['name']);
 @endphp
 

--- a/tests/Unit/CrudPanel/CrudPanelFakeFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFakeFieldsTest.php
@@ -120,7 +120,7 @@ class CrudPanelFakeFieldsTest extends BaseDBCrudPanelTest
         $this->crudPanel->addFields($this->fakeFieldsArray);
         $this->crudPanel->setModel(Article::class);
 
-        $compactedFakeFields = $this->crudPanel->compactFakeFields($this->fakeFieldsInputData, 'create');
+        $compactedFakeFields = $this->crudPanel->compactFakeFields($this->fakeFieldsInputData);
 
         $this->assertEquals($this->expectedInputDataWithCompactedFakeFields, $compactedFakeFields);
     }
@@ -129,9 +129,9 @@ class CrudPanelFakeFieldsTest extends BaseDBCrudPanelTest
     {
         $article = DB::table('articles')->where('id', 1)->first();
         $this->crudPanel->setModel(Article::class);
-        $this->crudPanel->addFields($this->fakeFieldsArray, 'update');
+        $this->crudPanel->addFields($this->fakeFieldsArray);
 
-        $compactedFakeFields = $this->crudPanel->compactFakeFields($this->fakeFieldsInputData, 'update', $article->id);
+        $compactedFakeFields = $this->crudPanel->compactFakeFields($this->fakeFieldsInputData);
 
         $this->assertEquals($this->expectedInputDataWithCompactedFakeFields, $compactedFakeFields);
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We are able to read fake fields, but unable to create them when used in subfields.

### AFTER - What is happening after this PR?

We can save and display fake fields properly.


## HOW

### How did you achieve that, in technical terms?

Refactored fake fields to account for the fact that they can be nested.



### Is it a breaking change or non-breaking change?

Non in 4.2


### How can we test the before & after?

Uncomment the `select_grouped` and `select2_grouped` in `CaveCrudController` so they become available as fields inside Cave crud and Story Crud.

This branch points to https://github.com/Laravel-Backpack/CRUD/tree/use-create-recursively branch and should use the same demo PR to be tested.
