### PR TITLE
[BUG] add more checks, change execution order in strippedRequest

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -479,17 +479,17 @@ trait Fields
     {
         $setting = $this->getOperationSetting('strippedRequest');
 
-        // if an invokable class was passed
-        // eg. \App\Http\Requests\BackpackStrippedRequest
-        if (class_exists($setting)) {
-            $setting = new $setting();
-
-            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting).' is not invokable.');
-        }
-
         // if a closure was passed
         if (is_callable($setting)) {
             return $setting($request);
+        }
+
+        // if an invokable class was passed
+        // eg. \App\Http\Requests\BackpackStrippedRequest
+        if (is_string($setting) && class_exists($setting)) {
+            $setting = new $setting();
+
+            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting).' is not invokable.');
         }
 
         return $request->only($this->getAllFieldNames());


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Wrongly we were trying to check if a `closure` was an existing class. 

### AFTER - What is happening after this PR?

This change prevents that from happen:
1- it changes the execution order, so if the `$setting` is callable deal with it right way.
2- add an `is_string` check before checking if class_exists.

### How can we test the before & after?

`$this->crud->setOperationSetting('strippedRequest', function() { return; })` is enough to trigger the error.