### PR TITLE
Show getting started widget on dashboard (on localhost)

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -36,6 +36,13 @@ return [
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',
 
+    // ---------
+    // DASHBOARD
+    // ---------
+
+    // Show "Getting Started with Backpack" info block?
+    'show_getting_started' => (app()->env == 'local'),
+
     // ------
     // STYLES
     // ------

--- a/src/resources/views/base/dashboard.blade.php
+++ b/src/resources/views/base/dashboard.blade.php
@@ -1,13 +1,20 @@
 @extends(backpack_view('blank'))
 
 @php
-    $widgets['before_content'][] = [
-        'type'        => 'jumbotron',
-        'heading'     => trans('backpack::base.welcome'),
-        'content'     => trans('backpack::base.use_sidebar'),
-        'button_link' => backpack_url('logout'),
-        'button_text' => trans('backpack::base.logout'),
-    ];
+    if (config('backpack.base.show_getting_started')) {
+        $widgets['before_content'][] = [
+            'type'        => 'view',
+            'view'        => 'backpack::inc.getting_started',
+        ];
+    } else {
+        $widgets['before_content'][] = [
+            'type'        => 'jumbotron',
+            'heading'     => trans('backpack::base.welcome'),
+            'content'     => trans('backpack::base.use_sidebar'),
+            'button_link' => backpack_url('logout'),
+            'button_text' => trans('backpack::base.logout'),
+        ];
+    }
 @endphp
 
 @section('content')

--- a/src/resources/views/base/inc/getting_started.blade.php
+++ b/src/resources/views/base/inc/getting_started.blade.php
@@ -1,0 +1,110 @@
+<div class="card">
+  <div class="card-body">
+
+    <h3>Getting Started</h3>
+    <p>If it's your first time using Backpack, we heavily recommend you follow the steps below:</p>
+
+    <div id="accordion" role="tablist">
+      <div class="card mb-1">
+        <div class="card-header bg-light" id="headingOne" role="tab">
+          <h5 class="mb-0"><a data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne" class="collapsed text-dark"><span class="badge badge-warning mr-2 mt-n2">1</span>Create your first CRUD <small class="float-right mt-2">1 min</small></a></h5>
+        </div>
+        <div class="collapse" id="collapseOne" role="tabpanel" aria-labelledby="headingOne" data-parent="#accordion" style="">
+          <div class="card-body">
+            <p>You've already got a model, <code class="text-primary bg-light p-1 rounded">App\Models\User</code>... all Laravel projects do. So <strong>let's create a page to administer users</strong>. We want the admin to Create, Read, Update and Delete them. In Backpack, we call that a <a href="https://backpackforlaravel.com/docs/5.x/crud-basics" target="blank">CRUD</a>. And you can easily generate one for an existing Eloquent model, by running:</p>
+            <p>
+              <code class="text-primary bg-light p-1 rounded">php artisan backpack:crud user</code>
+            </p>
+            <p>Go ahead, run it. You'll notice it has:</p>
+            <ul>
+              <li>added an item to the sidebar, in <code class="text-primary bg-light p-1 rounded">resources/views/vendor/backpack/base/inc/sidebar_content.blade.php</code></li>
+              <li>added a route, inside <code class="text-primary bg-light p-1 rounded">routes/backpack/custom.php</code></li>
+              <li>created <code class="text-primary bg-light p-1 rounded">app/Http/Controllers/Admin/UserCrudController.php</code></li>
+              <li>created <code class="text-primary bg-light p-1 rounded">app/Http/Requests/UserRequest.php</code></li>
+            </ul>
+            <p>You can now click on the new sidebar item (or <a href="{{ backpack_url('user') }}">here</a>) and you'll be able to see the entries in the <code class="text-primary bg-light p-1 rounded">users</code> table. Even though generated CRUDs work out-of-the-box, they might not be <i>exactly</i> what you need. But that's where Backpack shines, in how easy it is to customize.</p>
+
+            <p>To dig a little deeper, let's make a few changes to the Users CRUD.</p>
+            <p><strong>1. Let's remove the "password" column</strong> - no point in showing it. To do that, go to <code class="text-primary bg-light p-1 rounded">UserCrudController::setupListOperation()</code> and remove the line saying <code class="text-primary bg-light p-1 rounded">CRUD::column('password');</code>. Easy-peasy, right?</p>
+            <p><strong>2. On Create & Update, let's add validation to forms</strong>. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation" target="_blank">multiple ways to add validation</a>, but for this simple example, let's just use <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-field-attributes" target="_blank">field attribute validation</a>:</p>
+            <ul>
+              <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, let's remove <code class="text-primary bg-light p-1 rounded">use App\Http\Requests\UserRequest;</code> from the top;</li>
+              <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, let's remove <code class="text-primary bg-light p-1 rounded">CRUD::setValidation(UserRequest::class);</code> from <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>;</li>
+              <li>let's delete the <code class="text-primary bg-light p-1 rounded">App\Http\Requests\UserRequest;</code> file;</li>
+              <li>now we're left with zero validation inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>;</li>
+              <li>a quick way to add validation is to go to <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> and specify validation rules directly on the fields:
+              <p>
+                <pre class="text-primary bg-light p-1 rounded">
+  CRUD::field('name')->validationRules('required|min:5');
+  CRUD::field('email')->validationRules('required|email|unique:users,email');
+  CRUD::field('password')->validationRules('required');
+                </pre>
+              </p>
+              </li>
+            </ul>
+            <p><strong>3. On Create, let's hash the password.</strong> Ok so... now that we have basic validation, if we create a new User, it'll work. But if you look in the database... you'll notice the password is stored in plain text. We don't want that - we want it hashed. There are multiple ways to achieve this - inside the Model, the Request or the CrudController. Let's use Model Events inside UserCrudController. Here's how our <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> would look, with the validation above rules and us tapping into the <code class="text-primary bg-light p-1 rounded">creating</code> event, to hash the password:</p>
+            <p>
+              <pre class="text-primary bg-light p-1 rounded">
+    protected function setupCreateOperation()
+    {
+        CRUD::field('name')->validationRules('required|min:5');
+        CRUD::field('email')->validationRules('required|email|unique:users,email');
+        CRUD::field('password')->validationRules('required');
+
+        \App\Models\User::creating(function ($entry) {
+            $entry->password = \Hash::make($entry->password);
+        });
+    }
+              </pre>
+            </p>
+            <p><strong>4. On Update, let's not require the password</strong>. It should only be needed if an admin wants to change it, right? That means the validation rules will be different for "password". But it'll also be different for "email" (on Update we need to pass the ID to the unique rule in Laravel). Since 2/3 rules are different, let's just delete what was inside <code class="text-primary bg-light p-1 rounded">setupUpdateOperation()</code> and code it from scratch:</p>
+            <p>
+              <pre class="text-primary bg-light p-1 rounded">
+    protected function setupUpdateOperation()
+    {
+        CRUD::field('name')->validationRules('required|min:5');
+        CRUD::field('email')->validationRules('required|email|unique:users,email,'.CRUD::getCurrentEntryId());
+        CRUD::field('password')->hint('Type a password to change it.');
+
+        \App\Models\User::updating(function ($entry) {
+            if (request('password') == null) {
+                $entry->password = $entry->getOriginal('password');
+            } else {
+                $entry->password = \Hash::make(request('password'));
+            }
+        });
+    }
+              </pre>
+            </p>
+            <p>That's it. You have a working Users CRUD. Plus, you've already learned some not-so-easy-to-do things, like using Model events inside CrudController and using field-validation instead of form-request-validation. Of course, this only scratches the surface of what Backpack can do. So we heavily recommend you move on to the next step, and learn the basics.</p>
+          </div>
+        </div>
+      </div>
+      <div class="card mb-1">
+        <div class="card-header bg-light" id="headingTwo" role="tab">
+          <h5 class="mb-0"><a class="collapsed text-dark" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"><span class="badge badge-warning mr-2 mt-n2">2</span>Learn the basics <small class="float-right mt-2">20-30 min</small></a></h5>
+        </div>
+        <div class="collapse" id="collapseTwo" role="tabpanel" aria-labelledby="headingTwo" data-parent="#accordion" style="">
+          <div class="card-body">
+            <p>So you've created your first CRUD? Excellent. Now it's time to understand <i>how it works</i> and <i>what else you can do</i>. Time to learn the basics - how to build and customize admin panels using Backpack. Please follow one of the courses below, depending on how you prefer to learn:</p>
+            <ul>
+              <li><strong><a target="_blank" href="https://backpackforlaravel.com/docs/5.x/getting-started-videos">Video Course</a></strong> - 31 minutes</li>
+              <li><strong><a target="_blank" href="https://backpackforlaravel.com/docs/5.x/getting-started-basics">Text Course</a></strong> - 20 minutes</li>
+              <li><strong><a target="_blank" href="https://backpackforlaravel.com/getting-started-emails">Email Course</a></strong> - 1 email per day, for 4 days, 5 minutes each</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="card mb-1">
+        <div class="card-header bg-light" id="headingThree" role="tab">
+          <h5 class="mb-0"><a class="collapsed text-dark" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"><span class="badge badge-warning mr-2 mt-n2">3</span>Hide this notice <small class="float-right mt-2">1 min</small></a></h5>
+        </div>
+        <div class="collapse" id="collapseThree" role="tabpanel" aria-labelledby="headingThree" data-parent="#accordion" style="">
+          <div class="card-body">Go to your <code class="text-primary bg-light p-1 rounded">config/backpack/base.php</code> and change <code class="text-primary bg-light p-1 rounded">show_getting_started</code> to <code class="text-primary bg-light p-1 rounded">false</code>.</div>
+        </div>
+      </div>
+    </div>
+
+    <p class="mt-3 mb-0"><small>* this card is only visible on <i>localhost</i>. Follow the last step to hide it from <i>localhost</i> too.</small></p>
+  </div>
+</div>

--- a/src/resources/views/base/inc/getting_started.blade.php
+++ b/src/resources/views/base/inc/getting_started.blade.php
@@ -15,7 +15,7 @@
             <p>
               <code class="text-primary bg-light p-1 rounded">php artisan backpack:crud user</code>
             </p>
-            <p>Go ahead, run it. You'll notice it has:</p>
+            <p>Go ahead, run it in your terminal. You'll notice it has:</p>
             <ul>
               <li>added an item to the sidebar, in <code class="text-primary bg-light p-1 rounded">resources/views/vendor/backpack/base/inc/sidebar_content.blade.php</code></li>
               <li>added a route, inside <code class="text-primary bg-light p-1 rounded">routes/backpack/custom.php</code></li>
@@ -28,12 +28,15 @@
 
             <div class="collapse" id="customizeUsersCRUD">
               <p><strong>1. Let's remove the "password" column</strong> - no point in showing it. To do that, go to <code class="text-primary bg-light p-1 rounded">UserCrudController::setupListOperation()</code> and remove the line saying <code class="text-primary bg-light p-1 rounded">CRUD::column('password');</code>. Easy-peasy, right?</p>
-              <p><strong>2. On Create & Update, let's add validation to forms</strong>. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation" target="_blank">multiple ways to add validation</a>, but for this simple example, let's just use <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-field-attributes" target="_blank">field attribute validation</a>:</p>
+              <p><strong>2. On Create & Update, let's add validation to forms</strong>. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation" target="_blank">multiple ways to add validation (A, B, C)</a>. Let's change the standard <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-formrequests" target="_blank">validation using FormRequests</a> (A), to a simpler validation using <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-field-attributes" target="_blank">field attributes</a> (C):</p>
               <ul>
-                <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, let's remove <code class="text-primary bg-light p-1 rounded">use App\Http\Requests\UserRequest;</code> from the top;</li>
-                <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, let's remove <code class="text-primary bg-light p-1 rounded">CRUD::setValidation(UserRequest::class);</code> from <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>;</li>
-                <li>let's delete the <code class="text-primary bg-light p-1 rounded">App\Http\Requests\UserRequest;</code> file;</li>
-                <li>now we're left with zero validation inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>;</li>
+                <li>to remove the current validation:<br>
+                  <ul>
+                    <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, remove <code class="text-primary bg-light p-1 rounded">use App\Http\Requests\UserRequest;</code> from the top;</li>
+                    <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, remove <code class="text-primary bg-light p-1 rounded">CRUD::setValidation(UserRequest::class);</code> from <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>;</li>
+                    <li>delete the <code class="text-primary bg-light p-1 rounded">App\Http\Requests\UserRequest;</code> file;</li>
+                  </ul>
+                </li>
                 <li>a quick way to add validation is to go to <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> and specify validation rules directly on the fields:
                 <p>
                   <pre class="text-primary bg-light p-1 rounded">
@@ -44,7 +47,7 @@
                 </p>
                 </li>
               </ul>
-              <p><strong>3. On Create, let's hash the password.</strong> Ok so... now that we have basic validation, if we create a new User, it'll work. But if you look in the database... you'll notice the password is stored in plain text. We don't want that - we want it hashed. There are multiple ways to achieve this - inside the Model, the Request or the CrudController. Let's use Model Events inside UserCrudController. Here's how our <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> would look, with the validation above rules and us tapping into the <code class="text-primary bg-light p-1 rounded">creating</code> event, to hash the password:</p>
+              <p><strong>3. On Create, let's hash the password.</strong> Currently, if we create a new User, it'll work. But if you look in the database... you'll notice the password is stored in plain text. We don't want that - we want it hashed. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#use-events-in-your-setup-method" target="_blank">multiple ways to achieve this too</a>. Let's use Model Events inside <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>. Here's how our method could look, when we also tap into the <code class="text-primary bg-light p-1 rounded">creating</code> event, to hash the password:</p>
               <p>
                 <pre class="text-primary bg-light p-1 rounded">
       protected function setupCreateOperation()
@@ -59,7 +62,7 @@
       }
                 </pre>
               </p>
