### PR TITLE
[Suggestion] JS Fields - Initialize argument

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -60,7 +60,8 @@
             return input;
         }
 
-        change(closure) {
+        change(closure, initialize) {
+            initialize ??= window.crud.initializeFields;
             const bindedClosure = closure.bind(this);
             const fieldChanged = (event, values) => bindedClosure(this, event, values);
 
@@ -75,13 +76,16 @@
 
             this.input?.addEventListener('input', fieldChanged, false);
             this.$input.change(fieldChanged);
-            fieldChanged();
+
+            if(initialize) {
+                fieldChanged();
+            }
 
             return this;
         }
 
-        onChange(closure) {
-            this.change(closure);
+        onChange(closure, initialize = null) {
+            this.change(closure, initialize);
         }
 
         show(value = true) {
@@ -146,6 +150,8 @@
      */
     window.crud = {
         ...window.crud,
+
+        initializeFields: true,
 
         // Create a field from a given name
         field: name => new CrudField(name),

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -60,8 +60,7 @@
             return input;
         }
 
-        change(closure, initialize) {
-            initialize ??= window.crud.initializeFields;
+        change(closure, initialize = false) {
             const bindedClosure = closure.bind(this);
             const fieldChanged = (event, values) => bindedClosure(this, event, values);
 
@@ -84,7 +83,7 @@
             return this;
         }
 
-        onChange(closure, initialize = null) {
+        onChange(closure, initialize = false) {
             return this.change(closure, initialize);
         }
 
@@ -150,8 +149,6 @@
      */
     window.crud = {
         ...window.crud,
-
-        initializeFields: true,
 
         // Create a field from a given name
         field: name => new CrudField(name),


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fields are always initialized by default.

### AFTER - What is happening after this PR?

Devs have the option to do not initialize fields.


### Is it a breaking change?

No


### How can we test the before & after?

before;
```
crud.field('visible').onChange(field => console.log(`Value was changed`));
```

after;
```
crud.field('visible').onChange(field => console.log(`Value was changed`), false);
```

And devs my also change the defaults;

```
crud.initializeFields = false;
```