### PR TITLE
Image column to support private s3 or compatible bucket

### DIFF
--- a/src/resources/views/crud/columns/image.blade.php
+++ b/src/resources/views/crud/columns/image.blade.php
@@ -20,9 +20,9 @@
       $href = $src = $column['value'];
     } elseif (isset($column['disk'])) { // image from a different disk (like s3 bucket)
     
-      if (!empty($column['private_s3_bucket'])) {
+      if (!empty($column['temporary'])) {
           $href = $src = Storage::disk($column['disk'])
-              ->temporaryUrl($column['prefix'].$column['value'], now()->addMinute());
+              ->temporaryUrl($column['prefix'].$column['value'], now()->addMinutes((int) $column['temporary']));
       } else {
           $href = $src = Storage::disk($column['disk'])->url($column['prefix'].$column['value']);
       }

--- a/src/resources/views/crud/columns/image.blade.php
+++ b/src/resources/views/crud/columns/image.blade.php
@@ -20,6 +20,9 @@
       $href = $src = $column['value'];
     } elseif (isset($column['disk'])) { // image from a different disk (like s3 bucket)
       $href = $src = Storage::disk($column['disk'])->url($column['prefix'].$column['value']);
+    } elseif (isset($column['disk']) && !empty($column['private_s3_bucket']))  {
+        $href = $src = Storage::disk($column['disk'])
+            ->temporaryUrl($column['prefix'].$column['value'], now()->addMinute());
     } else { // plain-old image, from a local disk
       $href = $src = asset($column['prefix'] . $column['value']);
     }

--- a/src/resources/views/crud/columns/image.blade.php
+++ b/src/resources/views/crud/columns/image.blade.php
@@ -19,10 +19,14 @@
     if (preg_match('/^data\:image\//', $column['value'])) { // base64_image
       $href = $src = $column['value'];
     } elseif (isset($column['disk'])) { // image from a different disk (like s3 bucket)
-      $href = $src = Storage::disk($column['disk'])->url($column['prefix'].$column['value']);
-    } elseif (isset($column['disk']) && !empty($column['private_s3_bucket']))  {
-        $href = $src = Storage::disk($column['disk'])
-            ->temporaryUrl($column['prefix'].$column['value'], now()->addMinute());
+    
+      if (!empty($column['private_s3_bucket'])) {
+          $href = $src = Storage::disk($column['disk'])
+              ->temporaryUrl($column['prefix'].$column['value'], now()->addMinute());
+      } else {
+          $href = $src = Storage::disk($column['disk'])->url($column['prefix'].$column['value']);
+      }
+      
     } else { // plain-old image, from a local disk
       $href = $src = asset($column['prefix'] . $column['value']);
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If the file is stored in a private S3 or private S3 compatible bucket, the image fetching will fail

### AFTER - What is happening after this PR?

If 'private_s3_bucket' key is true, use temporaryUrl() instead of url()


## HOW

If 'private_s3_bucket' key is true, use temporaryUrl() instead of url().

### Is it a breaking change?

No


### How can we test the before & after?

Create a private S3 bucket, dump some files there and try.

## Additional Notes

I named it 'private_s3_bucket' but in practice it could be a DigitalOcean, Linode or many other private s3 compatible bucket so maybe a different key name is a better choice. In some other libraries, I see that they use temporaryUrl() if user specified that the visibility is set to private (e.g. ->visibility('private') )

As for expiry time I give it 1 minute, I think that is way more than enough time for the private image to load. I did not provide a parameter to configure how long the duration should last.
