### PR TITLE
mention pro when view not found for fields as a suggestion

### DIFF
--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -11,14 +11,15 @@ class BackpackProRequiredException extends \Exception
      * @return \Illuminate\Http\Response
      */
     public function render($request)
-    {   
+    {
         // 0, by default, pass only what is a feature we construct the rest of the message
-        // 1 use the provided message in full 
-        switch($this->getCode()) {
+        // 1 use the provided message in full
+        switch ($this->getCode()) {
             case 0:
                 $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.';
                 break;
         }
+
         return response(view('errors.500', ['exception' => $this]), 500);
     }
 }

--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Backpack\CRUD\app\Exceptions;
+
+class BackpackProRequiredException extends \Exception
+{
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.';
+        return response(view('errors.500', ['exception' => $this]), 500);
+    }
+}

--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -16,7 +16,7 @@ class BackpackProRequiredException extends \Exception
         // 1 use the provided message in full
         switch ($this->getCode()) {
             case 0:
-                $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.';
+                $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install the Backpack\PRO addon from backpackforlaravel.com';
                 break;
         }
 

--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -11,8 +11,14 @@ class BackpackProRequiredException extends \Exception
      * @return \Illuminate\Http\Response
      */
     public function render($request)
-    {
-        $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.';
+    {   
+        // 0, by default, pass only what is a feature we construct the rest of the message
+        // 1 use the provided message in full 
+        switch($this->getCode()) {
+            case 0:
+                $this->message = $this->message.' is a Backpack PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.';
+                break;
+        }
         return response(view('errors.500', ['exception' => $this]), 500);
     }
 }

