### PR TITLE
initial rector dry-run setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpunit/phpunit": "~8.0|~7.0|~9.0",
         "scrutinizer/ocular": "~1.7|~1.1",
         "orchestra/testbench": "^7.0|^6.0|^5.0|^4.0|^3.0",
-        "spatie/laravel-translatable": "^4.0|^5.0|^6.0"
+        "spatie/laravel-translatable": "^4.0|^5.0|^6.0",
+        "rector/rector": "^0.13.10"
     },
     "autoload": {
         "psr-4": {
@@ -63,7 +64,8 @@
     "scripts": {
         "test": "vendor/bin/phpunit --testdox",
         "test-failing": "vendor/bin/phpunit --order-by=defects --stop-on-failure",
-        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text"
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text",
+        "rector-dry-run": "./vendor/bin/rector process --dry-run"
     },
     "extra": {
         "branch-alias": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Laravel\Set\LaravelSetList;
+use Rector\Nette\Set\NetteSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    // is your PHP version different from the one you refactor to? [default: your PHP version], uses PHP_VERSION_ID format
+    $rectorConfig->phpVersion(PhpVersion::PHP_73);
+
+    $rectorConfig->paths([
+        __DIR__.'/src',
+    ]);
+
+    // How to ignore or skip specific paths or files
+    // https://github.com/rectorphp/rector/blob/HEAD//docs/how_to_ignore_rule_or_paths.md
+
+    // register a single rule
+    // full list here: https://github.com/rectorphp/rector/blob/HEAD//docs/rector_rules_overview.md
+    // $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // Path to PHPStan with extensions, that PHPStan in Rector uses to determine types
+    // $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
+
+    // Static Reflection and Autoload
+    // https://github.com/rectorphp/rector/blob/HEAD//docs/static_reflection_and_autoload.md
+
+    // use short version of import names rather than the fully qualified paths
+    // https://github.com/rectorphp/rector/blob/main/docs/auto_import_names.md
+    $rectorConfig->importNames();
+
+    // define sets of rules
+    $rectorConfig->sets([
+        // DowngradeLevelSetList::DOWN_TO_PHP_73,
+        // LevelSetList::UP_TO_PHP_81,
+        // LaravelSetList::LARAVEL_90,
+        // SetList::CODE_QUALITY,
+        // SetList::DEAD_CODE, // remove unused code
+        // SetList::PRIVATIZATION, // make visibility more private, make some class and variables final.etc
+        // SetList::NAMING,
+        SetList::TYPE_DECLARATION, // declare those types natively or in docblock for older PHP versions
+        // SetList::EARLY_RETURN,
+        // SetList::TYPE_DECLARATION_STRICT, // not too sure of the difference between this and TYPE_DECLARATION
+        // NetteSetList::NETTE_UTILS_CODE_QUALITY,
+        // PHPUnitSetList::PHPUNIT_CODE_QUALITY,
+        // SetList::CODING_STYLE, // u prob use pint instead for code style.
+    ]);
+};


### PR DESCRIPTION
An initial setup of rector, this is different from my other PR.

My Other PR is more of a github action that run the downgrade rule on new PRs and suggest what code need to be changed to be compatible with PHP 7.3

This PR is more of something you and your team could run by yourself when you wanted to do some quick refactoring.

The configuration and comments are in rector.php. I included my most commonly used rules there with links to useful resources

To run it, try 1 of the following commands

composer rector-dry-run // i added an entry to composer.json scripts
./vendor/bin/rector --dry-run
./vendor/bin/rector process --dry-run