### PR TITLE
Extend config to support custom Vite styles and scripts

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -68,6 +68,7 @@ return [
     ],
 
     // CSS files that are loaded in all pages, using Laravel's @vite() helper
+    // Please note that support for Vite was added in Laravel 9.19. Earlier versions are not able to use this feature.
     'vite_styles' => [ // resource file_path
         // 'resources/css/app.css' => '',
     ],

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -67,6 +67,11 @@ return [
         // 'css/app.css' => '',
     ],
 
+    // CSS files that are loaded in all pages, using Laravel's @vite() helper
+    'vite_styles' => [ // resource file_path
+        // 'resources/css/app.css' => '',
+    ],
+
     // ------
     // HEADER
     // ------
@@ -139,8 +144,13 @@ return [
     ],
 
     // JS files that are loaded in all pages, using Laravel's mix() helper
-    'mix_scripts' => [// file_path => manifest_directory_path
+    'mix_scripts' => [ // file_path => manifest_directory_path
         // 'js/app.js' => '',
+    ],
+
+    // JS files that are loaded in all pages, using Laravel's @vite() helper
+    'vite_scripts' => [ // resource file_path
+        // 'resources/js/app.js',
     ],
 
     // -------------

--- a/src/resources/views/base/inc/head.blade.php
+++ b/src/resources/views/base/inc/head.blade.php
@@ -8,7 +8,7 @@
 
     @yield('before_styles')
     @stack('before_styles')
-    
+
     @if (config('backpack.base.styles') && count(config('backpack.base.styles')))
         @foreach (config('backpack.base.styles') as $path)
         <link rel="stylesheet" type="text/css" href="{{ asset($path).'?v='.config('backpack.base.cachebusting_string') }}">
@@ -19,6 +19,10 @@
         @foreach (config('backpack.base.mix_styles') as $path => $manifest)
         <link rel="stylesheet" type="text/css" href="{{ mix($path, $manifest) }}">
         @endforeach
+    @endif
+
+    @if (config('backpack.base.vite_styles') && count(config('backpack.base.vite_styles')))
+        @vite(config('backpack.base.vite_styles'))
     @endif
 
     @yield('after_styles')

--- a/src/resources/views/base/inc/scripts.blade.php
+++ b/src/resources/views/base/inc/scripts.blade.php
@@ -10,6 +10,10 @@
     @endforeach
 @endif
 
+@if (config('backpack.base.vite_scripts') && count(config('backpack.base.vite_scripts')))
+    @vite(config('backpack.base.vite_scripts'))
+@endif
+
 @include('backpack::inc.alerts')
 
 <!-- page script -->


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Assets built with the new Laravel Vite setup must be added by manually overriding the `head.blade.php` and `scripts.blade.php` files and adding the `@vite()` directive.

### AFTER - What is happening after this PR?

Users are now able to add their assets built with Vite directly in the configuration side to side with the custom Mix styles and scripts.
Side note: Vite will be the go-to way to handle asset bundling in the future, as decided by the Laravel core team. So it makes sense to provide support for it in the near future.


## HOW

### How did you achieve that, in technical terms?

- The config is extended with a `vite_scripts` and a `vite_styles` option. Both are simple arrays, currently there is no option to specify a custom `manifest.json` file for the Vite helper so it is left out.
- The `base/inc/head.blade.php` view was extended with a block that adds the `@vite()` helper in the same way the current `mix_styles` are loaded.
- The `base/inc/scripts.blade.php` view was extended with a block that adds the `@vite()` helper in the same way the current `mix_styles` are loaded.

### Is it a breaking change?

I am not sure how backwards compatibility is handled in Backpack at the moment. **The `@vite()` helper was addded in Laravel 9.19.**
Adding a style or script to the config will output the directive itself without rendering, but users must upgrade to Laravel 9.19 anyway to be able to use Vite in the first place. Example with Laravel 9.10:
![Bildschirmfoto 2022-07-13 um 18 59 44](https://user-images.githubusercontent.com/1816101/178789826-c9ac5322-fdfc-4835-a879-882fe7f0185a.png)

Is there a suggested way to handle Blade template backwards compatibility?


### How can we test the before & after?

This feature can be tested by [setting up Vite asset bundling](https://laravel.com/docs/9.x/vite) as described in the Laravel docs. After installing Backpack, add a custom stylesheet or script to the new config and load the admin dashboard.
