### PR TITLE
dependabot for github action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
   ignore:
   - dependency-name: css-loader
     versions:
@@ -28,3 +23,8 @@ updates:
     versions:
     - 10.1.0
     - 10.1.1
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10
   ignore:
   - dependency-name: css-loader
     versions:


### PR DESCRIPTION
Keep your 3rd party github actions up to date too. The github actions you used in your github workflows