### PR TITLE
fix required fields (asterisc) inside repeatable

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -194,7 +194,7 @@ trait Validation
 
         // merge any previous required fields with current ones
         $requiredFields = array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields);
-        
+
         // since this COULD BE called twice (to support the previous syntax where developers needed to call `setValidation` after the field definition)
         // and to make this change non-breaking, we are going to return an unique array. There is NO WARM returning repeated names, but there is also
         // no sense in doing it, so array_unique() it is.

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -194,11 +194,12 @@ trait Validation
 
         // merge any previous required fields with current ones
         $requiredFields = array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields);
+        
         // since this COULD BE called twice (to support the previous syntax where developers needed to call `setValidation` after the field definition)
         // and to make this change non-breaking, we are going to return an unique array. There is NO WARM returning repeated names, but there is also
         // no sense in doing it, so array_unique() it is.
         $requiredFields = array_unique($requiredFields);
-        dump($requiredFields);
+
         $this->setOperationSetting('requiredFields', $requiredFields);
     }
 

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -191,8 +191,7 @@ trait Validation
                 }
             }
         }
-
-        $this->setOperationSetting('requiredFields', $requiredFields);
+        $this->setOperationSetting('requiredFields', array_unique(array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields)));
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -194,7 +194,7 @@ trait Validation
 
         // merge any previous required fields with current ones
         $requiredFields = array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields);
-        // since this COULD BE called twice (to support the previous syntax where developers needed to call `setValidation` after the field definition) 
+        // since this COULD BE called twice (to support the previous syntax where developers needed to call `setValidation` after the field definition)
         // and to make this change non-breaking, we are going to return an unique array. There is NO WARM returning repeated names, but there is also
         // no sense in doing it, so array_unique() it is.
         $requiredFields = array_unique($requiredFields);

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -191,7 +191,15 @@ trait Validation
                 }
             }
         }
-        $this->setOperationSetting('requiredFields', array_unique(array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields)));
+
+        // merge any previous required fields with current ones
+        $requiredFields = array_merge($this->getOperationSetting('requiredFields') ?? [], $requiredFields);
+        // since this COULD BE called twice (to support the previous syntax where developers needed to call `setValidation` after the field definition) 
+        // and to make this change non-breaking, we are going to return an unique array. There is NO WARM returning repeated names, but there is also
+        // no sense in doing it, so array_unique() it is.
+        $requiredFields = array_unique($requiredFields);
+        dump($requiredFields);
+        $this->setOperationSetting('requiredFields', $requiredFields);
     }
 
     /**

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -6,15 +6,18 @@
     foreach($field['wrapper'] as $attributeKey => $value) {
         $field['wrapper'][$attributeKey] = !is_string($value) && $value instanceof \Closure ? $value($crud, $field, $entry ?? null) : $value ?? '';
     }
-	// if the field is required in the FormRequest, it should have an asterisk.
-	// we add the base entity to the field name to account for nested relation fields validated with `field.*.key`
-	$fieldName = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$field['name'] : $field['name'];
-	$fieldName = is_array($fieldName) ? current($fieldName) : $fieldName;
-	$required = (isset($action) && $crud->isRequired($fieldName)) ? ' required' : '';
+	// if the field is required in any of the crud validatiors (FormRequest, Controller or Field validation) 
+	// we add an astherisc for it. Case it's a subfield, that check is done upstream in repeatable_row. 
+	// the reason for that is that here the field name is already the repeatable name: parent[row][fieldName]
+	if(!isset($field['parentFieldName'])) {
+		$fieldName = is_array($field['name']) ? current($field['name']) : $field['name'];
+		$required = (isset($action) && $crud->isRequired($fieldName)) ? ' required' : '';
+	}
 	
 	// if the developer has intentionally set the required attribute on the field
 	// forget whatever is in the FormRequest, do what the developer wants
-	$required = isset($field['showAsterisk']) ? ($field['showAsterisk'] ? ' required' : '') : $required;
+	// subfields also get here with `showAsterisk` already set.
+	$required = isset($field['showAsterisk']) ? ($field['showAsterisk'] ? ' required' : '') : ($required ?? '');
 	
 	$field['wrapper']['class'] = $field['wrapper']['class'] ?? "form-group col-sm-12";
 	$field['wrapper']['class'] = $field['wrapper']['class'].$required;

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -6,7 +6,7 @@
     foreach($field['wrapper'] as $attributeKey => $value) {
         $field['wrapper'][$attributeKey] = !is_string($value) && $value instanceof \Closure ? $value($crud, $field, $entry ?? null) : $value ?? '';
     }
-	// if the field is required in any of the crud validatiors (FormRequest, Controller or Field validation) 
+	// if the field is required in any of the crud validators (FormRequest, controller validation or field validation) 
 	// we add an astherisc for it. Case it's a subfield, that check is done upstream in repeatable_row. 
 	// the reason for that is that here the field name is already the repeatable name: parent[row][fieldName]
 	if(!isset($field['parentFieldName'])) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The repeatable fields could not properly get the astheriscs!

This PR needs another one in PRO to properly work.

### AFTER - What is happening after this PR?

It correctly displays the asteriscs when fields are required.


## HOW

### How did you achieve that, in technical terms?

fixed the way we handle subfields when required.



### Is it a breaking change or non-breaking change?
non


### How can we test the before & after?

add some repeatable fields with `required` in the form request `repeatable.*.field => 'required'`. No asterics for required fields. After the PR, they have the asteriscs!
