### PR TITLE
Add support for single-method Laravel Accessors and Mutators

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -489,22 +489,4 @@ class CrudPanel
 
         return $results;
     }
-
-    /**
-     * Check if the method in the given model has any parameters.
-     *
-     * @param  object  $model
-     * @param  string  $method
-     * @return bool
-     */
-    private function modelMethodHasParameters($model, $method)
-    {
-        $reflectClassMethod = new \ReflectionMethod(get_class($model), $method);
-
-        if ($reflectClassMethod->getNumberOfParameters() > 0) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -194,10 +194,9 @@ trait ColumnsProtectedMethods
             if (method_exists($this->model, $possibleMethodName)) {
 
                 // check model method for possibility of beeing a relationship
-                $column['entity'] =  $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
+                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
 
-                if($column['entity']) {
-
+                if ($column['entity']) {
                     $parts = explode('.', $column['entity']);
 
                     $attribute_in_relation = false;
@@ -219,6 +218,7 @@ trait ColumnsProtectedMethods
                         $column['attribute'] = $column['attribute'] ?? end($parts);
                     }
                 }
+
                 return $column;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -194,9 +194,10 @@ trait ColumnsProtectedMethods
             if (method_exists($this->model, $possibleMethodName)) {
 
                 // check model method for possibility of beeing a relationship
-                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
+                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $possibleMethodName) ? $column['name'] : false;
 
-                if ($column['entity']) {
+                if($column['entity']) {
+
                     $parts = explode('.', $column['entity']);
 
                     $attribute_in_relation = false;
@@ -218,7 +219,6 @@ trait ColumnsProtectedMethods
                         $column['attribute'] = $column['attribute'] ?? end($parts);
                     }
                 }
-
                 return $column;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -193,8 +193,8 @@ trait ColumnsProtectedMethods
             // if the first part of the string exists as method in the model
             if (method_exists($this->model, $possibleMethodName)) {
 
-                // check model method for possibility of beeing a relationship
-                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $possibleMethodName) ? $column['name'] : false;
+                // check model method for possibility of being a relationship
+                $column['entity'] = $this->modelMethodIsRelationship($this->model, $possibleMethodName) ? $column['name'] : false;
 
                 if ($column['entity']) {
                     $parts = explode('.', $column['entity']);
@@ -226,8 +226,8 @@ trait ColumnsProtectedMethods
         // if there's a method on the model with this name
         if (method_exists($this->model, $column['name'])) {
 
-             // check model method for possibility of beeing a relationship
-            $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
+             // check model method for possibility of being a relationship
+            $column['entity'] = $this->modelMethodIsRelationship($this->model, $column['name']);
 
             return $column;
         }
@@ -238,8 +238,8 @@ trait ColumnsProtectedMethods
             $possibleMethodName = Str::replaceLast('_id', '', $column['name']);
 
             if (method_exists($this->model, $possibleMethodName)) {
-                // check model method for possibility of beeing a relationship
-                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $possibleMethodName);
+                // check model method for possibility of being a relationship
+                $column['entity'] = $this->modelMethodIsRelationship($this->model, $possibleMethodName);
 
                 return $column;
             }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -196,8 +196,7 @@ trait ColumnsProtectedMethods
                 // check model method for possibility of beeing a relationship
                 $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $possibleMethodName) ? $column['name'] : false;
 
-                if($column['entity']) {
-
+                if ($column['entity']) {
                     $parts = explode('.', $column['entity']);
 
                     $attribute_in_relation = false;
@@ -219,6 +218,7 @@ trait ColumnsProtectedMethods
                         $column['attribute'] = $column['attribute'] ?? end($parts);
                     }
                 }
+
                 return $column;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -190,34 +190,35 @@ trait ColumnsProtectedMethods
         if (strpos($column['name'], '.') !== false) {
             $possibleMethodName = Str::before($column['name'], '.');
 
-            // if the first part of the string exists as method,
-            // it is a relationship
+            // if the first part of the string exists as method in the model
             if (method_exists($this->model, $possibleMethodName)) {
 
-                // if it has parameters it's not a relation method.
-                $column['entity'] = $this->modelMethodHasParameters($this->model, $possibleMethodName) ? false : $column['name'];
+                // check model method for possibility of beeing a relationship
+                $column['entity'] =  $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
 
-                $parts = explode('.', $column['entity']);
+                if($column['entity']) {
 
-                $attribute_in_relation = false;
+                    $parts = explode('.', $column['entity']);
 
-                $model = $this->model;
+                    $attribute_in_relation = false;
 
-                // here we are going to iterate through all relation parts to check
-                // if the attribute is present in the relation string.
-                foreach ($parts as $i => $part) {
-                    try {
-                        $model = $model->$part()->getRelated();
-                    } catch (\Exception $e) {
-                        $attribute_in_relation = true;
+                    $model = $this->model;
+
+                    // here we are going to iterate through all relation parts to check
+                    // if the attribute is present in the relation string.
+                    foreach ($parts as $i => $part) {
+                        try {
+                            $model = $model->$part()->getRelated();
+                        } catch (\Exception $e) {
+                            $attribute_in_relation = true;
+                        }
+                    }
+                    // if the user setup the attribute in relation string, we are not going to infer that attribute from model
+                    // instead we get the defined attribute by the user.
+                    if ($attribute_in_relation) {
+                        $column['attribute'] = $column['attribute'] ?? end($parts);
                     }
                 }
-                // if the user setup the attribute in relation string, we are not going to infer that attribute from model
-                // instead we get the defined attribute by the user.
-                if ($attribute_in_relation) {
-                    $column['attribute'] = $column['attribute'] ?? end($parts);
-                }
-
                 return $column;
             }
         }
@@ -225,8 +226,8 @@ trait ColumnsProtectedMethods
         // if there's a method on the model with this name
         if (method_exists($this->model, $column['name'])) {
 
-            // if it has parameters it's not a relation method.
-            $column['entity'] = $this->modelMethodHasParameters($this->model, $column['name']) ? false : $column['name'];
+             // check model method for possibility of beeing a relationship
+            $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $column['name']);
 
             return $column;
         }
@@ -237,9 +238,8 @@ trait ColumnsProtectedMethods
             $possibleMethodName = Str::replaceLast('_id', '', $column['name']);
 
             if (method_exists($this->model, $possibleMethodName)) {
-
-                // if it has parameters it's not a relation method.
-                $column['entity'] = $this->modelMethodHasParameters($this->model, $possibleMethodName) ? false : $possibleMethodName;
+                // check model method for possibility of beeing a relationship
+                $column['entity'] = $this->checkMethodPropertiesForRelationship($this->model, $possibleMethodName);
 
                 return $column;
             }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -142,16 +142,17 @@ trait FieldsProtectedMethods
         //if the name is dot notation we are sure it's a relationship
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
-            // if it has parameters it's not a relation method.
-            $field['entity'] = $this->modelMethodHasParameters($model, $possibleMethodName) ? false : $field['name'];
+            // check model method for possibility of beeing a relationship
+            $field['entity'] =  $this->checkMethodPropertiesForRelationship($model, $field['name']);
 
             return $field;
         }
 
         // if there's a method on the model with this name
         if (method_exists($model, $field['name'])) {
-            // if it has parameters it's not a relation method.
-            $field['entity'] = $this->modelMethodHasParameters($model, $field['name']) ? false : $field['name'];
+           
+            // check model method for possibility of beeing a relationship
+            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
 
             return $field;
         }
@@ -162,8 +163,8 @@ trait FieldsProtectedMethods
             $possibleMethodName = Str::replaceLast('_id', '', $field['name']);
 
             if (method_exists($model, $possibleMethodName)) {
-                // if it has parameters it's not a relation method.
-                $field['entity'] = $this->modelMethodHasParameters($model, $possibleMethodName) ? false : $possibleMethodName;
+                // check model method for possibility of beeing a relationship
+                $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $possibleMethodName);
 
                 return $field;
             }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -142,16 +142,16 @@ trait FieldsProtectedMethods
         //if the name is dot notation we are sure it's a relationship
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
-            // check model method for possibility of beeing a relationship
-            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $possibleMethodName) ? $field['name'] : false;
+            // check model method for possibility of being a relationship
+            $field['entity'] = $this->modelMethodIsRelationship($model, $possibleMethodName) ? $field['name'] : false;
 
             return $field;
         }
 
         // if there's a method on the model with this name
         if (method_exists($model, $field['name'])) {
-            // check model method for possibility of beeing a relationship
-            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
+            // check model method for possibility of being a relationship
+            $field['entity'] = $this->modelMethodIsRelationship($model, $field['name']);
 
             return $field;
         }
