### PR TITLE
Load view namespaces into crud instead of config

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -275,7 +275,7 @@ class CrudButton
         $type = $this->name;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, array_merge(config('backpack.crud.view_namespaces.buttons'), $this->crud()->get('viewNamespaces')['buttons'] ?? []));
+        }, $this->crud()->getAllViewNamespacesFor('buttons'));
 
         return array_merge([$this->content], $paths);
     }

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -273,10 +273,9 @@ class CrudButton
     private function getViewPathsWithFallbacks()
     {
         $type = $this->name;
-
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, config('backpack.crud.view_namespaces.buttons'));
+        }, array_merge(config('backpack.crud.view_namespaces.buttons'), $this->crud()->get('viewNamespaces')['buttons'] ?? []));
 
         return array_merge([$this->content], $paths);
     }

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -275,7 +275,7 @@ class CrudButton
         $type = $this->name;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, $this->crud()->getAllViewNamespacesFor('buttons'));
+        }, $this->crud()->getViewNamespacesFor('buttons'));
 
         return array_merge([$this->content], $paths);
     }

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -146,7 +146,7 @@ class CrudFilter
     public function getNamespacedViewWithFallbacks()
     {
         $type = $this->type;
-        $namespaces = config('backpack.crud.view_namespaces.filters');
+        $namespaces = array_merge(config('backpack.crud.view_namespaces.filters'), $this->crud()->get('viewNamespaces')['filters'] ?? []);
 
         if ($this->viewNamespace != 'crud::filters') {
             $namespaces = array_merge([$this->viewNamespace], $namespaces);

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -146,7 +146,7 @@ class CrudFilter
     public function getNamespacedViewWithFallbacks()
     {
         $type = $this->type;
-        $namespaces = $this->crud()->getAllViewNamespacesFor('filters');
+        $namespaces = $this->crud()->getViewNamespacesFor('filters');
 
         if ($this->viewNamespace != 'crud::filters') {
             $namespaces = array_merge([$this->viewNamespace], $namespaces);

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -146,7 +146,7 @@ class CrudFilter
     public function getNamespacedViewWithFallbacks()
     {
         $type = $this->type;
-        $namespaces = array_merge(config('backpack.crud.view_namespaces.filters'), $this->crud()->get('viewNamespaces')['filters'] ?? []);
+        $namespaces = $this->crud()->getAllViewNamespacesFor('filters');
 
         if ($this->viewNamespace != 'crud::filters') {
             $namespaces = array_merge([$this->viewNamespace], $namespaces);

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -14,6 +14,7 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\FakeColumns;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\FakeFields;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Fields;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Filters;
+use Backpack\CRUD\app\Library\CrudPanel\Traits\HasViewNamespaces;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\HeadingsAndTitles;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Input;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Macroable;
@@ -38,7 +39,7 @@ use Illuminate\Support\Arr;
 class CrudPanel
 {
     // load all the default CrudPanel features
-    use Create, Read, Search, Update, Delete, Input, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships;
+    use Create, Read, Search, Update, Delete, Input, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships, HasViewNamespaces;
     // allow developers to add their own closures to this object
     use Macroable;
 

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -18,16 +18,14 @@ trait HasViewNamespaces
     }
 
     /**
-     * Return the resulting array after merging the base namespaces
-     * with the ones stored for the given domain.
+     * Return all the view namespaces including the ones stored in the laravel config files.
      *
      * @param  string  $domain  (eg. fields, filters, buttons)
-     * @param  mixed  $viewNamespacesFromConfigKey
      * @return array
      */
-    public function getAllViewNamespacesFor(string $domain, mixed $viewNamespacesFromConfigKey = null)
+    public function getAllViewNamespacesFor(string $domain)
     {
-        $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain, $viewNamespacesFromConfigKey);
+        $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain);
 
         return array_unique(array_merge($viewNamespacesFromConfig, $this->getViewNamespacesFor($domain)));
     }
@@ -42,7 +40,7 @@ trait HasViewNamespaces
     public function addViewNamespacesFor(string $domain, array $viewNamespaces)
     {
         foreach ((array) $viewNamespaces as $viewNamespace) {
-            $this->addViewNamespace($domain, $viewNamespace);
+            $this->addViewNamespaceFor($domain, $viewNamespace);
         }
     }
 
@@ -62,14 +60,30 @@ trait HasViewNamespaces
     }
 
     /**
-     * Return the config view_namespace key for the given domain.
+     * Return the array of view namespaces for backpack components from the Laravel config files.
+     * It uses the default `backpack.crud.view_namespaces` key or a custom provided key.
      *
      * @param  string  $domain
      * @param  mixed  $customConfigKey
      * @return array
      */
-    private function getViewNamespacesFromConfigFor(string $domain, mixed $customConfigKey)
+    private function getViewNamespacesFromConfigFor(string $domain, mixed $customConfigKey = null)
     {
         return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ?? [];
+    }
+
+    /**
+     * Return all the view namespaces using a developer provided config key.
+     * Allow developer to use view namespaces from other config keys.
+     *
+     * @param  string  $domain  (eg. fields, filters, buttons)
+     * @param  string  $viewNamespacesFromConfigKey
+     * @return array
+     */
+    public function getViewNamespacesWithFallbackFor(string $domain, string $viewNamespacesFromConfigKey)
+    {
+        $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain, $viewNamespacesFromConfigKey);
+
+        return array_unique(array_merge($viewNamespacesFromConfig, $this->getAllViewNamespacesFor($domain)));
     }
 }

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -7,27 +7,16 @@ trait HasViewNamespaces
     private $viewNamespaces = [];
 
     /**
-     * Return the namespaces stored for the given domain.
-     *
-     * @param  string  $domain  (eg. fields, filters, buttons)
-     * @return array
-     */
-    private function getViewNamespacesFor(string $domain)
-    {
-        return $this->viewNamespaces[$domain] ?? [];
-    }
-
-    /**
      * Return all the view namespaces including the ones stored in the laravel config files.
      *
      * @param  string  $domain  (eg. fields, filters, buttons)
      * @return array
      */
-    public function getAllViewNamespacesFor(string $domain)
+    public function getViewNamespacesFor(string $domain)
     {
         $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain);
 
-        return array_unique(array_merge($viewNamespacesFromConfig, $this->getViewNamespacesFor($domain)));
+        return array_unique(array_merge($viewNamespacesFromConfig, $this->viewNamespaces[$domain] ?? []));
     }
 
     /**
@@ -81,6 +70,6 @@ trait HasViewNamespaces
     {
         $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain, $viewNamespacesFromConfigKey);
 
-        return array_unique(array_merge($viewNamespacesFromConfig, $this->getAllViewNamespacesFor($domain)));
+        return array_unique(array_merge($viewNamespacesFromConfig, $this->getViewNamespacesFor($domain)));
     }
 }

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -7,12 +7,12 @@ trait HasViewNamespaces
     private $viewNamespaces = [];
 
     /**
-     * Return the namespaces stored for the given domain. (fields, filters, buttons etc).
+     * Return the namespaces stored for the given domain. 
      *
-     * @param  string  $domain
+     * @param  string  $domain (eg. fields, filters, buttons)
      * @return array
      */
