### PR TITLE
Fix date_range not being saved when subfield (and any other field with array names)

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -41,15 +41,17 @@ trait FakeFields
                 // field is represented by the subfields
                 if (isset($field['subfields']) && isset($field['model']) && $field['model'] === get_class($model)) {
                     foreach ($field['subfields'] as $subfield) {
-                        $subfieldName = Str::afterLast($subfield['name'], '.');
-                        $isSubfieldFake = $subfield['fake'] ?? false;
-                        $subFakeFieldKey = isset($subfield['store_in']) ? $subfield['store_in'] : 'extras';
+                        foreach((array)$subfield['name'] as $subfieldName) {
+                            $subfieldName = Str::afterLast($subfieldName, '.');
+                            $isSubfieldFake = $subfield['fake'] ?? false;
+                            $subFakeFieldKey = isset($subfield['store_in']) ? $subfield['store_in'] : 'extras';
 
-                        if (array_key_exists($subfieldName, $requestInput) && $isSubfieldFake) {
-                            $this->addCompactedField($requestInput, $subfieldName, $subFakeFieldKey);
+                            if (array_key_exists($subfieldName, $requestInput) && $isSubfieldFake) {
+                                $this->addCompactedField($requestInput, $subfieldName, $subFakeFieldKey);
 
-                            if (! in_array($subFakeFieldKey, $compactedFakeFields)) {
-                                $compactedFakeFields[] = $subFakeFieldKey;
+                                if (! in_array($subFakeFieldKey, $compactedFakeFields)) {
+                                    $compactedFakeFields[] = $subFakeFieldKey;
+                                }
                             }
                         }
                     }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -241,27 +241,29 @@ trait Update
             $name = is_string($subfield) ? $subfield : $subfield['name'];
             // if the subfield name does not contain a dot we just need to check
             // if it has subfields and return the result accordingly.
-            if (! Str::contains($name, '.')) {
-                // when subfields are present, $relatedModel->{$name} returns a model instance
-                // otherwise returns the model attribute.
-                if ($relatedModel->{$name}) {
-                    if (isset($subfield['subfields'])) {
-                        $result[$name] = [$relatedModel->{$name}->only(array_column($subfield['subfields'], 'name'))];
-                    } else {
-                        $result[$name] = $relatedModel->{$name};
+            foreach((array)$subfield['name'] as $name) {
+                if (! Str::contains($name, '.')) {
+                    // when subfields are present, $relatedModel->{$name} returns a model instance
+                    // otherwise returns the model attribute.
+                    if ($relatedModel->{$name}) {
+                        if (isset($subfield['subfields'])) {
+                            $result[$name] = [$relatedModel->{$name}->only(array_column($subfield['subfields'], 'name'))];
+                        } else {
+                            $result[$name] = $relatedModel->{$name};
+                        }
                     }
-                }
-            } else {
-                // if the subfield name contains a dot, we are going to iterate through
-                // those parts to get the last connected part and parse it for returning.
-                // $iterator would be either a string (the attribute in model, eg: street)
-                // or a model instance (eg: AddressModel)
-                $iterator = $relatedModel;
-                foreach (explode('.', $name) as $part) {
-                    $iterator = $iterator->$part;
-                }
+                } else {
+                    // if the subfield name contains a dot, we are going to iterate through
+                    // those parts to get the last connected part and parse it for returning.
+                    // $iterator would be either a string (the attribute in model, eg: street)
+                    // or a model instance (eg: AddressModel)
+                    $iterator = $relatedModel;
+                    foreach (explode('.', $name) as $part) {
+                        $iterator = $iterator->$part;
+                    }
 
-                Arr::set($result, $name, (! is_string($iterator) && ! is_null($iterator) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
+                    Arr::set($result, $name, (! is_string($iterator) && ! is_null($iterator) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
+                }
             }
         }
 

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -1124,7 +1124,8 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertCount(0, $planets);
     }
 
-    public function testCreateHasManyRelationWithArrayedNameSubfields() {
+    public function testCreateHasManyRelationWithArrayedNameSubfields()
+    {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
         $this->crudPanel->addField([
@@ -1135,8 +1136,8 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                 ],
                 [
                     'name' => ['start_date', 'end_date'],
-                    'type' => 'date_range'
-                ]
+                    'type' => 'date_range',
+                ],
             ],
         ], 'both');
 
@@ -1151,12 +1152,12 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                     'id' => null,
                     'title' => 'this is the star 1 title',
                     'start_date' => '2021-02-26',
-                    'end_date' => '2091-01-26'
+                    'end_date' => '2091-01-26',
                 ],
                 [
                     'title' => 'this is the star 2 title',
                     'end_date' => '2021-02-26',
-                    'start_date' => '2091-01-26'
+                    'start_date' => '2091-01-26',
                 ],
             ],
         ];
@@ -1171,7 +1172,8 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $this->assertEquals($inputData['universes'][1]['start_date'], $entry->universes()->find(2)->start_date);
     }
 
-    public function testCreateHasOneRelationWithArrayedNameSubfields() {
+    public function testCreateHasOneRelationWithArrayedNameSubfields()
+    {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->setOperation('create');
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
@@ -1183,7 +1185,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                         'name' => 'nickname',
                     ],
                     [
-                        'name' => ['start_date', 'end_date']
+                        'name' => ['start_date', 'end_date'],
                     ],
                     [
                         'name' => 'profile_picture',
@@ -1204,9 +1206,9 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                     'nickname' => 'i_have_has_one',
                     'profile_picture' => 'ohh my picture 1.jpg',
                     'start_date' => '2021-02-26',
-                    'end_date' => '2091-01-26'
+                    'end_date' => '2091-01-26',
                 ],
-            ]
+            ],
         ];
 
         $entry = $this->crudPanel->create($inputData);
