### PR TITLE
remove deprecated strftime() in PHP 8.1

### DIFF
--- a/src/resources/views/crud/fields/datetime.blade.php
+++ b/src/resources/views/crud/fields/datetime.blade.php
@@ -9,7 +9,7 @@ if (isset($field['value']) && ($field['value'] instanceof \Carbon\CarbonInterfac
 
 $timestamp = strtotime(old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '');
 
-$value = $timestamp ? strftime('%Y-%m-%dT%H:%M:%S', $timestamp) : '';
+$value = $timestamp ? date('Y-m-d\TH:i:s', $timestamp) : '';
 @endphp
 
 @include('crud::fields.inc.wrapper_start')


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in #4583 strftime() is deprecated in PHP 8.1 and will be removed in PHP 9.0

### AFTER - What is happening after this PR?

We use the alternative `date()` helper as suggested in https://php.watch/versions/8.1/strftime-gmstrftime-deprecated and by @Polfo in the reported issue.


### Is it a breaking change?

No


### How can we test the before & after?

![image](https://user-images.githubusercontent.com/7188159/183394261-971756f1-4b4e-471b-a257-62fa26f5a7cb.png)