### PR TITLE
Fix for MongoDB: Configurable order by primary key check

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -119,7 +119,7 @@ trait Search
             }
         }
 
-        $key = $this->model->getKeyName();        
+        $key = $this->model->getKeyName();
         $hasOrderByPrimaryKey = $this->hasOrderByPrimaryKey($key);
 
         // show newest items first, by default (if no order has been set for the primary column)
@@ -132,8 +132,8 @@ trait Search
 
     /**
      * Check if the crud query is ordered by primary key or not.
-     * 
-     * @param string $key
+     *
+     * @param  string  $key
      * @return bool
      */
     private function hasOrderByPrimaryKey(string $key)
@@ -141,20 +141,19 @@ trait Search
         // Note to self: `toBase()` returns also the orders contained in global scopes, while `getQuery()` don't.
         $orderBy = $this->query->toBase()->orders;
         $table = $this->model->getTable();
-        
+
         // developer can use this method to override the way crud checks for primary key order in the query
-        if (method_exists($this->model, 'getOrderByPrimaryKey'))
-        {
+        if (method_exists($this->model, 'getOrderByPrimaryKey')) {
             return $this->model->getOrderByPrimaryKey($orderBy, $table, $key);
         }
 
-        // no point in using this method if driver is not sql, developer should define their own 
+        // no point in using this method if driver is not sql, developer should define their own
         // `getOrderByPrimaryKey` function in model that should return true/false
         if ($this->driverIsSql()) {
             return collect($orderBy)->some(function ($item) use ($key, $table) {
-                    return (isset($item['column']) && $item['column'] === $key)
+                return (isset($item['column']) && $item['column'] === $key)
                         || (isset($item['sql']) && str_contains($item['sql'], "$table.$key"));
-                });
+            });
         }
 
         // nothing we can do at this point, we don't know what else to do, neither if query is ordered


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We know there are some mongdb users using Backpack. 
We don't optimize specifically for mongodb nor "official" support it, but usually if we properly write our sql stuff and leave some bits extensible, mongodb and other dbms can work with backpack too. 

It was reported here https://github.com/Laravel-Backpack/CRUD/issues/4601 that some of our code is conflicting for mongodb users because we don't leave an open door for them to work with this bit. 

So what I did was:
- moved the `check for primary key order` into a function
- added the possibility for developer to define a model method that determines if there is primary key order or not
- added a constrain that only runs our code for sure in sql dbs
- if we can't determine it, we bail with "true" so that we don't try to apply the crud order as we can't determine if it has order or not. 

I tought about other solution:
- introducing a ListOperation config, let's say `addPrimaryKeyOrder => true`, that if dev changed to false we would not apply any order. 

The reason why I didn't choose this solution was because applying our default primary key order, on mongodb for example, is not the issue, the issue is `how we determine if it has order or not`, that's why I opted for the second one that allow developer to keep using Backpack default functionality, just providing a different way to check if it has primary key order or not. 

@tabacitu what you think in terms of architecture and solution ? Is checking for sqlDriver too much ? Technically $order[sql] would only be available with sql drivers... 
At the current moment, we will return that there is no order, but the truth is that we don't know if there is order or not. (there is, we just cannot find it properly).

Cheers
