### PR TITLE
Use case insensitive search in PostgreSQL

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Carbon\Carbon;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
 use Validator;
 
 trait Search
@@ -61,11 +62,18 @@ trait Search
 
         // sensible fallback search logic, if none was explicitly given
         if ($column['tableColumn']) {
+
+            $like = 'like';
+
+            if ($query->getGrammar() instanceof PostgresGrammar) {
+                $like = 'ilike';
+            }
+
             switch ($columnType) {
                 case 'email':
                 case 'text':
                 case 'textarea':
-                    $query->orWhere($this->getColumnWithTableNamePrefixed($query, $column['name']), 'like', '%'.$searchTerm.'%');
+                    $query->orWhere($this->getColumnWithTableNamePrefixed($query, $column['name']), $like, '%'.$searchTerm.'%');
                     break;
 
                 case 'date':
@@ -82,7 +90,7 @@ trait Search
                 case 'select':
                 case 'select_multiple':
                     $query->orWhereHas($column['entity'], function ($q) use ($column, $searchTerm) {
-                        $q->where($this->getColumnWithTableNamePrefixed($q, $column['attribute']), 'like', '%'.$searchTerm.'%');
+                        $q->where($this->getColumnWithTableNamePrefixed($q, $column['attribute']), $like, '%'.$searchTerm.'%');
                     });
                     break;
 

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -62,7 +62,6 @@ trait Search
 
         // sensible fallback search logic, if none was explicitly given
         if ($column['tableColumn']) {
-
             $like = 'like';
 
             if ($query->getGrammar() instanceof PostgresGrammar) {


### PR DESCRIPTION
Use the ILIKE operator to search columns ignoring case

## WHY

### BEFORE - What was wrong? What was happening before this PR?
Searching in list views was case sensitive when using PostgreSQL leading to difficulties finding desired results.

### AFTER - What is happening after this PR?
Searches in list views return matching results regardless of their case in the database.

## HOW

### How did you achieve that, in technical terms?
By using PostgreSQL's ILIKE operator as described here: https://www.postgresql.org/docs/8.3/functions-matching.html

### Is it a breaking change?
No, unless there are any fringe users running PostgreSQL and expecting their searches to be very strict.

### How can we test the before & after?
#### Using PostgreSQL:
##### Before
Perform a search that exactly matches the case in a column, see results.
Perform the same search but with text that varies from data in column, see no results.
##### After
Perform a search that exactly matches the case in a column, see results.
Perform the same search but with text that varies from data in column, see results.

#### Using other drivers, eg. MySQL, SQLite
See no change in behavior.