### PR TITLE
force-delete & restore button with full functionality

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -109,6 +109,10 @@ class CrudController extends Controller
          */
         $this->crud->applyConfigurationFromSettings($operationName);
 
+        if ($this->crud->hasAccess('forceDelete')) {
+            $this->crud->addClause('withTrashedFiltered');
+        }
+        
         /*
          * THEN, run the corresponding setupXxxOperation if it exists.
          */

--- a/src/app/Http/Controllers/Operations/ForceDeleteRestoreOperation.php
+++ b/src/app/Http/Controllers/Operations/ForceDeleteRestoreOperation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Siberfx\CRUD\app\Http\Controllers\Operations;
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Illuminate\Support\Facades\Route;
 

--- a/src/app/Http/Controllers/Operations/ForceDeleteRestoreOperation.php
+++ b/src/app/Http/Controllers/Operations/ForceDeleteRestoreOperation.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Siberfx\CRUD\app\Http\Controllers\Operations;
+
+use Illuminate\Support\Facades\Route;
+
+trait ForceDeleteRestoreOperation
+{
+    /**
+     * Define which routes are needed for this operation.
+     *
+     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
+     * @param string $routeName  Prefix of the route name.
+     * @param string $controller Name of the current CrudController.
+     */
+    protected function setupForceDeleteRestoreRoutes($segment, $routeName, $controller)
+    {
+        Route::delete($segment.'/{id}/forceDelete', [
+            'as'        => $routeName.'.forceDelete',
+            'uses'      => $controller.'@forceDelete',
+            'operation' => 'forceDelete',
+        ]);
+
+        Route::post($segment.'/{id}/restore', [
+            'as'        => $routeName.'.restore',
+            'uses'      => $controller.'@restore',
+            'operation' => 'restore',
+        ]);
+    }
+
+    /**
+     * Add the default settings, buttons, etc that this operation needs.
+     */
+    protected function setupForceDeleteDefaults()
+    {
+        $this->crud->allowAccess('forceDelete');
+        $this->crud->allowAccess('restore');
+
+        $this->crud->operation('forceDelete', function () {
+            $this->crud->loadDefaultOperationSettingsFromConfig();
+        });
+
+        $this->crud->operation('list', function () {
+            $this->crud->addButton('line', 'restore', 'view', 'crud::buttons.restore', 'end');
+            $this->crud->addButton('line', 'force-delete', 'view', 'crud::buttons.force-delete', 'end');
+
+        });
+    }
+
+    /**
+     * @param $id
+     * @return mixed
+     */
+    public function forceDelete($id)
+    {
+        $this->crud->hasAccessOrFail('forceDelete');
+
+        return $this->crud->model->withTrashed()->find($id)->forceDelete();
+
+    }
+
+
+    /**
+     * @param $id
+     * @return mixed
+     */
+    public function restore($id)
+    {
+        $this->crud->hasAccessOrFail('restore');
+
+        return $this->crud->model->withTrashed()->find($id)->restore();
+
+    }
+}

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Models\Traits;
 
