### PR TITLE
use APP_ENV instead of app()->env in show_getting_started

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -41,7 +41,7 @@ return [
     // ---------
 
     // Show "Getting Started with Backpack" info block?
-    'show_getting_started' => (app()->env == 'local'),
+    'show_getting_started' => env('APP_ENV') == 'local',
 
     // ------
     // STYLES


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Installed 5.3.1, got this in my face:

<img width="1502" alt="CleanShot 2022-08-08 at 20 20 24@2x" src="https://user-images.githubusercontent.com/1032474/183476321-dfba6d97-0f4c-4ecf-b9ee-bdb31a309f1c.png">


### AFTER - What is happening after this PR?

No longer that in my face 👀


## HOW

### How did you achieve that, in technical terms?

Used the env variable directly.



### Is it a breaking change?

No

