### PR TITLE
Add hint text to the Columns for showOperation

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -26,6 +26,7 @@ namespace Backpack\CRUD\app\Library\CrudPanel;
  * @method self visibleInShow(bool $value)
  * @method self priority(int $value)
  * @method self key(string $value)
+ * @method self hint(string $value)
  */
 class CrudColumn
 {

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -54,6 +54,10 @@
 		            <tr>
 		                <td>
 		                    <strong>{!! $column['label'] !!}:</strong>
+                            {{-- HINT --}}
+                            @if (isset($column['hint']))
+                                <p class="help-block">{!! $column['hint'] !!}</p>
+                            @endif
 		                </td>
                         <td>
                         	@php


### PR DESCRIPTION
Closes #4587

## WHY

### BEFORE - What was wrong? What was happening before this PR?

No way for adding help text on columns for `showOperation`

### AFTER - What is happening after this PR?

This gives ability to add `hint` (help text) on columns for `showOperation`


## HOW

### How did you achieve that, in technical terms?

1. Added `hint(string $value)` doc comment to the `CrudColumn` class
2. Added `hint` with check like it is done in `fields`
```PHP
{{-- HINT --}}
@if (isset($column['hint']))
    <p class="help-block">{!! $column['hint'] !!}</p>
@endif
```


### Is it a breaking change?

No, no and again no 😎

### How can we test the before & after?

Before this it was impossible adding `hint`(help text) on columns for `showOperation`