-              <p><strong>4. On Update, let's not require the password</strong>. It should only be needed if an admin wants to change it, right? That means the validation rules will be different for "password". But it'll also be different for "email" (on Update we need to pass the ID to the unique rule in Laravel). Since 2/3 rules are different, let's just delete what was inside <code class="text-primary bg-light p-1 rounded">setupUpdateOperation()</code> and code it from scratch:</p>
+              <p><strong>4. On Update, let's not require the password</strong>. It should only be needed if an admin wants to change it, right? That means the validation rules will be different for "password". But then again... the rules will also be different for "email", right? On Update, we need to pass the ID to the unique rule in Laravel. Since 2/3 rules are different, let's just delete what was inside <code class="text-primary bg-light p-1 rounded">setupUpdateOperation()</code> and code it from scratch:</p>
               <p>
                 <pre class="text-primary bg-light p-1 rounded">
       protected function setupUpdateOperation()
@@ -78,7 +81,9 @@
       }
                 </pre>
               </p>
-              <p>That's it. You have a working Users CRUD. Plus, you've already learned some not-so-easy-to-do things, like using Model events inside CrudController and using field-validation instead of form-request-validation. Of course, this only scratches the surface of what Backpack can do. So we heavily recommend you move on to the next step, and learn the basics.</p>
+              <p>
+                That's it. You have a working Users CRUD. Plus, you've already learned some advanced techniques, like <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#use-events-in-your-setup-method" target="_blank">using Model events inside CrudController</a> and <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#b-validating-fields-using-a-rules-array" target="_blank">using field-attribute-validation instead of form-request-validation</a>. Of course, this only scratches the surface of what Backpack can do. To really understand how it works, and how you can best use Backpack's features, <strong>we heavily recommend you move on to the next step, and learn the basics.</strong>
+              </p>
             </div>
           </div>
         </div>

