### PR TITLE
text column to support PHP Enum casting

### DIFF
--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -13,6 +13,8 @@
 
     if(is_array($column['value'])) {
         $column['value'] = json_encode($column['value']);
+    } elseif (function_exists('enum_exists') && $column['value'] instanceof \UnitEnum) {
+        $column['value'] = $column['value']->value;
     }
 
     if(!empty($column['value'])) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some of us do this in our model casts to take advantage of PHP 8.1 Enums to ensure a given column can only contain a set of specific values

protected $casts = [
    'status' => StatusEnum::class
]

But in backpack it will be an error

mb_strwidth(): Argument #1 ($string) must be of type string

### AFTER - What is happening after this PR?

Display the enum value


## HOW

### How did you achieve that, in technical terms?

1st we use the function_exists('enum_exists') check, then if that functions exist, we know we are at least on a PHP version that supports PHP enums and check if the value is an instance of UnitEnum, if it is then we call ->value to get the enum value

This is how i see laravel support PHP Enums currently. See Line 26

https://github.com/laravel/framework/blob/0f1eb9ef9d3846eeca0e6bfac77ddd67ce8ca12b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php#L26

Additionally, concepts like toString() does not exist for PHP Enums (they are not allowed to implement Stringable interface). So we have to handle it at the column view file level (or maybe at the level before it is passed to the column/field blade file)

### Is it a breaking change?

No


### How can we test the before & after?

Cast a text column to php enum and use the text column