--- a/src/app/Http/Controllers/ChartController.php
+++ b/src/app/Http/Controllers/ChartController.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
-class ChartController extends \Backpack\Pro\Http\Controllers\ChartController
-{
+if ( backpack_pro()) {
+    class ChartController extends \Backpack\Pro\Http\Controllers\ChartController
+    {
+    }
 }

--- a/src/app/Http/Controllers/ChartController.php
+++ b/src/app/Http/Controllers/ChartController.php
@@ -2,7 +2,7 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
-if ( backpack_pro()) {
+if (backpack_pro()) {
     class ChartController extends \Backpack\Pro\Http\Controllers\ChartController
     {
     }

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -36,7 +36,7 @@ class CrudController extends Controller
             $this->crud = app()->make('crud');
 
             $this->crud->setRequest($request);
-            
+
             $this->setupDefaults();
             $this->setup();
             $this->setupConfigurationForCurrentOperation();

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -36,9 +36,7 @@ class CrudController extends Controller
             $this->crud = app()->make('crud');
 
             $this->crud->setRequest($request);
-
-            $this->initializeOperationTraits();
-
+            
             $this->setupDefaults();
             $this->setup();
             $this->setupConfigurationForCurrentOperation();
@@ -117,36 +115,6 @@ class CrudController extends Controller
          */
         if (method_exists($this, $setupClassName)) {
             $this->{$setupClassName}();
-        }
-    }
-
-    /**
-     * This function calls the initialize functions from the Operations traits.
-     *
-     * Aims to simulate the `bootTraitName` functionality that Laravel provides for Models
-     * allowing the Operation traits to have an "initialization" function.
-     *
-     * We look for traits that follow the `Operations` naming convention ending with `Operation`.
-     * In the found traits we will look for a method with the signature: `initializeTraitName`
-     *
-     * @return void
-     */
-    private function initializeOperationTraits()
-    {
-        $traits = get_declared_traits() ?? [];
-
-        foreach ($traits as $trait) {
-            $traitName = Str::afterLast($trait, '\\');
-
-            if (! Str::endsWith($traitName, 'Operation')) {
-                continue;
-            }
-
-            $method = 'initialize'.$traitName;
-
-            if (method_exists($this, $method)) {
-                $this->{$method}();
-            }
         }
     }
 }

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -33,8 +33,12 @@ class CrudController extends Controller
         // It's done inside a middleware closure in order to have
         // the complete request inside the CrudPanel object.
         $this->middleware(function ($request, $next) {
+            
             $this->crud = app()->make('crud');
+
             $this->crud->setRequest($request);
+
+            $this->initializeOperationTraits();
 
             $this->setupDefaults();
             $this->setup();
@@ -115,5 +119,35 @@ class CrudController extends Controller
         if (method_exists($this, $setupClassName)) {
             $this->{$setupClassName}();
         }
+    }
+
+    /**
+     * This function calls the initialize functions from the Operations traits.
+     * 
+     * Aims to simulate the `bootTraitName` functionality that Laravel provides for Models
+     * allowing the Operation traits to have an "initialization" function.
+     * 
+     * We look for traits that follow the `Operations` naming convention ending with `Operation`.
+     * In the found traits we will look for a method with the signature: `initializeTraitName`
+     * 
+     * @return void
+     * 
+     */
+    private function initializeOperationTraits() {
+        $traits = get_declared_traits() ?? [];
+
+        foreach($traits as $trait) {
+            $traitName = Str::afterLast($trait, '\\');
+
+            if (!Str::endsWith($traitName, 'Operation')) {
+                continue;
+            }
+
+            $method = 'initialize'.$traitName;
+
+            if(method_exists($this, $method)) {
+                $this->{$method}();
+            }
+        } 
     }
 }

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -33,7 +33,6 @@ class CrudController extends Controller
         // It's done inside a middleware closure in order to have
         // the complete request inside the CrudPanel object.
         $this->middleware(function ($request, $next) {
-            
             $this->crud = app()->make('crud');
 
             $this->crud->setRequest($request);
@@ -123,31 +122,31 @@ class CrudController extends Controller
 
     /**
      * This function calls the initialize functions from the Operations traits.
-     * 
+     *
      * Aims to simulate the `bootTraitName` functionality that Laravel provides for Models
      * allowing the Operation traits to have an "initialization" function.
-     * 
+     *
      * We look for traits that follow the `Operations` naming convention ending with `Operation`.
      * In the found traits we will look for a method with the signature: `initializeTraitName`
-     * 
+     *
      * @return void
-     * 
      */
-    private function initializeOperationTraits() {
+    private function initializeOperationTraits()
+    {
         $traits = get_declared_traits() ?? [];
 
-        foreach($traits as $trait) {
+        foreach ($traits as $trait) {
             $traitName = Str::afterLast($trait, '\\');
 
-            if (!Str::endsWith($traitName, 'Operation')) {
+            if (! Str::endsWith($traitName, 'Operation')) {
                 continue;
             }
 
             $method = 'initialize'.$traitName;
 
-            if(method_exists($this, $method)) {
+            if (method_exists($this, $method)) {
                 $this->{$method}();
             }
-        } 
+        }
     }
 }

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -2,7 +2,24 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-trait BulkCloneOperation
-{
-    use \Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation;
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::class)) {
+    trait ProBulkCloneOperation {
+        public function initializeProBulkCloneOperation() {
+            throw new BackpackProRequiredException('BulkCloneOperation');
+        }
+    }
+}
+
+if(trait_exists(ProBulkCloneOperation::class)) {
+    trait BulkCloneOperation
+    {
+        use ProBulkCloneOperation;
+    }
+}else{
+    trait BulkCloneOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation;
+    }   
 }

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -5,23 +5,25 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 $loadFakeTrait = false;
-if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::class)) {
+if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::class)) {
     $loadFakeTrait = true;
-    trait ProBulkCloneOperation {
-        public function initializeProBulkCloneOperation() {
+    trait ProBulkCloneOperation
+    {
+        public function initializeProBulkCloneOperation()
+        {
             throw new BackpackProRequiredException('BulkCloneOperation');
         }
     }
 }
 
-if($loadFakeTrait) {
+if ($loadFakeTrait) {
     trait BulkCloneOperation
     {
         use ProBulkCloneOperation;
     }
-}else{
+} else {
     trait BulkCloneOperation
     {
         use \Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation;
-    }   
+    }
 }

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -5,19 +5,12 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 if (! backpack_pro()) {
-    trait ProBulkCloneOperation
+    trait BulkCloneOperation
     {
         public function setupBulkCloneOperationDefaults()
         {
             throw new BackpackProRequiredException('BulkCloneOperation');
         }
-    }
-}
-
-if (! backpack_pro()) {
-    trait BulkCloneOperation
-    {
-        use ProBulkCloneOperation;
     }
 } else {
     trait BulkCloneOperation

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -4,7 +4,9 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
+$loadFakeTrait = false;
 if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::class)) {
+    $loadFakeTrait = true;
     trait ProBulkCloneOperation {
         public function initializeProBulkCloneOperation() {
             throw new BackpackProRequiredException('BulkCloneOperation');
@@ -12,7 +14,7 @@ if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::c
     }
 }
 
-if(trait_exists(ProBulkCloneOperation::class)) {
+if($loadFakeTrait) {
     trait BulkCloneOperation
     {
         use ProBulkCloneOperation;

--- a/src/app/Http/Controllers/Operations/BulkCloneOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkCloneOperation.php
@@ -4,19 +4,17 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
-$loadFakeTrait = false;
-if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkCloneOperation::class)) {
-    $loadFakeTrait = true;
+if (! backpack_pro()) {
     trait ProBulkCloneOperation
     {
-        public function initializeProBulkCloneOperation()
+        public function setupBulkCloneOperationDefaults()
         {
             throw new BackpackProRequiredException('BulkCloneOperation');
         }
     }
 }
 
-if ($loadFakeTrait) {
+if (! backpack_pro()) {
     trait BulkCloneOperation
     {
         use ProBulkCloneOperation;

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -5,23 +5,25 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 $loadFakeTrait = false;
-if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::class)) {
+if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::class)) {
     $loadFakeTrait = true;
-    trait ProBulkDeleteOperation {
-        public function initializeProBulkDeleteOperation() {
+    trait ProBulkDeleteOperation
+    {
+        public function initializeProBulkDeleteOperation()
+        {
             throw new BackpackProRequiredException('BulkDeleteOperation');
         }
     }
 }
 
-if($loadFakeTrait) {
+if ($loadFakeTrait) {
     trait BulkDeleteOperation
     {
         use ProBulkDeleteOperation;
     }
-}else{
+} else {
     trait BulkDeleteOperation
     {
         use \Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation;
-    }   
+    }
 }

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -4,19 +4,17 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
-$loadFakeTrait = false;
-if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::class)) {
-    $loadFakeTrait = true;
+if (! backpack_pro()) {
     trait ProBulkDeleteOperation
     {
-        public function initializeProBulkDeleteOperation()
+        public function setupBulkDeleteOperationDefaults()
         {
             throw new BackpackProRequiredException('BulkDeleteOperation');
         }
     }
 }
 
-if ($loadFakeTrait) {
+if (! backpack_pro()) {
     trait BulkDeleteOperation
     {
         use ProBulkDeleteOperation;

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -2,7 +2,24 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-trait BulkDeleteOperation
-{
-    use \Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation;
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::class)) {
+    trait ProBulkDeleteOperation {
+        public function initializeProBulkDeleteOperation() {
+            throw new BackpackProRequiredException('BulkDeleteOperation');
+        }
+    }
+}
+
+if(trait_exists(ProBulkDeleteOperation::class)) {
+    trait BulkDeleteOperation
+    {
+        use ProBulkDeleteOperation;
+    }
+}else{
+    trait BulkDeleteOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation;
+    }   
 }

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -4,7 +4,9 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
+$loadFakeTrait = false;
 if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::class)) {
+    $loadFakeTrait = true;
     trait ProBulkDeleteOperation {
         public function initializeProBulkDeleteOperation() {
             throw new BackpackProRequiredException('BulkDeleteOperation');
@@ -12,7 +14,7 @@ if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\BulkDeleteOperation::
     }
 }
 
-if(trait_exists(ProBulkDeleteOperation::class)) {
+if($loadFakeTrait) {
     trait BulkDeleteOperation
     {
         use ProBulkDeleteOperation;

--- a/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkDeleteOperation.php
@@ -5,19 +5,12 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 if (! backpack_pro()) {
-    trait ProBulkDeleteOperation
+    trait BulkDeleteOperation
     {
         public function setupBulkDeleteOperationDefaults()
         {
             throw new BackpackProRequiredException('BulkDeleteOperation');
         }
-    }
-}
-
-if (! backpack_pro()) {
-    trait BulkDeleteOperation
-    {
-        use ProBulkDeleteOperation;
     }
 } else {
     trait BulkDeleteOperation

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -4,7 +4,9 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
+$loadFakeTrait = false;
 if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class)) {
+    $loadFakeTrait = true;
     trait ProCloneOperation {
         public function initializeProCloneOperation() {
             throw new BackpackProRequiredException('CloneOperation');
@@ -12,7 +14,7 @@ if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class
     }
 }
 
-if(trait_exists(ProCloneOperation::class)) {
+if($loadFakeTrait) {
     trait CloneOperation
     {
         use ProCloneOperation;

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -4,19 +4,17 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
-$loadFakeTrait = false;
-if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class)) {
-    $loadFakeTrait = true;
+if (! backpack_pro()) {
     trait ProCloneOperation
     {
-        public function initializeProCloneOperation()
+        public function setupCloneOperationDefaults()
         {
             throw new BackpackProRequiredException('CloneOperation');
         }
     }
 }
 
-if ($loadFakeTrait) {
+if (! backpack_pro()) {
     trait CloneOperation
     {
         use ProCloneOperation;

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -5,23 +5,25 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 $loadFakeTrait = false;
-if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class)) {
+if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class)) {
     $loadFakeTrait = true;
-    trait ProCloneOperation {
-        public function initializeProCloneOperation() {
+    trait ProCloneOperation
+    {
+        public function initializeProCloneOperation()
+        {
             throw new BackpackProRequiredException('CloneOperation');
         }
     }
 }
 
-if($loadFakeTrait) {
+if ($loadFakeTrait) {
     trait CloneOperation
     {
         use ProCloneOperation;
     }
-}else{
+} else {
     trait CloneOperation
     {
         use \Backpack\Pro\Http\Controllers\Operations\CloneOperation;
-    }   
+    }
 }

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -2,7 +2,24 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-trait CloneOperation
-{
-    use \Backpack\Pro\Http\Controllers\Operations\CloneOperation;
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\CloneOperation::class)) {
+    trait ProCloneOperation {
+        public function initializeProCloneOperation() {
+            throw new BackpackProRequiredException('CloneOperation');
+        }
+    }
+}
+
+if(trait_exists(ProCloneOperation::class)) {
+    trait CloneOperation
+    {
+        use ProCloneOperation;
+    }
+}else{
+    trait CloneOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\CloneOperation;
+    }   
 }

--- a/src/app/Http/Controllers/Operations/CloneOperation.php
+++ b/src/app/Http/Controllers/Operations/CloneOperation.php
@@ -5,19 +5,12 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 if (! backpack_pro()) {
-    trait ProCloneOperation
+    trait CloneOperation
     {
         public function setupCloneOperationDefaults()
         {
             throw new BackpackProRequiredException('CloneOperation');
         }
-    }
-}
-
-if (! backpack_pro()) {
-    trait CloneOperation
-    {
-        use ProCloneOperation;
     }
 } else {
     trait CloneOperation

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -4,7 +4,9 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
+$loadFakeTrait = false;
 if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class)) {
+    $loadFakeTrait = true;
     trait ProFetchOperation {
         public function initializeProFetchOperation() {
             throw new BackpackProRequiredException('FetchOperation');
@@ -12,7 +14,7 @@ if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class
     }
 }
 
-if(trait_exists(ProFetchOperation::class)) {
+if($loadFakeTrait) {
     trait FetchOperation
     {
         use ProFetchOperation;

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -5,23 +5,25 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 $loadFakeTrait = false;
-if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class)) {
+if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class)) {
     $loadFakeTrait = true;
-    trait ProFetchOperation {
-        public function initializeProFetchOperation() {
+    trait ProFetchOperation
+    {
+        public function initializeProFetchOperation()
+        {
             throw new BackpackProRequiredException('FetchOperation');
         }
     }
 }
 
-if($loadFakeTrait) {
+if ($loadFakeTrait) {
     trait FetchOperation
     {
         use ProFetchOperation;
     }
-}else{
+} else {
     trait FetchOperation
     {
         use \Backpack\Pro\Http\Controllers\Operations\FetchOperation;
-    }   
+    }
 }

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -2,7 +2,24 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-trait FetchOperation
-{
-    use \Backpack\Pro\Http\Controllers\Operations\FetchOperation;
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class)) {
+    trait ProFetchOperation {
+        public function initializeProFetchOperation() {
+            throw new BackpackProRequiredException('FetchOperation');
+        }
+    }
+}
+
+if(trait_exists(ProFetchOperation::class)) {
+    trait FetchOperation
+    {
+        use ProFetchOperation;
+    }
+}else{
+    trait FetchOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\FetchOperation;
+    }   
 }

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -4,19 +4,17 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
-$loadFakeTrait = false;
-if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\FetchOperation::class)) {
-    $loadFakeTrait = true;
+if (! backpack_pro()) {
     trait ProFetchOperation
     {
-        public function initializeProFetchOperation()
+        public function setupFetchOperationDefaults()
         {
             throw new BackpackProRequiredException('FetchOperation');
         }
     }
 }
 
-if ($loadFakeTrait) {
+if (! backpack_pro()) {
     trait FetchOperation
     {
         use ProFetchOperation;

--- a/src/app/Http/Controllers/Operations/FetchOperation.php
+++ b/src/app/Http/Controllers/Operations/FetchOperation.php
@@ -5,19 +5,12 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 if (! backpack_pro()) {
-    trait ProFetchOperation
+    trait FetchOperation
     {
         public function setupFetchOperationDefaults()
         {
             throw new BackpackProRequiredException('FetchOperation');
         }
-    }
-}
-
-if (! backpack_pro()) {
-    trait FetchOperation
-    {
-        use ProFetchOperation;
     }
 } else {
     trait FetchOperation

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -5,23 +5,25 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 $loadFakeTrait = false;
-if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation::class)) {
+if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation::class)) {
     $loadFakeTrait = true;
-    trait ProInlineCreateOperation {
-        public function initializeProInlineCreateOperation() {
+    trait ProInlineCreateOperation
+    {
+        public function initializeProInlineCreateOperation()
+        {
             throw new BackpackProRequiredException('InlineCreateOperation');
         }
     }
 }
 
-if($loadFakeTrait) {
+if ($loadFakeTrait) {
     trait InlineCreateOperation
     {
         use ProInlineCreateOperation;
     }
-}else{
+} else {
     trait InlineCreateOperation
     {
         use \Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation;
-    }   
+    }
 }

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -4,19 +4,17 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
-$loadFakeTrait = false;
-if (! trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation::class)) {
-    $loadFakeTrait = true;
+if (! backpack_pro()) {
     trait ProInlineCreateOperation
     {
-        public function initializeProInlineCreateOperation()
+        public function setupInlineCreateOperationDefaults()
         {
             throw new BackpackProRequiredException('InlineCreateOperation');
         }
     }
 }
 
-if ($loadFakeTrait) {
+if (! backpack_pro()) {
     trait InlineCreateOperation
     {
         use ProInlineCreateOperation;

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -4,7 +4,9 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
+$loadFakeTrait = false;
 if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation::class)) {
+    $loadFakeTrait = true;
     trait ProInlineCreateOperation {
         public function initializeProInlineCreateOperation() {
             throw new BackpackProRequiredException('InlineCreateOperation');
@@ -12,7 +14,7 @@ if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation
     }
 }
 
-if(trait_exists(ProFetchOperation::class)) {
+if($loadFakeTrait) {
     trait InlineCreateOperation
     {
         use ProInlineCreateOperation;

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -2,7 +2,24 @@
 
 namespace Backpack\CRUD\app\Http\Controllers\Operations;
 
-trait InlineCreateOperation
-{
-    use \Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation;
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if(!trait_exists(\Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation::class)) {
+    trait ProInlineCreateOperation {
+        public function initializeProInlineCreateOperation() {
+            throw new BackpackProRequiredException('InlineCreateOperation');
+        }
+    }
+}
+
+if(trait_exists(ProFetchOperation::class)) {
+    trait InlineCreateOperation
+    {
+        use ProInlineCreateOperation;
+    }
+}else{
+    trait InlineCreateOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\InlineCreateOperation;
+    }   
 }

--- a/src/app/Http/Controllers/Operations/InlineCreateOperation.php
+++ b/src/app/Http/Controllers/Operations/InlineCreateOperation.php
@@ -5,19 +5,12 @@ namespace Backpack\CRUD\app\Http\Controllers\Operations;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 
 if (! backpack_pro()) {
-    trait ProInlineCreateOperation
+    trait InlineCreateOperation
     {
         public function setupInlineCreateOperationDefaults()
         {
             throw new BackpackProRequiredException('InlineCreateOperation');
         }
-    }
-}
-
-if (! backpack_pro()) {
-    trait InlineCreateOperation
-    {
-        use ProInlineCreateOperation;
     }
 } else {
     trait InlineCreateOperation

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel;
 
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 use Closure;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -25,7 +26,7 @@ class CrudFilter
     public function __construct($options, $values, $logic, $fallbackLogic)
     {
         if (! backpack_pro()) {
-            abort(500, 'Backpack filters are a PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.');
+            throw new BackpackProRequiredException('Filter');
         }
 
         // if filter exists

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 use Exception;
 
 /**
@@ -129,7 +130,7 @@ trait Read
     public function enableDetailsRow()
     {
         if (! backpack_pro()) {
-            abort(500, 'Details row is a PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.');
+            throw new BackpackProRequiredException('Details row');
         }
 
         $this->setOperationSetting('detailsRow', true);
@@ -316,7 +317,7 @@ trait Read
     public function enableExportButtons()
     {
         if (! backpack_pro()) {
-            abort(500, 'Export buttons are a PRO feature. Please purchase and install <a href="https://backpackforlaravel.com/pricing">Backpack\PRO</a>.');
+            throw new BackpackProRequiredException('Export buttons');
         }
 
         $this->setOperationSetting('exportButtons', true);

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -311,7 +311,7 @@ trait Views
 
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?', 1);
+            throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos.' . (backpack_pro() ? '' : ' If you are trying to use a PRO field, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, "Cannot find '{$viewPath}' field view in any of the regular locations.");
     }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -308,6 +308,6 @@ trait Views
         }
 
         // if no view exists, in any of the directories above... no bueno
-        abort(500, "Cannot find '{$viewPath}' field view in any of the regular locations.");
+        abort(500, 'Cannot find '.$viewPath.' field view. Was it a typo? Trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field?</a>');
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -308,6 +308,6 @@ trait Views
         }
 
         // if no view exists, in any of the directories above... no bueno
-        abort(500, 'Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you're trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?');
+        abort(500, 'Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?');
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -311,7 +311,7 @@ trait Views
 
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos.' . (backpack_pro() ? '' : ' If you are trying to use a PRO field, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
+            throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO field, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, "Cannot find '{$viewPath}' field view in any of the regular locations.");
     }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -310,7 +310,7 @@ trait Views
         }
 
         // if no view exists, in any of the directories above... no bueno
-        if(!backpack_pro()) {
+        if (! backpack_pro()) {
             throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?', 1);
         }
         abort(500, "Cannot find '{$viewPath}' field view in any of the regular locations.");

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
 trait Views
 {
     // -------
@@ -308,6 +310,9 @@ trait Views
         }
 
         // if no view exists, in any of the directories above... no bueno
-        abort(500, 'Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?');
+        if(!backpack_pro()) {
+            throw new BackpackProRequiredException('Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?', 1);
+        }
+        abort(500, "Cannot find '{$viewPath}' field view in any of the regular locations.");
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -308,6 +308,6 @@ trait Views
         }
 
         // if no view exists, in any of the directories above... no bueno
-        abort(500, 'Cannot find '.$viewPath.' field view. Was it a typo? Trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field?</a>');
+        abort(500, 'Cannot find the field view: '.$viewPath.'. Please check for typos. Alternatively, maybe you're trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO field</a>?');
     }
 }

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library;
 
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 use Illuminate\Support\Fluent;
 
 /**
@@ -144,7 +145,10 @@ class Widget extends Fluent
             }
         }
         // if no view exists, in any of the directories above... no bueno
-        abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO widget</a>?');
+        if(!backpack_pro()) {
+            throw new BackpackProRequiredException('Cannot find the view for «'.$this->type.'» widget type. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO widget</a>?', 1);
+        }
+        abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
         
     }
 

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -145,11 +145,10 @@ class Widget extends Fluent
             }
         }
         // if no view exists, in any of the directories above... no bueno
-        if(!backpack_pro()) {
+        if (! backpack_pro()) {
             throw new BackpackProRequiredException('Cannot find the view for «'.$this->type.'» widget type. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO widget</a>?', 1);
         }
         abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
-        
     }
 
     // -------

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -143,8 +143,9 @@ class Widget extends Fluent
                 return $path;
             }
         }
-
-        return config('backpack.base.component_view_namespaces.widgets')[0].'.'.$this->type;
+        // if no view exists, in any of the directories above... no bueno
+        abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO widget</a>?');
+        
     }
 
     // -------

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -146,7 +146,7 @@ class Widget extends Fluent
         }
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the widget view: '.$viewPath.'. Please check for typos.' . (backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
+            throw new BackpackProRequiredException('Cannot find the widget view: '.$viewPath.'. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
     }

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -146,7 +146,7 @@ class Widget extends Fluent
         }
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the view for «'.$this->type.'» widget type. Please check for typos. Alternatively, maybe you are trying to use a <a href="https://backpackforlaravel.com/products/pro-for-unlimited-projects" target="_blank">PRO widget</a>?', 1);
+            throw new BackpackProRequiredException('Cannot find the widget view: '.$viewPath.'. Please check for typos.' . (backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
     }

--- a/tests/Unit/CrudPanel/CrudPanelReadTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReadTest.php
@@ -277,7 +277,7 @@ class CrudPanelReadTest extends BaseDBCrudPanelTest
     public function testEnableDetailsRow()
     {
         if (! backpack_pro()) {
-            $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+            $this->expectException(\Backpack\CRUD\app\Exceptions\BackpackProRequiredException::class);
         }
 
         $this->crudPanel->setOperation('create');
@@ -312,7 +312,7 @@ class CrudPanelReadTest extends BaseDBCrudPanelTest
     public function testEnableExportButtons()
     {
         if (! backpack_pro()) {
-            $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+            $this->expectException(\Backpack\CRUD\app\Exceptions\BackpackProRequiredException::class);
         }
 
         $this->crudPanel->enableExportButtons();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We only said to dev that the view was not found. That was confusing for devs updating form 4 > 5 because the views "existed" in the previous version and now it was not clear why they didn't exist anymore.

### AFTER - What is happening after this PR?

Changed message a bit so it mentions the PRO fields as a suggestion on why view was not found.
