### PR TITLE
Add fix command in 4.0

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -19,6 +19,7 @@ class BackpackServiceProvider extends ServiceProvider
         \Backpack\CRUD\app\Console\Commands\PublishBackpackUserModel::class,
         \Backpack\CRUD\app\Console\Commands\PublishBackpackMiddleware::class,
         \Backpack\CRUD\app\Console\Commands\PublishView::class,
+        \Backpack\CRUD\app\Console\Commands\Fix::class,
     ];
 
     // Indicates if loading of the provider is deferred.

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -3,8 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class Fix extends Command
 {
@@ -39,8 +37,9 @@ class Fix extends Command
         $this->line('Checking error views...');
 
         // check if the `resources/views/errors` directory exists
-        if (!is_dir($errorsDirectory)) {
+        if (! is_dir($errorsDirectory)) {
             $this->info('Your error views are not vulnerable. Nothing to do here.');
+
             return;
         }
 
@@ -51,8 +50,9 @@ class Fix extends Command
         });
 
         // check if there are actually views inside the directory
-        if (!count($views)) {
+        if (! count($views)) {
             $this->info('Your error views are not vulnerable. Nothing to do here.');
+
             return;
         }
 

--- a/src/app/Console/Commands/Fix.php
+++ b/src/app/Console/Commands/Fix.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class Fix extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:fix';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix known Backpack security issues.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->fixErrorViews();
+    }
+
+    private function fixErrorViews()
+    {
+        $errorsDirectory = base_path('resources/views/errors');
+
+        $this->line('Checking error views...');
+
+        // check if the `resources/views/errors` directory exists
+        if (!is_dir($errorsDirectory)) {
+            $this->info('Your error views are not vulnerable. Nothing to do here.');
+            return;
+        }
+
+        $views = scandir($errorsDirectory);
+        $views = array_filter($views, function ($file) {
+            // eliminate ".", ".." and any hidden files like .gitignore or .gitkeep
+            return substr($file, 0, 1) != '.';
+        });
+
+        // check if there are actually views inside the directory
+        if (!count($views)) {
+            $this->info('Your error views are not vulnerable. Nothing to do here.');
+            return;
+        }
+
+        $autofixed = true;
+        foreach ($views as $key => $view) {
+            $contents = file_get_contents($errorsDirectory.'/'.$view);
+
+            // does it even work with exception messages?
+            if (strpos($contents, '->getMessage()') == false) {
+                continue;
+            }
+
+            // does it already escape the exception message?
+            if (strpos($contents, 'e($exception->getMessage())') !== false) {
+                $this->info($view.' was ok.');
+                continue;
+            }
+
+            // cover the most likely scenario, where the file has not been edited at all
+            $new_contents = str_replace('$exception->getMessage()?$exception->getMessage():$default_error_message', '$exception->getMessage()?e($exception->getMessage()):$default_error_message', $contents);
+
+            if ($new_contents != $contents) {
+                file_put_contents($errorsDirectory.'/'.$view, $new_contents);
+                $this->info($view.' has been fixed.');
+                continue;
+            }
+
+            $this->error($view.' could not be fixed automatically.');
+            $autofixed = false;
+        }
+
+        if ($autofixed == false) {
+            $this->error('Some error views could not be fixed automatically. Please look inside your "resources/views/errors" directory and make sure exception messages are escaped before outputting. It should be e($exception->getMessage()) instead of $exception->getMessage(). Alternatively, outputting should be done using {{ }} instead of {!! !!}');
+        }
+    }
+}

--- a/src/resources/error_views/400.blade.php
+++ b/src/resources/error_views/400.blade.php
@@ -12,5 +12,5 @@
   @php
     $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
   @endphp
-  {!! isset($exception)? ($exception->getMessage()?$e(exception->getMessage()):$default_error_message): $default_error_message !!}
+  {!! isset($exception)? ($exception->getMessage()?e($exception->getMessage()):$default_error_message): $default_error_message !!}
 @endsection


### PR DESCRIPTION
This is a BLIND PR. It _should_ work, because it does in 4.1 and 5.x, but I was NOT able to test this yet, because I couldn't convince my sustem to install php 7.2 any more.

This needs testing with PHP 7.2 and L7 (or L6) before merging.

Can someone help me out please? Does someone still have it or can easily switch? The easiest way to test this was to install a fresh copy of Laravel, and Backpack 4.0 on top.