### PR TITLE
Removed is countable helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -232,22 +232,7 @@ if (! function_exists('square_brackets_to_dots')) {
     }
 }
 
-if (! function_exists('is_countable')) {
-    /**
-     * We need this because is_countable was only introduced in PHP 7.3,
-     * and in PHP 7.2 you should check if count() argument is really countable.
-     * This function may be removed in future if PHP >= 7.3 becomes a requirement.
-     *
-     * @param $obj
-     * @return bool
-     */
-    function is_countable($obj)
-    {
-        return is_array($obj) || $obj instanceof Countable;
-    }
-}
-
-if (! function_exists('old_empty_or_null')) {
+if (!function_exists('old_empty_or_null')) {
     /**
      * This method is an alternative to Laravel's old() helper, which mistakenly
      * returns NULL it two cases:

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -232,7 +232,7 @@ if (! function_exists('square_brackets_to_dots')) {
     }
 }
 
-if (!function_exists('old_empty_or_null')) {
+if (! function_exists('old_empty_or_null')) {
     /**
      * This method is an alternative to Laravel's old() helper, which mistakenly
      * returns NULL it two cases:


### PR DESCRIPTION
## WHY

CRUD supports Laravel 8.26+, and Laravel 8 supports php 7.3 - 8.1.

https://www.php.net/manual/en/function.is-countable.php
_(PHP 7 >= 7.3.0, PHP 8)_


### Is it a breaking change or non-breaking change?

I don't think so.