### PR TITLE
The set is expecting wrong param type

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -26,7 +26,7 @@ trait Settings
      * Setter for the settings key-value store.
      *
      * @param  string  $key  Usually operation.name (ex: reorder.max_level)
-     * @param  bool  $value  True/false depending on success.
+     * @param  string  $value  The value being set
      */
     public function set(string $key, $value)
     {


### PR DESCRIPTION
## WHY
The set method expects bool. Any documented use of this method though passes a string of the view name as second argument. 


### BEFORE - What was wrong? What was happening before this PR?

Examples in the documentation: https://backpackforlaravel.com/docs/4.1/crud-api#custom-views 
Were bool type be enforced it would return an error.

### AFTER - What is happening after this PR?

Changes doc `@param` to expect a string param


## HOW

### How did you achieve that, in technical terms?

Just updated PHPdoc section


### Is it a breaking change or non-breaking change?

No, non breaking. 


### How can we test the before & after?

Run PHP Static Analysis / Larastan
before it gives an error: `Parameter #2 $value of method Backpack\CRUD\app\Library\CrudPanel\CrudPanel::set() expects bool, string given` 
