### PR TITLE
Update infoPostFix in italian language

### DIFF
--- a/src/resources/lang/it/crud.php
+++ b/src/resources/lang/it/crud.php
@@ -85,7 +85,7 @@ return [
     'info'           => 'Visualizzando da _START_ a _END_ record di _TOTAL_',
     'infoEmpty'      => 'Non vi sono elementi',
     'infoFiltered'   => '(filtrati da _MAX_ record totali)',
-    'infoPostFix'    => ',',
+    'infoPostFix'    => '.',
     'thousands'      => '.',
     'lengthMenu'     => '_MENU_ record per pagina',
     'loadingRecords' => 'Caricamento...',


### PR DESCRIPTION
This makes the `infoPostFix` consistent accross languages.

Italian was the only using `,` instead of `.`

This was initially reported in https://github.com/Laravel-Backpack/CRUD/issues/3934

