### PR TITLE
Fix database count, option to disable counting

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -71,10 +71,14 @@ trait ListOperation
     {
         $this->crud->hasAccessOrFail('list');
 
+        $showEntryCount = $this->crud->getOperationSetting('showEntryCount');
+
+        $totalRows = $showEntryCount ? $this->crud->model->count() : 0;
+
         $this->crud->applyUnappliedFilters();
 
-        $totalRows = $this->crud->model->count();
-        $filteredRows = $this->crud->query->toBase()->getCountForPagination();
+        $filteredRows = $showEntryCount ? $this->crud->query->toBase()->getCountForPagination() : 0;
+
         $startIndex = request()->input('start') ?: 0;
         // if a search term was present
         if (request()->input('search') && request()->input('search')['value']) {

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -72,10 +72,10 @@ trait ListOperation
         $this->crud->hasAccessOrFail('list');
 
         $showEntryCount = $this->crud->getOperationSetting('showEntryCount');
-        
+
         $this->crud->setOperationSetting('unfilteredQueryCount', request('unfilteredQueryCount') ?? $this->crud->getOperationSetting('unfilteredQueryCount'));
-        
-        $totalRows = !$showEntryCount ? 0 : $this->crud->getOperationSetting('unfilteredQueryCount') ?? $this->crud->getQueryCount();
+
+        $totalRows = ! $showEntryCount ? 0 : $this->crud->getOperationSetting('unfilteredQueryCount') ?? $this->crud->getQueryCount();
 
         $this->crud->applyUnappliedFilters();
 
@@ -130,8 +130,8 @@ trait ListOperation
             $this->crud->orderByWithPrefix($this->crud->model->getKeyName(), 'DESC');
         }
 
-        $filteredRows = !$showEntryCount ? 0 : $this->crud->getQueryCount();
-        
+        $filteredRows = ! $showEntryCount ? 0 : $this->crud->getQueryCount();
+
         $entries = $this->crud->getEntries();
 
         return $this->crud->getEntriesAsJsonForDatatables($entries, $totalRows, $filteredRows, $startIndex);

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -102,8 +102,8 @@ class CrudFilter
     public function apply($input = null)
     {
         // before applying filters, store the base query count
-        $this->crud()->setOperationSetting('unfilteredQueryCount', !$this->crud()->getOperationSetting('showEntryCount') ? 0 : (request('unfilteredQueryCount') ?? $this->crud()->getOperationSetting('unfilteredQueryCount') ?? $this->crud()->getQueryCount()));
-        
+        $this->crud()->setOperationSetting('unfilteredQueryCount', ! $this->crud()->getOperationSetting('showEntryCount') ? 0 : (request('unfilteredQueryCount') ?? $this->crud()->getOperationSetting('unfilteredQueryCount') ?? $this->crud()->getQueryCount()));
+
         // mark the field as already applied
         $this->applied(true);
 

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -101,6 +101,9 @@ class CrudFilter
      */
     public function apply($input = null)
     {
+        // before applying filters, store the base query count
+        $this->crud()->setOperationSetting('unfilteredQueryCount', !$this->crud()->getOperationSetting('showEntryCount') ? 0 : (request('unfilteredQueryCount') ?? $this->crud()->getOperationSetting('unfilteredQueryCount') ?? $this->crud()->getQueryCount()));
+        
         // mark the field as already applied
         $this->applied(true);
 

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -150,47 +150,48 @@ trait Query
     }
 
     /**
-     * navigates the current crud query where clauses to get he columns that should be selected
-     * 
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * navigates the current crud query where clauses to get he columns that should be selected.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return array
      */
-    public function getQueryColumnsFromWheres($query) {
+    public function getQueryColumnsFromWheres($query)
+    {
         $wheresColumns = [];
-        foreach($query->wheres as $where) {
-            switch($where['type'])  {
-                case 'Basic': {
+        foreach ($query->wheres as $where) {
+            switch ($where['type']) {
+                case 'Basic':
                     $wheresColumns[] = $where['column'];
-                }
+
                 break;
-                case 'Nested': {
+                case 'Nested':
                     $wheres = $where['query']->wheres;
-                    foreach($wheres as $subWhere) {
-                        if($subWhere['type'] === 'Basic') {
+                    foreach ($wheres as $subWhere) {
+                        if ($subWhere['type'] === 'Basic') {
                             $wheresColumns[] = $subWhere['column'];
                         }
-                        if($subWhere['type'] === 'Exists') {
-                            foreach($subWhere['query']->wheres as $existSubWhere) {
-                                if($existSubWhere['type'] === 'Column') {
+                        if ($subWhere['type'] === 'Exists') {
+                            foreach ($subWhere['query']->wheres as $existSubWhere) {
+                                if ($existSubWhere['type'] === 'Column') {
                                     $wheresColumns[] = $existSubWhere['first'];
                                 }
                             }
                         }
                     }
-                }
+
                 break;
-                case 'Column': {
+                case 'Column':
                     $wheresColumns[] = $where['first'];
-                }
+
                 break;
-                case 'Exists': {
+                case 'Exists':
                     $wheres = $where['query']->wheres;
-                    foreach($wheres as $subWhere) {
-                        if($subWhere['type'] === 'Column') {
+                    foreach ($wheres as $subWhere) {
+                        if ($subWhere['type'] === 'Column') {
                             $wheresColumns[] = $subWhere['first'];
                         }
                     }
-                }
+
                 break;
             }
         }
@@ -199,15 +200,18 @@ trait Query
     }
 
     /**
-     * count of available entries from the current crud query
-     * 
+     * count of available entries from the current crud query.
+     *
      * @return int
      */
-    public function getQueryCount() {
+    public function getQueryCount()
+    {
         $crudQuery = $this->query->toBase()->clone();
         $crudQueryColumns = $this->getQueryColumnsFromWheres($crudQuery);
         // remove table prefix from select columns and add the model key in case it doesn't exist.
-        $crudQueryColumns = array_map(function($item) { return \Str::afterLast($item,'.'); }, array_merge($crudQueryColumns, [$this->model->getKeyName()]));
+        $crudQueryColumns = array_map(function ($item) {
+            return \Str::afterLast($item, '.');
+        }, array_merge($crudQueryColumns, [$this->model->getKeyName()]));
         $crudQueryColumns = array_unique($crudQueryColumns);
 
         return $crudQuery->newQuery()->select('id')->selectRaw("count('".$this->model->getKeyName()."') as total_rows")->fromSub($crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset'])->select($crudQueryColumns), 'monsters')->get()->first()->total_rows;

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -59,5 +59,5 @@ return [
     'searchOperator' => 'like',
 
     // Displays the `Showing X of XX entries (filtered  from X entries)`
-    'showEntryCount' => true
+    'showEntryCount' => true,
 ];

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -57,4 +57,7 @@ return [
     // If you are using PostgreSQL you might want to change
     // to `ilike` for case-insensitive search
     'searchOperator' => 'like',
+
+    // Displays the `Showing X of XX entries (filtered  from X entries)`
+    'showEntryCount' => true
 ];

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -248,7 +248,10 @@
           searching: @json($crud->getOperationSetting('searchableTable') ?? true),
           ajax: {
               "url": "{!! url($crud->route.'/search').'?'.Request::getQueryString() !!}",
-              "type": "POST"
+              "type": "POST",
+              "data": {
+                "unfilteredQueryCount": "{{$crud->getOperationSetting('unfilteredQueryCount') ?? false}}"
+            },
           },
           dom:
             "<'row hidden'<'col-sm-6'i><'col-sm-6 d-print-none'f>>" +
@@ -257,7 +260,6 @@
       }
   }
   </script>
-
   @include('crud::inc.export_buttons')
 
   <script type="text/javascript">

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -125,7 +125,9 @@
         localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url', new_url);
       },
       dataTableConfiguration: {
-
+        @if (!$crud->getOperationSetting('showEntryCount')) 
+        bInfo: false,
+        @endif
         @if ($crud->getResponsiveTable())
         responsive: {
             details: {


### PR DESCRIPTION
Mainly this fixes:

1- the total count was always done from model query (Select *), so even if ou apply a scope in your query the total count would also display the ones that the scope discards.
**Example:** 100 users in db, 20 are active. If you apply to the panel: `$this->crud->addClause('active')`, it would still show the total 100 instead of 20 (notice it's a panel query setting like model scopes not filters). 

2 - couldn't handle much data without crashing :-|
At the moment I am working with 500k records with load times under a second depending on db config and the amount of columns needed in query.
-Best times achieved with: `primary` and `unique` keys set on a `bigInteger` as the model key. 

3 - possiblity to don't  use the count functionality at all. 
Even if super optimized, counting 2bill rows is still **counting 2bill rows**, some time will be spent on this operation. If this total/filtered information is not relevant to you, it's better to disable it completely. 

I am pretty sure this needs some docs and probably some refactoring, but I am super curious about the times you will get on your test bench scenario @tabacitu so I put it together to work I think in 90%+ of scenarions (haven't found one failing yet .. but) 
Please be advised about what I told about setting the correct indexes on the columns that are searchable/filterable and having `unique` on the primary key really helps!