--- a/src/resources/views/base/inc/getting_started.blade.php
+++ b/src/resources/views/base/inc/getting_started.blade.php
@@ -7,7 +7,7 @@
     <div id="accordion" role="tablist">
       <div class="card mb-1">
         <div class="card-header bg-light" id="headingOne" role="tab">
-          <h5 class="mb-0"><a data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne" class="collapsed text-dark"><span class="badge badge-warning mr-2 mt-n2">1</span>Create your first CRUD <small class="float-right mt-2">1 min</small></a></h5>
+          <h5 class="mb-0"><a data-toggle="collapse" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne" class="collapsed text-dark"><span class="badge badge-warning mr-2 mt-n2">1</span>Create your first CRUD <small class="float-right mt-2">1-5 min</small></a></h5>
         </div>
         <div class="collapse" id="collapseOne" role="tabpanel" aria-labelledby="headingOne" data-parent="#accordion" style="">
           <div class="card-body">


### PR DESCRIPTION
## WHY

Addresses https://github.com/Laravel-Backpack/ideas/issues/170

### BEFORE - What was wrong? What was happening before this PR?

After you installed Backpack for the first time, you were greeted by a blank dashboard, that did nothing to guide you on your next steps:

<img width="1391" alt="CleanShot 2022-08-04 at 16 47 59@2x" src="https://user-images.githubusercontent.com/1032474/182863236-b30f7507-0c4a-4e1f-bb53-efec874bceaf.png">


