### PR TITLE
fix filters from custom namespace

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -148,7 +148,7 @@ class CrudFilter
         $namespaces = config('backpack.crud.view_namespaces.filters');
 
         if ($this->viewNamespace != 'crud::filters') {
-            $namespaces[] = $this->viewNamespace;
+            $namespaces = array_merge([$this->viewNamespace], $namespaces);
         }
 
         return array_map(function ($item) use ($type) {

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -145,10 +145,15 @@ class CrudFilter
     public function getNamespacedViewWithFallbacks()
     {
         $type = $this->type;
+        $namespaces = config('backpack.crud.view_namespaces.filters');
+
+        if ($this->viewNamespace != 'crud::filters') {
+            $namespaces[] = $this->viewNamespace;
+        }
 
         return array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, config('backpack.crud.view_namespaces.filters'));
+        }, $namespaces);
     }
 
     // ---------------------


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If you used a filter from a custom namespace, for example:
```php
        CRUD::filter('from_to')
            ->type('date_range_refresh')
            ->viewNamespace('feedback::filters')
            ->label('Date range')
            ->whenActive(function ($value) {
                $dates = json_decode($value);
                $this->crud->addClause('where', 'created_at', '>=', $dates->from);
                $this->crud->addClause('where', 'created_at', '<=', $dates->to . ' 23:59:59');
            });
```

You got a big fat error:
<img width="1281" alt="CleanShot 2022-03-25 at 19 39 53@2x" src="https://user-images.githubusercontent.com/1032474/160173323-8b3dde9f-5cb4-49e4-abba-6e3f41565f7d.png">

Because we were checking all filter namespaces defined in the config, but NEVER the filter namespace actually defined by the user.

### AFTER - What is happening after this PR?

No more error, it'll put the given namespace as the first one in the namespaces list.


## HOW

### How did you achieve that, in technical terms?

Code is self-explanatory.



### Is it a breaking change?

Non-breaking, it's a bug fix.


### How can we test the before & after?

Place a filter in a weird directory, then try to load it from there (you can use the syntax above). It won't work. After the PR... it'll work.