### PR TITLE
use closest instead of find

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -10,7 +10,7 @@
         constructor(fieldName) {
             this.name = fieldName;
             this.wrapper = $('[bp-field-name="'+ this.name +'"]');
-            this.input = this.wrapper.find("[bp-field-main-input");
+            this.input = this.wrapper.closest("[bp-field-main-input");
             // if no bp-field-main-input has been declared in the field itself,
             // assume it's the first input in that wrapper, whatever it is
             if (this.input.length == 0) {


### PR DESCRIPTION
Some fields where not found if using `find()` cause find only searches the direct descendants, and `closest` will traverse the DOM up the element searching everything. 

From my tests the other fields/scenarios keep working fine with closest, and it's necessary to make `browse_multiple` work. 

