### PR TITLE
Password Validation improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^9.0|^8.39",
+        "laravel/framework": "^9.0|^8.78",
         "prologue/alerts": "^1.0|^0.4",
         "digitallyhappy/assets": "^2.0.1",
         "creativeorange/gravatar": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^9.0|^8.26",
+        "laravel/framework": "^9.0|^8.39",
         "prologue/alerts": "^1.0|^0.4",
         "digitallyhappy/assets": "^2.0.1",
         "creativeorange/gravatar": "~1.0",

--- a/src/Backpack.php
+++ b/src/Backpack.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Backpack\CRUD;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+
+class Backpack
+{
+    /**
+     * The callback that will generate the "default" version of backpack password rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultPasswordRulesCallback;
+
+    /**
+     * Get the default configuration of the password rule.
+     *
+     * @return static
+     */
+    public static function passwordRulesDefault()
+    {
+        $password = is_callable(static::$defaultPasswordRulesCallback)
+            ? call_user_func(static::$defaultPasswordRulesCallback)
+            : static::$defaultPasswordRulesCallback;
+
+        return $password instanceof Rule ? $password : Password::min(8);
+    }
+    
+    /**
+     * Set the default callback to be used for determining a password's default rules.
+     *
+     * If no arguments are passed, the default password rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|null
+     */
+    public static function passwordRulesDefaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::passwordRulesDefault();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof Password) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.Password::class);
+        }
+
+        static::$defaultPasswordRulesCallback = $callback;
+    }
+}

--- a/src/Backpack.php
+++ b/src/Backpack.php
@@ -12,7 +12,7 @@ class Backpack
      *
      * @var string|array|callable|null
      */
-    public static $defaultPasswordRulesCallback;
+    protected static $defaultPasswordRulesCallback;
 
     /**
      * Get the default configuration of the password rule.

--- a/src/Backpack.php
+++ b/src/Backpack.php
@@ -15,7 +15,7 @@ class Backpack
     protected static $defaultPasswordRulesCallback;
 
     /**
-     * Get the default configuration of the password rule.
+     * Get the default configuration of backpack password rule.
      *
      * @return static
      */
