### PR TITLE
use main branch for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,7 +6,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - 4.1
-      - v5
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Renamed the `v5` branch to `main`. Then this PR merges `master` into `main`. From now on, all Backpack repos should have
- their primary branch, called `main`;
- version branches for older versions (eg. `4.0`, `4.1` etc for CRUD, then `v5`, `v6` after we release v6, v14 etc); 