### PR TITLE
hotfix: arrayed parent names can't be used

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -268,7 +268,7 @@ trait FieldsProtectedMethods
                 $subfield = ['name' => $subfield];
             }
 
-            $subfield['parentFieldName'] = $field['name'];
+            $subfield['parentFieldName'] = is_array($field['name']) ? false : $field['name'];
 
             if (! isset($field['model'])) {
                 // we're inside a simple 'repeatable' with no model/relationship, so

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -9,7 +9,7 @@
 	// if the field is required in any of the crud validators (FormRequest, controller validation or field validation) 
 	// we add an astherisc for it. Case it's a subfield, that check is done upstream in repeatable_row. 
 	// the reason for that is that here the field name is already the repeatable name: parent[row][fieldName]
-	if(!isset($field['parentFieldName'])) {
+	if(!isset($field['parentFieldName']) || !$field['parentFieldName']) {
 		$fieldName = is_array($field['name']) ? current($field['name']) : $field['name'];
 		$required = (isset($action) && $crud->isRequired($fieldName)) ? ' required' : '';
 	}


### PR DESCRIPTION
hey @tabacitu 

please merge this asap. 

we have caught a similar issue thanks to the tests here https://github.com/Laravel-Backpack/CRUD/pull/4220#issuecomment-1114712616 but this one was in the interface for a specific field, guess who!!!

The specific problem is the fact that checklist uses `subfields`, and it's assumed that a "subsomething" have a parent, but in checklist parent is `[roles,permissions]` .. whatever, I'am tired of complaining about that field, since technically an array cannot be "parent" of something, unless we talk about multi-parenting ... let's not.
I decided to not setup the `parentFieldName` if the parent name is an array. In our use cases the `parentName` is expected to be string or bool. 

Please accept my humble apologies for not testing this field specifically. We should be good.