### PR TITLE
Update backpack_users_have_email helper and add email_column to config

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -12,7 +12,7 @@ return [
     */
 
     // Date & Datetime Format Syntax: https://carbon.nesbot.com/docs/#api-localization
-    'default_date_format'     => 'D MMM YYYY',
+    'default_date_format' => 'D MMM YYYY',
     'default_datetime_format' => 'D MMM YYYY, HH:mm',
 
     // Direction, according to language
@@ -272,8 +272,12 @@ return [
     // Username column for authentication
     // The Backpack default is the same as the Laravel default (email)
     // If you need to switch to username, you also need to create that column in your db
-    'authentication_column'      => 'email',
+    'authentication_column' => 'email',
     'authentication_column_name' => 'Email',
+
+    // As default backpack will use email column as username
+    // If we change email column as "authentication_column", then we can set email column here to not break recovery password and keep working route:list
+    'email_column' => 'email',
 
     // The guard that protects the Backpack admin panel.
     // If null, the config.auth.defaults.guard value will be used.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -95,7 +95,7 @@ if (! function_exists('backpack_users_have_email')) {
         $user_model_fqn = config('backpack.base.user_model_fqn');
         $user = new $user_model_fqn();
 
-        return \Schema::hasColumn($user->getTable(), 'email');
+        return \Schema::hasColumn($user->getTable(), config('backpack.base.email_column') ?? 'email');
     }
 }
 


### PR DESCRIPTION
## WHY
This PR was explain in https://github.com/Laravel-Backpack/CRUD/pull/4225 

### BEFORE - What was wrong? What was happening before this PR?

If we change email column on user table, route:list fail and backpack_users_have_email always will return false, even if foo column contain email

### AFTER - What is happening after this PR?

Now developers can set username columna and email column and could be different columns

## HOW

### How did you achieve that, in technical terms?

Update backpack_users_have_email, now developers are free to use any column as username and any as email, they can set this in base.php

### Is it a breaking change?

No, but maybe because is needed update base.php config file


### How can we test the before & after?

Change name to email column on user table and set it on base.php
