### PR TITLE
add invokable support to strippedRequest

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -479,6 +479,14 @@ trait Fields
     {
         $setting = $this->getOperationSetting('strippedRequest');
 
+        // if an invokable class was passed
+        // eg. \App\Http\Requests\BackpackStrippedRequest
+        if (class_exists($setting)) {
+            $setting = new $setting();
+            return $setting($request);
+        }
+
+        // if a closure was passed
         if (is_callable($setting)) {
             return $setting($request);
         }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -484,7 +484,7 @@ trait Fields
         if (class_exists($setting)) {
             $setting = new $setting();
 
-            return $setting($request);
+            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting) . ' is not invokable.');
         }
 
         // if a closure was passed

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -483,6 +483,7 @@ trait Fields
         // eg. \App\Http\Requests\BackpackStrippedRequest
         if (class_exists($setting)) {
             $setting = new $setting();
+
             return $setting($request);
         }
 

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -484,7 +484,7 @@ trait Fields
         if (class_exists($setting)) {
             $setting = new $setting();
 
-            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting) . ' is not invokable.');
+            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting).' is not invokable.');
         }
 
         // if a closure was passed

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -37,6 +37,6 @@ return [
 
     // Before saving the entry, how would you like the request to be stripped?
     //  - false - use Backpack's default (ONLY save inputs that have fields)
-    //  - invokable class - custom stripping (eg. App\Http\Requests\StripBackpackRequest::class)
+    //  - invokable class - custom stripping (the return should be an array with input names) 
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
 ];

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -35,15 +35,17 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-/**
- * Before saving the entry, how would you like the request to be stripped?
- * - false - fall back to Backpack's default (ONLY save inputs that have fields)
- * - closure - process your own request (example removes all inputs that begin with underscode).
- *
- * @param  \Illuminate\Http\Request  $request
- * @return array
- */
+   /**
+    * Before saving the entry, how would you like the request to be stripped?
+    * - false - use Backpack's default (ONLY save inputs that have fields)
+    * - closure - custom request processing (quick, but will stop config caching)
+    * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class
+    *
+    * @param  \Illuminate\Http\Request  $request
+    * @return array
+    */
+    // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
-    // }),
+    //  }),
 ];

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -35,15 +35,15 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-   /**
-    * Before saving the entry, how would you like the request to be stripped?
-    * - false - use Backpack's default (ONLY save inputs that have fields)
-    * - closure - custom request processing (quick, but will stop config caching)
-    * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @return array
-    */
+/**
+ * Before saving the entry, how would you like the request to be stripped?
+ * - false - use Backpack's default (ONLY save inputs that have fields)
+ * - closure - custom request processing (quick, but will stop config caching)
+ * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class.
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -35,17 +35,8 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-/**
- * Before saving the entry, how would you like the request to be stripped?
- * - false - use Backpack's default (ONLY save inputs that have fields)
- * - closure - custom request processing (quick, but will stop config caching)
- * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class.
- *
- * @param  \Illuminate\Http\Request  $request
- * @return array
- */
+    // Before saving the entry, how would you like the request to be stripped?
+    //  - false - use Backpack's default (ONLY save inputs that have fields)
+    //  - invokable class - custom stripping (eg. App\Http\Requests\StripBackpackRequest::class)
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
-    // 'strippedRequest' => (function ($request) {
-    //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
-    //  }),
 ];

