### PR TITLE
CrudColumn `getAttributeValue()` method

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -144,6 +144,16 @@ class CrudColumn
     }
 
     /**
+     * Check if the CrudColumn object has a certain attribute defined.
+     *
+     * @param  bool  $attribute  name of the attribute
+     */
+    public function hasAttribute($attribute)
+    {
+        return isset($this->attributes[$attribute]);
+    }
+
+    /**
      * Get the value for a certain attribute on the CrudColumn object.
      *
      * @param  string  $attribute  name of the attribute

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -143,6 +143,16 @@ class CrudColumn
         return $this;
     }
 
+    /**
+     * Get the value for a certain attribute on the CrudColumn object.
+     *
+     * @param string $attribute name of the attribute
+     */
+    public function getAttributeValue($attribute)
+    {
+        return $this->attributes[$attribute];
+    }
+
     // -----------------
     // DEBUGGING METHODS
     // -----------------

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -150,7 +150,7 @@ class CrudColumn
      */
     public function getAttributeValue($attribute)
     {
-        return $this->attributes[$attribute];
+        return $this->attributes[$attribute] ?? null;
     }
 
     // -----------------


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

`Backpack\CRUD\app\Library\CrudPanel\CrudColumn` atributes are protected, and it's correct 👌
But, it would be useful if we could access them, specially in Editable Columns.

### AFTER - What is happening after this PR?

This exposes a public method `getAttributeValue()`, to access column attributes.

### Is it a breaking change?

No.
