### PR TITLE
Removed last bits of placeholder

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -268,9 +268,13 @@ return [
     // What kind of avatar will you like to show to the user?
     // Default: gravatar (automatically use the gravatar for their email)
     // Other options:
-    // - placehold (generic image with their first letter)
+    // - null (generic image with their first letter)
     // - example_method_name (specify the method on the User model that returns the URL)
     'avatar_type' => 'gravatar',
+
+    // Gravatar fallback options are 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'
+    // 'blank' will keep the generic image with the user first letter
+    'gravatar_fallback' => 'blank',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -96,22 +96,12 @@ if (! function_exists('backpack_avatar_url')) {
      */
     function backpack_avatar_url($user)
     {
-        $firstLetter = $user->getAttribute('name') ? mb_substr($user->name, 0, 1, 'UTF-8') : 'A';
-        $placeholder = 'https://via.placeholder.com/160x160/00a65a/ffffff/&text='.$firstLetter;
-
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
                 if (backpack_users_have_email()) {
-                    return Gravatar::fallback('https://via.placeholder.com/160x160/00a65a/ffffff/&text='.$firstLetter)->get($user->email);
-                } else {
-                    return $placeholder;
+                    return Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email);
                 }
                 break;
-
-            case 'placehold':
-                return $placeholder;
-                break;
-
             default:
                 return method_exists($user, config('backpack.base.avatar_type')) ? $user->{config('backpack.base.avatar_type')}() : $user->{config('backpack.base.avatar_type')};
                 break;

--- a/src/resources/views/base/inc/menu_user_dropdown.blade.php
+++ b/src/resources/views/base/inc/menu_user_dropdown.blade.php
@@ -1,7 +1,7 @@
 <li class="nav-item dropdown pr-4">
   <a class="nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" style="position: relative;width: 35px;height: 35px;margin: 0 10px;">
     <img class="img-avatar" src="{{ backpack_avatar_url(backpack_auth()->user()) }}" alt="{{ backpack_auth()->user()->name }}" onerror="this.style.display='none'" style="margin: 0;position: absolute;left: 0;z-index: 1;">
-    <span class="backpack-avatar-menu-container" style="position: absolute;left: 0;width: 100%;background-color: #00a65a;border-radius: 50%;color: #FFF;line-height: 35px;">
+    <span class="backpack-avatar-menu-container" style="position: absolute;left: 0;width: 100%;background-color: #00a65a;border-radius: 50%;color: #FFF;line-height: 35px;font-size: 85%;font-weight: 300;">
       {{backpack_user()->getAttribute('name') ? mb_substr(backpack_user()->name, 0, 1, 'UTF-8') : 'A'}}
     </span>
   </a>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I stumble in the `helper.php` and found some old stuff that is consuming resources unnecessarily.
We no longer need to placehold since we mimic the behavior of it with css.

### AFTER - What is happening after this PR?

This css solution is saving a few Kb's for the end user.

![image](https://user-images.githubusercontent.com/1838187/153777257-78eab93c-7845-4983-b9da-f25379c0da9b.png)

## HOW

### Is it a breaking change or non-breaking change?

This isn't a breaking change, this was introduced in v4 as an offline fallback.

---
In the between, I noticed Gravatar supports a lot of "funny" fallbacks, and added `gravatar_fallback` to configs.

![image](https://user-images.githubusercontent.com/1838187/153777401-cfe9249b-e838-4e64-9aba-c6f173705559.png)

![image](https://user-images.githubusercontent.com/1838187/153777414-ec1698b1-9a2f-42f3-a950-2889bbac2932.png)

