### PR TITLE
only add the hidden input in case it doesn't exist

### DIFF
--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -207,12 +207,12 @@
             let idCurrent = el.data('id');
             //add hidden field with this value
             let nameInput = field.find('.hidden_fields_primary').data('name');
-            let inputToAdd = $('<input type="hidden" class="primary_hidden" name="'+nameInput+'[]" value="'+idCurrent+'">');
+            if(field.find('input.primary_hidden[value="'+idCurrent+'"]').length === 0) {
+              let inputToAdd = $('<input type="hidden" class="primary_hidden" name="'+nameInput+'[]" value="'+idCurrent+'">');
 
-            field.find('.hidden_fields_primary').append(inputToAdd);
-            field.find('.hidden_fields_primary').find('input').first().val(idCurrent).trigger('change');
-            field.find('.hidden_fields_primary').find('input').first().val()
-
+              field.find('.hidden_fields_primary').append(inputToAdd);
+              field.find('.hidden_fields_primary').find('input.primary_hidden[value="'+idCurrent+'"]').trigger('change');
+            }
             $.each(dependencyJson[idCurrent], function(key, value){
               //check and disable secondies checkbox
               field.find('input.secondary_list[value="'+value+'"]').prop( "checked", true );


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The hidden input were create twice, one for the `old/database value` and another when the check event was parsed with JS. This lead to #4461 since only one of the input was removed leaving the other behind.

### AFTER - What is happening after this PR?

We only add the JS input case it doesn't exist previously.

## HOW

### How did you achieve that, in technical terms?

checking for input presence before adding the second input that was causing issues.

### Is it a breaking change?

not

### How can we test the before & after?

In PermissionManager UserCrud, load one user with one role already selected from db, and then remove that role and save. It will lead to errors and you will notice that the last role value had been sent because the input was not properly removed (it had 2 inputs and only one was removed).



