### PR TITLE
Asterisks for repeatable fields

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait Validation
@@ -179,7 +178,7 @@ trait Validation
                         $name_string = '';
 
                         foreach ($entity_array as $arr_key => $array_entity) {
-                            if($array_entity === '*') {
+                            if ($array_entity === '*') {
                                 continue;
                             }
                             $name_string .= ($arr_key === 0) ? $array_entity : '['.$array_entity.']';
@@ -192,7 +191,7 @@ trait Validation
                 }
             }
         }
-       
+
         $this->setOperationSetting('requiredFields', $requiredFields);
     }
 
@@ -210,7 +209,7 @@ trait Validation
             return false;
         }
 
-        if(Str::contains($inputKey, '.')) {
+        if (Str::contains($inputKey, '.')) {
             $entity_array = explode('.', $inputKey);
             $name_string = '';
             foreach ($entity_array as $arr_key => $array_entity) {

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -2,7 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait Validation
 {
@@ -178,7 +179,10 @@ trait Validation
                         $name_string = '';
 
                         foreach ($entity_array as $arr_key => $array_entity) {
-                            $name_string .= ($arr_key == 0) ? $array_entity : '['.$array_entity.']';
+                            if($array_entity === '*') {
+                                continue;
+                            }
+                            $name_string .= ($arr_key === 0) ? $array_entity : '['.$array_entity.']';
                         }
 
                         $key = $name_string;
@@ -188,7 +192,7 @@ trait Validation
                 }
             }
         }
-
+       
         $this->setOperationSetting('requiredFields', $requiredFields);
     }
 
@@ -204,6 +208,15 @@ trait Validation
     {
         if (! $this->hasOperationSetting('requiredFields')) {
             return false;
+        }
+
+        if(Str::contains($inputKey, '.')) {
+            $entity_array = explode('.', $inputKey);
+            $name_string = '';
+            foreach ($entity_array as $arr_key => $array_entity) {
+                $name_string .= ($arr_key === 0) ? $array_entity : '['.$array_entity.']';
+            }
+            $inputKey = $name_string;
         }
 
         return in_array($inputKey, $this->getOperationSetting('requiredFields'));

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -6,8 +6,10 @@
     foreach($field['wrapper'] as $attributeKey => $value) {
         $field['wrapper'][$attributeKey] = !is_string($value) && $value instanceof \Closure ? $value($crud, $field, $entry ?? null) : $value ?? '';
     }
-	// if the field is required in the FormRequest, it should have an asterisk
-	$required = (isset($action) && $crud->isRequired($field['name'], $action)) ? ' required' : '';
+	// if the field is required in the FormRequest, it should have an asterisk.
+	// we add the base entity to the field name to account for nested relation fields validated with `field.*.key`
+	$fieldName = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$field['name'] : $field['name'];
+	$required = (isset($action) && $crud->isRequired($fieldName)) ? ' required' : '';
 	
 	// if the developer has intentionally set the required attribute on the field
 	// forget whatever is in the FormRequest, do what the developer wants

--- a/src/resources/views/crud/fields/repeatable.blade.php
+++ b/src/resources/views/crud/fields/repeatable.blade.php
@@ -18,6 +18,7 @@
     $field['min_rows'] =  $field['min_rows'] ?? 0;
     $field['subfields'] = $field['subfields'] ?? $field['fields'] ?? [];
     $field['reorder'] = $field['reorder'] ?? true;
+    $field['wrapper']['class']  = isset($field['wrapper']['class']) ? $field['wrapper']['class'].' repeatable-group' : 'form-group col-sm-12 repeatable-group';
 
     if($field['reorder'] !== false) {
         switch(gettype($field['reorder'])) {

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -20,16 +20,6 @@
     <!-- CRUD FORM CONTENT - crud_fields_styles stack -->
     @stack('crud_fields_styles')
 
-    {{-- Temporary fix on 4.1 --}}
-    <style>
-      .form-group.required label:not(:empty):not(.form-check-label)::after {
-        content: '';
-      }
-      .form-group.required > label:not(:empty):not(.form-check-label)::after {
-        content: ' *';
-        color: #ff0000;
-      }
-    </style>
 @endsection
 
 @section('after_scripts')
@@ -142,7 +132,6 @@
       @if ($crud->inlineErrorsEnabled() && $errors->any())
 
         window.errors = {!! json_encode($errors->messages()) !!};
-        // console.error(window.errors);
 
         $.each(errors, function(property, messages){
 
@@ -154,10 +143,22 @@
                         $('[name="' + normalizedProperty + '[]"]') :
                         $('[name="' + normalizedProperty + '"]'),
                         container = field.parents('.form-group');
-
-            container.addClass('text-danger');
-            container.children('input, textarea, select').addClass('is-invalid');
-
+            
+            // iterate the inputs to add invalid classes to fields and red text to the field container.
+            container.children('input, textarea, select').each(function() {
+                let containerField = $(this);
+                // add the invalida class to the field.
+                containerField.addClass('is-invalid');
+                // get field container
+                let container = containerField.parent('.form-group');
+                
+                // if container is a repeatable group we don't want to add red text to the whole group,
+                // we only want to add it to the fields that have errors inside that repeatable.
+                if(!container.hasClass('repeatable-group')){
+                  container.addClass('text-danger');
+                }
+            });
+            
             $.each(messages, function(key, msg){
                 // highlight the input that errored
                 var row = $('<div class="invalid-feedback d-block">' + msg + '</div>');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

You could not show the astheriscs in repeatable fields like reported by @tabacitu here: https://github.com/Laravel-Backpack/CRUD/issues/4088

### AFTER - What is happening after this PR?

You can safely validate the attributes and they would show the required astheriscs when needed. 

Also you will notice that the whole group of fields will not turn ALL red when only one of them fails. 

The only thing that this PR don't cover is https://github.com/Laravel-Backpack/CRUD/issues/4089 as it is labeled as COULD.

### Is it a breaking change or non-breaking change?

I don't think it breaks nothing, I kept the old logic, but added a bit to account for nested fields when checking if they are required.

### How can we test the before & after?

@tabacitu could do the same test he did in #4088 but will notice that thing will work. 👍 (I hope.... 🙏 )
