### PR TITLE
Fluent columns, add key() function to properly allow overrides

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -25,6 +25,7 @@ namespace Backpack\CRUD\app\Library\CrudPanel;
  * @method self visibleInExport(bool $value)
  * @method self visibleInShow(bool $value)
  * @method self priority(int $value)
+ * @method self key(string $value)
  */
 class CrudColumn
 {
@@ -64,6 +65,24 @@ class CrudColumn
     public static function name($name)
     {
         return new static($name);
+    }
+
+    /**
+     * Change the CrudColumn key
+     *
+     * @param  string  $key  New key for the column
+     * @return CrudColumn
+     */
+    public function key(string $key)
+    {
+        if(!isset($this->attributes['name'])) {
+            abort(500, 'Column name must be defined before changing the key.');
+        }
+        if ($this->crud()->hasColumnWhere('key', $this->attributes['key'])) {
+            $this->crud()->setColumnDetails($this->attributes['key'], array_merge($this->attributes, ['key' => $key]));
+        }
+        $this->attributes['key'] = $key;
+        return $this;
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -68,20 +68,21 @@ class CrudColumn
     }
 
     /**
-     * Change the CrudColumn key
+     * Change the CrudColumn key.
      *
      * @param  string  $key  New key for the column
      * @return CrudColumn
      */
     public function key(string $key)
     {
-        if(!isset($this->attributes['name'])) {
+        if (! isset($this->attributes['name'])) {
             abort(500, 'Column name must be defined before changing the key.');
         }
         if ($this->crud()->hasColumnWhere('key', $this->attributes['key'])) {
             $this->crud()->setColumnDetails($this->attributes['key'], array_merge($this->attributes, ['key' => $key]));
         }
         $this->attributes['key'] = $key;
+
         return $this;
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4500 very well explained.

### AFTER - What is happening after this PR?

We can change the column key.


## HOW

### How did you achieve that, in technical terms?

Created a `key()` method on `CrudColumn` to properly handle the column key changing,

### Is it a breaking change?

No


### How can we test the before & after?

In demo `InvoiceCrudController`, change `CRUD::column('owner')` to `CRUD::column('owner')->key('test')`
