### PR TITLE
check if method exists before calling

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -194,7 +194,7 @@ trait Update
      */
     private function setupRelatedModelLocale($model)
     {
-        if ($model->translationEnabled()) {
+        if (method_exists($model, 'translationEnabled') && $model->translationEnabled()) {
             $locale = request('_locale', \App::getLocale());
             if (in_array($locale, array_keys($model->getAvailableLocales()))) {
                 $model->setLocale($locale);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in [306](https://github.com/Laravel-Backpack/PermissionManager/issues/306) when I introduced the `translationEnabled()` into subfields I wrongly assumed that all subfields models would have the `CrudTrait`. 

### AFTER - What is happening after this PR?

We check for method existance before calling.
