### PR TITLE
Fix incorrect phpdoc return type on performSaveAction method

### DIFF
--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -82,7 +82,7 @@ trait UpdateOperation
     /**
      * Update the specified resource in the database.
      *
-     * @return \Illuminate\Http\Response
+     * @return array|\Illuminate\Http\RedirectResponse
      */
     public function update()
     {

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -322,7 +322,7 @@ trait SaveActions
      * Redirect to the correct URL, depending on which save action has been selected.
      *
      * @param  string  $itemId
-     * @return \Illuminate\Http\Response
+     * @return array|\Illuminate\Http\RedirectResponse
      */
     public function performSaveAction($itemId = null)
     {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `performSaveAction` listed `\Illuminate\Http\Response` as return type in the PHPDoc block, however it returned either a  `\Illuminate\Http\RedirectResponse` or `array`.

### AFTER - What is happening after this PR?

The PHPDoc block lists the correct type.


## HOW

### Is it a breaking change?

No