### PR TITLE
field entity should be false if not otherwise specified

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -52,7 +52,7 @@ trait Create
         $relationFields = [];
 
         foreach ($fields as $field) {
-            if (isset($field['model']) && $field['model'] !== false) {
+            if (isset($field['model']) && $field['model'] !== false && $field['entity'] !== false) {
                 array_push($relationFields, $field);
             }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -138,6 +138,9 @@ trait FieldsProtectedMethods
             return $field;
         }
 
+        // by default, entity is false if we cannot link it with guessing functions to a relation
+        $field['entity'] = false;
+
         // if the name is an array it's definitely not a relationship
         if (is_array($field['name'])) {
             return $field;

--- a/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAutoSetTest.php
@@ -456,6 +456,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'binaryCol' => [
             'name'       => 'binaryCol',
@@ -466,6 +467,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'booleanCol' => [
             'name' => 'booleanCol',
@@ -476,6 +478,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values' => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'charCol' => [
             'name'       => 'charCol',
@@ -486,6 +489,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'dateCol' => [
             'name'       => 'dateCol',
@@ -496,6 +500,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'dateTimeCol' => [
             'name'       => 'dateTimeCol',
@@ -506,6 +511,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'dateTimeTzCol' => [
             'name'       => 'dateTimeTzCol',
@@ -516,6 +522,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'decimalCol' => [
             'name'       => 'decimalCol',
@@ -526,6 +533,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'doubleCol' => [
             'name'       => 'doubleCol',
@@ -536,6 +544,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'enumCol' => [
             'name'       => 'enumCol',
@@ -546,6 +555,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'floatCol' => [
             'name'       => 'floatCol',
@@ -556,6 +566,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'integerCol' => [
             'name'       => 'integerCol',
@@ -566,6 +577,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'ipAddressCol' => [
             'name'       => 'ipAddressCol',
@@ -576,6 +588,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'jsonCol' => [
             'name'       => 'jsonCol',
@@ -586,6 +599,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'jsonbCol' => [
             'name'       => 'jsonbCol',
@@ -596,6 +610,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'longTextCol' => [
             'name'       => 'longTextCol',
@@ -606,6 +621,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'macAddressCol' => [
             'name'       => 'macAddressCol',
@@ -616,6 +632,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'mediumIntegerCol' => [
             'name'       => 'mediumIntegerCol',
@@ -626,6 +643,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'mediumTextCol' => [
             'name'       => 'mediumTextCol',
@@ -636,6 +654,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'smallIntegerCol' => [
             'name'       => 'smallIntegerCol',
@@ -646,6 +665,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'stringCol' => [
             'name'       => 'stringCol',
@@ -656,6 +676,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'textCol' => [
             'name'       => 'textCol',
@@ -666,6 +687,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'timeCol' => [
             'name'       => 'timeCol',
@@ -676,6 +698,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'timeTzCol' => [
             'name'       => 'timeTzCol',
@@ -686,6 +709,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'tinyIntegerCol' => [
             'name'       => 'tinyIntegerCol',
@@ -696,6 +720,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'timestampCol' => [
             'name'       => 'timestampCol',
@@ -706,6 +731,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'timestampTzCol' => [
             'name'       => 'timestampTzCol',
@@ -716,6 +742,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
         'uuidCol' => [
             'name'       => 'uuidCol',
@@ -726,6 +753,7 @@ class CrudPanelAutoSetTest extends BaseDBCrudPanelTest
             'values'     => [],
             'attributes' => [],
             'autoset'    => true,
+            'entity' => false,
         ],
     ];
 

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -21,6 +21,7 @@ class CrudPanelFieldsTest extends BaseDBCrudPanelTest
             'name'  => 'field1',
             'label' => 'Field1',
             'type'  => 'text',
+            'entity' => false,
         ],
     ];
 
@@ -56,11 +57,13 @@ class CrudPanelFieldsTest extends BaseDBCrudPanelTest
             'name'  => 'field1',
             'label' => 'Field1',
             'type'  => 'text',
+            'entity' => false,
         ],
         'field2' => [
             'name'  => 'field2',
             'label' => 'Field2',
             'type'  => 'text',
+            'entity' => false,
         ],
     ];
 
@@ -84,16 +87,19 @@ class CrudPanelFieldsTest extends BaseDBCrudPanelTest
             'name'  => 'field1',
             'label' => 'Field1',
             'type'  => 'text',
+            'entity' => false,
         ],
         'field2' => [
             'name'  => 'field2',
             'label' => 'Field2',
             'type'  => 'text',
+            'entity' => false,
         ],
         'field3' => [
             'name'  => 'field3',
             'label' => 'Field3',
             'type'  => 'text',
+            'entity' => false,
         ],
     ];
 
@@ -153,61 +159,73 @@ class CrudPanelFieldsTest extends BaseDBCrudPanelTest
             'name'  => 'field1',
             'label' => 'Field1',
             'type'  => 'text',
+            'entity' => false,
         ],
         'field2' => [
             'name'  => 'field2',
             'type'  => 'address',
             'label' => 'Field2',
+            'entity' => false,
         ],
         'field3' => [
             'name'  => 'field3',
             'type'  => 'address',
             'label' => 'Field3',
+            'entity' => false,
         ],
         'field4' => [
             'name'  => 'field4',
             'type'  => 'checkbox',
             'label' => 'Field4',
+            'entity' => false,
         ],
         'field5' => [
             'name'  => 'field5',
             'type'  => 'date',
             'label' => 'Field5',
+            'entity' => false,
         ],
         'field6' => [
             'name'  => 'field6',
             'type'  => 'email',
             'label' => 'Field6',
+            'entity' => false,
         ],
         'field7' => [
             'name'  => 'field7',
             'type'  => 'hidden',
             'label' => 'Field7',
+            'entity' => false,
         ],
         'field8' => [
             'name'  => 'field8',
             'type'  => 'password',
             'label' => 'Field8',
+            'entity' => false,
         ],
         'field9' => [
             'name'  => 'field9',
             'type'  => 'select2',
             'label' => 'Field9',
+            'entity' => false,
         ],
         'field10' => [
             'name'  => 'field10',
             'type'  => 'select2_multiple',
             'label' => 'Field10',
+            'entity' => false,
         ],
         'field11' => [
             'name'  => 'field11',
             'type'  => 'table',
             'label' => 'Field11',
+            'entity' => false,
         ],
         'field12' => [
             'name'  => 'field12',
             'type'  => 'url',
             'label' => 'Field12',
+            'entity' => false,
         ],
     ];
 

--- a/tests/Unit/CrudPanel/CrudPanelReadTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReadTest.php
@@ -57,21 +57,25 @@ class CrudPanelReadTest extends BaseDBCrudPanelTest
             'name'  => 'content',
             'label' => 'The Content',
             'type'  => 'text',
+            'entity' => false,
         ],
         'metas' => [
             'name'  => 'metas',
             'label' => 'Metas',
             'type'  => 'text',
+            'entity' => false,
         ],
         'tags' => [
             'name'  => 'tags',
             'label' => 'Tags',
             'type'  => 'text',
+            'entity' => false,
         ],
         'extras' => [
             'name'  => 'extras',
             'label' => 'Extras',
             'type'  => 'text',
+            'entity' => false,
         ],
     ];
 
@@ -81,24 +85,28 @@ class CrudPanelReadTest extends BaseDBCrudPanelTest
             'label' => 'The Content',
             'type'  => 'text',
             'value' => 'Some Content',
+            'entity' => false,
         ],
         'metas' => [
             'name'  => 'metas',
             'label' => 'Metas',
             'type'  => 'text',
             'value' => '{"meta_title":"Meta Title Value","meta_description":"Meta Description Value"}',
+            'entity' => false,
         ],
         'tags' => [
             'name'  => 'tags',
             'label' => 'Tags',
             'type'  => 'text',
             'value' => '{"tags":["tag1","tag2","tag3"]}',
+            'entity' => false,
         ],
         'extras' => [
             'name'  => 'extras',
             'label' => 'Extras',
             'type'  => 'text',
             'value' => '{"extra_details":["detail1","detail2","detail3"]}',
+            'entity' => false,
         ],
         'id' => [
             'name'  => 'id',

--- a/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
@@ -32,21 +32,25 @@ class CrudPanelUpdateTest extends BaseDBCrudPanelTest
             'name'  => 'id',
             'type'  => 'hidden',
             'label' => 'Id',
+            'entity' => false,
         ],
         'name' => [
             'name'  => 'name',
             'label' => 'Name',
             'type'  => 'text',
+            'entity' => false,
         ],
         'email' => [
             'name'  => 'email',
             'type'  => 'email',
             'label' => 'Email',
+            'entity' => false,
         ],
         'password' => [
             'name'  => 'password',
             'type'  => 'password',
             'label' => 'Password',
+            'entity' => false,
         ],
     ];
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We stated: `makeSureFieldHasEntity()`, and we failed our users. 

### AFTER - What is happening after this PR?

we `makeSureFieldHasEntity()`, by default `false`.

## HOW

### How did you achieve that, in technical terms?

Setup a default value for entity. 

### Is it a breaking change?

I don't think so, if you didn't specify entity you will never have the `entity` key in your field definition, now you will have it and it will be `false`. 

In regard to adding a check for `$entity !== false` for relation I also think it's not a BC, since our code already uses `entity` as the source of truth for a relationship. 
So if it's a relationship, guessed or developer provided, it must have `entity` set. 


### How can we test the before & after?

Try adding a select2 field to something that is not a relationship:

```php
$this->crud->addField([
            'name'              => 'select2_field',
            'label'             => 'select2',
            'type'              => 'select2',
            'model' => \App\Models\Icon::class,
            'attribute' => 'name',
            'fake' => true,      
            'wrapper' => ['class' => 'form-group col-md-3'],
        ]);
```
This would say that entity is missing, then we set `entity => false`, then it will say that there is no `relation_type` set, and you don't know what to do because this is not a relation. You can tricky it but still ... We can do better. 

