### PR TITLE
[v5] use a fresh relation instance to create related items

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -305,7 +305,6 @@ trait Create
 
             // create the item relations if any.
             $this->createRelationsForItem($item, $relationInputs);
-
         }
 
         // use the collection of sent ids to match agains database ids, delete the ones not found in the submitted ids.

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -298,13 +298,14 @@ trait Create
             // we either find the matched entry by local_key (usually `id`)
             // and update the values from the input
             // or create a new item from input
-            $item = $relation->updateOrCreate([$relation_local_key => $relation_local_key_value], $directInputs);
+            $item = $entry->{$relationMethod}()->updateOrCreate([$relation_local_key => $relation_local_key_value], $directInputs);
 
-            // we store the item local key do we can match them with database and check if any item was deleted
+            // we store the item local key so we can match them with database and check if any item was deleted
             $relatedItemsSent[] = $item->{$relation_local_key};
 
-            // create the item relations if any
+            // create the item relations if any.
             $this->createRelationsForItem($item, $relationInputs);
+
         }
 
         // use the collection of sent ids to match agains database ids, delete the ones not found in the submitted ids.

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -885,7 +885,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
 
         $universes = $entry->fresh()->universes;
         $this->assertCount(2, $universes);
-        $this->assertEquals([1,2], $universes->pluck('id')->toArray());
+        $this->assertEquals([1, 2], $universes->pluck('id')->toArray());
 
         $inputData['universes'] = [
             [
@@ -895,11 +895,11 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         ];
 
         $this->crudPanel->update($entry->id, $inputData);
-        
+
         $this->assertEquals($inputData['universes'][0]['title'], $entry->fresh()->universes->first()->title);
         $this->assertEquals($inputData['universes'][0]['id'], $entry->fresh()->universes->first()->id);
         $this->assertEquals(1, Universe::all()->count());
-        
+
         $inputData['universes'] = [
             [
                 'id' => null,

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -855,6 +855,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
             'remember_token' => null,
             'universes'          => [
                 [
+                    'id' => null,
                     'title' => 'this is the star 1 title',
                 ],
                 [
@@ -872,16 +873,44 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $inputData['universes'] = [
             [
                 'id' => 1,
-                'title' => 'only one star with changed title',
+                'title' => 'star 1 with changed title',
+            ],
+            [
+                'id' => 2,
+                'title' => 'star 2 with changed title',
             ],
         ];
 
         $this->crudPanel->update($entry->id, $inputData);
 
-        $this->assertCount(1, $entry->fresh()->universes);
+        $universes = $entry->fresh()->universes;
+        $this->assertCount(2, $universes);
+        $this->assertEquals([1,2], $universes->pluck('id')->toArray());
 
+        $inputData['universes'] = [
+            [
+                'id' => 1,
+                'title' => 'only one star with changed title',
+            ],
+        ];
+
+        $this->crudPanel->update($entry->id, $inputData);
+        
         $this->assertEquals($inputData['universes'][0]['title'], $entry->fresh()->universes->first()->title);
         $this->assertEquals($inputData['universes'][0]['id'], $entry->fresh()->universes->first()->id);
+        $this->assertEquals(1, Universe::all()->count());
+        
+        $inputData['universes'] = [
+            [
+                'id' => null,
+                'title' => 'new star 3',
+            ],
+        ];
+
+        $this->crudPanel->update($entry->id, $inputData);
+
+        $this->assertEquals($inputData['universes'][0]['title'], $entry->fresh()->universes->first()->title);
+        $this->assertEquals(3, $entry->fresh()->universes->first()->id);
         $this->assertEquals(1, Universe::all()->count());
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

creatable "many" entries (aka subfields), where not properly finding the correct relations because on create we were using the same outdated relation instance. reported here: https://github.com/Laravel-Backpack/CRUD/issues/4169

### AFTER - What is happening after this PR?

We use a clean relation instance when creating the items, this way they can properly be identified in the foreach loop, because we "deconstruct" each item in a "many relation" so we can create the item and create item relations when they exist.


## HOW

### How did you achieve that, in technical terms?

used a new relation istance (that takes into account previous items in the relation) to create the current item. using the same `$relation` for all the items will result in keys beeing messed up because they don't exists in the relation. 

### Is it a breaking change or non-breaking change?

Non breaking.


### How can we test the before & after?

I added tests for this scenario, so to test it you basically run the test suit without the changes in `Create.php`, and then run with the changes.


