### PR TITLE
stop mentioning Backpack/Base

### DIFF
--- a/src/resources/views/base/inc/sidebar_content.blade.php
+++ b/src/resources/views/base/inc/sidebar_content.blade.php
@@ -1,2 +1,2 @@
-<!-- This file is used to store sidebar items, starting with Backpack\Base 0.9.0 -->
+<!-- This file is used to store sidebar items, inside the Backpack admin panel -->
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('dashboard') }}"><i class="la la-home nav-icon"></i> {{ trans('backpack::base.dashboard') }}</a></li>


### PR DESCRIPTION
Found a mention to Backpack/Base in `sidebar_content.blade.php`

That's so confusing, Backpack has stopped using that repo 2-3 years ago.