### PR TITLE
JS library - Changed closure args

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -29,6 +29,11 @@
             if(this.input.length === 0) {
                 this.input = this.wrapper.find('input, textarea, select').first();
             }
+
+            // Validate that the field has been found
+            if(this.wrapper.length === 0 || this.input.length === 0) {
+                console.error(`CrudField "${this.name}" was not found.`);
+            }
         }
 
         get value() {

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -7,9 +7,10 @@
      * too, by exposing the main components (name, wrapper, input).
      */
     class CrudField {
-        constructor(fieldName) {
-            this.name = fieldName;
-            this.wrapper = $(`[bp-field-name*="${this.name}"][bp-field-wrapper]`);
+        constructor(name) {
+            this.name = name;
+            this.wrapper = $(`[bp-field-name*="${name}"][bp-field-wrapper]`);
+            this.type = this.wrapper.attr('bp-field-type');
            
             // search input in ancestors
             this.input = this.wrapper.closest('[bp-field-main-input]');
@@ -42,14 +43,8 @@
         }
 
         change(closure) {
-            const fieldChanged = event => {
-                const wrapper = this.input.closest('[bp-field-wrapper=true]');
-                const name = wrapper.attr('bp-field-name');
-                const type = wrapper.attr('bp-field-type');
-                const value = this.input.val();
-
-                closure(event, value, name, type);
-            };
+            const bindedClosure = closure.bind(this);
+            const fieldChanged = event => bindedClosure(this, event);
 
             this.input[0]?.addEventListener('input', fieldChanged, false);
             $(this.input).change(fieldChanged);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The event was first, even if it was rarely or never used.

```js
crud.field('visible').onChange((event, value) => {
  crud.field('visible_where').show(value === 1);
});
```

### AFTER - What is happening after this PR?

`field` is first, `event` is second 👌


```js
crud.field('visible').onChange(field => {
  crud.field('visible_where').show(field.value === 1);
});
```

🎉 **ALSO** 🎉

`CrudField` class is binded to the closure, so this can also be done;

```js
crud.field('visible').onChange(function() {
  crud.field('visible_where').show(this.value === 1);
});
```

Although I prefer the first option 🤷‍♂️

### Is it a breaking change?

Yes, it changes the order of the closure args, so I'm also pushing a PR to the demo.

https://github.com/Laravel-Backpack/demo/pull/391