### PR TITLE
In show_fields, use `getFirstFieldView()` method

### DIFF
--- a/src/resources/views/crud/inc/show_fields.blade.php
+++ b/src/resources/views/crud/inc/show_fields.blade.php
@@ -1,17 +1,5 @@
 {{-- Show the inputs --}}
 @foreach ($fields as $field)
-    @php
-        // if the namespace is given, use that, no questions asked, otherwise
-        // load it from the first view_namespace that holds that field
-        if (isset($field['view_namespace'])) {
-            $fieldPaths = [$field['view_namespace'].'.'.$field['type']];
-        } else {
-            $fieldPaths = array_map(function($item) use ($field) {
-                return $item.'.'.$field['type'];
-            }, config('backpack.crud.view_namespaces.fields'));
-        }
-    @endphp
-
-    @includeFirst($fieldPaths, ['field' => $field])
+    @include($crud->getFirstFieldView($field['type'], $field['view_namespace'] ?? false), $field)
 @endforeach
 


### PR DESCRIPTION
...instead of manually doing the same thing in the blade file.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

In `show_fields` we were doing the same thing as in `CRUD::getFirstFieldView()`, instead of calling that method.

### AFTER - What is happening after this PR?

We call `CRUD::getFirstFieldView()`


## HOW

### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

Create in Monster & MenuItem should work before, should work after, and show all fields.