-    public function getViewNamespacesFor(string $domain)
+    private function getViewNamespacesFor(string $domain)
     {
         return $this->viewNamespaces[$domain] ?? [];
     }
@@ -21,7 +21,7 @@ trait HasViewNamespaces
      * Return the resulting array after merging the base namespaces
      * with the ones stored for the given domain.
      *
-     * @param  string  $domain
+     * @param  string  $domain (eg. fields, filters, buttons)
      * @param  null|string  $configNamespace
      * @return array
      */
@@ -33,9 +33,9 @@ trait HasViewNamespaces
     }
 
     /**
-     * Adds multiple namespaces to the given domain (buttons, fields, columns etc).
+     * Adds multiple namespaces to a given domain.
      *
-     * @param  string  $domain
+     * @param  string  $domain (eg. fields, filters, buttons)
      * @param  array  $viewNamespaces
      * @return void
      */
@@ -47,9 +47,9 @@ trait HasViewNamespaces
     }
 
     /**
-     * Add a new view namespace for the given domain (buttons, fields, columns etc).
+     * Add a new view namespace for a given domain.
      *
-     * @param  string  $domain
+     * @param  string  $domain (eg. fields, filters, buttons)
      * @param  string  $viewNamespace
      * @return void
      */

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -22,10 +22,10 @@ trait HasViewNamespaces
      * with the ones stored for the given domain.
      *
      * @param  string  $domain  (eg. fields, filters, buttons)
-     * @param  null|string  $viewNamespacesFromConfigKey
+     * @param  mixed  $viewNamespacesFromConfigKey
      * @return array
      */
