### PR TITLE
Fix users do not have an associated email address

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -83,7 +83,7 @@ if (! function_exists('backpack_users_have_email')) {
         $user_model_fqn = config('backpack.base.user_model_fqn');
         $user = new $user_model_fqn();
 
-        return \Schema::hasColumn($user->getTable(), 'email');
+        return \Schema::hasColumn($user->getTable(), backpack_authentication_column());
     }
 }
 


### PR DESCRIPTION
fix users do not have an associated email address

## WHY

### BEFORE - What was wrong? What was happening before this PR?

- You could not run ```php artisan route:list``` If you use different column instead of backpack default column for storing user emails.
- You could not use ```backpack_users_have_email``` function properly as it will always return ```false```

### AFTER - What is happening after this PR?

- ```backpack_users_have_email``` returns the right flag now
- ```php artisan route:list``` returns the list of all the routes

## HOW

### How did you achieve that, in technical terms?

replaced ```email``` by ```backpack_authentication_column``` function inside method ```backpack_users_have_email```


### Is it a breaking change or non-breaking change?

non-breaking

### How can we test the before & after?

Try changing the ```authentication_column``` value in ```base.php``` e.g, username and then run ```php artisan r:l``` command from terminal.