### PR TITLE
add viewNamespace alias to array definition for consistency

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -40,7 +40,7 @@ class CrudFilter
             $this->key = Str::camel($options['name']);
             $this->type = $options['type'] ?? $this->type;
             $this->label = $options['label'] ?? $this->crud()->makeLabel($this->name);
-            $this->viewNamespace = $options['view_namespace'] ?? $this->viewNamespace;
+            $this->viewNamespace = $options['viewNamespace'] ?? $options['view_namespace'] ?? $this->viewNamespace;
             $this->view = $this->type;
             $this->placeholder = $options['placeholder'] ?? '';
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Well ... I needed to go to the docs to view the field array definition for testing purposes as it was not working as with fluent `viewNamespace`. 

### AFTER - What is happening after this PR?

Added `viewNamespace` as an alias to `view_namespace` in filter definition


### Is it a breaking change?

I don't think so. 

Edit: this points to v5, but feel free to point to #4288 and merge this commit there. 