### PR TITLE
support repeatable fields in js api

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -117,14 +117,13 @@
                 return new CrudField(fieldName);
             });
         },
-        repeatable: function(fields, repeatableName, rowNumber = false) {
-            if(Array.isArray(fields)) {
-                return fields.map(function(fieldName) {
-                    return new CrudField(fieldName, repeatableName, rowNumber);
-                });  
-            }else{
-                return new CrudField(fields, repeatableName, rowNumber);
-            }
+        subfield: function(field, repeatableName, rowNumber = false) {
+            return new CrudField(fields, repeatableName, rowNumber);
+        },
+        subfields: function(fields, repeatableName, rowNumber = false) {
+            return fields.map(function(fieldName) {
+                return new CrudField(fieldName, repeatableName, rowNumber);
+            });  
         }
     }
 </script>


### PR DESCRIPTION
this adds support to work with repeatable fields using the same js api. 

added the `repeatable(fieldName, repeatableName, rowNumber)` helper so developer can target fields inside the repeatable in specific rows. 

```php
crud.repeatable('field_1', 'repeatable').change(function(e, value, rowNumber) {
    if(value.length > 0) {
        crud.repeatable('field_2', 'repeatable', rowNumber).hide(); 
    }
});
```

Also needs this PR in PRO: https://github.com/DigitallyHappy/backpack-pro/pull/38