-    public function getAllViewNamespacesFor(string $domain, string $viewNamespacesFromConfigKey = null)
+    public function getAllViewNamespacesFor(string $domain, mixed $viewNamespacesFromConfigKey = null)
     {
         $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain, $viewNamespacesFromConfigKey);
 
@@ -65,10 +65,10 @@ trait HasViewNamespaces
      * Return the config view_namespace key for the given domain.
      *
      * @param  string  $domain
-     * @param  null|string  $customConfigKey
+     * @param  mixed  $customConfigKey
      * @return array
      */
-    private function getViewNamespacesFromConfigFor(string $domain, null|string $customConfigKey)
+    private function getViewNamespacesFromConfigFor(string $domain, mixed $customConfigKey)
     {
         return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ?? [];
     }

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -1,0 +1,71 @@
+<?php
+namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
+
+trait HasViewNamespaces {
+    private $viewNamespaces = [];
+    /**
+     * Return the namespaces stored for the given domain. (fields, filters, buttons etc)
+     * 
+     * @param string $domain
+     * @return array
+     */
+    public function getViewNamespacesFor(string $domain) 
+    {
+        return $this->viewNamespaces[$domain] ?? [];
+    }
+
+    /**
+     * Return the resulting array after merging the base namespaces
+     * with the ones stored for the given domain 
+     * 
+     * @param string $domain
+     * @param null|string $configNamespace
+     * @return array
+     */
+    public function getAllViewNamespacesFor(string $domain, string $configNamespace = null) 
+    {
+        $configNamespace ??= $this->getConfigNamespaceFor($domain);
+        return array_unique(array_merge(config($configNamespace) ?? [], $this->getViewNamespacesFor($domain)));
+    }
+
+    /**
+     * Adds multiple namespaces to the given domain (buttons, fields, columns etc)
+     * 
+     * @param string $domain
+     * @param array $viewNamespaces
+     * 
+     * @return void
+     */
+    public function addViewNamespacesFor(string $domain, array $viewNamespaces) 
+    {
+        foreach((array)$viewNamespaces as $viewNamespace) {
+            $this->addViewNamespace($domain, $viewNamespace);
+        }    
+    }
+
+    /**
+     * Add a new view namespace for the given domain (buttons, fields, columns etc)
+     * 
+     * @param string $domain
+     * @param string $viewNamespace
+     * 
+     * @return void
+     */
+    public function addViewNamespaceFor(string $domain, string $viewNamespace) 
+    {
+        $domainNamespaces = $this->viewNamespaces[$domain] ?? [];
+        if(!in_array($viewNamespace, $domainNamespaces)) {
+            $this->viewNamespaces[$domain][] = $viewNamespace;
+        }
+    }
+
+    /**
+     * Return the config view_namespace key for the given domain
+     * 
+     * @param string $domain
+     * @return string
+     */
+    private function getConfigNamespaceFor(string $domain) {
+        return 'backpack.crud.view_namespaces.'.$domain;
+    }
+}

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -7,9 +7,9 @@ trait HasViewNamespaces
     private $viewNamespaces = [];
 
     /**
-     * Return the namespaces stored for the given domain. 
+     * Return the namespaces stored for the given domain.
      *
-     * @param  string  $domain (eg. fields, filters, buttons)
+     * @param  string  $domain  (eg. fields, filters, buttons)
      * @return array
      */
     private function getViewNamespacesFor(string $domain)
@@ -21,7 +21,7 @@ trait HasViewNamespaces
      * Return the resulting array after merging the base namespaces
      * with the ones stored for the given domain.
      *
-     * @param  string  $domain (eg. fields, filters, buttons)
+     * @param  string  $domain  (eg. fields, filters, buttons)
      * @param  null|string  $configNamespace
      * @return array
      */
@@ -35,7 +35,7 @@ trait HasViewNamespaces
     /**
      * Adds multiple namespaces to a given domain.
      *
-     * @param  string  $domain (eg. fields, filters, buttons)
+     * @param  string  $domain  (eg. fields, filters, buttons)
      * @param  array  $viewNamespaces
      * @return void
      */
@@ -49,7 +49,7 @@ trait HasViewNamespaces
     /**
      * Add a new view namespace for a given domain.
      *
-     * @param  string  $domain (eg. fields, filters, buttons)
+     * @param  string  $domain  (eg. fields, filters, buttons)
      * @param  string  $viewNamespace
      * @return void
      */

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -1,71 +1,74 @@
 <?php
