### PR TITLE
Change CrudField.input signature from jQuery to DOM element

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -11,24 +11,7 @@
             this.name = name;
             this.wrapper = $(`[bp-field-name*="${name}"][bp-field-wrapper]`);
             this.type = this.wrapper.attr('bp-field-type');
-           
-            // search input in ancestors
-            this.input = this.wrapper.closest('[bp-field-main-input]');
-
-            // search input in children
-            if (this.input.length === 0) {
-                this.input = this.wrapper.find('[bp-field-main-input]');
-            }
-
-            // if no bp-field-main-input has been declared in the field itself, try to find an input with that name inside wraper
-            if (this.input.length === 0) {
-                this.input = this.wrapper.find(`input[bp-field-name="${this.name}"], textarea[bp-field-name="${this.name}"], select[bp-field-name="${this.name}"]`).first();
-            }
-
-            // if nothing works, use the first input found in field wrapper.
-            if(this.input.length === 0) {
-                this.input = this.wrapper.find('input, textarea, select').first();
-            }
+            this.input = this.mainInput;
 
             // Validate that the field has been found
             if(this.wrapper.length === 0 || this.input.length === 0) {
@@ -45,6 +28,30 @@
             }
 
             return value;
+        }
+
+        get mainInput() {
+            let input;
+
+            // search input in ancestors
+            input = this.wrapper.closest('[bp-field-main-input]');
+
+            // search input in children
+            if (input.length === 0) {
+                input = this.wrapper.find('[bp-field-main-input]');
+            }
+
+            // if no bp-field-main-input has been declared in the field itself, try to find an input with that name inside wraper
+            if (input.length === 0) {
+                input = this.wrapper.find(`input[bp-field-name="${this.name}"], textarea[bp-field-name="${this.name}"], select[bp-field-name="${this.name}"]`).first();
+            }
+
+            // if nothing works, use the first input found in field wrapper.
+            if(input.length === 0) {
+                input = this.wrapper.find('input, textarea, select').first();
+            }
+
+            return input;
         }
 
         change(closure) {

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -11,7 +11,8 @@
             this.name = name;
             this.wrapper = $(`[bp-field-name*="${name}"][bp-field-wrapper]`);
             this.type = this.wrapper.attr('bp-field-type');
-            this.input = this.mainInput;
+            this.input = this.mainInput[0];
+            this.$input = this.mainInput;
 
             // Validate that the field has been found
             if(this.wrapper.length === 0 || this.input.length === 0) {
@@ -20,7 +21,7 @@
         }
 
         get value() {
-            let value = this.input.val();
+            let value = this.input.value;
 
             // Parse the value if it's a number
             if (value.length && !isNaN(value)) {
@@ -67,8 +68,8 @@
                 return this;
             }
 
-            this.input[0]?.addEventListener('input', fieldChanged, false);
-            $(this.input).change(fieldChanged);
+            this.$input[0]?.addEventListener('input', fieldChanged, false);
+            this.$input.change(fieldChanged);
             fieldChanged();
 
             return this;
@@ -80,7 +81,7 @@
 
         show(value = true) {
             this.wrapper.toggleClass('d-none', !value);
-            this.input.trigger(`backpack:field.${value ? 'show' : 'hide'}`);
+            this.$input.trigger(`backpack:field.${value ? 'show' : 'hide'}`);
             return this;
         }
 
@@ -89,8 +90,8 @@
         }
 
         enable(value = true) {
-            this.input.attr('disabled', !value && 'disabled');
-            this.input.trigger(`backpack:field.${value ? 'enable' : 'disable'}`);
+            this.$input.attr('disabled', !value && 'disabled');
+            this.$input.trigger(`backpack:field.${value ? 'enable' : 'disable'}`);
             return this;
         }
 
@@ -100,7 +101,7 @@
 
         require(value = true) {
             this.wrapper.toggleClass('required', value);
-            this.input.trigger(`backpack:field.${value ? 'require' : 'unrequire'}`);
+            this.$input.trigger(`backpack:field.${value ? 'require' : 'unrequire'}`);
             return this;
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Antonio was trying to remove jQuery form the CrudField API, but kept having problems with converting the selectors from jQuery to JS (surprise!! 😅). We couldn't move forward on adding repeatable support or anything else, because we were waiting on that.

Since it might take a lot of time, I've tried to find a way to separate the breaking change. **What we need right now is a working version of the final API**. I don't care if behind the scenes it uses jQuery or not. We can always refactor later, as long as it's a non-breaking change.

### AFTER - What is happening after this PR?

I've moved selecting the input to its own function, that returns a DOM Element. That means when the jQuery PR (currently https://github.com/Laravel-Backpack/CRUD/pull/4391 ) is ready, it should only have zero breaking changes. 

This way:
- we can continue to adding support for stuff, testing, etc;
- Antonio can continue his crusade of removing jQuery 😀 though it'll probably be a better idea to just redo it after we're done with the whole thing;

## HOW

### How did you achieve that, in technical terms?

- Moved the selectors from the constructor to a getter. Even though a getter might not be the best choice here, because the input won't change after CrudField construction, it'll just stay the same for ever.
- Changed the signature of `this.input` from jQuery object to DOM Element, so a few more changes were needed where we selected the input. See commit history for that.
- We now have two input properties on the `CrudField`:
    - `this.input` - returns a DOM element;
    - `this.$input` - returns a jQuery object;

With very small changes, this should help us compare what gets selected using jQuery and what gets selected using JS, to make sure it matches 100%. I'm not saying we should document `this.$input`. We shouldn't. If we can remove jQuery, we should remove it entirely. But for now, it should be useful to us.

### Is it a breaking change?

Yes. It changes the signature of `CrudField.input`.
