### PR TITLE
Fix `mb_strwidth()` Passing null to parameter 1 is deprecated #4492

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -179,6 +179,7 @@ if (! function_exists('mb_ucfirst')) {
      */
     function mb_ucfirst($string, $encoding = false)
     {
+        $string = $string ?? '';
         $encoding = $encoding ? $encoding : mb_internal_encoding();
 
         $strlen = mb_strlen($string, $encoding);

--- a/src/resources/views/crud/columns/email.blade.php
+++ b/src/resources/views/crud/columns/email.blade.php
@@ -11,7 +11,7 @@
     $column['text'] = '-';
 
     if(!empty($value)) {
-        $column['text'] = $column['prefix'].Str::limit(strip_tags($value), $column['limit'], "[...]").$column['suffix'];
+        $column['text'] = $column['prefix'].Str::limit(strip_tags($value ?? ''), $column['limit'], "[...]").$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -7,7 +7,7 @@
     $column['prefix']  = $column['prefix'] ?? '';
     $column['suffix']  = $column['suffix'] ?? '';
     $column['text']    = $column['prefix'].
-                         Str::limit($value, $column['limit'], "[...]").
+                         Str::limit($value ?? '', $column['limit'], "[...]").
                          $column['suffix'];
 @endphp
 

--- a/src/resources/views/crud/columns/model_function_attribute.blade.php
+++ b/src/resources/views/crud/columns/model_function_attribute.blade.php
@@ -8,7 +8,7 @@
     $column['prefix']  = $column['prefix'] ?? '';
     $column['suffix']  = $column['suffix'] ?? '';
     $column['text']    = $column['prefix'].
-                         Str::limit($value, $column['limit'], "[...]").
+                         Str::limit($value ?? '', $column['limit'], "[...]").
                          $column['suffix'];
 @endphp
 

--- a/src/resources/views/crud/columns/phone.blade.php
+++ b/src/resources/views/crud/columns/phone.blade.php
@@ -10,7 +10,7 @@
     $column['text'] = '';
 
     if(!empty($value)) {
-        $column['text'] = $column['prefix'].Str::limit(strip_tags($value), $column['limit'], "[...]").$column['suffix'];
+        $column['text'] = $column['prefix'].Str::limit(strip_tags($value ?? ''), $column['limit'], "[...]").$column['suffix'];
     }
 @endphp
 

--- a/src/resources/views/crud/columns/row_number.blade.php
+++ b/src/resources/views/crud/columns/row_number.blade.php
@@ -5,7 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
 	$column['text'] = 	$column['prefix'].
-						Str::limit(strip_tags($rowNumber), $column['limit'], "[...]").
+						Str::limit(strip_tags($rowNumber ?? ''), $column['limit'], "[...]").
 						$column['suffix'];
 @endphp
 

--- a/src/resources/views/crud/columns/select.blade.php
+++ b/src/resources/views/crud/columns/select.blade.php
@@ -8,7 +8,7 @@
 
     $attributes = $crud->getRelatedEntriesAttributes($entry, $column['entity'], $column['attribute']);
     foreach ($attributes as $key => &$text) {
-        $text = Str::limit($text, $column['limit'], '[...]');
+        $text = Str::limit($text ?? '', $column['limit'], '[...]');
     }
 @endphp
 

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -16,7 +16,7 @@
     }
 
     foreach ($results_array as $key => $text) {
-        $results_array[$key] = Str::limit($text, $column['limit'], '[...]');
+        $results_array[$key] = Str::limit($text ?? '', $column['limit'], '[...]');
     }
 @endphp
 

--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -7,7 +7,7 @@
     $column['limit'] = $column['limit'] ?? 40;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['text'] = $column['prefix'].Str::limit($value, $column['limit'], '[...]').$column['suffix'];
+    $column['text'] = $column['prefix'].Str::limit($value ?? '', $column['limit'], '[...]').$column['suffix'];
 @endphp
 
 <span>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

#4492 

### AFTER - What is happening after this PR?

solved


## HOW

### How did you achieve that, in technical terms?

`?? ''` to replace null


### Is it a breaking change?

no


### How can we test the before & after?

I would be happy to complement a test. I looked at the existing test like` tests/Unit/CrudPanel/CrudPanelColumnsTest.php` but did not find how to test the blade when null.
