### PR TITLE
Add input field prefix & suffix where possible

### DIFF
--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -2,12 +2,17 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-    	type="color"
-    	name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="color"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
     	>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/date.blade.php
+++ b/src/resources/views/crud/fields/date.blade.php
@@ -11,12 +11,17 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-        type="date"
-        name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="date"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
         >
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -15,13 +15,18 @@ $value = $timestamp ? strftime('%Y-%m-%dT%H:%M:%S', $timestamp) : '';
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-        type="datetime-local"
-        name="{{ $field['name'] }}"
-        value="{{ $value }}"
-        @include('crud::fields.inc.attributes')
-        >
 
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="datetime-local"
+            name="{{ $field['name'] }}"
+            value="{{ $value }}"
+            @include('crud::fields.inc.attributes')
+        >
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+    
     {{-- HINT --}}
     @if (isset($field['hint']))
         <p class="help-block">{!! $field['hint'] !!}</p>

--- a/src/resources/views/crud/fields/email.blade.php
+++ b/src/resources/views/crud/fields/email.blade.php
@@ -2,12 +2,17 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-    	type="email"
-    	name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="email"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
     	>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/month.blade.php
+++ b/src/resources/views/crud/fields/month.blade.php
@@ -2,12 +2,17 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-        type="month"
-        name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="month"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
         >
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/password.blade.php
+++ b/src/resources/views/crud/fields/password.blade.php
@@ -10,11 +10,16 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-    	type="password"
-    	name="{{ $field['name'] }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="password"
+            name="{{ $field['name'] }}"
+            @include('crud::fields.inc.attributes')
     	>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -21,25 +21,29 @@
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
 
-    <select
-        name="{{ $field['name'] }}"
-        @include('crud::fields.inc.attributes')
-        >
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <select
+            name="{{ $field['name'] }}"
+            @include('crud::fields.inc.attributes')
+            >
 
-        @if ($field['allows_null'])
-            <option value="">-</option>
-        @endif
+            @if ($field['allows_null'])
+                <option value="">-</option>
+            @endif
 
-        @if (count($options))
-            @foreach ($options as $connected_entity_entry)
-                @if($current_value == $connected_entity_entry->getKey())
-                    <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
-                @else
-                    <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
-                @endif
-            @endforeach
-        @endif
-    </select>
+            @if (count($options))
+                @foreach ($options as $connected_entity_entry)
+                    @if($current_value == $connected_entity_entry->getKey())
+                        <option value="{{ $connected_entity_entry->getKey() }}" selected>{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                    @else
+                        <option value="{{ $connected_entity_entry->getKey() }}">{{ $connected_entity_entry->{$field['attribute']} }}</option>
+                    @endif
+                @endforeach
+            @endif
+        </select>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -16,43 +16,47 @@
             $categorylessEntries = $related_model::doesnthave($field['group_by'])->get();
         }
     @endphp
-    <select
-        name="{{ $field['name'] }}"
-        style="width: 100%"
-        @include('crud::fields.inc.attributes', ['default_class' =>  'form-control'])
-        >
 
-            @if ($field['allows_null'])
-                <option value="">-</option>
-            @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <select
+            name="{{ $field['name'] }}"
+            @include('crud::fields.inc.attributes', ['default_class' =>  'form-control'])
+            >
 
-            @if (isset($field['model']) && isset($field['group_by']))
-                @foreach ($categories as $category)
-                    <optgroup label="{{ $category->{$field['group_by_attribute']} }}">
-                        @foreach ($category->{$field['group_by_relationship_back']} as $subEntry)
-                            <option value="{{ $subEntry->getKey() }}"
-                                @if ( ( old($field['name']) && old($field['name']) == $subEntry->getKey() ) || (isset($field['value']) && $subEntry->getKey()==$field['value']))
-                                     selected
-                                @endif
-                            >{{ $subEntry->{$field['attribute']} }}</option>
-                        @endforeach
-                    </optgroup>
-                @endforeach
-
-                @if ($categorylessEntries->count())
-                    <optgroup label="-">
-                        @foreach ($categorylessEntries as $subEntry)
-
-                            @if($current_value == $subEntry->getKey())
-                                <option value="{{ $subEntry->getKey() }}" selected>{{ $subEntry->{$field['attribute']} }}</option>
-                            @else
-                                <option value="{{ $subEntry->getKey() }}">{{ $subEntry->{$field['attribute']} }}</option>
-                            @endif
-                        @endforeach
-                    </optgroup>
+                @if ($field['allows_null'])
+                    <option value="">-</option>
                 @endif
-            @endif
-    </select>
+
+                @if (isset($field['model']) && isset($field['group_by']))
+                    @foreach ($categories as $category)
+                        <optgroup label="{{ $category->{$field['group_by_attribute']} }}">
+                            @foreach ($category->{$field['group_by_relationship_back']} as $subEntry)
+                                <option value="{{ $subEntry->getKey() }}"
+                                    @if ( ( old($field['name']) && old($field['name']) == $subEntry->getKey() ) || (isset($field['value']) && $subEntry->getKey()==$field['value']))
+                                        selected
+                                    @endif
+                                >{{ $subEntry->{$field['attribute']} }}</option>
+                            @endforeach
+                        </optgroup>
+                    @endforeach
+
+                    @if ($categorylessEntries->count())
+                        <optgroup label="-">
+                            @foreach ($categorylessEntries as $subEntry)
+
+                                @if($current_value == $subEntry->getKey())
+                                    <option value="{{ $subEntry->getKey() }}" selected>{{ $subEntry->{$field['attribute']} }}</option>
+                                @else
+                                    <option value="{{ $subEntry->getKey() }}">{{ $subEntry->{$field['attribute']} }}</option>
+                                @endif
+                            @endforeach
+                        </optgroup>
+                    @endif
+                @endif
+        </select>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/time.blade.php
+++ b/src/resources/views/crud/fields/time.blade.php
@@ -2,12 +2,17 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-    	type="time"
-    	name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="time"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
     	>
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))

--- a/src/resources/views/crud/fields/url.blade.php
+++ b/src/resources/views/crud/fields/url.blade.php
@@ -2,13 +2,18 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-    	type="url"
-    	name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+    
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="url"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
     	>
-
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+    
     {{-- HINT --}}
     @if (isset($field['hint']))
         <p class="help-block">{!! $field['hint'] !!}</p>

--- a/src/resources/views/crud/fields/week.blade.php
+++ b/src/resources/views/crud/fields/week.blade.php
@@ -2,12 +2,17 @@
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
-    <input
-        type="week"
-        name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-        @include('crud::fields.inc.attributes')
+
+    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+        @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
+        <input
+            type="week"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
         >
+        @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
+    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
 
     {{-- HINT --}}
     @if (isset($field['hint']))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Not all fields had support for a prefix and/or suffix.

### AFTER - What is happening after this PR?

This PR adds prefix & suffix support to the following fields:
- color
- date
- datetime
- email
- month
- password
- time
- url
- week


## HOW

### How did you achieve that, in technical terms?

Copied the relevant markup from the text field, where prefix & suffix was implemented correctly.



### Is it a breaking change?

No.


### How can we test the before & after?

Compare the visual results from following statement:
```php
CRUD::field('your-field')->type('url')->prefix('Your prefix')->suffix('Your suffix');
```