+
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-trait HasViewNamespaces {
+trait HasViewNamespaces
+{
     private $viewNamespaces = [];
+
     /**
-     * Return the namespaces stored for the given domain. (fields, filters, buttons etc)
-     * 
-     * @param string $domain
+     * Return the namespaces stored for the given domain. (fields, filters, buttons etc).
+     *
+     * @param  string  $domain
      * @return array
      */
-    public function getViewNamespacesFor(string $domain) 
+    public function getViewNamespacesFor(string $domain)
     {
         return $this->viewNamespaces[$domain] ?? [];
     }
 
     /**
      * Return the resulting array after merging the base namespaces
-     * with the ones stored for the given domain 
-     * 
-     * @param string $domain
-     * @param null|string $configNamespace
+     * with the ones stored for the given domain.
+     *
+     * @param  string  $domain
+     * @param  null|string  $configNamespace
      * @return array
      */
-    public function getAllViewNamespacesFor(string $domain, string $configNamespace = null) 
+    public function getAllViewNamespacesFor(string $domain, string $configNamespace = null)
     {
         $configNamespace ??= $this->getConfigNamespaceFor($domain);
+
         return array_unique(array_merge(config($configNamespace) ?? [], $this->getViewNamespacesFor($domain)));
     }
 
     /**
-     * Adds multiple namespaces to the given domain (buttons, fields, columns etc)
-     * 
-     * @param string $domain
-     * @param array $viewNamespaces
-     * 
+     * Adds multiple namespaces to the given domain (buttons, fields, columns etc).
+     *
+     * @param  string  $domain
+     * @param  array  $viewNamespaces
      * @return void
      */
-    public function addViewNamespacesFor(string $domain, array $viewNamespaces) 
+    public function addViewNamespacesFor(string $domain, array $viewNamespaces)
     {
-        foreach((array)$viewNamespaces as $viewNamespace) {
+        foreach ((array) $viewNamespaces as $viewNamespace) {
             $this->addViewNamespace($domain, $viewNamespace);
-        }    
+        }
     }
 
     /**
-     * Add a new view namespace for the given domain (buttons, fields, columns etc)
-     * 
-     * @param string $domain
-     * @param string $viewNamespace
-     * 
+     * Add a new view namespace for the given domain (buttons, fields, columns etc).
+     *
+     * @param  string  $domain
+     * @param  string  $viewNamespace
      * @return void
      */
-    public function addViewNamespaceFor(string $domain, string $viewNamespace) 
+    public function addViewNamespaceFor(string $domain, string $viewNamespace)
     {
         $domainNamespaces = $this->viewNamespaces[$domain] ?? [];
-        if(!in_array($viewNamespace, $domainNamespaces)) {
+        if (! in_array($viewNamespace, $domainNamespaces)) {
             $this->viewNamespaces[$domain][] = $viewNamespace;
         }
     }
 
     /**
-     * Return the config view_namespace key for the given domain
-     * 
-     * @param string $domain
+     * Return the config view_namespace key for the given domain.
+     *
+     * @param  string  $domain
      * @return string
      */
-    private function getConfigNamespaceFor(string $domain) {
+    private function getConfigNamespaceFor(string $domain)
+    {
         return 'backpack.crud.view_namespaces.'.$domain;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -53,10 +53,7 @@ trait HasViewNamespaces
      */
     public function addViewNamespaceFor(string $domain, string $viewNamespace)
     {
-        $domainNamespaces = $this->viewNamespaces[$domain] ?? [];
-        if (! in_array($viewNamespace, $domainNamespaces)) {
-            $this->viewNamespaces[$domain][] = $viewNamespace;
-        }
+        $this->viewNamespaces[$domain][] = $viewNamespace;  
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -22,14 +22,14 @@ trait HasViewNamespaces
      * with the ones stored for the given domain.
      *
      * @param  string  $domain  (eg. fields, filters, buttons)
-     * @param  null|string  $configNamespace
+     * @param  null|string  $viewNamespacesFromConfigKey
      * @return array
      */
-    public function getAllViewNamespacesFor(string $domain, string $configNamespace = null)
+    public function getAllViewNamespacesFor(string $domain, string $viewNamespacesFromConfigKey = null)
     {
-        $configNamespace ??= $this->getConfigNamespaceFor($domain);
+        $viewNamespacesFromConfig = $this->getViewNamespacesFromConfigFor($domain, $viewNamespacesFromConfigKey);
 
-        return array_unique(array_merge(config($configNamespace) ?? [], $this->getViewNamespacesFor($domain)));
+        return array_unique(array_merge($viewNamespacesFromConfig, $this->getViewNamespacesFor($domain)));
     }
 
     /**
@@ -65,10 +65,11 @@ trait HasViewNamespaces
      * Return the config view_namespace key for the given domain.
      *
      * @param  string  $domain
-     * @return string
+     * @param  null|string  $customConfigKey
+     * @return array
      */
-    private function getConfigNamespaceFor(string $domain)
+    private function getViewNamespacesFromConfigFor(string $domain, null|string $customConfigKey)
     {
-        return 'backpack.crud.view_namespaces.'.$domain;
+        return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ?? [];
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -313,7 +313,7 @@ trait Search
             // including the configured view_namespaces
             $columnPaths = array_map(function ($item) use ($column) {
                 return $item.'.'.$column['type'];
-            }, $this->getAllViewNamespacesFor('columns'));
+            }, $this->getViewNamespacesFor('columns'));
 
             // but always fall back to the stock 'text' column
             // if a view doesn't exist

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -313,7 +313,7 @@ trait Search
             // including the configured view_namespaces
             $columnPaths = array_map(function ($item) use ($column) {
                 return $item.'.'.$column['type'];
-            }, array_merge(config('backpack.crud.view_namespaces.columns'), $this->get('viewNamespaces')['columns'] ?? []));
+            }, $this->getAllViewNamespacesFor('columns'));
 
             // but always fall back to the stock 'text' column
             // if a view doesn't exist

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -313,7 +313,7 @@ trait Search
             // including the configured view_namespaces
             $columnPaths = array_map(function ($item) use ($column) {
                 return $item.'.'.$column['type'];
-            }, array_merge(config('backpack.crud.view_namespaces.columns'), $this->get('viewNamespaces')['columns'] ?? []));
+            }, config('backpack.crud.view_namespaces.columns'));
 
             // but always fall back to the stock 'text' column
             // if a view doesn't exist

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -313,7 +313,7 @@ trait Search
             // including the configured view_namespaces
             $columnPaths = array_map(function ($item) use ($column) {
                 return $item.'.'.$column['type'];
-            }, config('backpack.crud.view_namespaces.columns'));
+            }, array_merge(config('backpack.crud.view_namespaces.columns'), $this->get('viewNamespaces')['columns'] ?? []));
 
             // but always fall back to the stock 'text' column
             // if a view doesn't exist

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -290,18 +290,17 @@ trait Views
      * @param  bool|string  $viewNamespace  Optional override, to use this namespace instead of the viewstack.
      * @return string
      */
