### PR TITLE
call request parameters directly from InputBag

### DIFF
--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -375,7 +375,7 @@ trait SaveActions
                     return $crud->hasAccess('list');
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
+                    return $request->request->has('_http_referrer') ? $request->request->get('_http_referrer') : $crud->route;
                 },
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
@@ -385,13 +385,13 @@ trait SaveActions
                     return $crud->hasAccess('update');
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    $itemId = $itemId ?: $request->input('id');
+                    $itemId = $itemId ?: $request->request->get('id');
                     $redirectUrl = $crud->route.'/'.$itemId.'/edit';
-                    if ($request->has('_locale')) {
-                        $redirectUrl .= '?_locale='.$request->input('_locale');
+                    if ($request->request->has('_locale')) {
+                        $redirectUrl .= '?_locale='.$request->request->get('_locale');
                     }
-                    if ($request->has('_current_tab')) {
-                        $redirectUrl = $redirectUrl.'#'.$request->get('_current_tab');
+                    if ($request->request->has('_current_tab')) {
+                        $redirectUrl = $redirectUrl.'#'.$request->request->get('_current_tab');
                     }
 
                     return $redirectUrl;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #4593 

Since our `SaveActions` redirect closure runs after the request is parsed and crud finished doing the save/update operations, we    should call the `has` and `get` methods directly in the InputBag because calling it in the `Larave\Request` would make the Request class to reconstruct, and if for example your deleted a temporary file (that you already handled) an error would be thrown. 

There is a easy way to reproduce using SpatieMediaLibrary because after adding the media it removes the temporary file from the disk, and our `$request->has('some_attribute')` after that would fail. 

