### PR TITLE
fix #4175 - nestedSortable was not working with jQuery UI 1.13+

### DIFF
--- a/src/public/packages/nestedSortable/jquery.mjs.nestedSortable2.js
+++ b/src/public/packages/nestedSortable/jquery.mjs.nestedSortable2.js
@@ -264,6 +264,12 @@
 			childLevels = this._getChildLevels(this.helper);
 			newList = document.createElement(o.listType);
 
+	        // dragDirection object is required by jquery.ui.sortable.js 1.13+
+	       	this.dragDirection = {
+		      	vertical: this._getDragVerticalDirection(),
+				horizontal: this._getDragHorizontalDirection()
+	    	};
+
 			//Rearrange
 			for (i = this.items.length - 1; i >= 0; i--) {
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

See https://github.com/Laravel-Backpack/CRUD/issues/4175 - the Reorder operation stopped working because of a jQueryUI 1.13 and nestedSortable v2 bug.

See https://github.com/ilikenwf/nestedSortable/pull/137 for screenshots.

### AFTER - What is happening after this PR?

It works.


## HOW

### How did you achieve that, in technical terms?

Manual patch to the nestedSortable js file.



### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

Try to use the Reorder operation... won't work. Afterwards... it'll work. 
