### PR TITLE
set locale on entry on operations that need them

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -79,7 +79,7 @@ trait ShowOperation
         if ($this->crud->get('show.softDeletes') && in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
             $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
         } else {
-            $this->data['entry'] = $this->crud->getEntry($id);
+            $this->data['entry'] = $this->crud->getEntryWithLocale($id);
         }
 
         $this->data['crud'] = $this->crud;

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -67,7 +67,7 @@ trait UpdateOperation
         $id = $this->crud->getCurrentEntryId() ?? $id;
         $this->crud->setOperationSetting('fields', $this->crud->getUpdateFields());
         // get the info for that entry
-        $this->data['entry'] = $this->crud->getEntry($id);
+        $this->data['entry'] = $this->crud->getEntryWithLocale($id);
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();
         $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_name;

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -65,13 +65,14 @@ trait UpdateOperation
         $this->crud->hasAccessOrFail('update');
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
-        $this->crud->setOperationSetting('fields', $this->crud->getUpdateFields());
         // get the info for that entry
+
         $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+        $this->crud->setOperationSetting('fields', $this->crud->getUpdateFields());
+
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();
         $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.edit').' '.$this->crud->entity_name;
-
         $this->data['id'] = $id;
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -83,6 +83,7 @@ trait Read
                 $this->entry->setLocale($locale);
             }
         }
+
         return $this->entry;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -65,6 +65,28 @@ trait Read
     }
 
     /**
+     * Find and retrieve an entry in the database or fail.
+     * When found, make sure we set the Locale on it.
+     *
+     * @param int The id of the row in the db to fetch.
+     * @return \Illuminate\Database\Eloquent\Model The row in the db.
+     */
+    public function getEntryWithLocale($id)
+    {
+        if (! $this->entry) {
+            $this->entry = $this->getEntry($id);
+        }
+
+        if ($this->entry->translationEnabled()) {
+            $locale = request('_locale', \App::getLocale());
+            if (in_array($locale, array_keys($this->entry->getAvailableLocales()))) {
+                $this->entry->setLocale($locale);
+            }
+        }
+        return $this->entry;
+    }
+
+    /**
      * Return a Model builder instance with the current crud query applied.
      *
      * @return \Illuminate\Database\Eloquent\Builder


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Can't view entry in other locales than edit/show

### AFTER - What is happening after this PR?

You can get the entry with or without locale set, update and show operation now get entry with locale set


## HOW

### How did you achieve that, in technical terms?

set the locale on entry


### Is it a breaking change?

no
