### PR TITLE
[bug] fix when ConvertEmptyStringsToNull is disabled for M-M relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -119,7 +119,7 @@ trait Create
                     break;
                 case 'BelongsToMany':
                 case 'MorphToMany':
-                    $values = $relationDetails['values'][$relationMethod] ?? [];
+                    $values = (isset($relationDetails['values'][$relationMethod]) && !empty($relationDetails['values'][$relationMethod])) ? $relationDetails['values'][$relationMethod] : [];
                     $values = is_string($values) ? json_decode($values, true) : $values;
                     $relationValues = [];
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -119,8 +119,13 @@ trait Create
                     break;
                 case 'BelongsToMany':
                 case 'MorphToMany':
-                    $values = (isset($relationDetails['values'][$relationMethod]) && !empty($relationDetails['values'][$relationMethod])) ? $relationDetails['values'][$relationMethod] : [];
+                    $values = $relationDetails['values'][$relationMethod] ?? [];
                     $values = is_string($values) ? json_decode($values, true) : $values;
+                    
+                    // disabling ConvertEmptyStringsToNull middleware may return null from json_decode() if an empty string is used.
+                    // we need to make sure no null value can go foward so we reassure that values is not null after json_decode()
+                    $values = $values ?? [];
+                    
                     $relationValues = [];
 
                     if (is_array($values) && is_multidimensional_array($values)) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

saving the form with empty many to many relationship crashes, check this issue https://github.com/Laravel-Backpack/CRUD/issues/4527

### AFTER - What is happening after this PR?

with this fix the save is working as expected


## HOW

### How did you achieve that, in technical terms?

instead of only checking for null, we need to check for empty values as well such as the empty string sent by the browser when the field is empty



### Is it a breaking change?

No


### How can we test the before & after?

reproduce the issue reported above (https://github.com/Laravel-Backpack/CRUD/issues/4527)
