### PR TITLE
Validate field name attribute

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -32,6 +32,10 @@ class CrudField
 
     public function __construct($name)
     {
+        if(empty($field)) {
+            abort(500, 'Field name can\'t be empty.');
+        }
+
         $field = $this->crud()->firstFieldWhere('name', $name);
 
         // if field exists

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -32,7 +32,7 @@ class CrudField
 
     public function __construct($name)
     {
-        if(empty($name)) {
+        if (empty($name)) {
             abort(500, 'Field name can\'t be empty.');
         }
 

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -32,7 +32,7 @@ class CrudField
 
     public function __construct($name)
     {
-        if(empty($field)) {
+        if (empty($field)) {
             abort(500, 'Field name can\'t be empty.');
         }
 

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -32,7 +32,7 @@ class CrudField
 
     public function __construct($name)
     {
-        if (empty($field)) {
+        if(empty($name)) {
             abort(500, 'Field name can\'t be empty.');
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -107,7 +107,7 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasName($field)
     {
-        if(empty($field)) {
+        if (empty($field)) {
             abort(500, 'Field name can\'t be empty');
         }
 
@@ -256,8 +256,7 @@ trait FieldsProtectedMethods
         }
 
         foreach ($field['subfields'] as $key => $subfield) {
-
-            if(empty($field)) {
+            if (empty($field)) {
                 abort(500, 'Field name can\'t be empty');
             }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -107,6 +107,10 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasName($field)
     {
+        if(empty($field)) {
+            abort(500, 'Field name can\'t be empty');
+        }
+
         if (is_string($field)) {
             return ['name' => $field];
         }
@@ -252,6 +256,11 @@ trait FieldsProtectedMethods
         }
 
         foreach ($field['subfields'] as $key => $subfield) {
+
+            if(empty($field)) {
+                abort(500, 'Field name can\'t be empty');
+            }
+
             // make sure the field definition is an array
             if (is_string($subfield)) {
                 $subfield = ['name' => $subfield];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Field with empty string names were beeing allowed and raising weird errors. We should not allow that scenario to happen as we don't allow fields without name at all. 

Refs: #4250 

### AFTER - What is happening after this PR?

empty field names raise an error.


### Is it a breaking change?

No
