### PR TITLE
make select2 halo similar to other fields

### DIFF
--- a/src/resources/assets/scss/customs/_form.scss
+++ b/src/resources/assets/scss/customs/_form.scss
@@ -47,5 +47,12 @@ form {
         box-shadow: 0 0 0 2px #e1dcfb;
         color: #495057;
         outline: 0;
+        border-radius: 4px;
+    }
+
+    .select2.select2-container.select2-container--focus,
+    .select2.select2-container.select2-container--open .select2-selection {
+        border-color: #9080f1;
+        border: 1px solid #9080f1 !important;
     }
 }


### PR DESCRIPTION
A small improvement on @jorgetwgroup solution with the halo, making it more "similar" to other select2 halos. (the neon when the field is focused)

Now:
![image](https://user-images.githubusercontent.com/7188159/187398256-74c464d8-a114-4262-b9a6-0385868d66c0.png)

Cheers