### PR TITLE
[v6] Enhance save action return type

### DIFF
--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -82,7 +82,7 @@ trait UpdateOperation
     /**
      * Update the specified resource in the database.
      *
-     * @return array|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     public function update()
     {

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -321,7 +321,7 @@ trait SaveActions
      * Redirect to the correct URL, depending on which save action has been selected.
      *
      * @param  string  $itemId
-     * @return array|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     public function performSaveAction($itemId = null)
     {
@@ -345,12 +345,12 @@ trait SaveActions
 
         // if the request is AJAX, return a JSON response
         if ($this->getRequest()->ajax()) {
-            return [
+            return response()->json([
                 'success'      => true,
                 'data'         => $this->entry,
                 'redirect_url' => $redirectUrl,
                 'referrer_url' => $referrer_url ?? false,
-            ];
+            ]);
         }
 
         if (isset($referrer_url)) {


### PR DESCRIPTION
*Note:* please merge #4480 first; it contains the first (non-breaking) commit of this change.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `performSaveAction` returned either a `\Illuminate\Http\RedirectResponse` or an `array`, with the latter being auto-converted into a JSON response by Laravel. This seems to be a bit ambiguous.

### AFTER - What is happening after this PR?

The `array` is manually converted into a `\Illuminate\Http\JSONResponse` instance, which seems more consistent with the other possible return type.


## HOW


### Is it a breaking change?

Technically yes; however only those who were manually using the return result AND checking for it to be an array, then treating it as an array. Since this was never before listed as possible return type, this seems unlikely.
