### PR TITLE
Rector PHP Downgrade Dry Run Github Action

### DIFF
--- a/.github/workflows/rector-php-downgrade.yml
+++ b/.github/workflows/rector-php-downgrade.yml
@@ -1,0 +1,33 @@
+name: Rector PHP Downgrade Dry Run
+
+on: [pull_request]
+
+jobs:
+  rector-php-downgrade:
+    name: Run Rector PHP Downgrade Dry Run
+    runs-on: ubuntu-latest
+
+    steps:
+      -   uses: actions/checkout@v3
+          with:
+            ref: ${{ github.head_ref }}
+
+      -   name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: '8.1'
+            extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, gmp
+            tools: composer:v2
+            coverage: none
+
+      -   name: Cache composer dependencies
+          uses: actions/cache@v3
+          with:
+            path: vendor
+            key: composer-${{ hashFiles('composer.lock') }}
+
+      -   name: Run composer install
+          run: composer install -n --prefer-dist
+
+      -   name: Rector PHP Downgrade Dry Run
+          run: ./vendor/bin/rector process --dry-run --config rector-downgrade.php 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpunit/phpunit": "~8.0|~7.0|~9.0",
         "scrutinizer/ocular": "~1.7|~1.1",
         "orchestra/testbench": "^7.0|^6.0|^5.0|^4.0|^3.0",
-        "spatie/laravel-translatable": "^4.0|^5.0|^6.0"
+        "spatie/laravel-translatable": "^4.0|^5.0|^6.0",
+        "rector/rector": "^0.13.10"
     },
     "autoload": {
         "psr-4": {

--- a/rector-downgrade.php
+++ b/rector-downgrade.php
@@ -1,0 +1,16 @@
+<?php
+
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->sets([
+        DowngradeLevelSetList::DOWN_TO_PHP_73
+    ]);
+};


### PR DESCRIPTION
Just a github action that run Rector on pull requests and point out where need to be downgraded to PHP 7.3 (the minimum PHP version Laravel 8 supports) and how.

It is a dry run output does not attempt to make any commits.

Credits to: https://getrector.org/blog/how-all-frameworks-can-bump-to-php-81-and-you-can-use-older-php