### PR TITLE
Update PHPDoc of addFilter and addFilterToCollection

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -45,7 +45,7 @@ trait Filters
      * Add a filter to the CRUD table view.
      *
      * @param  array  $options  Name, type, label, etc.
-     * @param  bool|array|\Closure  $values  The HTML for the filter.
+     * @param  bool|string|array|\Closure  $values  The HTML for the filter.
      * @param  bool|\Closure  $filterLogic  Query modification (filtering) logic when filter is active.
      * @param  bool|\Closure  $fallbackLogic  Query modification (filtering) logic when filter is not active.
      */
@@ -62,7 +62,7 @@ trait Filters
      * The filter will NOT get applied.
      *
      * @param  array  $options  Name, type, label, etc.
-     * @param  bool|array|\Closure  $values  The HTML for the filter.
+     * @param  bool|string|array|\Closure  $values  The HTML for the filter.
      * @param  bool|\Closure  $filterLogic  Query modification (filtering) logic when filter is active.
      * @param  bool|\Closure  $fallbackLogic  Query modification (filtering) logic when filter is not active.
      */


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The PHPDoc for the argument `$values` coming from the methods `addFilter()` and `addFilterToCollection()` didn't handle the `string` type. The methods are located in `\App\Library\CrudPanel\Traits\Filters.php`.

### AFTER - What is happening after this PR?

I add the `string` type in the PHPDoc for these 2 methods.


## HOW

### How did you achieve that, in technical terms?

I used PHPStan in my project and it threw an error when I call the `addFilter()` method with a string for the argument `$values`. A string is required for this argument when using the filter Select2_Ajax.


### Is it a breaking change?

No.


### How can we test the before & after?

You can use PHPStan like me, or just use a string for this argument and see that nothing is broken with my changes.
