### PR TITLE
Fix select2 first focus

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -81,18 +81,8 @@
      */
     function handleFocusOnSelect2Field(firstField){
         $('.select2-search__field').remove();
-        firstField.select2('open');
+        firstField.select2('focus');
     }
-
-    /*
-    * Hacky fix for a bug in select2 with jQuery 3.6.0's new nested-focus "protection"
-    * see: https://github.com/select2/select2/issues/5993
-    * see: https://github.com/jquery/jquery/issues/4382
-    *
-    */
-    $(document).on('select2:open', () => {
-        document.querySelector('.select2-search__field').focus();
-    });
 
     jQuery('document').ready(function($){
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

On open "select2_from_ajax_multiple" field, auto-focus other field with same class.

![Screen Shot 2022-08-23 at 11 59 43](https://user-images.githubusercontent.com/44643608/186206310-6c429f66-ccb9-45a1-96da-dd716f701447.png)


### AFTER - What is happening after this PR?

"select2_from_ajax_multiple" will work normally, not loosing current focus


## HOW

### How did you achieve that, in technical terms?

Change focus to normal behavior and deleted auto-focus function


### Is it a breaking change?

No


### How can we test the before & after?

Try to reply image selection
