### PR TITLE
Fix for translatable models to use the crud query too

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -75,6 +75,7 @@ trait Read
     {
         // build the model query from the main crud query
         $this->model = $this->model->setQuery($this->query->getQuery())->getModel();
+
         return $this->model->findOrFail($id);
     }
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -55,14 +55,21 @@ trait Read
      */
     public function getEntry($id)
     {
-        // build the model query from the main crud query
-        $this->model = $this->model->setQuery($this->query->getQuery())->getModel();
         if (! $this->entry) {
-            $this->entry = $this->model->findOrFail($id);
+            $this->entry = $this->getModelWithCrudQuery()->findOrFail($id);
             $this->entry = $this->entry->withFakes();
         }
 
         return $this->entry;
+    }
+
+    /**
+     * Return a Model builder instance with the current crud query applied.
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    private function getModelWithCrudQuery() {
+        return $this->model->setQuery($this->query->getQuery());
     }
 
     /**
@@ -73,10 +80,7 @@ trait Read
      */
     public function getEntryWithoutFakes($id)
     {
-        // build the model query from the main crud query
-        $this->model = $this->model->setQuery($this->query->getQuery())->getModel();
-
-        return $this->model->findOrFail($id);
+        return $this->getModelWithCrudQuery()->findOrFail($id);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -65,10 +65,11 @@ trait Read
 
     /**
      * Return a Model builder instance with the current crud query applied.
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    private function getModelWithCrudQuery() {
+    private function getModelWithCrudQuery()
+    {
         return $this->model->setQuery($this->query->getQuery());
     }
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -68,7 +68,7 @@ trait Read
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    private function getModelWithCrudQuery()
+    public function getModelWithCrudPanelQuery()
     {
         return $this->model->setQuery($this->query->getQuery());
     }

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -55,8 +55,10 @@ trait Read
      */
     public function getEntry($id)
     {
+        // build the model query from the main crud query
+        $this->model = $this->model->setQuery($this->query->getQuery())->getModel();
         if (! $this->entry) {
-            $this->entry = $this->query->findOrFail($id);
+            $this->entry = $this->model->findOrFail($id);
             $this->entry = $this->entry->withFakes();
         }
 
@@ -71,7 +73,9 @@ trait Read
      */
     public function getEntryWithoutFakes($id)
     {
-        return $this->query->findOrFail($id);
+        // build the model query from the main crud query
+        $this->model = $this->model->setQuery($this->query->getQuery())->getModel();
+        return $this->model->findOrFail($id);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -56,7 +56,7 @@ trait Read
     public function getEntry($id)
     {
         if (! $this->entry) {
-            $this->entry = $this->getModelWithCrudQuery()->findOrFail($id);
+            $this->entry = $this->getModelWithCrudPanelQuery()->findOrFail($id);
             $this->entry = $this->entry->withFakes();
         }
 
@@ -81,7 +81,7 @@ trait Read
      */
     public function getEntryWithoutFakes($id)
     {
-        return $this->getModelWithCrudQuery()->findOrFail($id);
+        return $this->getModelWithCrudPanelQuery()->findOrFail($id);
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

So I tried to fix a problem in #4259 , that was the fact that the `getEntry()` didn't respect the query constrains that you setup in your CrudPanels. I forgot about the fact that translatable field overwritte the calls to some methods like `find, findOrFail` etc and those methods were not properly called.

### AFTER - What is happening after this PR?

After this PR, instead of using the `query` directly, we setup the query in the model and go back to using the model. This solution covers the regular cases and the translatable ones as reported in #4307 

## HOW

### How did you achieve that, in technical terms?

By setting the model base query to whatever query you have in your crud, for example, if you use an `active()` scope `$this->crud->query->active()`. 

### Is it a breaking change?

Nop, it's a fix, we only moved the query inside the model instead of using it directly, so the translatable magic methods gets called.

### How can we test the before & after?

In a translatable crud (Products in demo), Create an entry, translate it in some language and you will see that no matter what language you are in, you always get the "default" language, because the magic methods in `HasTranslations` are not called. 
