### PR TITLE
fix summernote change event callback

### DIFF
--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -51,7 +51,7 @@
 
             let summernotCallbacks = { 
                 onChange: function(contents, $editable) {
-                    element.trigger('change');
+                    element.val(contents).trigger('change');
                 }
             }
 


### PR DESCRIPTION
Previously the change event was raised while the old value was still on the textarea, one character out of sync with the editor.

now we update the textarea value before triggering the change event.