### PR TITLE
fix #4188 - bulk actions in safari

### DIFF
--- a/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
+++ b/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
@@ -49,10 +49,6 @@
                 enableOrDisableBulkButtons();
             });
         }
-
-        // activate checkbox if the page reloaded and the item is remembered as selected
-        // make it so that the function above is run after each DataTable draw event
-        crud.addFunctionToDataTablesDrawEventQueue('addOrRemoveCrudCheckedItem');
     }
 
     if (typeof markCheckboxAsCheckedIfPreviouslySelected !== 'function') {
@@ -61,10 +57,6 @@
                 .querySelectorAll('input.crud_bulk_actions_line_checkbox[data-primary-key-value]')
                 .forEach(elem => elem.checked = crud.checkedItems?.length && crud.checkedItems.indexOf(elem.dataset.primaryKeyValue) > -1);
         }
-
-        // activate checkbox if the page reloaded and the item is remembered as selected
-        // make it so that the function above is run after each DataTable draw event
-        crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
     }
 
     if (typeof addBulkActionMainCheckboxesFunctionality !== 'function') {
@@ -90,19 +82,18 @@
             // Stop propagation of href on the first column
             document.querySelectorAll('table td.dtr-control a').forEach(link => link.onclick = e => e.stopPropagation());
         }
-
-        // run this function on DataTable draw event
-        crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
     }
 
     if (typeof enableOrDisableBulkButtons !== 'function') {
         function enableOrDisableBulkButtons() {
             document.querySelectorAll('.bulk-button').forEach(btn => btn.classList.toggle('disabled', !crud.checkedItems?.length));
         }
-
-        // run this function on DataTable draw event
-        crud.addFunctionToDataTablesDrawEventQueue('enableOrDisableBulkButtons');
     }
+
+    crud.addFunctionToDataTablesDrawEventQueue('addOrRemoveCrudCheckedItem');
+    crud.addFunctionToDataTablesDrawEventQueue('markCheckboxAsCheckedIfPreviouslySelected');
+    crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
+    crud.addFunctionToDataTablesDrawEventQueue('enableOrDisableBulkButtons');
     </script>
     @endLoadOnce
 @endif


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

[Bulk actions didn't work in Safari](https://github.com/Laravel-Backpack/CRUD/issues/4188)

### AFTER - What is happening after this PR?

They do.


## HOW

### How did you achieve that, in technical terms?

Moved adding the functions to the datatables draw queue to the bottom of the file, like they were before https://github.com/Laravel-Backpack/CRUD/pull/3331/files#diff-f30982c331697c61e733b204a0df5d7a102aa1eacb8e051c66d56cf3c941c542



### Is it a breaking change or non-breaking change?

Non-breaking.

### How can we test the before & after?

Click bulk action checkbox in Safari, should now work.
