### PR TITLE
Check for class instead of value

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -156,7 +156,7 @@ trait Update
                 if (! $model) {
                     return;
                 }
-                
+
                 $model = $this->getModelWithFakes($model);
 
                 // if `entity` contains a dot here it means developer added a main HasOne/MorphOne relation with dot notation
@@ -258,15 +258,16 @@ trait Update
                     // $iterator would be either a string (the attribute in model, eg: street)
                     // or a model instance (eg: AddressModel)
                     $iterator = $relatedModel;
-     
+
                     foreach (explode('.', $name) as $part) {
                         $iterator = $iterator->$part;
                     }
-   
-                    Arr::set($result, $name, ( is_a($iterator, 'Illuminate\Database\Eloquent\Model', true) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
+
+                    Arr::set($result, $name, (is_a($iterator, 'Illuminate\Database\Eloquent\Model', true) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
                 }
             }
         }
+
         return $result;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -156,7 +156,7 @@ trait Update
                 if (! $model) {
                     return;
                 }
-
+                
                 $model = $this->getModelWithFakes($model);
 
                 // if `entity` contains a dot here it means developer added a main HasOne/MorphOne relation with dot notation
@@ -258,15 +258,15 @@ trait Update
                     // $iterator would be either a string (the attribute in model, eg: street)
                     // or a model instance (eg: AddressModel)
                     $iterator = $relatedModel;
+     
                     foreach (explode('.', $name) as $part) {
                         $iterator = $iterator->$part;
                     }
-
-                    Arr::set($result, $name, (! is_string($iterator) && ! is_null($iterator) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
+   
+                    Arr::set($result, $name, ( is_a($iterator, 'Illuminate\Database\Eloquent\Model', true) ? $this->getModelWithFakes($iterator)->getAttributes() : $iterator));
                 }
             }
         }
-
         return $result;
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In the process tof getting the subfields values, we were checking against iterator value (string or null) to check if we should get the fakes for the model or not. This lead to unwanted behaviour in case it's an integer for example. Reported here: https://github.com/Laravel-Backpack/CRUD/issues/4387

### AFTER - What is happening after this PR?

If it's not a Model instance, we don't get fakes for it.


## HOW

### How did you achieve that, in technical terms?

Instead of checking iterator value, I check iterator class type and parents to see if it's a Model.



### Is it a breaking change?

noin


### How can we test the before & after?

It's described on issue details.