### PR TITLE
add backpack input identifier to select multiple fields

### DIFF
--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -11,7 +11,7 @@
     <select
         name="{{ $field['name'] }}@if ($field['multiple'])[]@endif"
         @include('crud::fields.inc.attributes')
-        @if ($field['multiple'])multiple @endif
+        @if ($field['multiple'])multiple bp-field-main-input @endif
         >
 
         @if ($field['allows_null'] && !$field['multiple'])

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -25,6 +25,7 @@
     	class="form-control"
         name="{{ $field['name'] }}[]"
         @include('crud::fields.inc.attributes')
+        bp-field-main-input
     	multiple>
 
     	@if (count($options))


### PR DESCRIPTION
We use an hidden input to submit in place of the multiple selects when they are empty. 
This tells backpack that the real input is the select element and not the hidden one. 

https://github.com/Laravel-Backpack/CRUD/issues/4329