### PR TITLE
Update base.php Italian translation file

### DIFF
--- a/src/resources/lang/it/base.php
+++ b/src/resources/lang/it/base.php
@@ -66,4 +66,6 @@ return [
     'confirm_email'        => 'Conferma E-mail',
     'choose_new_password'  => 'Scegli una nuova password',
     'confirm_new_password' => 'Conferma la nuova password',
+    'throttled'            => 'Hai richiesto un reset della password di recente. Per favore, controlla la tua email. Se non hai ricevuto la mail, allora riprova più tardi.',
+    'throttled_request'    => 'Hai eseguito troppi tentativi. Per favore, aspetta qualche minuto quindi riprova.',
 ];


### PR DESCRIPTION
Added two missing translations

## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was missing translations for italian locale

### AFTER - What is happening after this PR?

No more english strings in an italian app


## HOW

### How did you achieve that, in technical terms?

Simply added two array entries



### Is it a breaking change?

No

### How can we test the before & after?

Try a password reset for a few time using app with 'it' as locale
Before my modification, the error message was in english. Now is in italian