### PR TITLE
CrudFields - Subfields callbacks on the fly

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -80,6 +80,7 @@
             if(this.isSubfield) {
                 window.crud.subfieldsCallbacks[this.parent.name] ??= [];
                 window.crud.subfieldsCallbacks[this.parent.name].push({ closure, field: this });
+                this.wrapper.trigger('CrudField:callbacksUpdated');
                 return this;
             }
 
@@ -95,7 +96,7 @@
             if(this.isSubfield) {
                 window.crud.subfieldsCallbacks[this.parent.name]?.forEach(callback => callback.triggerChange = true);
             } else {
-                this.$input.trigger(`change`);
+                this.$input.trigger('change');
             }
 
             return this;

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -80,7 +80,7 @@
             if(this.isSubfield) {
                 window.crud.subfieldsCallbacks[this.parent.name] ??= [];
                 window.crud.subfieldsCallbacks[this.parent.name].push({ closure, field: this });
-                this.wrapper.trigger('CrudField:callbacksUpdated');
+                this.wrapper.trigger('CrudField:subfieldCallbacksUpdated');
                 return this;
             }
 


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/4478.

This will trigger an event once callbacks are updated, that way, repeatable, or any other field can listen for updates and proceed accordingly.

### Is it a breaking change?

No 🙌
It just triggers an event.

---

This is going to be used by; https://github.com/Laravel-Backpack/PRO/pull/80
