### PR TITLE
Avatar without email

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,7 +110,7 @@ if (! function_exists('backpack_avatar_url')) {
     {
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
-                if (backpack_users_have_email() && !empty($user->email)) {
+                if (backpack_users_have_email() && ! empty($user->email)) {
                     return Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email);
                 } else {
                     return method_exists($user, 'placehold') ? $user->placehold() : $user->placehold;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,8 +110,10 @@ if (! function_exists('backpack_avatar_url')) {
     {
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
-                if (backpack_users_have_email()) {
+                if (backpack_users_have_email() && !empty($user->email)) {
                     return Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email);
+                } else {
+                    return method_exists($user, 'placehold') ? $user->placehold() : $user->placehold;
                 }
                 break;
             default:


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If delete or set empty email user column, gravatar fail with 500 error. Details on #4302 

### AFTER - What is happening after this PR?

Can delete or set empty email user column and not 500 error.


## HOW

### How did you achieve that, in technical terms?

On helper check if gravatar is the default avatar_type, check if email column exists and is not empty, i not exists or is empty, set de default avatar_type to placehold.



### Is it a breaking change?

no


### How can we test the before & after?

Delete or set empty email column on user table.
