### PR TITLE
Fix select2 input focus & select2 multiple input remove

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -80,9 +80,18 @@
      * @param {jQuery} firstField
      */
     function handleFocusOnSelect2Field(firstField){
-        $('.select2-search__field').remove();
         firstField.select2('focus');
     }
+
+    /*
+    * Hacky fix for a bug in select2 with jQuery 3.6.0's new nested-focus "protection"
+    * see: https://github.com/select2/select2/issues/5993
+    * see: https://github.com/jquery/jquery/issues/4382
+    *
+    */
+    $(document).on('select2:open', () => {
+        setTimeout(() => document.querySelector('.select2-container--open .select2-search__field').focus(), 200);
+    });
 
     jQuery('document').ready(function($){
 

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -90,7 +90,7 @@
     *
     */
     $(document).on('select2:open', () => {
-        setTimeout(() => document.querySelector('.select2-container--open .select2-search__field').focus(), 200);
+        setTimeout(() => document.querySelector('.select2-container--open .select2-search__field').focus(), 100);
     });
 
     jQuery('document').ready(function($){


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

On open select2 search input doesnt focus and select2_multiple broken, because remove "select2-search__field".

### AFTER - What is happening after this PR?

On open select2, input is focus, and select2_multiple work normally.
Now is possible no navigate by select2 as normal field, with tab, space, up, down and enter keys.


## HOW

### How did you achieve that, in technical terms?

setTimeout was add to way input is created and focus on it
Delete the line who remove "search__field"


### Is it a breaking change?

No


### How can we test the before & after?

Try any select2 will be working normally now.
