### PR TITLE
fix (update): dynamically get pivot accessor when saving n-n relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -136,7 +136,7 @@ trait Update
                         case 'BelongsToMany':
                         case 'MorphToMany':
                             // for any given model, we grab the attributes that belong to our pivot table.
-                            $item = $model->pivot->getAttributes();
+                            $item = $model->{$relation->getPivotAccessor()}->getAttributes();
                             $item[$relationMethod] = $model->getKey();
                             $result->push($item);
                             break;


### PR DESCRIPTION
## WHY

Minor bug fix

### BEFORE - What was wrong? What was happening before this PR?

[Here is the bug report](https://github.com/Laravel-Backpack/CRUD/issues/4398)

### AFTER - What is happening after this PR?

Bug seems to go away :)


## HOW

### How did you achieve that, in technical terms?

Tested on local machine, followed error traces.



### Is it a breaking change?

Shouldn't be, it's quite a small change


### How can we test the before & after?

??