### AFTER - What is happening after this PR?

On localhost, we show a different widget instead of the plain one, that instructs devs on the 3 important steps that would introduce them to Backpack:

<img width="1391" alt="CleanShot 2022-08-04 at 16 49 24@2x" src="https://user-images.githubusercontent.com/1032474/182863553-3f395a68-0d97-4ffc-a26d-5d538bea3fe6.png">


## HOW

### How did you achieve that, in technical terms?

Added a `view` widget instead of the current one, when needed.

### Is it a breaking change?

Yes and no... I mean... it's non-breaking, because it's only visual and only on localhost. But it's also breaking, because it's visual and it'll happen to existing projects that haven't customized their dashboard... To get rid of this, devs have to go to their config file and set it to `false`...

### Is this ready?

I don't know... Let's call it an advanced first draft. I think it goes a long way towards introducing people to Backpack but... it's not as good as it could be... then again, it could take us a few weeks to polish this and create videos for it. So until then... this first draft is better than nothing...

<img width="1501" alt="CleanShot 2022-08-04 at 16 56 52@2x" src="https://user-images.githubusercontent.com/1032474/182865216-c32ed626-bb5f-4368-970c-17dce6ee96af.png">

Then if you click the last link here, new text will appear, to make some customizations:

<img width="1496" alt="CleanShot 2022-08-04 at 16 57 48@2x" src="https://user-images.githubusercontent.com/1032474/182865399-58e9d993-4465-4d55-b616-8b9c3f82af4a.png">

And the other two accordion items are pretty basic:
<img width="1503" alt="CleanShot 2022-08-04 at 16 58 19@2x" src="https://user-images.githubusercontent.com/1032474/182865520-49ea7769-9e26-4559-ad84-d31961e25eaf.png">

And

<img width="1502" alt="CleanShot 2022-08-04 at 16 58 33@2x" src="https://user-images.githubusercontent.com/1032474/182865586-e9fc879e-bf0b-44ec-b71c-657ed7461e42.png">


---

What I don't know right now is if... I didn't go a bit overboard with explaining how to do password/unique validation, and using Model Events... Not sure if this qualifies as crash course (good) or too much, too soon (bad). 

I'll sleep on it. Eager to hear what others think too.
