### PR TITLE
Add style focus to select2

### DIFF
--- a/src/resources/assets/scss/customs/_form.scss
+++ b/src/resources/assets/scss/customs/_form.scss
@@ -1,42 +1,51 @@
 form {
-  .form-group.required>label:not(:empty):not(.form-check-label)::after {
-    content: ' *';
-    color: #ff0000;
-  }
-
-  .help-block {
-    margin-top: .25rem;
-    margin-bottom: .25rem;
-    color: #73818f;
-    font-size: 0.9em;
-  }
-
-  .nav-tabs .nav-link:hover {
-    border-bottom: none;
-    color: #384c74;
-  }
-
-  .select2-container--bootstrap {
-    .select2-selection--single {
-      padding-top: 8px;
-      padding-bottom: 8px;
-      min-height: 38px;
+    .form-group.required>label:not(:empty):not(.form-check-label)::after {
+        content: ' *';
+        color: #ff0000;
     }
 
-    .select2-selection--multiple {
-      min-height: 38px;
-
-      .select2-search--inline .select2-search__field {
-        min-height: 36px;
-      }
-
-      .select2-selection__choice {
-        margin-top: 6px;
-      }
-
-      .select2-selection__clear {
-        margin-top: 8px;
-      }
+    .help-block {
+        margin-top: .25rem;
+        margin-bottom: .25rem;
+        color: #73818f;
+        font-size: 0.9em;
     }
-  }
+
+    .nav-tabs .nav-link:hover {
+        border-bottom: none;
+        color: #384c74;
+    }
+
+    .select2-container--bootstrap {
+        .select2-selection--single {
+            padding-top: 8px;
+            padding-bottom: 8px;
+            min-height: 38px;
+        }
+
+        .select2-selection--multiple {
+            min-height: 38px;
+
+            .select2-search--inline .select2-search__field {
+                min-height: 36px;
+            }
+
+            .select2-selection__choice {
+                margin-top: 6px;
+            }
+
+            .select2-selection__clear {
+                margin-top: 8px;
+            }
+        }
+    }
+
+    .select2.select2-container.select2-container--focus,
+    .select2.select2-container.select2-container--open {
+        background-color: #fff;
+        border-color: #9080f1;
+        box-shadow: 0 0 0 2px #e1dcfb;
+        color: #495057;
+        outline: 0;
+    }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

select2 didnt show any style to know we are focus on it

![Screen Shot 2022-08-23 at 14 24 42](https://user-images.githubusercontent.com/44643608/186236747-f933bdc3-6b32-4c8a-bb98-e7c3f77a6e34.png)


### AFTER - What is happening after this PR?

select2 will show focus border as any other field

![Screen Shot 2022-08-23 at 14 22 48](https://user-images.githubusercontent.com/44643608/186236783-cc4c7cf0-a0a6-4f8f-a06b-a4453c1a20cb.png)


## HOW

### How did you achieve that, in technical terms?

Add styles to opened and focused select2

@tabacitu @pxpm is needed run npm update to compile and publish again:
public/packages/backpack/base/css/blue-bundle.css
public/packages/backpack/base/css/bundle.css

### Is it a breaking change?

Yes


### How can we test the before & after?

You can check style of select2 before and after npm update
