### PR TITLE
Comparing string classes instead of objects

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -342,11 +342,11 @@ trait Relationships
 
         if ($returnType) {
             $returnType = $returnType->getName();
-            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Casts\Attribute')) {
+            if (is_a($returnType, 'Illuminate\Database\Eloquent\Casts\Attribute', true)) {
                 return false;
             }
 
-            if (is_a((new $returnType), 'Illuminate\Database\Eloquent\Relations\Relation')) {
+            if (is_a($returnType, 'Illuminate\Database\Eloquent\Relations\Relation', true)) {
                 return $method;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -343,13 +343,6 @@ trait Relationships
         if ($returnType) {
             $returnType = $returnType->getName();
 
-            // this check is to make sure we don't autoload the class when checking strings instead of objects.
-            // the third parameter of is_a() allow us to check strings, but it also autoloads the class
-            // in case it does not exists. The classes we want to check against EXIST.
-            if(!class_exists($returnType, false)) {
-                return false;
-            }
-            // the above check 
             if (is_a($returnType, 'Illuminate\Database\Eloquent\Casts\Attribute', true)) {
                 return false;
             }

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -342,6 +342,14 @@ trait Relationships
 
         if ($returnType) {
             $returnType = $returnType->getName();
+
+            // this check is to make sure we don't autoload the class when checking strings instead of objects.
+            // the third parameter of is_a() allow us to check strings, but it also autoloads the class
+            // in case it does not exists. The classes we want to check against EXIST.
+            if(!class_exists($returnType, false)) {
+                return false;
+            }
+            // the above check 
             if (is_a($returnType, 'Illuminate\Database\Eloquent\Casts\Attribute', true)) {
                 return false;
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in #4178 there was an error in the way we initialized classes to check the possibility of a relation. 

### AFTER - What is happening after this PR?

Fixed the initialization problem by not instantiating objects.


## HOW

### How did you achieve that, in technical terms?

instead of using `is_a()` with objects, I set the third parameter to `true`, that allow us to checks strings as we are sure our return type is a string. 

### Is it a breaking change or non-breaking change?

non-breaking I hope 🙏 

