### PR TITLE
Use e() when dumping the exception message on error pages

### DIFF
--- a/src/resources/error_views/400.blade.php
+++ b/src/resources/error_views/400.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/401.blade.php
+++ b/src/resources/error_views/401.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/403.blade.php
+++ b/src/resources/error_views/403.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/404.blade.php
+++ b/src/resources/error_views/404.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/405.blade.php
+++ b/src/resources/error_views/405.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/408.blade.php
+++ b/src/resources/error_views/408.blade.php
@@ -13,5 +13,5 @@
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a>, refresh the page and try again.";
 
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/429.blade.php
+++ b/src/resources/error_views/429.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> and try again, or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/500.blade.php
+++ b/src/resources/error_views/500.blade.php
@@ -12,5 +12,5 @@
 	@php
 	  $default_error_message = "An internal server error has occurred. If the error persists please contact the development team.";
 	@endphp
-	{!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+	{!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection

--- a/src/resources/error_views/503.blade.php
+++ b/src/resources/error_views/503.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "The server is overloaded or down for maintenance. Please try again later.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection


### PR DESCRIPTION
When we were echoing the default exception message, we did not sanitize the message, so the GET parameter was echoed on page.