+use Illuminate\Support\Facades\Schema;
+
 trait CrudTrait
 {
     use HasIdentifiableAttribute;
@@ -14,5 +16,25 @@ trait CrudTrait
     public static function hasCrudTrait()
     {
         return true;
+    }
+    
+    /**
+     * @return string
+     */
+    public static function getTableName(): string
+    {
+        return with(new static)->getTable();
+    }
+
+    /**
+     * @param $query
+     * @return mixed
+     */
+    public static function scopeWithTrashedFiltered($query)
+    {
+        if (Schema::hasColumn(self::getTableName(), 'deleted_at')) {
+            $query->withTrashed();
+        }
+        return $query;
     }
 }

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -42,6 +42,8 @@ return [
     'actions'                   => 'Actions',
     'preview'                   => 'Preview',
     'delete'                    => 'Delete',
+    'forceDelete'               => 'Permanently Delete',
+    'restore'                   => 'Restore',
     'admin'                     => 'Admin',
     'details_row'               => 'This is the details row. Modify as you please.',
     'details_row_loading_error' => 'There was an error loading the details. Please retry.',
@@ -57,6 +59,22 @@ return [
     'delete_confirmation_not_message'             => "There's been an error. Your item might not have been deleted.",
     'delete_confirmation_not_deleted_title'       => 'Not deleted',
     'delete_confirmation_not_deleted_message'     => 'Nothing happened. Your item is safe.',
+
+     'force_delete_confirm'                             => 'Are you sure you want to force to delete this item permanently?',
+    'force_delete_confirmation_title'                   => 'Item Permanently Deleted',
+    'force_delete_confirmation_message'                 => 'The item has been permanently deleted successfully.',
+    'force_delete_confirmation_not_title'               => 'NOT deleted',
+    'force_delete_confirmation_not_message'             => "There's been an error. Your item might not have been deleted.",
+    'force_delete_confirmation_not_deleted_title'       => 'Not deleted',
+    'force_delete_confirmation_not_deleted_message'     => 'Nothing happened. Your item is not permanently deleted.',
+
+    'restore_confirm'                              => 'Are you sure you want to restore this item?',
+    'restore_confirmation_title'                   => 'Item Is Restored',
+    'restore_confirmation_message'                 => 'The item has been restored successfully.',
+    'restore_confirmation_not_title'               => 'NOT restored',
+    'restore_confirmation_not_message'             => "There's been an error. Your item might not have been restored.",
+    'restore_confirmation_not_deleted_title'       => 'Not restored',
+    'restore_confirmation_not_deleted_message'     => 'Nothing happened. Your item is not restored.',
 
     // Bulk actions
     'bulk_no_entries_selected_title'   => 'No entries selected',

--- a/src/resources/views/crud/buttons/force-delete.blade.php
+++ b/src/resources/views/crud/buttons/force-delete.blade.php
@@ -1,0 +1,102 @@
+@if ($crud->hasAccess('forceDelete') && $entry->deleted_at !== null)
+	<a href="javascript:void(0)"
+       onclick="forceDeleteEntry(this)"
+       data-route="{{ url($crud->route.'/'.$entry->getKey().'/forceDelete') }}"
+       class="btn btn-sm btn-link"
+       data-button-type="forceDelete">
+        <i style="color: red" class="la la-times"></i>
+        @if(config('siberfx.base.action_title')){{ trans('siberfx::crud.forceDelete') }}@endif
+	</a>
+@endif
+
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+<script>
+
+	if (typeof forceDeleteEntry != 'function') {
+	  $("[data-button-type=forceDelete]").unbind('click');
+
+	  function forceDeleteEntry(button) {
+		// ask for confirmation before deleting an item
+		// e.preventDefault();
+		var route = $(button).attr('data-route');
+
+		swal({
+		  title: "{!! trans('siberfx::base.warning') !!}",
+		  text: "{!! trans('siberfx::crud.force_delete_confirm') !!}",
+		  icon: "warning",
+		  buttons: ["{!! trans('siberfx::crud.cancel') !!}", "{!! trans('siberfx::crud.delete') !!}"],
+		  dangerMode: true,
+		}).then((value) => {
+			if (value) {
+				$.ajax({
+			      url: route,
+			      type: 'DELETE',
+			      success: function(result) {
+			          if (result == 1) {
+						  // Redraw the table
+						  if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+							  // Move to previous page in case of deleting the only item in table
+							  if(crud.table.rows().count() === 1) {
+							    crud.table.page("previous");
+							  }
+
+							  crud.table.draw(false);
+						  }
+
+			          	  // Show a success notification bubble
+			              new Noty({
+		                    type: "success",
+		                    text: "{!! '<strong>'.trans('siberfx::crud.foce_delete_confirmation_title').'</strong><br>'.trans('siberfx::crud.force_delete_confirmation_message') !!}"
+		                  }).show();
+
+			              // Hide the modal, if any
+			              $('.modal').modal('hide');
+			          } else {
+			              // if the result is an array, it means
+			              // we have notification bubbles to show
+			          	  if (result instanceof Object) {
+			          	  	// trigger one or more bubble notifications
+			          	  	Object.entries(result).forEach(function(entry, index) {
+			          	  	  var type = entry[0];
+			          	  	  entry[1].forEach(function(message, i) {
+					          	  new Noty({
+				                    type: type,
+				                    text: message
+				                  }).show();
+			          	  	  });
+			          	  	});
+			          	  } else {// Show an error alert
+				              swal({
+				              	title: "{!! trans('siberfx::crud.force_delete_confirmation_not_title') !!}",
+	                            text: "{!! trans('siberfx::crud.force_delete_confirmation_not_message') !!}",
+				              	icon: "error",
+				              	timer: 4000,
+				              	buttons: false,
+				              });
+			          	  }
+			          }
+			      },
+			      error: function(result) {
+			          // Show an alert with the result
+			          swal({
+		              	title: "{!! trans('siberfx::crud.delete_confirmation_not_title') !!}",
+                        text: "{!! trans('siberfx::crud.delete_confirmation_not_message') !!}",
+		              	icon: "error",
+		              	timer: 4000,
+		              	buttons: false,
+		              });
+			      }
+			  });
+			}
+		});
+
+      }
+	}
+
+	// make it so that the function above is run after each DataTable draw event
+	// crud.addFunctionToDataTablesDrawEventQueue('forceDeleteEntry');
+</script>
+@if (!request()->ajax()) @endpush @endif

--- a/src/resources/views/crud/buttons/restore.blade.php
+++ b/src/resources/views/crud/buttons/restore.blade.php
@@ -1,0 +1,102 @@
+@if ($crud->hasAccess('restore') && $entry->deleted_at !== null)
+<a href="javascript:void(0)"
+   onclick="restoreEntry(this)"
+   data-route="{{ url($crud->route.'/'.$entry->getKey().'/restore') }}"
+   class="btn btn-sm btn-link"
+   data-button-type="restore">
+    <i style="color: green" class="la la-recycle"></i>
+    @if(config('siberfx.base.action_title')){{ trans('siberfx::crud.restore') }}@endif
+</a>
+@endif
+
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+<script>
+
+    if (typeof restoreEntry != 'function') {
+        $("[data-button-type=restore]").unbind('click');
+
+        function restoreEntry(button) {
+            // ask for confirmation before deleting an item
+            // e.preventDefault();
+            var route = $(button).attr('data-route');
+
+            swal({
+                title: "{!! trans('siberfx::base.notice') !!}",
+                text: "{!! trans('siberfx::crud.restore_confirm') !!}",
+                icon: "info",
+                buttons: ["{!! trans('siberfx::crud.cancel') !!}", "{!! trans('siberfx::crud.restore') !!}"],
+                dangerMode: true,
+            }).then((value) => {
+                if (value) {
+                    $.ajax({
+                        url: route,
+                        type: 'POST',
+                        success: function(result) {
+                            if (result == 1) {
+                                // Redraw the table
+                                if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+                                    // Move to previous page in case of deleting the only item in table
+                                    if(crud.table.rows().count() === 1) {
+                                        crud.table.page("previous");
+                                    }
+
+                                    crud.table.draw(false);
+                                }
+
+                                // Show a success notification bubble
+                                new Noty({
+                                    type: "success",
+                                    text: "{!! '<strong>'.trans('siberfx::crud.restore_confirmation_title').'</strong><br>'.trans('siberfx::crud.restore_confirmation_message') !!}"
+                                }).show();
+
+                                // Hide the modal, if any
+                                $('.modal').modal('hide');
+                            } else {
+                                // if the result is an array, it means
+                                // we have notification bubbles to show
+                                if (result instanceof Object) {
+                                    // trigger one or more bubble notifications
+                                    Object.entries(result).forEach(function(entry, index) {
+                                        var type = entry[0];
+                                        entry[1].forEach(function(message, i) {
+                                            new Noty({
+                                                type: type,
+                                                text: message
+                                            }).show();
+                                        });
+                                    });
+                                } else {// Show an error alert
+                                    swal({
+                                        title: "{!! trans('siberfx::crud.restore_confirmation_not_title') !!}",
+                                        text: "{!! trans('siberfx::crud.restore_confirmation_not_message') !!}",
+                                        icon: "info",
+                                        timer: 4000,
+                                        buttons: false,
+                                    });
+                                }
+                            }
+                        },
+                        error: function(result) {
+                            // Show an alert with the result
+                            swal({
+                                title: "{!! trans('siberfx::crud.restore_confirmation_not_title') !!}",
+                                text: "{!! trans('siberfx::crud.restore_confirmation_not_message') !!}",
+                                icon: "error",
+                                timer: 4000,
+                                buttons: false,
+                            });
+                        }
+                    });
+                }
+            });
+
+        }
+    }
+
+    // make it so that the function above is run after each DataTable draw event
+    // crud.addFunctionToDataTablesDrawEventQueue('restoreEntry');
+</script>
+@if (!request()->ajax()) @endpush @endif


### PR DESCRIPTION
## WHY
- just to contribute :)

### BEFORE - What was wrong? What was happening before this PR?

you dont have force delete and restore actions

### AFTER - What is happening after this PR?

generated new button sets for force-delete and restore, applied scope toqueries and added useful 2 methods in CrudTrait, 
checked in CrudController if has the access for forceDelete to be able to apply filterscope ( to avoid applying every model which has softdeletes to appear in list views even if the items are deleted )

## HOW

### How did you achieve that, in technical terms?

used your delete.blade.php just applied my own logic for both operations ( forceDelete, restore )

### Is it a breaking change?

it has to be :)


### How can we test the before & after?

just checking the code may bring the idea, its not complex change but it breaks nothing.
