### PR TITLE
Fixed a typo and added the type of $query

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -2,8 +2,11 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Database\Query\Builder;
+
 trait Query
 {
+    /** @var Builder */
     public $query;
 
     // ----------------
@@ -16,7 +19,7 @@ trait Query
      * Examples:
      * $this->crud->addClause('active');
      * $this->crud->addClause('type', 'car');
-     * $this->crud->addClause('where', 'name', '==', 'car');
+     * $this->crud->addClause('where', 'name', '=', 'car');
      * $this->crud->addClause('whereName', 'car');
      * $this->crud->addClause('whereHas', 'posts', function($query) {
      *     $query->activePosts();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Users may produce bugs by following the example usages in docblock with a typo. 

In [this file](https://github.com/Laravel-Backpack/CRUD/blob/main/src/app/Library/CrudPanel/Traits/Query.php), for the `addClause($function)` function.
```php
/**
     * Add another clause to the query (for ex, a WHERE clause).
     *
     * Examples:
     * $this->crud->addClause('active');
     * $this->crud->addClause('type', 'car');
     * $this->crud->addClause('where', 'name', '==', 'car'); <-- THIS ONE
     * $this->crud->addClause('whereName', 'car');
     * $this->crud->addClause('whereHas', 'posts', function($query) {
     *     $query->activePosts();
     * });
     *
     * @param  callable|string  $function
     * @return mixed
     */
    public function addClause($function)
```


### AFTER - What is happening after this PR?

- New users will be safe from producing bugs in the case mentioned above.
- Better IDE suggestion (based on mentioning `$query` type)

Closes #4595.

## HOW

### How did you achieve that, in technical terms?

- Fixed a typo in docblock comment
- Mentioned Object type of `Backpack\CRUD\app\Library\CrudPanel\Traits::query` in comment

### Is it a breaking change?

No, not at all.

### How can we test the before & after?

All changes are related to docblock comments. So no special testing is required.
