### PR TITLE
WIP: Remove spaces and new lines from column render

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -365,7 +365,9 @@ trait Search
             ->with('column', $column)
             ->with('entry', $entry)
             ->with('rowNumber', $rowNumber)
-            ->render();
+            ->render(function($view, $contents) {
+                return preg_replace('/\s\s+/', ' ',str_replace(array("\r", "\n"), '', $contents));
+            });
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -365,8 +365,8 @@ trait Search
             ->with('column', $column)
             ->with('entry', $entry)
             ->with('rowNumber', $rowNumber)
-            ->render(function($view, $contents) {
-                return preg_replace('/\s\s+/', ' ',str_replace(array("\r", "\n"), '', $contents));
+            ->render(function ($view, $contents) {
+                return preg_replace('/\s\s+/', ' ', str_replace(["\r", "\n"], '', $contents));
             });
     }
 

--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -27,21 +27,13 @@
     @if(!empty($column['value']))
         {{ $column['prefix'] }}
         @foreach($column['value'] as $key => $text)
-            @php
-                $related_key = $key;
-            @endphp
-
-            <span class="d-inline-flex">
-                @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+            <span class="d-inline-flex">@includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start', ['related_key' => $key])
                     @if($column['escaped'])
                         {{ $text }}
                     @else
                         {!! $text !!}
                     @endif
-                @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
-
-                @if(!$loop->last), @endif
-            </span>
+                @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end', ['related_key' => $key])@if(!$loop->last),@endif</span>
         @endforeach
         {{ $column['suffix'] }}
     @else


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported here: https://github.com/Laravel-Backpack/CRUD/issues/4270

Backpack columns are pieces of html when given to the datatables to render. 
They include the formating your wrote on the blade file like `\n` and `\r` etc so it will be presented in the "page source-code" as you wrote them.

When displaying in browser it's fine because browser know how to interpret it.
Trying to export that is not so funny! 🙃 

Thing is, in datatables columns we don't need the "source code formated", we just need everything to be there, even if in one single line. 

### AFTER - What is happening after this PR?

We strip `\n\r` and eveything than's more than one white space from the returned html.

The only downside I found out until now is that ` something.......like....this` will be transformed into: `something.like.this` (dots represents white spaces), anyway does anybody know any use case for double spaces ??

## HOW

### How did you achieve that, in technical terms?

transformed the returned html from view


### Is it a breaking change?

I hope not
