### PR TITLE
Add fluent methods and macro for field validation

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -37,9 +37,6 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function boot(\Illuminate\Routing\Router $router)
     {
-        // load the macros
-        include_once __DIR__.'/macros.php';
-
         $this->loadViewsWithFallbacks();
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
         $this->loadConfigs();
@@ -57,6 +54,9 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // load the macros
+        include_once __DIR__.'/macros.php';
+
         // Bind the CrudPanel object to Laravel's service container
         $this->app->singleton('crud', function ($app) {
             return new CrudPanel($app);

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -38,7 +38,7 @@ class BackpackServiceProvider extends ServiceProvider
     public function boot(\Illuminate\Routing\Router $router)
     {
         // load the macros
-        include_once(__DIR__.'/macros.php');
+        include_once __DIR__.'/macros.php';
 
         $this->loadViewsWithFallbacks();
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -103,14 +103,15 @@ class BackpackServiceProvider extends ServiceProvider
         }
     }
 
-    public function registerMacros() {
+    public function registerMacros()
+    {
         /**
-         * This macro adds the ability to convert a dot.notation into a [braket][notation] with some special 
+         * This macro adds the ability to convert a dot.notation into a [braket][notation] with some special
          * options that helps us in our usecases.
-         * 
+         *
          * - $ignore, usefull when you want to convert a laravel validator rule for nested items and you
          *   would like to ignore the `*` element from the string.
-         *  
+         *
          * - $keyFirst, when true will use the first part of the string as key and only bracket the remaining elements.
          *   eg: `address.street`
          *      - when true: `address[street]`
@@ -126,6 +127,7 @@ class BackpackServiceProvider extends ServiceProvider
                 }
                 $result .= ($key === 0 && $keyFirst) ? $part : '['.$part.']';
             }
+
             return $result;
         });
     }

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 
 class BackpackServiceProvider extends ServiceProvider
 {
@@ -40,11 +39,12 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function boot(\Illuminate\Routing\Router $router)
     {
+        include(__DIR__.'/macros.php');
+        
         $this->loadViewsWithFallbacks();
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
         $this->loadConfigs();
         $this->registerMiddlewareGroup($this->app->router);
-        $this->registerMacros();
         $this->setupRoutes($this->app->router);
         $this->setupCustomRoutes($this->app->router);
         $this->publishFiles();
@@ -101,35 +101,6 @@ class BackpackServiceProvider extends ServiceProvider
         if (config('backpack.base.setup_password_recovery_routes')) {
             $router->aliasMiddleware('backpack.throttle.password.recovery', ThrottlePasswordRecovery::class);
         }
-    }
-
-    public function registerMacros()
-    {
-        /**
-         * This macro adds the ability to convert a dot.notation into a [braket][notation] with some special
-         * options that helps us in our usecases.
-         *
-         * - $ignore, usefull when you want to convert a laravel validator rule for nested items and you
-         *   would like to ignore the `*` element from the string.
-         *
-         * - $keyFirst, when true will use the first part of the string as key and only bracket the remaining elements.
-         *   eg: `address.street`
-         *      - when true: `address[street]`
-         *      - when false: `[address][street]`
-         */
-        Str::macro('dotsToSquareBrackets', function ($string, $ignore = [], $keyFirst = false) {
-            $stringParts = explode('.', $string);
-            $result = '';
-
-            foreach ($stringParts as $key => $part) {
-                if (in_array($part, $ignore)) {
-                    continue;
-                }
-                $result .= ($key === 0 && $keyFirst) ? $part : '['.$part.']';
-            }
-
-            return $result;
-        });
     }
 
     public function publishFiles()

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -6,8 +6,6 @@ use Backpack\CRUD\app\Http\Middleware\ThrottlePasswordRecovery;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class BackpackServiceProvider extends ServiceProvider
@@ -39,8 +37,9 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function boot(\Illuminate\Routing\Router $router)
     {
-        include(__DIR__.'/macros.php');
-        
+        // load the macros
+        include_once(__DIR__.'/macros.php');
+
         $this->loadViewsWithFallbacks();
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
         $this->loadConfigs();
@@ -67,12 +66,6 @@ class BackpackServiceProvider extends ServiceProvider
         $this->app->singleton('widgets', function ($app) {
             return new Collection();
         });
-
-        // load a macro for Route,
-        // helps developers load all routes for a CRUD resource in one line
-        if (! Route::hasMacro('crud')) {
-            $this->addRouteMacro();
-        }
 
         // register the helper functions
         $this->loadHelpers();
@@ -178,47 +171,6 @@ class BackpackServiceProvider extends ServiceProvider
         if (file_exists(base_path().$this->customRoutesFilePath)) {
             $this->loadRoutesFrom(base_path().$this->customRoutesFilePath);
         }
-    }
-
-    /**
-     * The route macro allows developers to generate the routes for a CrudController,
-     * for all operations, using a simple syntax: Route::crud().
-     *
-     * It will go to the given CrudController and get the setupRoutes() method on it.
-     */
-    private function addRouteMacro()
-    {
-        Route::macro('crud', function ($name, $controller) {
-            // put together the route name prefix,
-            // as passed to the Route::group() statements
-            $routeName = '';
-            if ($this->hasGroupStack()) {
-                foreach ($this->getGroupStack() as $key => $groupStack) {
-                    if (isset($groupStack['name'])) {
-                        if (is_array($groupStack['name'])) {
-                            $routeName = implode('', $groupStack['name']);
-                        } else {
-                            $routeName = $groupStack['name'];
-                        }
-                    }
-                }
-            }
-            // add the name of the current entity to the route name prefix
-            // the result will be the current route name (not ending in dot)
-            $routeName .= $name;
-
-            // get an instance of the controller
-            if ($this->hasGroupStack()) {
-                $groupStack = $this->getGroupStack();
-                $groupNamespace = $groupStack && isset(end($groupStack)['namespace']) ? end($groupStack)['namespace'].'\\' : '';
-            } else {
-                $groupNamespace = '';
-            }
-            $namespacedController = $groupNamespace.$controller;
-            $controllerInstance = App::make($namespacedController);
-
-            return $controllerInstance->setupRoutes($name, $routeName, $controller);
-        });
     }
 
     public function loadViewsWithFallbacks()

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -222,7 +222,7 @@ class CrudField
         $this->attributes['validationMessages'] = $messages;
 
         // append the field name to the rule name of validationMessages array.
-        // eg: ['required => 'This field is required'] 
+        // eg: ['required => 'This field is required']
         // will be transformed into: ['field_name.required' => 'This field is required]
         $this->crud()->setValidationFromArray([], array_merge(...array_map(function ($rule, $message) {
             return [$this->attributes['name'].'.'.$rule => $message];

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -203,9 +203,11 @@ class CrudField
      * @param  string  $rules  the field rules: required|min:1|max:5
      * @return self
      */
-    public function validationRules(string $rules) {
+    public function validationRules(string $rules)
+    {
         $this->attributes['validationRules'] = $rules;
         $this->crud()->setValidationFromArray([$this->attributes['name'] => $rules]);
+
         return $this;
     }
 
@@ -215,14 +217,16 @@ class CrudField
      * @param  array  $messages  the messages for field rules: [required => please input something, min => the minimum allowed is 1]
      * @return self
      */
-    public function validationMessages(array $messages) {
+    public function validationMessages(array $messages)
+    {
         $this->attributes['validationMessages'] = $messages;
 
-        $this->crud()->setValidationFromArray([], array_merge(...array_map(function($rule, $message) {
-                                                        return [$this->attributes['name'].'.'.$rule => $message]; 
-                                                    },array_keys($messages), $messages)
+        $this->crud()->setValidationFromArray([], array_merge(...array_map(function ($rule, $message) {
+            return [$this->attributes['name'].'.'.$rule => $message];
+        }, array_keys($messages), $messages)
                                                 )
                                             );
+
         return $this;
     }
 

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -25,6 +25,8 @@ namespace Backpack\CRUD\app\Library\CrudPanel;
  * @method self wrapper(array $value)
  * @method self fake(bool $value)
  * @method self store_in(string $value)
+ * @method self validationRules(string $value)
+ * @method self validationMessages(array $value)
  */
 class CrudField
 {
@@ -193,6 +195,35 @@ class CrudField
         $this->attributes = $this->crud()->makeSureFieldHasNecessaryAttributes($this->attributes);
 
         return $this->save();
+    }
+
+    /**
+     * Save the validation rules on the CrudPanel per field basis.
+     *
+     * @param  string  $rules  the field rules: required|min:1|max:5
+     * @return self
+     */
+    public function validationRules(string $rules) {
+        $this->attributes['validationRules'] = $rules;
+        $this->crud()->setValidationFromArray([$this->attributes['name'] => $rules]);
+        return $this;
+    }
+
+    /**
+     * Save the validation messages on the CrudPanel per field basis.
+     *
+     * @param  array  $messages  the messages for field rules: [required => please input something, min => the minimum allowed is 1]
+     * @return self
+     */
+    public function validationMessages(array $messages) {
+        $this->attributes['validationMessages'] = $messages;
+
+        $this->crud()->setValidationFromArray([], array_merge(...array_map(function($rule, $message) {
+                                                        return [$this->attributes['name'].'.'.$rule => $message]; 
+                                                    },array_keys($messages), $messages)
+                                                )
+                                            );
+        return $this;
     }
 
     // ---------------

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -221,11 +221,12 @@ class CrudField
     {
         $this->attributes['validationMessages'] = $messages;
 
+        // append the field name to the rule name of validationMessages array.
+        // eg: ['required => 'This field is required'] 
+        // will be transformed into: ['field_name.required' => 'This field is required]
         $this->crud()->setValidationFromArray([], array_merge(...array_map(function ($rule, $message) {
             return [$this->attributes['name'].'.'.$rule => $message];
-        }, array_keys($messages), $messages)
-                                                )
-                                            );
+        }, array_keys($messages), $messages)));
 
         return $this;
     }

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -262,7 +262,7 @@ trait Validation
                     (is_array($rule) && array_search('required', $rule) !== false && array_search('required_', $rule) === false)
                 ) {
                     if (Str::contains($key, '.')) {
-                        $key = Str::dotsToSquareBrackets($key, ['*'], true);
+                        $key = Str::dotsToSquareBrackets($key, ['*']);
                     }
 
                     $requiredFields[] = $key;
@@ -296,7 +296,7 @@ trait Validation
         }
 
         if (Str::contains($inputKey, '.')) {
-            $inputKey = Str::dotsToSquareBrackets($inputKey, ['*'], true);
+            $inputKey = Str::dotsToSquareBrackets($inputKey, ['*']);
         }
 
         return in_array($inputKey, $this->getOperationSetting('requiredFields'));

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -262,7 +262,7 @@ trait Validation
                     (is_array($rule) && array_search('required', $rule) !== false && array_search('required_', $rule) === false)
                 ) {
                     if (Str::contains($key, '.')) {
-                        $key = $this->getStringFromDotNotationToBrackets($key);
+                        $key = Str::dotsToSquareBrackets($key, ['*'], true);
                     }
 
                     $requiredFields[] = $key;
@@ -296,31 +296,10 @@ trait Validation
         }
 
         if (Str::contains($inputKey, '.')) {
-            $inputKey = $this->getStringFromDotNotationToBrackets($inputKey);
+            $inputKey = Str::dotsToSquareBrackets($inputKey, ['*'], true);
         }
 
         return in_array($inputKey, $this->getOperationSetting('requiredFields'));
-    }
-
-    /**
-     * Return the dot.notation.string as bracket[notation][string].
-     *
-     * @param  string  $string  field name or input name
-     * @return string
-     */
-    private function getStringFromDotNotationToBrackets(string $string)
-    {
-        $stringParts = explode('.', $string);
-        $result = '';
-
-        foreach ($stringParts as $key => $part) {
-            if ($part === '*') {
-                continue;
-            }
-            $result .= ($key === 0) ? $part : '['.$part.']';
-        }
-
-        return $result;
     }
 
     /**

--- a/src/macros.php
+++ b/src/macros.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Str;
+
+
+
+/**
+ * This macro adds the ability to convert a dot.notation string into a [braket][notation] with some special
+ * options that helps us in our usecases.
+ *
+ * - $ignore: usefull when you want to convert a laravel validator rule for nested items and you
+ *   would like to ignore the `*` element from the string.
+ *
+ * - $keyFirst: when true, we will use the first part of the string as key and only bracket the remaining elements.
+ *   eg: `address.street`
+ *      - when true: `address[street]`
+ *      - when false: `[address][street]`
+ */
+if (! Str::hasMacro('dotsToSquareBrackets')) {
+    Str::macro('dotsToSquareBrackets', function ($string, $ignore = [], $keyFirst = true) {
+        $stringParts = explode('.', $string);
+        $result = '';
+
+        foreach ($stringParts as $key => $part) {
+            if (in_array($part, $ignore)) {
+                continue;
+            }
+            $result .= ($key === 0 && $keyFirst) ? $part : '['.$part.']';
+        }
+
+        return $result;
+    });
+}

--- a/src/macros.php
+++ b/src/macros.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 

--- a/src/macros.php
+++ b/src/macros.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 
 /**

--- a/src/macros.php
+++ b/src/macros.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 /**

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\Tests;
 
+use Backpack\CRUD\BackpackServiceProvider;
 use Orchestra\Testbench\TestCase;
 
 abstract class BaseTest extends TestCase
@@ -14,5 +15,12 @@ abstract class BaseTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            BackpackServiceProvider::class,
+        ];
     }
 }


### PR DESCRIPTION
refs: #4220 & #4284 

Refactor the helper function into a `Str` macro with the default behaviour of what you expect from a `dot->bracket`, so for `something.here.fine` it by default returns `[something][here][fine]` as it is what is expected from `dot->bracket` conversion. 

We have special use-cases:
- `ignore` certain parts of the string (if we need further customization here we can make the `ignore` parameter a closure, so you can ignore the third key without knowing what is there in advance). We use it to ignore the `astherisc` in the validation rules for nested items.
- `firstKey` that we use in backpack to identify the grouped array so when it's true we return: `something[here][fine]`. 

Notes:
- Str::of('smt')->dotsToSquareBrackets() will not work since the macro is registered in `Str` not in `Stringable`, and you need to pass the `string` into the macro. So it's: `Str::dotsToSquareBrackets($string, $ignore = [], $keyFirst = false)`
