### PR TITLE
Added `askHint` helper on PrettyCommandOutput

### DIFF
--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -231,6 +231,22 @@ trait PrettyCommandOutput
     }
 
     /**
+     * 
+     *
+     * @return void
+     */
+    public function askHint(string $question, array $hints, string $default)
+    {
+        $hints = collect($hints)
+            ->map(function ($hint) {
+                return " <fg=gray>│ $hint</>";
+            })
+            ->join(PHP_EOL);
+
+        return $this->ask($question.PHP_EOL.$hints, $default);
+    }
+
+    /**
      * Deletes one or multiple chars.
      *
      * @return void

--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -231,8 +231,6 @@ trait PrettyCommandOutput
     }
 
     /**
-     * 
-     *
      * @return void
      */
     public function askHint(string $question, array $hints, string $default)


### PR DESCRIPTION
This is part of https://github.com/Laravel-Backpack/Generators/pull/143.

## WHY

This allows for beautier questions with hints

![image](https://user-images.githubusercontent.com/1838187/188340017-e0253100-ce52-44de-93cb-8a46886627f5.png)

Syntax for this is something like;

```php
$result = $this->askHint(
    'Question?', [
        'First line hint',
        'Second line with <fb=blue>highlighted text</>',
        ...
    ], $default);
```
