### PR TITLE
Add readonly for JS API

### DIFF
--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -54,10 +54,10 @@
                   element.prop('checked', false);
                 }
 
-                hidden_element.on('CrudField:disable', function(e) {
+                hidden_element.on('CrudField:disable CrudField:readonlyOn', function(e) {
                   element.prop('disabled', true);
                 });
-                hidden_element.on('CrudField:enable', function(e) {
+                hidden_element.on('CrudField:enable CrudField:readonlyOff', function(e) {
                   element.removeAttr('disabled');
                 });
 

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -90,14 +90,13 @@
 
                 });
 
-                hidden_input.on('CrudField:disable', function(e) {
-                      checkboxes.attr('disabled', 'disabled');
-                  });
-
-                hidden_input.on('CrudField:enable', function(e) {
-                    checkboxes.removeAttr('disabled');
+                hidden_input.on('CrudField:disable CrudField:readonlyOn', function(e) {
+                  checkboxes.attr('disabled', 'disabled');
                 });
 
+                hidden_input.on('CrudField:enable CrudField:readonlyOff', function(e) {
+                  checkboxes.removeAttr('disabled');
+                });
             }
         </script>
         @endLoadOnce

--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -225,25 +225,25 @@
             });
           };
           
-          thisField.find('div.hidden_fields_primary').children('input').first().on('CrudField:disable', function(e) {
+          thisField.find('div.hidden_fields_primary').children('input').first().on('CrudField:disable CrudField:readonlyOn', function(e) {
               let input = $(e.target);
               input.parent().parent().find('input[type=checkbox]').attr('disabled', 'disabled');
               input.siblings('input').attr('disabled','disabled');
           });
 
-          thisField.find('div.hidden_fields_primary').children('input').first().on('CrudField:enable', function(e) {
+          thisField.find('div.hidden_fields_primary').children('input').first().on('CrudField:enable CrudField:readonlyOff', function(e) {
               let input = $(e.target);
               input.parent().parent().find('input[type=checkbox]').not('[forced-select]').removeAttr('disabled');
               input.siblings('input').removeAttr('disabled');
           });
 
-          thisField.find('div.hidden_fields_secondary').children('input').first().on('CrudField:disable', function(e) {
+          thisField.find('div.hidden_fields_secondary').children('input').first().on('CrudField:disable CrudField:readonlyOn', function(e) {
               let input = $(e.target);
               input.parent().parent().find('input[type=checkbox]').attr('disabled', 'disabled');
               input.siblings('input').attr('disabled','disabled');
           });
 
-          thisField.find('div.hidden_fields_secondary').children('input').first().on('CrudField:enable', function(e) {
+          thisField.find('div.hidden_fields_secondary').children('input').first().on('CrudField:enable CrudField:readonlyOff', function(e) {
               let input = $(e.target);
               input.parent().parent().find('input[type=checkbox]').not('[forced-select]').removeAttr('disabled');
               input.siblings('input').removeAttr('disabled');

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -64,13 +64,13 @@
                 $(this).siblings('label').attr('for', id+index);
             });
 
-            hiddenInput.on('CrudField:disable', function(e) {
+            hiddenInput.on('CrudField:disable CrudField:readonlyOn', function(e) {
                 element.find('.form-check input[type=radio]').each(function(index, item) {
                     $(this).prop('disabled', true);
                 });
             });
 
-            hiddenInput.on('CrudField:enable', function(e) {
+            hiddenInput.on('CrudField:enable CrudField:readonlyOff', function(e) {
                 element.find('.form-check input[type=radio]').each(function(index, item) {
                     $(this).removeAttr('disabled');
                 });

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -23,6 +23,7 @@
 
     <select
         name="{{ $field['name'] }}"
+        data-init-function="bpFieldInitSelectElement"
         @include('crud::fields.inc.attributes')
         >
 
@@ -47,3 +48,19 @@
     @endif
 
 @include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_scripts')
+@loadOnce('bpFieldInitSelectElement')
+<script>
+function bpFieldInitSelectElement(element) {
+    element.on('mousedown keydown keyup', function(e) {
+        if($(this).attr('readonly')) {
+            this.blur();
+            e.stopImmediatePropagation();
+            return false;
+        }
+    })
+}
+</script>
+@endLoadOnce
+@endpush

--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -10,6 +10,7 @@
     @if($field['multiple'])<input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />@endif
     <select
         name="{{ $field['name'] }}@if ($field['multiple'])[]@endif"
+        data-init-function="bpFieldInitSelectFromArrayElement"
         @include('crud::fields.inc.attributes')
         @if ($field['multiple'])multiple bp-field-main-input @endif
         >
@@ -34,3 +35,19 @@
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
 @include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_scripts')
+@loadOnce('bpFieldInitSelectFromArrayElement')
+<script>
+function bpFieldInitSelectFromArrayElement(element) {
+    element.on('mousedown keydown keyup', function(e) {
+        if($(this).attr('readonly')) {
+            this.blur();
+            e.stopImmediatePropagation();
+            return false;
+        }
+    })
+}
+</script>
+@endLoadOnce
+@endpush

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -19,6 +19,7 @@
     <select
         name="{{ $field['name'] }}"
         style="width: 100%"
+        data-init-function="bpFieldInitSelectGroupedElement"
         @include('crud::fields.inc.attributes', ['default_class' =>  'form-control'])
         >
 
@@ -59,3 +60,19 @@
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
 @include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_scripts')
+@loadOnce('bpFieldInitSelectGroupedElement')
+<script>
+function bpFieldInitSelectGroupedElement(element) {
+    element.on('mousedown keydown keyup', function(e) {
+        if($(this).attr('readonly')) {
+            this.blur();
+            e.stopImmediatePropagation();
+            return false;
+        }
+    })
+}
+</script>
+@endLoadOnce
+@endpush

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -25,6 +25,7 @@
     	class="form-control"
         name="{{ $field['name'] }}[]"
         @include('crud::fields.inc.attributes')
+        data-init-function="bpFieldInitSelectMultipleElement"
         bp-field-main-input
     	multiple>
 
@@ -46,3 +47,19 @@
     @endif
 
 @include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_scripts')
+@loadOnce('bpFieldInitSelectMultipleElement')
+<script>
+function bpFieldInitSelectMultipleElement(element) {
+    element.on('mousedown keydown keyup', function(e) {
+        if($(this).attr('readonly')) {
+            this.blur();
+            e.stopImmediatePropagation();
+            return false;
+        }
+    })
+}
+</script>
+@endLoadOnce
+@endpush

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -55,11 +55,11 @@
                 }
             }
 
-            element.on('CrudField:disable', function(e) {
+            element.on('CrudField:disable CrudField:readonlyOn', function(e) {
                 element.summernote('disable');
             });
 
-            element.on('CrudField:enable', function(e) {
+            element.on('CrudField:enable CrudField:readonlyOff', function(e) {
                 element.summernote('enable');
             });
             

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -139,36 +139,61 @@
   @loadOnce('bpFieldInitUploadElement')
     <script>
         function bpFieldInitUploadElement(element) {
-            var fileInput = element.find(".file_input");
-            var fileClearButton = element.find(".file_clear_button");
-            var fieldName = element.attr('data-field-name');
-            var inputWrapper = element.find(".backstrap-file");
-            var inputLabel = element.find(".backstrap-file-label");
+          var fileInput = element.find(".file_input");
+          var fileClearButton = element.find(".file_clear_button");
+          var fieldName = element.attr('data-field-name');
+          var inputWrapper = element.find(".backstrap-file");
+          var inputLabel = element.find(".backstrap-file-label");
 
-            fileClearButton.click(function(e) {
-                e.preventDefault();
-                $(this).parent().addClass('d-none');
+          fileClearButton.click(function(e) {
+              e.preventDefault();
+              $(this).parent().addClass('d-none');
 
-                fileInput.parent().removeClass('d-none');
-                fileInput.attr("value", "").replaceWith(fileInput.clone(true));
+              fileInput.parent().removeClass('d-none');
+              fileInput.attr("value", "").replaceWith(fileInput.clone(true));
 
-                // redo the selector, so we can use the same fileInput variable going forward
-                fileInput = element.find(".file_input");
+              // redo the selector, so we can use the same fileInput variable going forward
+              fileInput = element.find(".file_input");
 
-                // add a hidden input with the same name, so that the setXAttribute method is triggered
-                $("<input type='hidden' name='"+fieldName+"' value=''>").insertAfter(fileInput);
-            });
+              // add a hidden input with the same name, so that the setXAttribute method is triggered
+              $("<input type='hidden' name='"+fieldName+"' value=''>").insertAfter(fileInput);
+          });
 
-            fileInput.change(function() {
+          fileInput.change(function() {
+              if(!$(this).attr('readonly')) {
                 var path = $(this).val();
                 var path = path.replace("C:\\fakepath\\", "");
                 inputLabel.html(path);
                 // remove the hidden input, so that the setXAttribute method is no longer triggered
                 $(this).next("input[type=hidden]").remove();
-            });
+              }
+          });
 
-            element.on('CrudField:disable', function(e) {
-              element.children('.backstrap-file').find('input').prop('disabled', 'disabled');
+          element.on('CrudField:disable', function(e) {
+            changeUploadInputState(element, 'disabled', false);
+          });
+
+          element.on('CrudField:enable', function(e) {
+            changeUploadInputState(element, 'disabled');
+          });
+
+          element.on('CrudField:readonlyOn', function(e) {
+            changeUploadInputState(element, 'readonly', false);
+          });
+
+          element.on('CrudField:readonlyOff', function(e) {
+            changeUploadInputState(element, 'readonly');
+          });
+
+          function changeUploadInputState(element, attribute, enable = true) {
+
+            if(enable) {
+              element.children('.backstrap-file').find('input').removeAttr(attribute);
+              element.children('.existing-file').children('a.file_clear_button').unbind('click.prevent');
+              return;
+            }
+
+            element.children('.backstrap-file').find('input').prop(attribute, attribute);
               
               let $deleteButton = element.children('.existing-file').children('a.file_clear_button');
               
@@ -180,13 +205,7 @@
                   // make the event we just registered, the first to be triggered
                   $._data($deleteButton.get(0), "events").click.reverse();
               }
-          });
-
-          element.on('CrudField:enable', function(e) {
-            element.children('.backstrap-file').find('input').removeAttr('disabled');
-            element.children('.existing-file').children('a.file_clear_button').unbind('click.prevent');
-          });
-
+          }
         }
     </script>
   @endLoadOnce

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -162,20 +162,47 @@
 		        });
 
 		        fileInput.change(function() {
-	                inputLabel.html("Files selected. After save, they will show up above.");
-					let selectedFiles = [];
+					if(!$(this).attr('readonly')) {
+						inputLabel.html("Files selected. After save, they will show up above.");
+						let selectedFiles = [];
 
-					Array.from($(this)[0].files).forEach(file => {
-						selectedFiles.push({name: file.name, type: file.type})
-					});
+						Array.from($(this)[0].files).forEach(file => {
+							selectedFiles.push({name: file.name, type: file.type})
+						});
 
-					element.find('input').first().val(JSON.stringify(selectedFiles)).trigger('change');
-		        	// remove the hidden input, so that the setXAttribute method is no longer triggered
-					$(this).next("input[type=hidden]:not([name='clear_"+fieldName+"[]'])").remove();
+						element.find('input').first().val(JSON.stringify(selectedFiles)).trigger('change');
+						// remove the hidden input, so that the setXAttribute method is no longer triggered
+						$(this).next("input[type=hidden]:not([name='clear_"+fieldName+"[]'])").remove();
+					}
 		        });
 
 				element.find('input').on('CrudField:disable', function(e) {
-					element.children('.backstrap-file').find('input').prop('disabled', 'disabled');
+					changeUploadMultipleInputState(element, 'disabled', false);
+				});
+
+				element.on('CrudField:enable', function(e) {
+					changeUploadMultipleInputState(element, 'disabled');
+				});
+
+				element.on('CrudField:readonlyOn', function(e) {
+					changeUploadMultipleInputState(element, 'readonly', false);
+				});
+
+				element.on('CrudField:readonlyOff', function(e) {
+					changeUploadMultipleInputState(element, 'readonly');
+				});
+
+				function changeUploadMultipleInputState(element, attribute, enable = true) {
+
+					if(enable) {
+						element.children('.backstrap-file').find('input').removeAttr(attribute);
+						element.children('.existing-file').find('.file-preview').each(function(i, el) {
+							$(el).find('a.file-clear-button').unbind('click.prevent');
+						});
+						return;
+					}
+
+					element.children('.backstrap-file').find('input').prop(attribute, attribute);
 					element.children('.existing-file').find('.file-preview').each(function(i, el) {
 
 						let $deleteButton = $(el).find('a.file-clear-button');
@@ -189,14 +216,7 @@
 							$._data($deleteButton.get(0), "events").click.reverse();
 						}
 					});
-				});
-
-				element.on('CrudField:enable', function(e) {
-					element.children('.backstrap-file').find('input').removeAttr('disabled');
-					element.children('.existing-file').find('.file-preview').each(function(i, el) {
-						$(el).find('a.file-clear-button').unbind('click.prevent');
-					});
-				});
+				}
         	}
         </script>
         @endLoadOnce

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -137,6 +137,12 @@
             return this.require(!value);
         }
 
+        readonly(value = true) {
+            this.$input.attr('readonly', value && 'readonly');
+            this.$input.trigger(`CrudField:${value ? 'readonlyOn' : 'readonlyOff'}`);
+            return this;
+        }
+
         check(value = true) {
             this.wrapper.find('input[type=checkbox]').prop('checked', value).trigger('change');
             return this;


### PR DESCRIPTION
Pretty much the same behaviour as `disabled` but the input get's `readonly` attribute so it is submitted with form. 
All the other input elements are disabled the same (like removing an entry or adding an entry).

There are PR's in PRO and DEMO. 

