### PR TITLE
Add support ordering for translatable fields in List

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -102,7 +102,7 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name'])=='json'){
+                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json'){
                         $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
                     } else {
                         $this->crud->orderByWithPrefix($column['name'], $column_direction);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\DB;
 
 trait ListOperation
 {
@@ -101,7 +102,12 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    $this->crud->orderByWithPrefix($column['name'], $column_direction);
+                    if (in_array($column['name'],$this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name'])=='json'){
+                        $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
+                    }
+                    else {
+                        $this->crud->orderByWithPrefix($column['name'], $column_direction);
+                    }
                 }
 
                 // check for custom order logic in the column definition

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -102,7 +102,7 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json'){
+                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json') {
                         $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
                     } else {
                         $this->crud->orderByWithPrefix($column['name'], $column_direction);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -102,7 +102,7 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    if (isset($this->crud->model->translatable) and in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json') {
+                    if ($this->crud->model->translationEnabled() and $this->crud->model->isTranslatableAttribute($column['name']) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json') {
                         $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
                     } else {
                         $this->crud->orderByWithPrefix($column['name'], $column_direction);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -102,7 +102,7 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json') {
+                    if (isset($this->crud->model->translatable) and in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name']) == 'json') {
                         $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
                     } else {
                         $this->crud->orderByWithPrefix($column['name'], $column_direction);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -2,8 +2,8 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
 
 trait ListOperation
 {
@@ -102,10 +102,9 @@ trait ListOperation
                 $column = $this->crud->findColumnById($column_number);
                 if ($column['tableColumn'] && ! isset($column['orderLogic'])) {
                     // apply the current orderBy rules
-                    if (in_array($column['name'],$this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name'])=='json'){
+                    if (in_array($column['name'], $this->crud->model->translatable) and DB::getSchemaBuilder()->getColumnType($this->crud->model->getTable(), $column['name'])=='json'){
                         $this->crud->orderByWithPrefix($column['name'].'->'.\App::currentLocale(), $column_direction);
-                    }
-                    else {
+                    } else {
                         $this->crud->orderByWithPrefix($column['name'], $column_direction);
                     }
                 }

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -188,7 +188,6 @@ trait HasTranslations
             case 'findBySlug':
             case 'findBySlugOrFail':
             case 'hydrate':
-                
                 $translation_locale = \Request::input('_locale', \App::getLocale());
 
                 if ($translation_locale) {

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -187,7 +187,6 @@ trait HasTranslations
             case 'findMany':
             case 'findBySlug':
             case 'findBySlugOrFail':
-            case 'hydrate':
                 $translation_locale = \Request::input('_locale', \App::getLocale());
 
                 if ($translation_locale) {

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -187,7 +187,8 @@ trait HasTranslations
             case 'findMany':
             case 'findBySlug':
             case 'findBySlugOrFail':
-
+            case 'hydrate':
+                
                 $translation_locale = \Request::input('_locale', \App::getLocale());
 
                 if ($translation_locale) {


### PR DESCRIPTION
## WHY
When you use translatable field, and use JSON field type in database (in my case is PostgreSQL)
Ordering in List page broken


### BEFORE - What was wrong? What was happening before this PR?
when you try order data from json database field  you will get error
![image](https://user-images.githubusercontent.com/23197378/153441772-900cc9dc-c12d-47e3-a6a3-bd71089a5b1a.png)

### AFTER - What is happening after this PR?

Values in the user's current language sort fine 


## HOW

Added a check on the database field and a translatable field 

I tested this sorting syntax on my PostgeSQL database, but as far as I know the mysql uses the same syntax to access the json 
 field element 

### Is it a breaking change or non-breaking change?

Its a path improvements and fix bugs for translatable models
FIRST PR:
https://github.com/Laravel-Backpack/revise-operation/pull/16



### PS
For users who use the text format of the database, sorting does not cause an error, but it will also work incorrectly.
Therefore, I recommend using the json data format for translatable fields, it adds more options for interacting with data, including correct sorting by data when switching between languages 
