### PR TITLE
improve the boolean column's logic to more closely match PHP's boolea…

### DIFF
--- a/src/resources/views/crud/columns/boolean.blade.php
+++ b/src/resources/views/crud/columns/boolean.blade.php
@@ -9,21 +9,21 @@
         $column['value'] = $column['value']($entry);
     }
 
-    if (in_array($column['value'], [true, 1, '1'])) {
-        $related_key = 1;
-        if ( isset( $column['options'][1] ) ) {
-            $column['text'] = $column['options'][1];
-            $column['escaped'] = false;
-        } else {
-            $column['text'] = Lang::has('backpack::crud.yes') ? trans('backpack::crud.yes') : 'Yes';
-        }
-    } else {
+    if (in_array($column['value'], [null, false, 'false', 'FALSE', 0, '0'], true)) {
         $related_key = 0;
         if ( isset( $column['options'][0] ) ) {
             $column['text'] = $column['options'][0];
             $column['escaped'] = false;
         } else {
             $column['text'] = Lang::has('backpack::crud.no') ? trans('backpack::crud.no') : 'No';
+        }
+    } else {
+        $related_key = 1;
+        if ( isset( $column['options'][1] ) ) {
+            $column['text'] = $column['options'][1];
+            $column['escaped'] = false;
+        } else {
+            $column['text'] = Lang::has('backpack::crud.yes') ? trans('backpack::crud.yes') : 'Yes';
         }
     }
 


### PR DESCRIPTION
## WHY

The "[boolean](https://backpackforlaravel.com/docs/5.x/crud-columns#boolean-1)" column is unintuitive.

### BEFORE - What was wrong? What was happening before this PR?

The "boolean" column logic is unintuitive, and isn't very flexible, requiring the use of custom column types (eg. "closure") for otherwise straight-forward use cases.

### AFTER - What is happening after this PR?

The "boolean" column logic is more consistent with PHP's typing, so various database column datatypes can be cast to booleans more easily.


## HOW

### How did you achieve that, in technical terms?

Check for falsy values first.



### Is it a breaking change?

Yes.


### How can we test the before & after?

Before: Truthy values like 123, 'asd', etc. are cast to a falsy "No".
After: Truthy values like 123, 'asd', etc. are cast to a truthy "Yes".

Example:

```php
// assuming we have a model like this:
$entry->deleted_at = '2022-04-18 00:06:02';

// in PHP casting the deleted_at attribute to boolean would return true:
(bool) $entry->deleted_at; // true

// but using Backpack's "boolean" column doesn't function the same way, logically speaking
$this->crud->addColumn([
    'name' => 'deleted_at',
    'label'  => 'Deleted',
    'type'  => 'boolean',
]);

// in the blade template, the deleted_at value is not one of [true, 1, '1'] so it's assumed falsy
```
