### PR TITLE
add css that forces width on select2 placeholder

### DIFF
--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -7,23 +7,6 @@
     }
 @endphp
 
-@push('crud_fields_styles')
-    <style>
-        .nav-tabs-custom {
-            box-shadow: none;
-        }
-        .nav-tabs-custom > .nav-tabs.nav-stacked > li {
-            margin-right: 0;
-        }
-
-        .tab-pane .form-group h1:first-child,
-        .tab-pane .form-group h2:first-child,
-        .tab-pane .form-group h3:first-child {
-            margin-top: 0;
-        }
-    </style>
-@endpush
-
 @if ($crud->getFieldsWithoutATab()->filter(function ($value, $key) { return $value['type'] != 'hidden'; })->count())
 <div class="card">
     <div class="card-body row">
@@ -65,4 +48,33 @@
         </div>
     </div>
 </div>
+
+@push('crud_fields_styles')
+    <style>
+        .nav-tabs-custom {
+            box-shadow: none;
+        }
+        .nav-tabs-custom > .nav-tabs.nav-stacked > li {
+            margin-right: 0;
+        }
+
+        .tab-pane .form-group h1:first-child,
+        .tab-pane .form-group h2:first-child,
+        .tab-pane .form-group h3:first-child {
+            margin-top: 0;
+        }
+    </style>
+@endpush
+
+@push('crud_fields_scripts')
+    <script>
+        // when select2 is multiple and it's not on the first displayed tab the placeholder would
+        // not display correctly because the element was not "visible" on the page (hidden by tab)
+        // thus getting `0px` width. This makes sure that the placeholder element is always 100% width
+        $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+            $('.select2-search .select2-search--inline').css('width', '100%');
+            $('.select2-search__field').css('width', '100%');
+        })
+    </script>
+@endpush
 

--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -63,18 +63,18 @@
         .tab-pane .form-group h3:first-child {
             margin-top: 0;
         }
-    </style>
-@endpush
 
-@push('crud_fields_scripts')
-    <script>
-        // when select2 is multiple and it's not on the first displayed tab the placeholder would
-        // not display correctly because the element was not "visible" on the page (hidden by tab)
-        // thus getting `0px` width. This makes sure that the placeholder element is always 100% width
-        $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-            $('.select2-search .select2-search--inline').css('width', '100%');
-            $('.select2-search__field').css('width', '100%');
-        })
-    </script>
+        /*  
+            when select2 is multiple and it's not on the first displayed tab the placeholder would
+            not display correctly because the element was not "visible" on the page (hidden by tab)
+            thus getting `0px` width. This makes sure that the placeholder element is always 100% width
+            by preventing the select2 inline style (0px) from applying using !important
+        */
+        .select2-container, 
+        .select2-container li:only-child,
+        .select2-container input:placeholder-shown {
+            width: 100% !important;
+        }
+    </style>
 @endpush
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #4194 multiple selects2 would not properly display on page when they are inside a tab that is not the first one to be displayed.

### AFTER - What is happening after this PR?

They display fine.


## HOW

### How did you achieve that, in technical terms?

Added a script that forces the width of the placeholder container to be 100% of the parent element, even if not present in the current visible elements.


### Is it a breaking change or non-breaking change?

non-breaking


### How can we test the before & after?

In Monster demo, go create a new one, and then move to relationships tab. You will see that all select2 multiples are not displaying the placeholder correctly. (If you refresh the page in `relationships` tab they will work fine, but you will see that the ones in the `selects` tab will be broken, do the same in the selects tab by refreshing, they will work, relationship ones are broken.).

After this PR no more select multiple broken.
