### PR TITLE
only register input event in input type text and textarea

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -66,9 +66,12 @@
                 return this;
             }
 
-            this.input?.addEventListener('input', fieldChanged, false);
-            this.$input.change(fieldChanged);
-
+            if(typeof this.input !== 'undefined') {
+                if(['text', 'textarea'].includes(this.input.getAttribute('type'))) {
+                    this.input?.addEventListener('input', fieldChanged, false);
+                }
+                this.$input.change(fieldChanged);
+            }
             return this;
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I was having a hard time figuring out why `select_multiple` was triggering multiple times the change event, turns out that it was because the event was registered twice, on input and on change.

### AFTER - What is happening after this PR?

The event is only registered once for non text/textarea inputs.

## HOW

### How did you achieve that, in technical terms?

conditional checking!

