### PR TITLE
[Bug] Dependencies in repeatable containers

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -55,17 +55,11 @@ if (! function_exists('backpack_form_input')) {
             if (substr_count($row['name'], '[') === 1) {
                 // start in the first occurence since it's HasOne/MorphOne with dot notation (address[street] in request) to get the input name (address)
                 $inputNameStart = strpos($row['name'], '[') + 1;
-                $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
-                $inputNameLength = $inputNameEnd - $inputNameStart;
-                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
             } else {
                 // repeatable fields, we need to get the input name and the row number
                 // start on the second occurence since it's a repeatable and we want to bypass the row number (repeatableName[rowNumber][inputName])
                 $inputNameStart = strpos($row['name'], '[', strpos($row['name'], '[') + 1) + 1;
-                $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
-                $inputNameLength = $inputNameEnd - $inputNameStart;
-                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
-
+                
                 // get the array key (aka repeatable row) from field name
                 $startKey = strpos($row['name'], '[') + 1;
                 $endKey = strpos($row['name'], ']', $startKey);
@@ -73,6 +67,9 @@ if (! function_exists('backpack_form_input')) {
                 $repeatableRowKey = substr($row['name'], $startKey, $lengthKey);
             }
 
+            $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
+            $inputNameLength = $inputNameEnd - $inputNameStart;
+            $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
             $parentInputName = substr($row['name'], 0, strpos($row['name'], '['));
 
             if (isset($repeatableRowKey)) {
@@ -82,7 +79,6 @@ if (! function_exists('backpack_form_input')) {
 
             $result[$parentInputName][$inputName] = $row['value'];
         }
-
         return $result;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -40,32 +40,47 @@ if (! function_exists('backpack_form_input')) {
     function backpack_form_input()
     {
         $input = request('form') ?? [];
-
         $result = [];
+
         foreach ($input as $row) {
-            // parse the input name to extract the "arg" when using HasOne/MorphOne (address[street]) returns street as arg, address as key
-            $start = strpos($row['name'], '[');
-            $input_arg = null;
-            if ($start !== false) {
-                $end = strpos($row['name'], ']', $start + 1);
-                $length = $end - $start;
+            $repeatableRowKey = null;
 
-                $input_arg = substr($row['name'], $start + 1, $length - 1);
-                $input_arg = strlen($input_arg) >= 1 ? $input_arg : null;
-                $input_key = substr($row['name'], 0, $start);
-            } else {
-                $input_key = $row['name'];
+            // regular fields don't need any aditional parsing
+            if(strpos($row['name'], '[') === false) {
+                $result[$row['name']] = $row['value'];
+                continue;
             }
 
-            if (is_null($input_arg)) {
-                if (! isset($result[$input_key])) {
-                    $result[$input_key] = $start ? [$row['value']] : $row['value'];
-                } else {
-                    array_push($result[$input_key], $row['value']);
-                }
-            } else {
-                $result[$input_key][$input_arg] = $row['value'];
+            // dot notation fields
+            if(substr_count($row['name'], '[') === 1) { 
+                // start in the first occurence since it's HasOne/MorphOne with dot notation (address[street] in request) to get the input name (address)
+                $inputNameStart = strpos($row['name'], '[') +1;
+                $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
+                $inputNameLength = $inputNameEnd - $inputNameStart; 
+                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);  
+            }else{
+                // repeatable fields, we need to get the input name and the row number
+                // start on the second occurence since it's a repeatable and we want to bypass the row number (repeatableName[rowNumber][inputName])
+                $inputNameStart = strpos($row['name'], '[', strpos($row['name'], '[')+1)+1;
+                $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
+                $inputNameLength = $inputNameEnd - $inputNameStart;
+                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
+
+                // get the array key (aka repeatable row) from field name
+                $startKey = strpos($row['name'], '[') +1;
+                $endKey =  strpos($row['name'], ']', $startKey);
+                $lengthKey = $endKey - $startKey;
+                $repeatableRowKey = substr($row['name'], $startKey, $lengthKey);
             }
+
+            $parentInputName = substr($row['name'], 0, strpos($row['name'], '['));
+            
+            if(isset($repeatableRowKey)) {
+                $result[$parentInputName][$repeatableRowKey][$inputName] = $row['value'];
+                continue;
+            }
+            
+            $result[$parentInputName][$inputName] = $row['value'];
         }
 
         return $result;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -46,40 +46,40 @@ if (! function_exists('backpack_form_input')) {
             $repeatableRowKey = null;
 
             // regular fields don't need any aditional parsing
-            if(strpos($row['name'], '[') === false) {
+            if (strpos($row['name'], '[') === false) {
                 $result[$row['name']] = $row['value'];
                 continue;
             }
 
             // dot notation fields
-            if(substr_count($row['name'], '[') === 1) { 
+            if (substr_count($row['name'], '[') === 1) {
                 // start in the first occurence since it's HasOne/MorphOne with dot notation (address[street] in request) to get the input name (address)
-                $inputNameStart = strpos($row['name'], '[') +1;
+                $inputNameStart = strpos($row['name'], '[') + 1;
                 $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
-                $inputNameLength = $inputNameEnd - $inputNameStart; 
-                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);  
-            }else{
+                $inputNameLength = $inputNameEnd - $inputNameStart;
+                $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
+            } else {
                 // repeatable fields, we need to get the input name and the row number
                 // start on the second occurence since it's a repeatable and we want to bypass the row number (repeatableName[rowNumber][inputName])
-                $inputNameStart = strpos($row['name'], '[', strpos($row['name'], '[')+1)+1;
+                $inputNameStart = strpos($row['name'], '[', strpos($row['name'], '[') + 1) + 1;
                 $inputNameEnd = strpos($row['name'], ']', $inputNameStart);
                 $inputNameLength = $inputNameEnd - $inputNameStart;
                 $inputName = substr($row['name'], $inputNameStart, $inputNameLength);
 
                 // get the array key (aka repeatable row) from field name
-                $startKey = strpos($row['name'], '[') +1;
-                $endKey =  strpos($row['name'], ']', $startKey);
+                $startKey = strpos($row['name'], '[') + 1;
+                $endKey = strpos($row['name'], ']', $startKey);
                 $lengthKey = $endKey - $startKey;
                 $repeatableRowKey = substr($row['name'], $startKey, $lengthKey);
             }
 
             $parentInputName = substr($row['name'], 0, strpos($row['name'], '['));
-            
-            if(isset($repeatableRowKey)) {
+
+            if (isset($repeatableRowKey)) {
                 $result[$parentInputName][$repeatableRowKey][$inputName] = $row['value'];
                 continue;
             }
-            
+
             $result[$parentInputName][$inputName] = $row['value'];
         }
 

--- a/tests/Unit/CrudPanel/HelpersTest.php
+++ b/tests/Unit/CrudPanel/HelpersTest.php
@@ -1,70 +1,71 @@
 <?php
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
 use Illuminate\Http\Request;
 
 class HelpersTest extends BaseCrudPanelTest
 {
-    public function testBackpackFormInputParsesRepeatableFieldsFunction() {
-        
+    public function testBackpackFormInputParsesRepeatableFieldsFunction()
+    {
         $input = [
             'form' => [
                 [
                     'name' => 'repeatable[0][name]',
-                    'value' => 'first row name'
+                    'value' => 'first row name',
                 ],
                 [
                     'name' => 'repeatable[0][age]',
-                    'value' => '23'
+                    'value' => '23',
                 ],
                 [
                     'name' => 'repeatable[1][name]',
-                    'value' => 'second row name'
+                    'value' => 'second row name',
                 ],
                 [
                     'name' => 'repeatable[1][age]',
-                    'value' => '24'
+                    'value' => '24',
                 ],
-            ]
+            ],
         ];
 
         $request = new Request($input);
         app()->handle($request);
-        
+
         $expectedOutput = [
             'repeatable' => [
                 [
                     'name' => 'first row name',
-                    'age' => '23'
+                    'age' => '23',
                 ],
                 [
                     'name' => 'second row name',
-                    'age' => '24'
+                    'age' => '24',
                 ],
-            ]
+            ],
         ];
 
         $this->assertEquals($expectedOutput, backpack_form_input());
     }
 
-    public function testBackpackFormInputParsesDotNotationFields() {
-        
+    public function testBackpackFormInputParsesDotNotationFields()
+    {
         $input = [
             'form' => [
                 [
                     'name' => 'address[street]',
-                    'value' => 'street name'
+                    'value' => 'street name',
                 ],
                 [
                     'name' => 'address[postal_code]',
-                    'value' => '234'
+                    'value' => '234',
                 ],
-            ]
+            ],
         ];
 
         $request = new Request($input);
         app()->handle($request);
-        
+
         $expectedOutput = [
             'address' => [
                 'street' => 'street name',
@@ -75,44 +76,44 @@ class HelpersTest extends BaseCrudPanelTest
         $this->assertEquals($expectedOutput, backpack_form_input());
     }
 
-    public function testBackpackFormInputHandleDifferentInputTypesAtSameTime() {
-        
+    public function testBackpackFormInputHandleDifferentInputTypesAtSameTime()
+    {
         $input = [
             'form' => [
                 [
                     'name' => 'address[street]',
-                    'value' => 'street name'
+                    'value' => 'street name',
                 ],
                 [
                     'name' => 'address[postal_code]',
-                    'value' => '234'
+                    'value' => '234',
                 ],
                 [
                     'name' => 'repeatable[0][name]',
-                    'value' => 'first row name'
+                    'value' => 'first row name',
                 ],
                 [
                     'name' => 'repeatable[0][age]',
-                    'value' => '23'
+                    'value' => '23',
                 ],
                 [
                     'name' => 'repeatable[1][name]',
-                    'value' => 'second row name'
+                    'value' => 'second row name',
                 ],
                 [
                     'name' => 'repeatable[1][age]',
-                    'value' => '24'
+                    'value' => '24',
                 ],
                 [
                     'name' => 'simple_field',
-                    'value' => 'simple value'
-                ]
-            ]
+                    'value' => 'simple value',
+                ],
+            ],
         ];
 
         $request = new Request($input);
         app()->handle($request);
-        
+
         $expectedOutput = [
             'address' => [
                 'street' => 'street name',
@@ -121,11 +122,11 @@ class HelpersTest extends BaseCrudPanelTest
             'repeatable' => [
                 [
                     'name' => 'first row name',
-                    'age' => '23'
+                    'age' => '23',
                 ],
                 [
                     'name' => 'second row name',
-                    'age' => '24'
+                    'age' => '24',
                 ],
             ],
             'simple_field' => 'simple value',

--- a/tests/Unit/CrudPanel/HelpersTest.php
+++ b/tests/Unit/CrudPanel/HelpersTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+use Illuminate\Http\Request;
+
+class HelpersTest extends BaseCrudPanelTest
+{
+    public function testBackpackFormInputParsesRepeatableFieldsFunction() {
+        
+        $input = [
+            'form' => [
+                [
+                    'name' => 'repeatable[0][name]',
+                    'value' => 'first row name'
+                ],
+                [
+                    'name' => 'repeatable[0][age]',
+                    'value' => '23'
+                ],
+                [
+                    'name' => 'repeatable[1][name]',
+                    'value' => 'second row name'
+                ],
+                [
+                    'name' => 'repeatable[1][age]',
+                    'value' => '24'
+                ],
+            ]
+        ];
+
+        $request = new Request($input);
+        app()->handle($request);
+        
+        $expectedOutput = [
+            'repeatable' => [
+                [
+                    'name' => 'first row name',
+                    'age' => '23'
+                ],
+                [
+                    'name' => 'second row name',
+                    'age' => '24'
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expectedOutput, backpack_form_input());
+    }
+
+    public function testBackpackFormInputParsesDotNotationFields() {
+        
+        $input = [
+            'form' => [
+                [
+                    'name' => 'address[street]',
+                    'value' => 'street name'
+                ],
+                [
+                    'name' => 'address[postal_code]',
+                    'value' => '234'
+                ],
+            ]
+        ];
+
+        $request = new Request($input);
+        app()->handle($request);
+        
+        $expectedOutput = [
+            'address' => [
+                'street' => 'street name',
+                'postal_code' => '234',
+            ],
+        ];
+
+        $this->assertEquals($expectedOutput, backpack_form_input());
+    }
+
+    public function testBackpackFormInputHandleDifferentInputTypesAtSameTime() {
+        
+        $input = [
+            'form' => [
+                [
+                    'name' => 'address[street]',
+                    'value' => 'street name'
+                ],
+                [
+                    'name' => 'address[postal_code]',
+                    'value' => '234'
+                ],
+                [
+                    'name' => 'repeatable[0][name]',
+                    'value' => 'first row name'
+                ],
+                [
+                    'name' => 'repeatable[0][age]',
+                    'value' => '23'
+                ],
+                [
+                    'name' => 'repeatable[1][name]',
+                    'value' => 'second row name'
+                ],
+                [
+                    'name' => 'repeatable[1][age]',
+                    'value' => '24'
+                ],
+                [
+                    'name' => 'simple_field',
+                    'value' => 'simple value'
+                ]
+            ]
+        ];
+
+        $request = new Request($input);
+        app()->handle($request);
+        
+        $expectedOutput = [
+            'address' => [
+                'street' => 'street name',
+                'postal_code' => '234',
+            ],
+            'repeatable' => [
+                [
+                    'name' => 'first row name',
+                    'age' => '23'
+                ],
+                [
+                    'name' => 'second row name',
+                    'age' => '24'
+                ],
+            ],
+            'simple_field' => 'simple value',
+        ];
+
+        $this->assertEquals($expectedOutput, backpack_form_input());
+    }
+}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in https://github.com/Laravel-Backpack/CRUD/discussions/4097 I forgot to refactor the `backpack_form_input()` thus it would not work with new arrayable repeatable field names. **EDIT: technically I didn't forget, I was just waiting for us to have the `toggable` feature that would incorporate this one ... but since this one is broken atm, better fix it.**

### AFTER - What is happening after this PR?

They work.


## HOW

### How did you achieve that, in technical terms?

I refactored the function to account for arrayed names `something[0][whatever]`. 
Also there is a pending PR in `pro` repository that is needed to work in conjunction with this one.

### Is it a breaking change or non-breaking change?

non I guess, It was not working previously.


### How can we test the before & after?

use this field in monster:

```php
$this->crud->addField([
            'name' => 'vendors',
            'type' => 'repeatable',
            'subfields' => [
                [
                    'name' => 'something',
                    'type' => 'text',
                ],
                [
                    'name' => 'type',
                    'type' => 'select2',
                    'model' => 'App\Models\Product',
                    'attribute' => 'name',
                ],
                [ // select2_from_ajax: 1-n relationship
                    'label'                => 'Select2_from_ajax'.backpack_pro_badge(), // Table column heading
                    'type'                 => 'select2_from_ajax',
                    'name'                 => 'select2_from_ajax', // the column that contains the ID of that connected entity;
                    'entity'               => 'article', // the method that defines the relationship in your Model
                    'attribute'            => 'title', // foreign key attribute that is shown to user
                    'model'                => "Backpack\NewsCRUD\app\Models\Article", // foreign key model
                    'data_source'          => url('api/article'), // url to controller search function (with /{id} should return model)
                    'placeholder'          => 'Select an article', // placeholder for the select
                    'minimum_input_length' => 2, // minimum characters to type before querying results
                    'tab'                  => 'Selects',
                    'wrapperAttributes'    => ['class' => 'form-group col-md-4'],
                    'include_all_form_fields' => true, //sends the other form fields along with the request so it can be filtered.
    
                    'dependencies'         => ['type'],
                ],
            ]
        ]);
```

Check `backpack_form_input()` before and after in the `api/article` endpoint.

Don't forget about the PR in pro! 👍 

