### PR TITLE
JS fields - Allow multiple subfields callbacks

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -79,9 +79,7 @@
 
             if(this.isSubfield) {
                 window.crud.subfieldsCallbacks[this.parent.name] ??= [];
-                if(!window.crud.subfieldsCallbacks[this.parent.name].some( callbacks => callbacks['fieldName'] === this.name )) {
-                    window.crud.subfieldsCallbacks[this.parent.name].push({closure, field: this});
-                }
+                window.crud.subfieldsCallbacks[this.parent.name].push({ closure, field: this });
                 return this;
             }
 


### PR DESCRIPTION
> **Note** 
> This is pointing to #4455.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was a condition not allowing to add multiple event listeners to a subfield.

### AFTER - What is happening after this PR?

That condition no longer exists.


### Is it a breaking change?

No.


### How can we test the before & after?

Actually, there was an error in the previous code, so it was allowing adding multiple event listeners. Due to that error it's not possible to test the before and after.
