### PR TITLE
Support dot.notation fields in the selectors

### DIFF
--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -23,7 +23,7 @@
 	$field['wrapper']['class'] = $field['wrapper']['class'].$required;
 	$field['wrapper']['element'] = $field['wrapper']['element'] ?? 'div';
 	$field['wrapper']['bp-field-wrapper'] = 'true';
-	$field['wrapper']['bp-field-name'] = $field['name'];
+	$field['wrapper']['bp-field-name'] = square_brackets_to_dots($field['name']);
 	$field['wrapper']['bp-field-type'] = $field['type'];
 @endphp
 

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -10,7 +10,7 @@
         constructor(fieldName) {
             this.name = fieldName;
             this.wrapper = $("[bp-field-name="+ this.name +"]");
-            this.input = $("[bp-field-main-input][name="+ this.name +"]");
+            this.input = this.wrapper.find("[bp-field-main-input");
             // if no bp-field-main-input has been declared in the field itself,
             // assume it's the first input in that wrapper, whatever it is
             if (this.input.length == 0) {

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -9,12 +9,12 @@
     class CrudField {
         constructor(fieldName) {
             this.name = fieldName;
-            this.wrapper = $("[bp-field-name="+ this.name +"]");
+            this.wrapper = $('[bp-field-name="'+ this.name +'"]');
             this.input = this.wrapper.find("[bp-field-main-input");
             // if no bp-field-main-input has been declared in the field itself,
             // assume it's the first input in that wrapper, whatever it is
             if (this.input.length == 0) {
-                this.input = $("[bp-field-name="+ this.name +"] input, [bp-field-name="+ this.name +"] textarea, [bp-field-name="+ this.name +"] select").first();
+                this.input = $('[bp-field-name="'+ this.name +'"] input, [bp-field-name="'+ this.name +'"] textarea, [bp-field-name="'+ this.name +'"] select').first();
             }
             this.value = this.input.val();
         }


### PR DESCRIPTION
This adds the ability to work with `dot.notation` fields as selectors.

- remove the dependency on field name in the main-input identification by finding it inside the wrapper. 
- use literal strings to perform the query operations, allowing us to use `field.something` as the field name.