@@ -1227,8 +1229,8 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                     'name' => 'notes',
                 ],
                 [
-                    'name' => ['start_date', 'end_date']
-                ]
+                    'name' => ['start_date', 'end_date'],
+                ],
             ],
         ]);
 
@@ -1251,7 +1253,7 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
                     'superArticles' => $article->id,
                     'notes' => 'my first article note',
                     'start_date' => '2021-02-26',
-                    'end_date' => '2091-01-26'
+                    'end_date' => '2091-01-26',
                 ],
             ],
         ];

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -1123,4 +1123,144 @@ class CrudPanelCreateTest extends BaseDBCrudPanelTest
         $planets = PlanetNonNullable::all();
         $this->assertCount(0, $planets);
     }
+
+    public function testCreateHasManyRelationWithArrayedNameSubfields() {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'name'    => 'universes',
+            'subfields' => [
+                [
+                    'name' => 'title',
+                ],
+                [
+                    'name' => ['start_date', 'end_date'],
+                    'type' => 'date_range'
+                ]
+            ],
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name'           => $faker->name,
+            'email'          => $faker->safeEmail,
+            'password'       => bcrypt($faker->password()),
+            'remember_token' => null,
+            'universes'          => [
+                [
+                    'id' => null,
+                    'title' => 'this is the star 1 title',
+                    'start_date' => '2021-02-26',
+                    'end_date' => '2091-01-26'
+                ],
+                [
+                    'title' => 'this is the star 2 title',
+                    'end_date' => '2021-02-26',
+                    'start_date' => '2091-01-26'
+                ],
+            ],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(2, $entry->universes);
+
+        $this->assertEquals($inputData['universes'][0]['start_date'], $entry->universes()->first()->start_date);
+        $this->assertEquals($inputData['universes'][0]['end_date'], $entry->universes()->first()->end_date);
+        $this->assertEquals($inputData['universes'][1]['end_date'], $entry->universes()->find(2)->end_date);
+        $this->assertEquals($inputData['universes'][1]['start_date'], $entry->universes()->find(2)->start_date);
+    }
+
+    public function testCreateHasOneRelationWithArrayedNameSubfields() {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setOperation('create');
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
+        $this->crudPanel->addField(
+            [
+                'name' => 'accountDetails',
+                'subfields' => [
+                    [
+                        'name' => 'nickname',
+                    ],
+                    [
+                        'name' => ['start_date', 'end_date']
+                    ],
+                    [
+                        'name' => 'profile_picture',
+                    ],
+                ],
+            ]);
+
+        $faker = Factory::create();
+
+        $inputData = [
+            'name'           => $faker->name,
+            'email'          => $faker->safeEmail,
+            'password'       => bcrypt($faker->password()),
+            'remember_token' => null,
+            'roles'          => [1, 2],
+            'accountDetails' => [
+                [
+                    'nickname' => 'i_have_has_one',
+                    'profile_picture' => 'ohh my picture 1.jpg',
+                    'start_date' => '2021-02-26',
+                    'end_date' => '2091-01-26'
+                ],
+            ]
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+        $account_details = $entry->accountDetails()->first();
+
+        $this->assertEquals($account_details->start_date, '2021-02-26');
+        $this->assertEquals($account_details->end_date, '2091-01-26');
+    }
+
+    public function testBelongsToManyWithArrayedNameSubfields()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
+        $this->crudPanel->addField([
+            'name' => 'superArticles',
+            'subfields' => [
+                [
+                    'name' => 'notes',
+                ],
+                [
+                    'name' => ['start_date', 'end_date']
+                ]
+            ],
+        ]);
+
+        $faker = Factory::create();
+        $articleData = [
+            'content'     => $faker->text(),
+            'tags'        => $faker->words(3, true),
+            'user_id'     => 1,
+        ];
+
+        $article = Article::create($articleData);
+
+        $inputData = [
+            'name'           => $faker->name,
+            'email'          => $faker->safeEmail,
+            'password'       => bcrypt($faker->password()),
+            'remember_token' => null,
+            'superArticles'          => [
+                [
+                    'superArticles' => $article->id,
+                    'notes' => 'my first article note',
+                    'start_date' => '2021-02-26',
+                    'end_date' => '2091-01-26'
+                ],
+            ],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(1, $entry->fresh()->superArticles);
+        $superArticle = $entry->fresh()->superArticles->first();
+        $this->assertEquals($superArticle->pivot->start_date, '2021-02-26');
+        $this->assertEquals($superArticle->pivot->end_date, '2091-01-26');
+    }
 }

