### PR TITLE
CrudField JS API - add triggerChange method

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -75,13 +75,16 @@
 
             this.input?.addEventListener('input', fieldChanged, false);
             this.$input.change(fieldChanged);
-            fieldChanged();
 
             return this;
         }
 
         onChange(closure) {
             return this.change(closure);
+        }
+
+        triggerChange() {
+            this.$input.trigger(`change`);
         }
 
         show(value = true) {

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -60,7 +60,7 @@
             return input;
         }
 
-        change(closure) {
+        onChange(closure) {
             const bindedClosure = closure.bind(this);
             const fieldChanged = (event, values) => bindedClosure(this, event, values);
 
@@ -79,11 +79,7 @@
             return this;
         }
 
-        onChange(closure) {
-            return this.change(closure);
-        }
-
-        triggerChange() {
+        change() {
             this.$input.trigger(`change`);
         }
 


### PR DESCRIPTION
## WHY

Alternative to https://github.com/Laravel-Backpack/CRUD/pull/4426

### BEFORE - What was wrong? What was happening before this PR?

Upon pageload, we triggered the `change` event on all fields, so that a few common SCENARIOS work out-of-the-box. But even though it makes sense for those scenarios (eg. hide an input by default, then only show it if condition is true), it could pose big problems form custom fields... or anything else custom on page that captures the `change` event.

So instead of triggering `change` automatically... we should probably make it easier to trigger `change` manually, and instruct our devs to do so _if needed_.

### AFTER - What is happening after this PR?

If you do the same thing as before, the `custom_parent` field will NOT be hidden by default, because that closure hasn't been run:
```javascript
// EXAMPLE 4
// MUST: when a select has something specific selected, show a second field;
crud.field('parent').onChange(field => {
  crud.field('custom_parent').show(field.value === 6);
});
```

If you, as a developer, WANT that closure to be run on pageload, you can call an additional method afterwards, to instruct Backpack to do so:
```diff
// EXAMPLE 4
// MUST: when a select has something specific selected, show a second field;
crud.field('parent').onChange(field => {
  crud.field('custom_parent').show(field.value === 6);
- });
+ }).triggerChange();
```

To me this looks intuitive:
- specify what needs to happen onChange
- then trigger the change event

But... is it really intuitive, or just to me?

## HOW

### How did you achieve that, in technical terms?

- removed the automatic triggering of `change` on all fields;
- added a new method, `triggerChange()`, that devs can easily use;

### Is it a breaking change?

Yes, to the CrudField branch. But not to Backpack itself.