--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -37,6 +37,6 @@ return [
 
     // Before saving the entry, how would you like the request to be stripped?
     //  - false - use Backpack's default (ONLY save inputs that have fields)
-    //  - invokable class - custom stripping (the return should be an array with input names) 
+    //  - invokable class - custom stripping (the return should be an array with input names)
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
 ];

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -37,6 +37,6 @@ return [
 
     // Before saving the entry, how would you like the request to be stripped?
     //  - false - use Backpack's default (ONLY save inputs that have fields)
-    //  - invokable class - custom stripping (eg. App\Http\Requests\StripBackpackRequest::class)
+    //  - invokable class - custom stripping (the return should be an array with input names) 
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
 ];

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -9,7 +9,7 @@
 return [
     // Define the size/looks of the content div for all CRUDs
     // To override per view use $this->crud->setEditContentClass('class-string')
-    'contentClass'   => 'col-md-8 bold-labels',
+    'contentClass' => 'col-md-8 bold-labels',
 
     // When using tabbed forms (create & update), what kind of tabs would you like?
     'tabsType' => 'horizontal', //options: horizontal, vertical
@@ -35,15 +35,17 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-/**
- * Before saving the entry, how would you like the request to be stripped?
- * - false - fall back to Backpack's default (ONLY save inputs that have fields)
- * - closure - process your own request (example removes all inputs that begin with underscode).
- *
- * @param  \Illuminate\Http\Request  $request
- * @return array
- */
+   /**
+    * Before saving the entry, how would you like the request to be stripped?
+    * - false - use Backpack's default (ONLY save inputs that have fields)
+    * - closure - custom request processing (quick, but will stop config caching)
+    * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class
+    *
+    * @param  \Illuminate\Http\Request  $request
+    * @return array
+    */
+    // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
-    // }),
+    //  }),
 ];

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -35,15 +35,15 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-   /**
-    * Before saving the entry, how would you like the request to be stripped?
-    * - false - use Backpack's default (ONLY save inputs that have fields)
-    * - closure - custom request processing (quick, but will stop config caching)
-    * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @return array
-    */
+/**
+ * Before saving the entry, how would you like the request to be stripped?
+ * - false - use Backpack's default (ONLY save inputs that have fields)
+ * - closure - custom request processing (quick, but will stop config caching)
+ * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class.
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
     // 'strippedRequest' => (function ($request) {
     //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -35,17 +35,8 @@ return [
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,
 
-/**
- * Before saving the entry, how would you like the request to be stripped?
- * - false - use Backpack's default (ONLY save inputs that have fields)
- * - closure - custom request processing (quick, but will stop config caching)
- * - invokable class - eg. App\Http\Requests\StripBackpackRequest::class.
- *
- * @param  \Illuminate\Http\Request  $request
- * @return array
- */
+    // Before saving the entry, how would you like the request to be stripped?
+    //  - false - use Backpack's default (ONLY save inputs that have fields)
+    //  - invokable class - custom stripping (eg. App\Http\Requests\StripBackpackRequest::class)
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
-    // 'strippedRequest' => (function ($request) {
-    //     return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
-    //  }),
 ];

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -37,6 +37,6 @@ return [
 
     // Before saving the entry, how would you like the request to be stripped?
     //  - false - use Backpack's default (ONLY save inputs that have fields)
-    //  - invokable class - custom stripping (the return should be an array with input names) 
+    //  - invokable class - custom stripping (the return should be an array with input names)
     // 'strippedRequest' => App\Http\Requests\StripBackpackRequest::class,
 ];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

See #4503 

You couldn't do `php artisan config:cache` if you defined a custom `strippedRequest`.

### AFTER - What is happening after this PR?

You can define a custom `strippedRequest` AND have it cached, by making it an **invokable class** instead of a **closure**. So instead of defining your logic right there in the config file, you create a separate file to hold that logic:

```php
<?php

namespace App\Http\Requests;

use Illuminate\Http\Request;

class StripBackpackRequest
{
    public function __invoke(Request $request)
    {
        return $request->except('_token', '_method', '_http_referrer', '_current_tab', '_save_action');
    }
}

```

## HOW

### How did you achieve that, in technical terms?

Check if invokable, if so... invoke 😀

### Is it a breaking change?

Non-breaking.

### How can we test the before & after?

Before: 
- uncomment the closure in `config/backpack/operations/update.php`;
- if you try `php artisan config:cache` it will error;

After: 
- create the file above, then use that instead of the closure in your `config/backpack/operations/update.php`;
- if you try `php artisan config:cache` it should work just fine;

## TODO

- [ ] add documentation for the above... and maybe even for the [alternative solutions outlined here](https://github.com/Laravel-Backpack/CRUD/issues/4503#issuecomment-1177393044);