### PR TITLE
Add Missing sentences in Arabic for bulk actions

### DIFF
--- a/src/resources/lang/ar/crud.php
+++ b/src/resources/lang/ar/crud.php
@@ -15,6 +15,11 @@
     */
 
 return [
+
+
+
+
+
     'infoFiltered'                            => '(تمت التصفية من إجمالي _MAX_ صف)',
     'thousands'                               => ',',
     'admin'                                   => 'المشرف',
@@ -78,6 +83,7 @@ return [
     'changed_the'                             => 'غيرت',
     'in_the_database'                         => 'في قاعدة البيانات',
     'list'                                    => 'قائمة',
+    'reset'                     => 'تهيئة',
     'all'                                     => 'كل',
     'no'                                      => 'لا',
     'emptyTable'                              => 'لا تتوفر بيانات في الجدول',

--- a/src/resources/lang/ar/crud.php
+++ b/src/resources/lang/ar/crud.php
@@ -15,11 +15,6 @@
     */
 
 return [
-
-
-
-
-
     'infoFiltered'                            => '(تمت التصفية من إجمالي _MAX_ صف)',
     'thousands'                               => ',',
     'admin'                                   => 'المشرف',

--- a/src/resources/lang/ar/crud.php
+++ b/src/resources/lang/ar/crud.php
@@ -95,6 +95,28 @@ return [
     'delete_confirm'                          => 'هل أنت متأكد أنك تريد حذف هذا العنصر؟',
     'please_fix'                              => 'يرجى تصحيح الأخطاء التالية:',
 
+    // Bulk actions
+    'bulk_no_entries_selected_title'   => 'لم يتم تحديد إدخالات',
+    'bulk_no_entries_selected_message' => 'الرجاء تحديد عنصر واحد أو أكثر لتنفيذ إجراء جماعي عليهم.',
+
+    // Bulk delete
+    'bulk_delete_are_you_sure'   => 'هل انت متأكد من حذف عدد :number مدخل ؟',
+    'bulk_delete_sucess_title'   => 'تم حذف المدخلات',
+    'bulk_delete_sucess_message' => ' مدخل تم حذفة',
+    'bulk_delete_error_title'    => 'فشل الحذف',
+    'bulk_delete_error_message'  => 'واحد او اكثر من عنصر لم يتم حذفة',
+
+    // Bulk clone
+    'bulk_clone_are_you_sure'   => 'هل انت متأكد من نسخ عدد :number مدخل ؟',
+    'bulk_clone_sucess_title'   => 'تم نسخ المدخلات.',
+    'bulk_clone_sucess_message' => ' مدخلات تم نسخها.',
+    'bulk_clone_error_title'    => 'فشل النسخ.',
+    'bulk_clone_error_message'  => 'واحد او اكثر من العناصر لم تنسخ ، جرب مرة اخري.',
+
+    // Ajax errors
+    'ajax_error_title' => 'خطا',
+    'ajax_error_text'  => 'خطا عند تحميل الصفحة. من فضلك جرب مرة اخري.',
+
     // CRUD filters navbar view
     'apply' => 'تطبيق',
 


### PR DESCRIPTION
Add Missing Arabic words for bulk actions

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Missing sentences in Arabic

### AFTER - What is happening after this PR?

Is shown Now

## HOW

### How did you achieve that, in technical terms?

Added it



### Is it a breaking change?

no


### How can we test the before & after?

change local to ar and check bulk actions crud will be shown as missing lang like this
![image](https://user-images.githubusercontent.com/23424932/171191372-31553404-b551-4cc7-a8da-f7cd839c27e4.png)