### PR TITLE
Add fix command in 5.x

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -23,6 +23,7 @@ class BackpackServiceProvider extends ServiceProvider
         \Backpack\CRUD\app\Console\Commands\PublishBackpackMiddleware::class,
         \Backpack\CRUD\app\Console\Commands\PublishView::class,
         \Backpack\CRUD\app\Console\Commands\RequireDevTools::class,
+        \Backpack\CRUD\app\Console\Commands\Fix::class,
     ];
 
     // Indicates if loading of the provider is deferred.

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -3,8 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class Fix extends Command
 {
@@ -39,8 +37,9 @@ class Fix extends Command
         $this->line('Checking error views...');
 
         // check if the `resources/views/errors` directory exists
-        if (!is_dir($errorsDirectory)) {
+        if (! is_dir($errorsDirectory)) {
             $this->info('Your error views are not vulnerable. Nothing to do here.');
+
             return;
         }
 
@@ -51,8 +50,9 @@ class Fix extends Command
         });
 
         // check if there are actually views inside the directory
-        if (!count($views)) {
+        if (! count($views)) {
             $this->info('Your error views are not vulnerable. Nothing to do here.');
+
             return;
         }
 

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -76,7 +76,7 @@ class Fix extends Command
 
             if ($new_contents != $contents) {
                 file_put_contents($errorsDirectory.'/'.$view, $new_contents);
-                $this->info($view.' has been fixed.');
+                $this->warn($view.' has been fixed.');
                 continue;
             }
 

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class Fix extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:fix';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix known Backpack security issues.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->fixErrorViews();
+    }
+
+    private function fixErrorViews()
+    {
+        $errorsDirectory = base_path('resources/views/errors');
+
+        $this->line('Checking error views...');
+
+        // check if the `resources/views/errors` directory exists
+        if (!is_dir($errorsDirectory)) {
+            $this->info('Your error views are not vulnerable. Nothing to do here.');
+            return;
+        }
+
+        $views = scandir($errorsDirectory);
+        $views = array_filter($views, function ($file) {
+            // eliminate ".", ".." and any hidden files like .gitignore or .gitkeep
+            return substr($file, 0, 1) != '.';
+        });
+
+        // check if there are actually views inside the directory
+        if (!count($views)) {
+            $this->info('Your error views are not vulnerable. Nothing to do here.');
+            return;
+        }
+
+        $autofixed = true;
+        foreach ($views as $key => $view) {
+            $contents = file_get_contents($errorsDirectory.'/'.$view);
+
+            // does it even work with exception messages?
+            if (strpos($contents, '->getMessage()') == false) {
+                continue;
+            }
+
+            // does it already escape the exception message?
+            if (strpos($contents, 'e($exception->getMessage())') !== false) {
+                $this->info($view.' was ok.');
+                continue;
+            }
+
+            // cover the most likely scenario, where the file has not been edited at all
+            $new_contents = str_replace('$exception->getMessage()?$exception->getMessage():$default_error_message', '$exception->getMessage()?e($exception->getMessage()):$default_error_message', $contents);
+
+            if ($new_contents != $contents) {
+                file_put_contents($errorsDirectory.'/'.$view, $new_contents);
+                $this->info($view.' has been fixed.');
+                continue;
+            }
+
+            $this->error($view.' could not be fixed automatically.');
+            $autofixed = false;
+        }
+
+        if ($autofixed == false) {
+            $this->error('Some error views could not be fixed automatically. Please look inside your "resources/views/errors" directory and make sure exception messages are escaped before outputting. It should be e($exception->getMessage()) instead of $exception->getMessage(). Alternatively, outputting should be done using {{ }} instead of {!! !!}');
+        }
+    }
+}

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -18,7 +18,7 @@ class Fix extends Command
      *
      * @var string
      */
-    protected $description = 'Fix known Backpack security issues.';
+    protected $description = 'Fix known Backpack issues.';
 
     /**
      * Execute the console command.

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Console\Commands;
 
+use Artisan;
 use Illuminate\Console\Command;
 
 class Fix extends Command
@@ -28,6 +29,15 @@ class Fix extends Command
     public function handle()
     {
         $this->fixErrorViews();
+
+        if ($this->confirm('[SUGGESTION] Would you like to publish updated JS & CSS dependencies to public/packages?', false)) {
+            Artisan::call('vendor:publish', [
+                '--provider' => 'Backpack\CRUD\BackpackServiceProvider',
+                '--tag' => 'assets',
+                '--force' => 'true',
+            ]);
+            $this->info('Published latest CSS and JS assets to your public/packages directory.');
+        }
     }
 
     private function fixErrorViews()


### PR DESCRIPTION
This adds a `php artisan backpack:fix` command, that will see check for stuff. First (and only) thing it does is see if exception messages are escaped in your error views. But we could add more things later, if needed.