### PR TITLE
closes #4199

### DIFF
--- a/src/resources/views/crud/fields/image.blade.php
+++ b/src/resources/views/crud/fields/image.blade.php
@@ -283,22 +283,27 @@
                     if(crop) {
                         $rotateLeft.click(function() {
                             $mainImage.cropper("rotate", 90);
+                            $mainImage.trigger('cropend');
                         });
 
                         $rotateRight.click(function() {
                             $mainImage.cropper("rotate", -90);
+                            $mainImage.trigger('cropend');
                         });
 
                         $zoomIn.click(function() {
                             $mainImage.cropper("zoom", 0.1);
+                            $mainImage.trigger('cropend');
                         });
 
                         $zoomOut.click(function() {
                             $mainImage.cropper("zoom", -0.1);
+                            $mainImage.trigger('cropend');
                         });
 
                         $reset.click(function() {
                             $mainImage.cropper("reset");
+                            $mainImage.trigger('cropend');
                         });
                     }
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Using the crop tools on the image field with crop set to true, **does not** update the image value which will be sent to the server. 

### AFTER - What is happening after this PR?

Using the zoom, rotate or reset buttons now update the hidden image value with the same image the user is seeing as edited on screen.

## HOW

### How did you achieve that, in technical terms?

I've added the JQuery needed to trigger the 'cropend' event which will update the hidden image value

### Is it a breaking change or non-breaking change?

non-breaking change

### How can we test the before & after?

**Before**
1. Add an image field to a crud controller, set crop to true in the field config.
2. Press zoom a few times, ensuring that bounds are not changed (this updates the hiddenImage value)
3. Post the image and notice that the original image is posted

**After**
1. Add an image field to a crud controller, set crop to true in the field config.
2. Press zoom a few times, ensuring that bounds are not changed (this updates the hiddenImage value)
3. Post the image and notice that the zoomed image is posted
