### PR TITLE
Fix reorder operation - after dropping the item, all items expand

### DIFF
--- a/src/public/packages/nestedSortable/jquery.mjs.nestedSortable2.js
+++ b/src/public/packages/nestedSortable/jquery.mjs.nestedSortable2.js
@@ -820,10 +820,6 @@
 
 			if (o.isTree) {
 				replaceClass(item, o.branchClass, o.leafClass, doNotClear);
-
-				if (doNotClear && hasChildren) {
-					replaceClass(item, o.collapsedClass, o.expandedClass);
-				}
 			}
 
 			if (!doNotClear) {


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/4469.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported by Andrej Elsukov on email.
When you move an item on top of a collapsed set of item, it expands (that's ok). But after you drop it, ALL items expand:

![CleanShot 2022-06-28 at 10 43 40](https://user-images.githubusercontent.com/1032474/176122995-015487f2-c1f9-4e95-b4c1-5cbc2881ab85.gif)

### AFTER - What is happening after this PR?

The problem is fixed 👌


### Is it a breaking change?

I don't think so. Developers will need to publish the assets to get the update.

Also, the peace of code removed in this PR was also removed in the newest version of the package; https://github.com/ilikenwf/nestedSortable/blob/master/jquery.mjs.nestedSortable.js. We shouldn't update anyway, it's alpha apparently and our code is customized, it wouldn't work with the new version.


### How can we test the before & after?

Easiest way is to go to demo, find the `public\packages\nestedSortable\jquery.mjs.nestedSortable2.js`, and remove those 3 lines.
