### PR TITLE
Custom separator for multiple values in select columns

### DIFF
--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -7,6 +7,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 32;
     $column['separator'] = $column['separator'] ?? ',';
+    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -36,7 +37,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escaped'])
+                @if($column['escape_separator'])
                     {{ $column['separator'] }}
                 @else
                     {!! $column['separator'] !!}

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -6,6 +6,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 32;
+    $column['separator'] = $column['separator'] ?? ',';
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -32,9 +33,15 @@
                         {!! $text !!}
                     @endif
                 @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-
-                @if(!$loop->last), @endif
             </span>
+
+            @if(!$loop->last)
+                @if($column['escaped'])
+                    {{ $column['separator'] }}
+                @else
+                    {!! $column['separator'] !!}
+                @endif
+            @endif
         @endforeach
         {{ $column['suffix'] }}
     @else

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -7,7 +7,6 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 32;
     $column['separator'] = $column['separator'] ?? ',';
-    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -37,11 +36,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escape_separator'])
-                    {{ $column['separator'] }}
-                @else
-                    {!! $column['separator'] !!}
-                @endif
+                {!! $column['separator'] !!}
             @endif
         @endforeach
         {{ $column['suffix'] }}

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -5,7 +5,6 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['separator'] = $column['separator'] ?? ',';
-    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -44,11 +43,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escape_separator'])
-                    {{ $column['separator'] }}
-                @else
-                    {!! $column['separator'] !!}
-                @endif
+                {!! $column['separator'] !!}
             @endif
         @endforeach
         {{ $column['suffix'] }}

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -5,6 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['separator'] = $column['separator'] ?? ',';
+    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -43,7 +44,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escaped'])
+                @if($column['escape_separator'])
                     {{ $column['separator'] }}
                 @else
                     {!! $column['separator'] !!}

--- a/src/resources/views/crud/columns/select_from_array.blade.php
+++ b/src/resources/views/crud/columns/select_from_array.blade.php
@@ -4,6 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
+    $column['separator'] = $column['separator'] ?? ',';
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -39,9 +40,15 @@
                         {!! $text !!}
                     @endif
                 @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-
-                @if(!$loop->last), @endif
             </span>
+
+            @if(!$loop->last)
+                @if($column['escaped'])
+                    {{ $column['separator'] }}
+                @else
+                    {!! $column['separator'] !!}
+                @endif
+            @endif
         @endforeach
         {{ $column['suffix'] }}
     @else

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -7,7 +7,6 @@
     $column['limit'] = $column['limit'] ?? 32;
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
     $column['separator'] = $column['separator'] ?? ',';
-    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -44,11 +43,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escape_separator'])
-                    {{ $column['separator'] }}
-                @else
-                    {!! $column['separator'] !!}
-                @endif
+                {!! $column['separator'] !!}
             @endif
         @endforeach
         {{ $column['suffix'] }}

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -7,6 +7,7 @@
     $column['limit'] = $column['limit'] ?? 32;
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
     $column['separator'] = $column['separator'] ?? ',';
+    $column['escape_separator'] = $column['escape_separator'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -43,7 +44,7 @@
             </span>
 
             @if(!$loop->last)
-                @if($column['escaped'])
+                @if($column['escape_separator'])
                     {{ $column['separator'] }}
                 @else
                     {!! $column['separator'] !!}

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -6,6 +6,7 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['limit'] = $column['limit'] ?? 32;
     $column['attribute'] = $column['attribute'] ?? (new $column['model'])->identifiableAttribute();
+    $column['separator'] = $column['separator'] ?? ',';
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
@@ -39,9 +40,15 @@
                         {!! $text !!}
                     @endif
                 @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-
-                @if(!$loop->last), @endif
             </span>
+
+            @if(!$loop->last)
+                @if($column['escaped'])
+                    {{ $column['separator'] }}
+                @else
+                    {!! $column['separator'] !!}
+                @endif
+            @endif
         @endforeach
         {{ $column['suffix'] }}
     @else


### PR DESCRIPTION
## WHY

This PR will allow users to provide a custom separator when using `select*` type

### BEFORE - What was wrong? What was happening before this PR?

Before the PR it was adding elements with comma `,`

### AFTER - What is happening after this PR?

If the PR is merged, developers can provided the separator like `<br/>` to separate the `select*` columns. Still uses `,` if unspecified.


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change or non-breaking change?

**NO**


### How can we test the before & after?

??
