### PR TITLE
HOT FIX: remove php 8 code from function constructor

### DIFF
--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -53,7 +53,7 @@ trait HasViewNamespaces
      * @param  mixed  $customConfigKey
      * @return array
      */
-    private function getViewNamespacesFromConfigFor(string $domain, mixed $customConfigKey = null)
+    private function getViewNamespacesFromConfigFor(string $domain, $customConfigKey = null)
     {
         return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ?? [];
     }


### PR DESCRIPTION
reported in https://github.com/Laravel-Backpack/CRUD/issues/4531

I left behing an artifact with php 8 code that would break the app for anyone with PHP < 8.

