### PR TITLE
Work around for specific PRO versions

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -14,6 +14,7 @@ use Backpack\CRUD\app\Library\CrudPanel\Traits\FakeColumns;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\FakeFields;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Fields;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Filters;
+use Backpack\CRUD\app\Library\CrudPanel\Traits\HasViewNamespaces;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\HeadingsAndTitles;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Input;
 use Backpack\CRUD\app\Library\CrudPanel\Traits\Macroable;
@@ -38,7 +39,7 @@ use Illuminate\Support\Arr;
 class CrudPanel
 {
     // load all the default CrudPanel features
-    use Create, Read, Search, Update, Delete, Input, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships;
+    use Create, Read, Search, Update, Delete, Input, Errors, Reorder, Access, Columns, Fields, Query, Buttons, AutoSet, FakeFields, FakeColumns, AutoFocus, Filters, Tabs, Views, Validation, HeadingsAndTitles, Operations, SaveActions, Settings, Relationships, HasViewNamespaces;
     // allow developers to add their own closures to this object
     use Macroable;
 

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -7,8 +7,9 @@ use Backpack\CRUD\ViewNamespaces;
 trait HasViewNamespaces
 {
     /**
-     * This file is only needed because we messed up version constrains from 1.2 up to 1.2.6 of PRO version
-     * and any user that the license ended in the middle of those versions was not able to update
+     * This file is only needed because we messed up version constrains from 
+     * 1.2 up to 1.2.6 of PRO version and any user that the license ended 
+     * in the middle of those versions was not able to update
      * Backpack/CRUD up from 5.3.6.
      *
      * This should be removed in the next major version.

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -7,8 +7,8 @@ use Backpack\CRUD\ViewNamespaces;
 trait HasViewNamespaces
 {
     /**
-     * This file is only needed because we messed up version constrains from 
-     * 1.2 up to 1.2.6 of PRO version and any user that the license ended 
+     * This file is only needed because we messed up version constrains from
+     * 1.2 up to 1.2.6 of PRO version and any user that the license ended
      * in the middle of those versions was not able to update
      * Backpack/CRUD up from 5.3.6.
      *

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -4,19 +4,15 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\ViewNamespaces;
 
-
-
 trait HasViewNamespaces
 {
     /**
      * This file is only needed because we messed up version constrains from 1.2 up to 1.2.6 of PRO version
      * and any user that the license ended in the middle of those versions was not able to update
      * Backpack/CRUD up from 5.3.6.
-     * 
-     * This should be removed in the next major version.
      *
+     * This should be removed in the next major version.
      */
-
     public function addViewNamespacesFor(string $domain, array $viewNamespaces)
     {
         ViewNamespaces::addFor($domain, $viewNamespaces);

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
+
+use Backpack\CRUD\ViewNamespaces;
+
+trait HasViewNamespaces
+{
+    public function addViewNamespacesFor(string $domain, array $viewNamespaces)
+    {
+        ViewNamespaces::addFor($domain, $viewNamespaces);
+    }
+
+    public function addViewNamespaceFor(string $domain, string $viewNamespace)
+    {
+        ViewNamespaces::addFor($domain, $viewNamespace);
+    }
+}

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -4,8 +4,19 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\ViewNamespaces;
 
+
+
 trait HasViewNamespaces
 {
+    /**
+     * This file is only needed because we messed up version constrains from 1.2 up to 1.2.6 of PRO version
+     * and any user that the license ended in the middle of those versions was not able to update
+     * Backpack/CRUD up from 5.3.6.
+     * 
+     * This should be removed in the next major version.
+     *
+     */
+
     public function addViewNamespacesFor(string $domain, array $viewNamespaces)
     {
         ViewNamespaces::addFor($domain, $viewNamespaces);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We messed up the constrains from CRUD to PRO, and users that the licence ended between 1.2 and 1.2.6 were unable to update Backpack/CRUD past 5.3.6. 

### AFTER - What is happening after this PR?

They can ... I created a placeholder file that handle the calls in those versions. 


### Is it a breaking change?

Nopi!


### How can we test the before & after?

Go to PRO 1.2.1 for example, and try to load a page with CRUD 5.3.7++. 
