### PR TITLE
Fix typehint for query property in CrudPanel/Traits/Query.php

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -2,7 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
 
 trait Query
 {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `query` property of the `CrudPanel` was listed as instance of `Illuminate\Database\Query\Builder`. It is correctly typehinted in all method return types.

### AFTER - What is happening after this PR?

The `query` property of the `CrudPanel` is correctly listed as instance of `Illuminate\Database\Eloquent\Builder`.

Any model-based query in Laravel is based on the `Eloquent`-namespace version, which has some additional available methods on the query builder, like e.g. `whereHas` and other relation-based methods. Currently, when referencing `crud->query` in my codebase, the static analyzer produces errors like `Call to an undefined method Illuminate\Database\Query\Builder::whereHas()`.

## HOW

### Is it a breaking change?

No, just a static typehint improvement.
