### PR TITLE
Fix validation when no FormRequest provided

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -239,15 +239,16 @@ trait Validation
     }
 
     /**
-     * Checks if the current crud request is valid against the provided rules
-     * 
-     * @param array $rules
-     * @param array $messages
-     * 
+     * Checks if the current crud request is valid against the provided rules.
+     *
+     * @param  array  $rules
+     * @param  array  $messages
      * @return \Illuminate\Http\Request
      */
-    private function checkRequestValidity($rules, $messages) {
+    private function checkRequestValidity($rules, $messages)
+    {
         $this->getRequest()->validate($rules, $messages);
+
         return $this->getRequest();
     }
 

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -235,7 +235,20 @@ trait Validation
             return app(get_class($extendedRequest), ['rules' => $rules, 'messages' => $messages]);
         }
 
-        return ! empty($rules) ? $this->getRequest()->validate($rules, $messages) : $this->getRequest();
+        return ! empty($rules) ? $this->checkRequestValidity($rules, $messages) : $this->getRequest();
+    }
+
+    /**
+     * Checks if the current crud request is valid against the provided rules
+     * 
+     * @param array $rules
+     * @param array $messages
+     * 
+     * @return \Illuminate\Http\Request
+     */
+    private function checkRequestValidity($rules, $messages) {
+        $this->getRequest()->validate($rules, $messages);
+        return $this->getRequest();
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fixes: https://github.com/Laravel-Backpack/CRUD/issues/4381
When developers didn't provide FormRequest as a validator the returned validation would be the array of valid inputs instead of the full request instance. 

### AFTER - What is happening after this PR?

We validate the request but return the request instance. 


### Is it a breaking change?

No


### How can we test the before & after?

Go to monster, remove the `setValidation` from FormRequest, add in a field `validationRules`. 
