### PR TITLE
Color picker and summernote editor to trigger the change event

### DIFF
--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -13,6 +13,7 @@
         name="{{ $field['name'] }}"
         data-init-function="bpFieldInitSummernoteElement"
         data-options="{{ json_encode($field['options']) }}"
+        bp-field-main-input
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control summernote'])
         >{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}</textarea>
 
@@ -46,7 +47,16 @@
     @loadOnce('bpFieldInitSummernoteElement')
     <script>
         function bpFieldInitSummernoteElement(element) {
-            element.summernote(element.data('options'));
+             var summernoteOptions = element.data('options');
+
+            let summernotCallbacks = { 
+                onChange: function(contents, $editable) {
+                    element.trigger('change');
+                }
+            }
+            summernoteOptions['callbacks'] = summernotCallbacks;
+            
+            element.summernote(summernoteOptions); 
         }
     </script>
     @endLoadOnce

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -21,7 +21,7 @@
 
         change(closure) {
             this.input.change(function(event) {
-                var fieldWrapper = $(this).parent('[bp-field-wrapper=true]');
+                var fieldWrapper = $(this).closest('[bp-field-wrapper=true]');
                 var fieldName = fieldWrapper.attr('bp-field-name');
                 var fieldType = fieldWrapper.attr('bp-field-type');
                 var fieldValue = $(this).val();


### PR DESCRIPTION
The change in summernote is self explanatory, pretty much the same as the pro editors, each with their own method. 

The change from `parent()` to `closest()` is because some fields add other containers around the field itself, and calling `parent()` does not always return the correct wrapper element.  