### PR TITLE
fix infering the connecting key on HasMany relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -295,22 +295,22 @@ trait Create
     {
         $items = $relationDetails['values'][$relationMethod];
 
-        $relation_local_key = $relation->getLocalKeyName();
+        $relatedModelLocalKey = $relation->getRelated()->getKeyName();
 
         $relatedItemsSent = [];
-
+        
         foreach ($items as $item) {
             [$directInputs, $relationInputs] = $this->splitInputIntoDirectAndRelations($item, $relationDetails, $relationMethod);
             // for each item we get the inputs to create and the relations of it.
-            $relation_local_key_value = $item[$relation_local_key] ?? null;
+            $relatedModelLocalKeyValue = $item[$relatedModelLocalKey] ?? null;
 
             // we either find the matched entry by local_key (usually `id`)
             // and update the values from the input
-            // or create a new item from input
-            $item = $entry->{$relationMethod}()->updateOrCreate([$relation_local_key => $relation_local_key_value], $directInputs);
-
+            // or create a new item from input      
+            $item = $entry->{$relationMethod}()->updateOrCreate([$relatedModelLocalKey => $relatedModelLocalKeyValue], $directInputs);
+ 
             // we store the item local key so we can match them with database and check if any item was deleted
-            $relatedItemsSent[] = $item->{$relation_local_key};
+            $relatedItemsSent[] = $item->{$relatedModelLocalKey};
 
             // create the item relations if any.
             $this->createRelationsForItem($item, $relationInputs);
@@ -319,7 +319,7 @@ trait Create
         // use the collection of sent ids to match agains database ids, delete the ones not found in the submitted ids.
         if (! empty($relatedItemsSent)) {
             // we perform the cleanup of removed database items
-            $entry->{$relationMethod}()->whereNotIn($relation_local_key, $relatedItemsSent)->delete();
+            $entry->{$relationMethod}()->whereNotIn($relatedModelLocalKey, $relatedItemsSent)->delete();
         }
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -298,7 +298,7 @@ trait Create
         $relatedModelLocalKey = $relation->getRelated()->getKeyName();
 
         $relatedItemsSent = [];
-        
+
         foreach ($items as $item) {
             [$directInputs, $relationInputs] = $this->splitInputIntoDirectAndRelations($item, $relationDetails, $relationMethod);
             // for each item we get the inputs to create and the relations of it.
@@ -306,9 +306,9 @@ trait Create
 
             // we either find the matched entry by local_key (usually `id`)
             // and update the values from the input
-            // or create a new item from input      
+            // or create a new item from input
             $item = $entry->{$relationMethod}()->updateOrCreate([$relatedModelLocalKey => $relatedModelLocalKeyValue], $directInputs);
- 
+
             // we store the item local key so we can match them with database and check if any item was deleted
             $relatedItemsSent[] = $item->{$relatedModelLocalKey};
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -302,7 +302,7 @@ trait FieldsProtectedMethods
                     $entity = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$field['entity'] : $field['entity'];
                     $relationInstance = $this->getRelationInstance(['entity' => $entity]);
                     $field['subfields'] = Arr::prepend($field['subfields'], [
-                        'name' => $relationInstance->getLocalKeyName(),
+                        'name' => $relationInstance->getRelated()->getKeyName(),
                         'type' => 'hidden',
                     ]);
                 break;


### PR DESCRIPTION
## WHY

Reported in: https://github.com/Laravel-Backpack/CRUD/issues/4384

### BEFORE - What was wrong? What was happening before this PR?

I didn't take into account that people could override the model keys when building the HasMany creatable functionality, and in that case the `LocalKeyName` that we were using will be different from the expected, preventing users that changed the primary keys from using the HasMany creatable functionality. (basically it would only work if both models used the same key (as I tested with ID on both, I let this slip)).

### AFTER - What is happening after this PR?

I get the key name directly from model, making it work with any key developer uses (as it should be from start).

## HOW

### How did you achieve that, in technical terms?

Just resorted to get the key directly from the related model, see the relevant changed lines: 298 on Create.php . (the rest is just leaving the house cleaner than I found it). 


### Is it a breaking change?

No


### How can we test the before & after?

trying to use the HasMany functionality with models that have different keys, for example one have key `id`, the other have key `main_id`. It would fail before, and would work now! 
