### PR TITLE
Add string as parameter type in addClause function

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -22,7 +22,7 @@ trait Query
      *     $query->activePosts();
      * });
      *
-     * @param  callable  $function
+     * @param  callable|string  $function
      * @return mixed
      */
     public function addClause($function)


### PR DESCRIPTION
## WHY
To define parameter type
### BEFORE - What was wrong? What was happening before this PR?
In addClause function, the parameter type only callback. But, we can also use string as parameter such as 'where' as described in comment above the function. such as ```$this->crud->addClause('where', 'name', '==', 'car');```.
But, when we run static analysis, it throws an error, 

??

### AFTER - What is happening after this PR?
Now, static analysis does not throw the error. 
??


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change?
No
??


### How can we test the before & after?

??
