### PR TITLE
Update PHPDoc of getRequest with '\Illuminate\Http\Request'

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -83,7 +83,7 @@ class CrudPanel
     /**
      * Get the request instance for this CRUD.
      *
-     * @return  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Request
      */
     public function getRequest()
     {

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -81,9 +81,9 @@ class CrudPanel
     }
 
     /**
-     * [getRequest description].
+     * Get the request instance for this CRUD.
      *
-     * @return [type] [description]
+     * @return  \Illuminate\Http\Request
      */
     public function getRequest()
     {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was not description and return type on getRequest method PHPDoc.

### AFTER - What is happening after this PR?

I just add a description & add return type with '\Illuminate\Http\Request'


## HOW

### How did you achieve that, in technical terms?

When I access <code> $this->crud->getRequest()->input('name') </code>, my IDE can not read input() method. It show warning.



### Is it a breaking change?

No


### How can we test the before & after?

Just check in your IDE. If IDE can read and suggest all method of '\Illuminate\Http\Request' , it's working nicely.
