### PR TITLE
`old()` does not work in s/s2_multiple 

### DIFF
--- a/src/resources/views/crud/fields/select2_multiple.blade.php
+++ b/src/resources/views/crud/fields/select2_multiple.blade.php
@@ -15,6 +15,11 @@
     $field['placeholder'] = $field['placeholder'] ?? trans('backpack::crud.select_entries');
 
     $field['value'] = old_empty_or_null($field['name'], collect()) ??  $field['value'] ?? $field['default'] ?? collect();
+    
+    // when value is returned from crud panel it will be a collection, when returns from `old()` is already an array
+    if (is_a($field['value'], \Illuminate\Support\Collection::class)) {
+        $field['value'] = $field['value']->pluck($model_instance->getKeyName())->toArray();
+    }
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -37,7 +42,7 @@
 
         @if (isset($field['model']))
             @foreach ($field['options'] as $option)
-                @if(in_array($option->getKey(), $field['value']->pluck($option->getKeyName())->toArray()))
+                @if(in_array($option->getKey(), $field['value']))
                     <option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
                 @else
                     <option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -8,6 +8,10 @@
     $field['allows_null'] = $field['allows_null'] ?? true;
 
     $field['value'] = old_empty_or_null($field['name'], collect()) ??  $field['value'] ?? $field['default'] ?? collect();
+
+    if (is_a($field['value'], \Illuminate\Support\Collection::class)) {
+        $field['value'] = $field['value']->pluck(app($field['model'])->getKeyName())->toArray();
+    }
     
 @endphp
 
@@ -25,7 +29,7 @@
 
     	@if (count($options))
     		@foreach ($options as $option)
-				@if(in_array($option->getKey(), $field['value']->pluck($option->getKeyName())->toArray()))
+				@if(in_array($option->getKey(), $field['value']))
 					<option value="{{ $option->getKey() }}" selected>{{ $option->{$field['attribute']} }}</option>
 				@else
 					<option value="{{ $option->getKey() }}">{{ $option->{$field['attribute']} }}</option>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

select_multiple and select2_multiple were missing checking for `old()` array since we refactored the `old()` logic.

### AFTER - What is happening after this PR?

They now account for collections when getting the value from database, and arrays when getting from old.


## HOW

### How did you achieve that, in technical terms?

Instead of bloating the HTML of the field we convert the collections back into arrays and always use array in the field setup. 

### Is it a breaking change or non-breaking change?

non in 4.2


### How can we test the before & after?

If you had a select_multiple field with some value and your form submition fails you will get a fat error.

PS: @tabacitu select2_from_ajax_multiple already take into account the fact that the value could be an array or a collection.
