### PR TITLE
fix str_repeat error

### DIFF
--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -185,10 +185,11 @@ trait PrettyCommandOutput
         $this->maxWidth = $this->maxWidth ?? 128;
         $this->terminal = $this->terminal ?? new Terminal();
         $width = min($this->terminal->getWidth(), $this->maxWidth);
+        $dotLength = $width - 5 - strlen(strip_tags($text.$progress));
 
         $this->output->write(sprintf(
             "  $text <fg=gray>%s</> <fg=$color>%s</>",
-            str_repeat('.', $width - 5 - strlen(strip_tags($text.$progress))),
+            str_repeat('.', ($dotLength < 0) ? 1 : $dotLength),
             strtoupper($progress)
         ));
     }

--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -189,7 +189,7 @@ trait PrettyCommandOutput
 
         $this->output->write(sprintf(
             "  $text <fg=gray>%s</> <fg=$color>%s</>",
-            str_repeat('.', ($dotLength < 0) ? 1 : $dotLength),
+            str_repeat('.', ($dotLength < 1) ? 1 : $dotLength),
             strtoupper($progress)
         ));
     }


### PR DESCRIPTION
Reported in https://github.com/Laravel-Backpack/devtools-issues/issues/50

## WHY

### BEFORE - What was wrong? What was happening before this PR?

DevTools stopped working - no matter why you try to generate, it would throw a `str_repeat can't have 0 as input` error.

### AFTER - What is happening after this PR?

No error.

## HOW

### How did you achieve that, in technical terms?

The problem was how we calculated the number of dots in the output. There were cases where the number of dots became negative or zero which... obviously shouldn't happen.

### Is it a breaking change?

No, it is am important fix.
