### PR TITLE
all javascript operations working in checkbox and radio

### DIFF
--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -5,7 +5,6 @@
 @endphp
 @include('crud::fields.inc.wrapper_start')
     @include('crud::fields.inc.translatable_icon')
-    <div class="checkbox">
         <input type="hidden" name="{{ $field['name'] }}" value="{{ $field['value'] }}">
     	  <input type="checkbox"
           data-init-function="bpFieldInitCheckbox"
@@ -20,13 +19,12 @@
         	  @endforeach
           @endif
           >
-    	<label class="form-check-label font-weight-normal">{!! $field['label'] !!}</label>
+    	<label style="margin-bottom:0px;" class="font-weight-normal">{!! $field['label'] !!}</label>
 
         {{-- HINT --}}
         @if (isset($field['hint']))
             <p class="help-block">{!! $field['hint'] !!}</p>
         @endif
-    </div>
 @include('crud::fields.inc.wrapper_end')
 
 {{-- ########################################## --}}
@@ -55,6 +53,13 @@
                 } else {
                   element.prop('checked', false);
                 }
+
+                hidden_element.on('backpack_field.disabled', function(e) {
+                  element.prop('disabled', true);
+                });
+                hidden_element.on('backpack_field.enabled', function(e) {
+                  element.removeAttr('disabled');
+                });
 
                 // when the checkbox is clicked
                 // set the correct value on the hidden input

--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -19,7 +19,7 @@
         	  @endforeach
           @endif
           >
-    	<label style="margin-bottom:0px;" class="font-weight-normal">{!! $field['label'] !!}</label>
+    	<label class="font-weight-normal mb-0">{!! $field['label'] !!}</label>
 
         {{-- HINT --}}
         @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -19,7 +19,7 @@
 @include('crud::fields.inc.wrapper_start')
 
 
-        <label style="display: block;">{!! $field['label'] !!}</label>
+        <label class="d-block">{!! $field['label'] !!}</label>
         @include('crud::fields.inc.translatable_icon')
 
 

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -18,10 +18,10 @@
 
 @include('crud::fields.inc.wrapper_start')
 
-    <div>
-        <label>{!! $field['label'] !!}</label>
+
+        <label style="display: block;">{!! $field['label'] !!}</label>
         @include('crud::fields.inc.translatable_icon')
-    </div>
+
 
     <input type="hidden" value="{{ $optionValue }}" name="{{$field['name']}}" />
 
@@ -62,6 +62,18 @@
             element.find('.form-check input[type=radio]').each(function(index, item) {
                 $(this).attr('id', id+index);
                 $(this).siblings('label').attr('for', id+index);
+            });
+
+            hiddenInput.on('backpack_field.disabled', function(e) {
+                element.find('.form-check input[type=radio]').each(function(index, item) {
+                    $(this).prop('disabled', true);
+                });
+            });
+
+            hiddenInput.on('backpack_field.enabled', function(e) {
+                element.find('.form-check input[type=radio]').each(function(index, item) {
+                    $(this).removeAttr('disabled');
+                });
             });
 
             // when one radio input is selected

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -70,7 +70,6 @@
         }
 
         check(e) {
-            console.log(this.wrapper.find('input[type=checkbox]'));
             this.wrapper.find('input[type=checkbox]').prop('checked', true).trigger('change');
             return this;
         }


### PR DESCRIPTION
@tabacitu note that this points to https://github.com/Laravel-Backpack/CRUD/pull/4335 as it needed that PR functionality to work with. 

fully fixes checkbox and radio to work with js api. I checked the css for the classes/elements I removed, when found I added it inline. 