@@ -162,8 +162,8 @@ trait FieldsProtectedMethods
             $possibleMethodName = Str::replaceLast('_id', '', $field['name']);
 
             if (method_exists($model, $possibleMethodName)) {
-                // check model method for possibility of beeing a relationship
-                $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $possibleMethodName);
+                // check model method for possibility of being a relationship
+                $field['entity'] = $this->modelMethodIsRelationship($model, $possibleMethodName);
 
                 return $field;
             }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -143,14 +143,13 @@ trait FieldsProtectedMethods
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
             // check model method for possibility of beeing a relationship
-            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
+            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $possibleMethodName) ? $field['name'] : false;
 
             return $field;
         }
 
         // if there's a method on the model with this name
         if (method_exists($model, $field['name'])) {
-
             // check model method for possibility of beeing a relationship
             $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -143,14 +143,14 @@ trait FieldsProtectedMethods
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
             // check model method for possibility of beeing a relationship
-            $field['entity'] =  $this->checkMethodPropertiesForRelationship($model, $field['name']);
+            $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
 
             return $field;
         }
 
         // if there's a method on the model with this name
         if (method_exists($model, $field['name'])) {
-           
+
             // check model method for possibility of beeing a relationship
             $field['entity'] = $this->checkMethodPropertiesForRelationship($model, $field['name']);
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -324,7 +324,7 @@ trait Relationships
      * @param $method
      * @return bool|string
      */
-    private function checkMethodPropertiesForRelationship($model, $method)
+    private function modelMethodIsRelationship($model, $method)
     {
         $methodReflection = new \ReflectionMethod($model, $method);
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -313,45 +313,45 @@ trait Relationships
     /**
      * Checks the properties of the provided method to better verify if it could be a relation.
      * Case the method is not public, is not a relation.
-     * Case the return type is Attribute, or extends Attribute is not a relation method. 
+     * Case the return type is Attribute, or extends Attribute is not a relation method.
      * If the return type extends the Relation class is for sure a relation
      * Otherwise we just assume it's a relation.
-     * 
+     *
      * DEV NOTE: In future versions we will return `false` when no return type is set and make the return type mandatory for relationships.
-     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation. 
-     * 
+     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation.
+     *
      * @param $model
      * @param $method
-     * 
      * @return bool|string
-     * 
      */
-    private function checkMethodPropertiesForRelationship($model, $method) {
+    private function checkMethodPropertiesForRelationship($model, $method)
+    {
 
         // relationship methods does not have parameters.
-        if($this->modelMethodHasParameters($model, $method)) {
+        if ($this->modelMethodHasParameters($model, $method)) {
             return false;
         }
 
         $methodReflection = new \ReflectionMethod($model, $method);
 
         // relationships are always public methods.
-        if (!$methodReflection->isPublic()) {
+        if (! $methodReflection->isPublic()) {
             return false;
         }
 
         $returnType = $methodReflection->getReturnType();
 
-        if($returnType){
+        if ($returnType) {
             $returnType = $returnType->getName();
-            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
+            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
                 return false;
             }
 
-            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
+            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
                 return $method;
             }
         }
+
         return $method;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -309,4 +309,49 @@ trait Relationships
 
         return $pivotSelectorField;
     }
+
+    /**
+     * Checks the properties of the provided method to better verify if it could be a relation.
+     * Case the method is not public, is not a relation.
+     * Case the return type is Attribute, or extends Attribute is not a relation method. 
+     * If the return type extends the Relation class is for sure a relation
+     * Otherwise we just assume it's a relation.
+     * 
+     * DEV NOTE: In future versions we will return `false` when no return type is set and make the return type mandatory for relationships.
+     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation. 
+     * 
+     * @param $model
+     * @param $method
+     * 
+     * @return bool|string
+     * 
+     */
+    private function checkMethodPropertiesForRelationship($model, $method) {
+
+        // relationship methods does not have parameters.
+        if($this->modelMethodHasParameters($model, $method)) {
+            return false;
+        }
+
+        $methodReflection = new \ReflectionMethod($model, $method);
+
+        // relationships are always public methods.
+        if (!$methodReflection->isPublic()) {
+            return false;
+        }
+
+        $returnType = $methodReflection->getReturnType();
+
+        if($returnType){
+            $returnType = $returnType->getName();
+            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
+                return false;
+            }
+
+            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
+                return $method;
+            }
+        }
+        return $method;
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -313,22 +313,19 @@ trait Relationships
     /**
      * Checks the properties of the provided method to better verify if it could be a relation.
      * Case the method is not public, is not a relation.
-     * Case the return type is Attribute, or extends Attribute is not a relation method. 
+     * Case the return type is Attribute, or extends Attribute is not a relation method.
      * If the return type extends the Relation class is for sure a relation
      * Otherwise we just assume it's a relation.
-     * 
+     *
      * DEV NOTE: In future versions we will return `false` when no return type is set and make the return type mandatory for relationships.
-     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation. 
-     * 
+     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation.
+     *
      * @param $model
      * @param $method
-     * 
      * @return bool|string
-     * 
      */
-    private function checkMethodPropertiesForRelationship($model, $method) 
+    private function checkMethodPropertiesForRelationship($model, $method)
     {
-
         $methodReflection = new \ReflectionMethod($model, $method);
 
         // relationship methods function does not have parameters
@@ -337,22 +334,23 @@ trait Relationships
         }
 
         // relationships are always public methods.
-        if (!$methodReflection->isPublic()) {
+        if (! $methodReflection->isPublic()) {
             return false;
         }
 
         $returnType = $methodReflection->getReturnType();
 
-        if($returnType){
+        if ($returnType) {
             $returnType = $returnType->getName();
-            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
+            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
                 return false;
             }
 
-            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
+            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
                 return $method;
             }
         }
+
         return $method;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -313,45 +313,46 @@ trait Relationships
     /**
      * Checks the properties of the provided method to better verify if it could be a relation.
      * Case the method is not public, is not a relation.
-     * Case the return type is Attribute, or extends Attribute is not a relation method.
+     * Case the return type is Attribute, or extends Attribute is not a relation method. 
      * If the return type extends the Relation class is for sure a relation
      * Otherwise we just assume it's a relation.
-     *
+     * 
      * DEV NOTE: In future versions we will return `false` when no return type is set and make the return type mandatory for relationships.
-     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation.
-     *
+     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation. 
+     * 
      * @param $model
      * @param $method
+     * 
      * @return bool|string
+     * 
      */
-    private function checkMethodPropertiesForRelationship($model, $method)
+    private function checkMethodPropertiesForRelationship($model, $method) 
     {
-
-        // relationship methods does not have parameters.
-        if ($this->modelMethodHasParameters($model, $method)) {
-            return false;
-        }
 
         $methodReflection = new \ReflectionMethod($model, $method);
 
+        // relationship methods function does not have parameters
+        if ($methodReflection->getNumberOfParameters() > 0) {
+            return false;
+        }
+
         // relationships are always public methods.
-        if (! $methodReflection->isPublic()) {
+        if (!$methodReflection->isPublic()) {
             return false;
         }
 
         $returnType = $methodReflection->getReturnType();
 
-        if ($returnType) {
+        if($returnType){
             $returnType = $returnType->getName();
-            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
+            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
                 return false;
             }
 
-            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
+            if(is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
                 return $method;
             }
         }
-
         return $method;
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in #4163 , a new feature introduced by Laravel https://github.com/laravel/framework/pull/40022 allow developers to setup acessors and mutators using a different syntax. Backpack guessing abilities were broken by this change, as this functions would look similar to relation functions.

### AFTER - What is happening after this PR?

You can safely use the new Laravel feature.

## HOW

### How did you achieve that, in technical terms?

I prepared the grounds for us to move towards requiring return types in the relation functions that developer wants Backpack to guess from. I moved all logic that deals with checking method properties to a single method to reduce the margin of error until we don't make the change I talked before. 

Added a check for the function return type, since the new Laravel feature requires the developer to define the return type, we can safely exclude them from beeing relationships. 

Also added a check for method visibility as relationships methods are always public. 

Still not perfect until we enforce the return types, but is better than yesterday! 👍 

### Is it a breaking change or non-breaking change?

non-breaking

### How can we test the before & after?

Try adding the new Laravel feature in Monster model for example, before it would error. After it would work 👍 

```php
// text is a monster field that we want to mutate, not a relationship
protected function text(): Attribute {
        return new Attribute(
            get: fn($value) => ucfirst($value),
        );
    }
```