-    public static function getFirstFieldView($viewPath, $viewNamespace = false)
+    public function getFirstFieldView($viewPath, $viewNamespace = false)
     {
         // if a definite namespace was given, use that one
         if ($viewNamespace) {
             return $viewNamespace.'.'.$viewPath;
         }
-
         // otherwise, loop through all the possible view namespaces
         // until you find a view that exists
         $paths = array_map(function ($item) use ($viewPath) {
             return $item.'.'.$viewPath;
-        }, config('backpack.crud.view_namespaces.fields'));
+        }, array_merge(config('backpack.crud.view_namespaces.fields'), $this->get('viewNamespaces')['fields'] ?? []));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -300,7 +300,7 @@ trait Views
         // until you find a view that exists
         $paths = array_map(function ($item) use ($viewPath) {
             return $item.'.'.$viewPath;
-        }, array_merge(config('backpack.crud.view_namespaces.fields'), $this->get('viewNamespaces')['fields'] ?? []));
+        }, $this->getAllViewNamespacesFor('fields'));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {

--- a/src/app/Library/CrudPanel/Traits/Views.php
+++ b/src/app/Library/CrudPanel/Traits/Views.php
@@ -300,7 +300,7 @@ trait Views
         // until you find a view that exists
         $paths = array_map(function ($item) use ($viewPath) {
             return $item.'.'.$viewPath;
-        }, $this->getAllViewNamespacesFor('fields'));
+        }, $this->getViewNamespacesFor('fields'));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -136,7 +136,7 @@ class Widget extends Fluent
         $type = $this->type;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, app('crud')->getAllViewNamespacesFor('widgets', 'backpack.base.component_view_namespaces.widgets'));
