### PR TITLE
Add support for the repeatable field

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -116,7 +116,7 @@
                 subfield.isSubfield = true;
                 subfield.subfieldHolder = this.name;
             }else{
-                subfield.wrapper = $('[data-repeatable-identifier="'+this.name+'"][data-row-number="'+rowNumber+'"]');
+                subfield.wrapper = $('[data-repeatable-identifier="'+this.name+'"][data-row-number="'+rowNumber+'"]').find('[bp-field-wrapper][bp-field-name$="'+name+'"]');
                 subfield.input = subfield.wrapper.closest('[data-repeatable-input-name$="'+name+'"][bp-field-main-input]');
                 // if no bp-field-main-input has been declared in the field itself,
                 // assume it's the first input in that wrapper, whatever it is

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -9,7 +9,7 @@
     class CrudField {
         constructor(fieldName) {
             this.name = fieldName;
-            this.wrapper = $(`[bp-field-name*="${this.name}"][bp-field-wrapper]`);
+            this.wrapper = $(`[bp-field-name*="${this.name}"][bp-field-wrapper]`).first();
            
             // search input in ancestors
             this.input = this.wrapper.closest('[bp-field-main-input]');
@@ -42,11 +42,11 @@
         }
 
         change(closure) {
-            const fieldChanged = event => {
+            const fieldChanged = (event, values) => {
                 const wrapper = this.input.closest('[bp-field-wrapper=true]');
                 const name = wrapper.attr('bp-field-name');
                 const type = wrapper.attr('bp-field-type');
-                const value = this.input.val();
+                const value = typeof values === 'undefined' ? this.input.val() : values;
 
                 closure(event, value, name, type);
             };
@@ -117,7 +117,7 @@
                 subfield.subfieldHolder = this.name;
             }else{
                 subfield.wrapper = $('[data-repeatable-identifier="'+this.name+'"][data-row-number="'+rowNumber+'"]').find('[bp-field-wrapper][bp-field-name$="'+name+'"]');
-                subfield.input = subfield.wrapper.closest('[data-repeatable-input-name$="'+name+'"][bp-field-main-input]');
+                subfield.input = subfield.wrapper.find('[data-repeatable-input-name$="'+name+'"][bp-field-main-input]');
                 // if no bp-field-main-input has been declared in the field itself,
                 // assume it's the first input in that wrapper, whatever it is
                 if (subfield.input.length == 0) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Added support for subfields in other PR but the main "repeatable" container could not be targeted properly.

### AFTER - What is happening after this PR?

Developer can target and expect events from the main repeatable container as so `disable()` in a repeatable container field would disable all fields in container, plus disable new row, reorder and delete.


## HOW

### How did you achieve that, in technical terms?

Setup a custom change event handler on fields that will trigger the change in the "repeatable input" with the current value of the repeatable as a parameter. Implemented the disabling/enabling of all fields in a container. 


### Is it a breaking change?

no


### How can we test the before & after?

Added repeatable examples in demo: 

https://github.com/Laravel-Backpack/demo/pull/392

Also needs https://github.com/DigitallyHappy/backpack-pro/pull/43
