### PR TITLE
Added switch field

### DIFF
--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -1,0 +1,85 @@
+{{-- switch field --}}
+@php
+    $field['value'] = old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '0';
+    $field['options'] = $field['options'] ?? false;
+    $field['color'] = $field['color'] ?? 'primary';
+@endphp
+
+{{-- Wrapper --}}
+@include('crud::fields.inc.wrapper_start')
+
+    {{-- Translatable icon --}}
+    @include('crud::fields.inc.translatable_icon')
+
+    <div class="d-inline-flex">
+        {{-- Switch --}}
+        <label class="switch switch-sm switch-label switch-pill switch-{{ $field['color'] }}" style="margin-bottom: 0;">
+            <input
+                type="hidden"
+                name="{{ $field['name'] }}"
+                value="{{ $field['value'] }}" />
+            <input
+                type="checkbox"
+                data-init-function="bpFieldInitSwitch"
+                {{ (bool) $field['value'] ? 'checked' : '' }}
+                class="switch-input" />
+            <span
+                class="switch-slider"
+                data-checked="{{ $field['options'][0] ?? '' }}"
+                data-unchecked="{{ $field['options'][1] ?? '' }}">
+            </span>
+        </label>
+
+        {{-- Label --}}
+        <label class="font-weight-normal mb-0 ml-2">{!! $field['label'] !!}</label>
+    </div>
+
+    {{-- Label for the required * --}}
+    <label class="d-inline-flex m-0">&nbsp;</label>
+
+    {{-- Hint --}}
+    @isset($field['hint'])
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endisset
+@include('crud::fields.inc.wrapper_end')
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+
+{{-- FIELD JS - will be loaded in the after_scripts section --}}
+@push('crud_fields_scripts')
+    @loadOnce('bpFieldInitSwitch')
+    <script>
+        function bpFieldInitSwitch($element) {
+            let element = $element[0];
+            let hiddenElement = element.previousElementSibling;
+            let id = `switch_${hiddenElement.name}_${Math.random() * 1e18}`;
+
+            // set unique IDs so that labels are correlated with inputs
+            element.setAttribute('id', id);
+            element.parentElement.nextElementSibling.setAttribute('for', id);
+
+            // set the default checked/unchecked state
+            // if the field has been loaded with javascript
+            hiddenElement.value !== '0'
+                ? element.setAttribute('checked', true)
+                : element.removeAttribute('checked');
+
+            // JS Field API
+            $(hiddenElement).on('CrudField:disable', () => element.setAttribute('disabled', true));
+            $(hiddenElement).on('CrudField:enable', () => element.removeAttribute('disabled'));
+
+            // when the checkbox is clicked
+            // set the correct value on the hidden input
+            $element.on('change', () => {
+                hiddenElement.value = element.checked ? 1 : 0;
+                hiddenElement.dispatchEvent(new Event('change'));
+            });
+        }
+    </script>
+    @endLoadOnce
+@endpush
+
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -50,7 +50,7 @@
 
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
-    @loadOnce('bpFieldInitSwitch')
+    @loadOnce('bpFieldInitSwitchScript')
     <script>
         function bpFieldInitSwitch($element) {
             let element = $element[0];
@@ -81,6 +81,18 @@
     </script>
     @endLoadOnce
 @endpush
+
+@if(\Str::startsWith($field['color'], '#'))
+@push('crud_fields_styles')
+    @loadOnce('bpFieldInitSwitchStyle')
+    <style>
+        .switch .switch-input:checked+.switch-slider {
+            background-color: {{ $field['color'] }};
+        }
+    </style>
+    @endLoadOnce
+@endpush
+@endif
 
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}

--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -1,7 +1,8 @@
 {{-- switch field --}}
 @php
     $field['value'] = old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '0';
-    $field['options'] = $field['options'] ?? false;
+    $field['onLabel'] = $field['onLabel'] ?? '';
+    $field['offLabel'] = $field['offLabel'] ?? '';
     $field['color'] = $field['color'] ?? 'primary';
 @endphp
 
@@ -25,8 +26,8 @@
                 class="switch-input" />
             <span
                 class="switch-slider"
-                data-checked="{{ $field['options'][0] ?? '' }}"
-                data-unchecked="{{ $field['options'][1] ?? '' }}">
+                data-checked="{{ $field['onLabel'] ?? '' }}"
+                data-unchecked="{{ $field['offLabel'] ?? '' }}">
             </span>
         </label>
 

--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -14,7 +14,7 @@
 
     <div class="d-inline-flex">
         {{-- Switch --}}
-        <label class="switch switch-sm switch-label switch-pill switch-{{ $field['color'] }}" style="margin-bottom: 0;">
+        <label class="switch switch-sm switch-label switch-pill switch-{{ $field['color'] }} mb-0" style="--bg-color: {{ $field['color'] }};">
             <input
                 type="hidden"
                 name="{{ $field['name'] }}"
@@ -82,17 +82,15 @@
     @endLoadOnce
 @endpush
 
-@if(\Str::startsWith($field['color'], '#'))
 @push('crud_fields_styles')
     @loadOnce('bpFieldInitSwitchStyle')
     <style>
-        .switch .switch-input:checked+.switch-slider {
-            background-color: {{ $field['color'] }};
+        .switch-input:checked+.switch-slider {
+            background-color: var(--bg-color);
         }
     </style>
     @endLoadOnce
 @endpush
-@endif
 
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}


### PR DESCRIPTION
🎉 Switch field 🎉

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1838187/174276649-bd6e5db9-5419-4c46-9be8-5f4f1d14904d.png">

---

How to test it;
On Demo, `MonsterCrudController::getFieldsArrayForSimpleTab()` search for the `// Checkbox` and replace the `type` from `checkbox` to `switch` 👌

Optionally we can set the `color` to any bootstrap default color classes (`primary`, `secondary`, `info`, `warning`, `danger`, ...)
And also, `options` with emojis for the switch states.

```php
[
    'name' => 'checkbox',
    'label' => 'I have not read the terms and conditions and I never will.'.backpack_pro_badge(),
    'type' => 'switch',
    'tab' => 'Simple',
    // 'color' => 'danger',
    'options' => [
        '',
        '❌',
    ],
],
```