@@ -29,7 +29,7 @@ class Backpack
     }
     
     /**
-     * Set the default callback to be used for determining a password's default rules.
+     * Set the default callback to be used for determining backpack password's default rules.
      *
      * If no arguments are passed, the default password rule configuration will be returned.
      *

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -45,6 +45,7 @@ class BackpackServiceProvider extends ServiceProvider
         $this->setupRoutes($this->app->router);
         $this->setupCustomRoutes($this->app->router);
         $this->publishFiles();
+        Backpack::passwordRulesDefaults(config('backpack.base.password_validation_rules'));
         $this->sendUsageStats();
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -56,7 +56,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', 'min:8', ...config('backpack.base.password_validation_rules')],
+            'password'                         => ['required', 'confirmed', ...config('backpack.base.password_validation_rules')],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -57,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', 'min:8', Password::defaults()],
+            'password'                         => ['required', 'confirmed', 'min:8', ...config('backpack.base.password_validation_rules')],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Http\Controllers\Auth;
 
 use Backpack\CRUD\app\Library\Auth\RegistersUsers;
+use Backpack\CRUD\Backpack;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -56,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', ...config('backpack.base.password_validation_rules')],
+            'password'                         => ['required', 'confirmed', Backpack::passwordRulesDefaults()],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\app\Library\Auth\RegistersUsers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Validation\Rules\Password;
 use Validator;
 
 class RegisterController extends Controller
@@ -56,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => 'required|min:6|confirmed',
+            'password'                         => ['required', 'confirmed', Password::min(8)->uncompromised()],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -57,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', 'min:6', Password::defaults()],
+            'password'                         => ['required', 'confirmed', 'min:8', Password::defaults()],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -57,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', Password::min(8)->uncompromised()],
+            'password'                         => ['required', 'confirmed', 'min:8', Password::defaults()],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -57,7 +57,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => ['required', 'confirmed', 'min:8', Password::defaults()],
+            'password'                         => ['required', 'confirmed', 'min:6', Password::defaults()],
         ]);
     }
 

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -6,7 +6,6 @@ use Backpack\CRUD\app\Library\Auth\RegistersUsers;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Validation\Rules\Password;
 use Validator;
 
 class RegisterController extends Controller

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Rules\Password as PasswordValidation;
 use Illuminate\Validation\ValidationException;
 
 trait ResetsPasswords
@@ -69,7 +69,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', 'min:8', Password::defaults()],
+            'password' => ['required', 'confirmed', 'min:8', PasswordValidation::defaults()],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -68,7 +68,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', 'min:8', ...config('backpack.base.password_validation_rules')],
+            'password' => ['required', 'confirmed', ...config('backpack.base.password_validation_rules')],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -69,7 +69,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', 'min:8', PasswordValidation::defaults()],
+            'password' => ['required', 'confirmed', 'min:8', ...config('backpack.base.password_validation_rules')],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -69,7 +69,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', Password::min(8)->uncompromised()],
+            'password' => ['required', 'confirmed', 'min:8', Password::defaults()],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
 
 trait ResetsPasswords
@@ -68,7 +69,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|confirmed|min:8',
+            'password' => ['required', 'confirmed', Password::min(8)->uncompromised()],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\Auth;
 
+use Backpack\CRUD\Backpack;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -68,7 +69,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => ['required', 'confirmed', ...config('backpack.base.password_validation_rules')],
+            'password' => ['required', 'confirmed', Backpack::passwordRulesDefaults()],
         ];
     }
 

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Password as PasswordValidation;
 use Illuminate\Validation\ValidationException;
 
 trait ResetsPasswords

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -278,10 +278,7 @@ return [
     // 'blank' will keep the generic image with the user first letter
     'gravatar_fallback' => 'blank',
     
-    'password_validation_rules' => [
-        Password::min(8),
-        // Password::defaults(),
-    ],
+    'password_validation_rules' => Password::min(8),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -279,6 +279,7 @@ return [
     'gravatar_fallback' => 'blank',
     
     'password_validation_rules' => [
+        Password::min(8),
         // Password::defaults(),
     ],
 

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Validation\Rules\Password;
+
 return [
 
     /*
@@ -275,6 +277,10 @@ return [
     // Gravatar fallback options are 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'
     // 'blank' will keep the generic image with the user first letter
     'gravatar_fallback' => 'blank',
+    
+    'password_validation_rules' => [
+        // Password::defaults(),
+    ],
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Backpack\CRUD\app\Http\Controllers\Auth\RegisterController has a min password length of 6
Backpack\CRUD\app\Library\Auth\ResetsPasswords.php has a min password length of 8

NIST recommends a min password length of 8. laravel also use a min password length of 8 now by default

As an admin, we should also have stronger password requirements, like disallowing compromised passwords

https://laravel-news.com/password-validation-rule-object-in-laravel-8

### AFTER - What is happening after this PR?

min password length to be 8 on RegisterController
bump min laravel to 8.39
Use the uncompromised() rule.

## HOW

### How did you achieve that, in technical terms?

See the changes in the code

### Is it a breaking change?

There might be a tiny chance the user cannot upgrade from laravel 8.26 to 8.39

the uncompromised rule also makes a network call and might be inconvenient in local development if you are on a plane testing registration and resetting password. It is also common to use easy to guess passwords during local development. However that would be so unlikely.

https://haveibeenpwned.com/API/v3#PwnedPasswords

### How can we test the before & after?

Just use the register and reset password feature in backpack

### Side Thoughts?

Instead of doing Password::min(8)->uncompromised() we might want to use Password::defaults() to use the user password rules they defined in AuthServiceProvider boot method if they defined it. The ->rules() u see in the code example below requires laravel 8.87 however. While Password::defaults() exist since laravel 8.42

https://laravel.com/docs/8.x/validation#defining-default-password-rules

https://github.com/laravel/framework/commits/8.x/src/Illuminate/Validation/Rules/Password.php

```php
// AuthServiceProvider
public function boot(): void
{
        Password::defaults(function () {
            $rule = Password::min(8);

            return $this->app->isProduction()
                ? $rule
                    ->uncompromised()
                : $rule;
        });
}
```

Then in our validation rules. (Note that the ->rules() method is only added in 8.78)

```php
[
    'required', 
    'confirmed',
    'min:8',
    Password::defaults()->rules([ // The extra ->rules() method is added in laravel 8.78
        'additional-rules-we-might-want-to-enforce-for-the-password-field-like-uncompromised'
        'or it might be a bad idea',
    ]),
]
```