+        }, app('crud')->getViewNamespacesWithFallbackFor('widgets', 'backpack.base.component_view_namespaces.widgets'));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -145,7 +145,7 @@ class Widget extends Fluent
         }
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the widget view in the defined view namespaces. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
+            throw new BackpackProRequiredException('Cannot find the widget view: '.$this->type.'. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
     }

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+use Backpack\CRUD\app\Library\Traits\HasViewNamespaces;
 use Illuminate\Support\Fluent;
 
 /**
@@ -14,6 +15,7 @@ class Widget extends Fluent
 
     public function __construct($attributes)
     {
+        
         $this->attributes = $attributes;
 
         $this->save();
@@ -136,7 +138,7 @@ class Widget extends Fluent
         $type = $this->type;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, array_merge(config('backpack.base.component_view_namespaces.widgets'), $this->crud()->get('viewNamespaces')['widgets'] ?? []));
+        }, app('crud')->getAllViewNamespacesFor('widgets', 'backpack.base.component_view_namespaces.widgets'));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {
@@ -254,11 +256,6 @@ class Widget extends Fluent
         dump($this);
 
         return $this;
-    }
-
-    public function crud()
-    {
-        return app('crud');
     }
 
     /**

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -133,11 +133,10 @@ class Widget extends Fluent
                 return $path;
             }
         }
-
         $type = $this->type;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, config('backpack.base.component_view_namespaces.widgets'));
+        }, array_merge(config('backpack.base.component_view_namespaces.widgets'), $this->crud()->get('viewNamespaces')['widgets'] ?? []));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {
@@ -146,7 +145,7 @@ class Widget extends Fluent
         }
         // if no view exists, in any of the directories above... no bueno
         if (! backpack_pro()) {
-            throw new BackpackProRequiredException('Cannot find the widget view: '.$viewPath.'. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
+            throw new BackpackProRequiredException('Cannot find the widget view in the defined view namespaces. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
         abort(500, 'Cannot find the view for «'.$this->type.'» widget type. Please check for typos.');
     }
@@ -256,6 +255,12 @@ class Widget extends Fluent
 
         return $this;
     }
+
+    public function crud()
+    {
+        return app('crud');
+    }
+
 
     /**
      * Dump and die. Duumps the current object to the screen,

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Library;
 
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
-use Backpack\CRUD\app\Library\Traits\HasViewNamespaces;
 use Illuminate\Support\Fluent;
 
 /**
@@ -15,7 +14,6 @@ class Widget extends Fluent
 
     public function __construct($attributes)
     {
-        
         $this->attributes = $attributes;
 
         $this->save();

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -261,7 +261,6 @@ class Widget extends Fluent
         return app('crud');
     }
 
-
     /**
      * Dump and die. Duumps the current object to the screen,
      * so that the developer can see its contents, then stops

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -61,7 +61,7 @@
                         		// including the configured view_namespaces
                         		$columnPaths = array_map(function($item) use ($column) {
                         			return $item.'.'.$column['type'];
-                        		}, config('backpack.crud.view_namespaces.columns'));
+                        		}, array_merge(config('backpack.crud.view_namespaces.columns'), $crud->get('viewNamespaces')['columns'] ?? []));
 
                         		// but always fall back to the stock 'text' column
                         		// if a view doesn't exist

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -61,7 +61,7 @@
                         		// including the configured view_namespaces
                         		$columnPaths = array_map(function($item) use ($column) {
                         			return $item.'.'.$column['type'];
-                        		}, $crud->getAllViewNamespacesFor('columns'));
+                        		}, $crud->getViewNamespacesFor('columns'));
 
                         		// but always fall back to the stock 'text' column
                         		// if a view doesn't exist

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -61,7 +61,7 @@
                         		// including the configured view_namespaces
                         		$columnPaths = array_map(function($item) use ($column) {
                         			return $item.'.'.$column['type'];
-                        		}, array_merge(config('backpack.crud.view_namespaces.columns'), $crud->get('viewNamespaces')['columns'] ?? []));
+                        		}, $crud->getAllViewNamespacesFor('columns'));
 
                         		// but always fall back to the stock 'text' column
                         		// if a view doesn't exist


### PR DESCRIPTION
This points to the `export-operation` branch so that you can test everything @tabacitu .

This is the fix for what I think I made work here, but I didn't: https://github.com/Laravel-Backpack/better-exports/pull/7

We cannot rely on changing the config at the run-time, if the `viewNamespaces` are a panel requirement we should have a setting for it, or even create a property, where other packages can "publish" their view paths without messing with the configs. 

I did it as a crud setting here, but it's open for discussion on what's the best approach here.