### PR TITLE
JS fields - `change` consistent return

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -95,15 +95,12 @@
 
         change() {
             if(this.isSubfield) {
-                if(typeof window.crud.subfieldsCallbacks[this.parent.name].length !== 'undefined') {
-                    window.crud.subfieldsCallbacks[this.parent.name].forEach(item => {
-                        item.triggerChange = true;
-                    });
-                }
-                return this;
+                window.crud.subfieldsCallbacks[this.parent.name]?.forEach(callback => callback.triggerChange = true);
+            } else {
+                this.$input.trigger(`change`);
             }
 
-            this.$input.trigger(`change`);
+            return this;
         }
 
         show(value = true) {


### PR DESCRIPTION
> **Note** 
> This is pointing to #4455.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

`change` method didn't have a consistent return.
If it wasn't a subfield it would not return itself.

### AFTER - What is happening after this PR?

`change` always returns `this`.


### Is it a breaking change?

No.