--- a/tests/Unit/Models/AccountDetails.php
+++ b/tests/Unit/Models/AccountDetails.php
@@ -10,7 +10,7 @@ class AccountDetails extends Model
     use CrudTrait;
 
     protected $table = 'account_details';
-    protected $fillable = ['user_id', 'nickname', 'profile_picture', 'article_id'];
+    protected $fillable = ['user_id', 'nickname', 'profile_picture', 'article_id', 'start_date', 'end_date'];
 
     /**
      * Get the user for the account details.

--- a/tests/Unit/Models/Universe.php
+++ b/tests/Unit/Models/Universe.php
@@ -18,7 +18,7 @@ class Universe extends Model
     protected $table = 'universes';
     protected $primaryKey = 'id';
     public $timestamps = false;
-    protected $fillable = ['title'];
+    protected $fillable = ['title', 'start_date', 'end_date'];
     // protected $hidden = [];
     // protected $dates = [];
 

--- a/tests/Unit/Models/User.php
+++ b/tests/Unit/Models/User.php
@@ -63,7 +63,7 @@ class User extends Model
 
     public function superArticles()
     {
-        return $this->belongsToMany('Backpack\CRUD\Tests\Unit\Models\Article', 'articles_user')->withPivot('notes');
+        return $this->belongsToMany('Backpack\CRUD\Tests\Unit\Models\Article', 'articles_user')->withPivot(['notes', 'start_date', 'end_date']);
     }
 
     public function universes()

--- a/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
+++ b/tests/config/database/migrations/2017_09_08_000001_create_account_details_table.php
@@ -19,6 +19,8 @@ class CreateAccountDetailsTable extends Migration
             $table->string('nickname');
             $table->string('profile_picture');
             $table->bigInteger('article_id')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
             $table->timestamps();
 
             $table->foreign('user_id')

--- a/tests/config/database/migrations/2020_03_31_114745_create_pivotable_relations_tables.php
+++ b/tests/config/database/migrations/2020_03_31_114745_create_pivotable_relations_tables.php
@@ -41,6 +41,8 @@ class CreatePivotableRelationsTables extends Migration
             $table->integer('article_id')->unsigned();
             $table->integer('user_id')->unsigned();
             $table->string('notes');
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
             $table->nullableTimestamps();
         });
 
@@ -67,6 +69,8 @@ class CreatePivotableRelationsTables extends Migration
             $table->bigIncrements('id');
             $table->bigInteger('user_id');
             $table->string('title')->nullable();
+            $table->date('start_date')->nullable();
+            $table->date('end_date')->nullable();
         });
 
         Schema::create('planets', function (Blueprint $table) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There is a linked PR for this in PRO. The pro pr makes the arrayed names work in repeatable. This one makes the arrayed names save when used as subfields for relations. 

You could not use for example the CaveCrud or Story with a `date_range` field because it requires the name to be an array.

### AFTER - What is happening after this PR?

arrayed field names works on the relation saving process.

## HOW

### How did you achieve that, in technical terms?

accounted for array names where we used the `$subfield['name']` directly.



### Is it a breaking change?

I don't think so.


### How can we test the before & after?

Cave & Crud controller with a date_range field. (uncommend line 81 in cave). Also don't forget the PRO pr, otherwise it will break anyway. 

PS: added tests for this too 👍 