### PR TITLE
remove path separator from begin of string

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -180,7 +180,9 @@ class CrudPanel
      */
     public function setRoute($route)
     {
-        $this->route = $route;
+        $this->route = Str::of($route)->whenStartsWith('/', function ($string) {
+            return Str::after('/', $string);
+        });
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -180,9 +180,7 @@ class CrudPanel
      */
     public function setRoute($route)
     {
-        $this->route = Str::of($route)->whenStartsWith('/', function ($string) {
-            return Str::after($string, '/');
-        });
+        $this->route = ltrim($route, '/');
     }
 
     /**
@@ -196,6 +194,8 @@ class CrudPanel
      */
     public function setRouteName($route, $parameters = [])
     {
+        $route = ltrim($route, '.');
+
         $complete_route = $route.'.index';
 
         if (! \Route::has($complete_route)) {

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -181,7 +181,7 @@ class CrudPanel
     public function setRoute($route)
     {
         $this->route = Str::of($route)->whenStartsWith('/', function ($string) {
-            return Str::after('/', $string);
+            return Str::after($string, '/');
         });
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/Laravel-Backpack/CRUD/issues/4639

TLDR: Using empty `route_prefix` would lead to bugs in datatables script given that we assume the url to be `something/entity`, and when `something` (usually admin) is empty, datatables was unable to properly work.

### AFTER - What is happening after this PR?

No more buuugs 🐛 🐞 


## HOW

### How did you achieve that, in technical terms?

Removed the `/` if string starts with. Or the `.` (dot) when adding route with name.

### Is it a breaking change?

no

### How can we test the before & after?

add empty `route_prefix` in config. 
