### PR TITLE
Progress block fixes for multiline text

### DIFF
--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -187,9 +187,15 @@ trait PrettyCommandOutput
         $width = min($this->terminal->getWidth(), $this->maxWidth);
         $dotLength = $width - 5 - strlen(strip_tags($text.$progress));
 
+        // In case it doesn't fit the screen, add enough lines with dots
+        $textLength = strlen(strip_tags($text)) + 20;
+        $dotLength += floor($textLength / $width) * $width;
+
+        $this->consoleProgress = $progress;
+
         $this->output->write(sprintf(
             "  $text <fg=gray>%s</> <fg=$color>%s</>",
-            str_repeat('.', ($dotLength < 1) ? 1 : $dotLength),
+            str_repeat('.', max(1, $dotLength)),
             strtoupper($progress)
         ));
     }
@@ -199,14 +205,17 @@ trait PrettyCommandOutput
      *
      * @return void
      */
-    public function closeProgressBlock(string $text = 'done', string $color = 'green')
+    public function closeProgressBlock(string $progress = 'done', string $color = 'green')
     {
-        $this->deleteChars(20);
+        $deleteSize = max(strlen($this->consoleProgress ?? ''), strlen($progress)) + 1;
+        $newDotSize = $deleteSize - strlen($progress) - 1;
+
+        $this->deleteChars($deleteSize);
 
         $this->output->write(sprintf(
             "<fg=gray>%s</> <fg=$color>%s</>",
-            str_repeat('.', 19 - strlen($text)),
-            strtoupper($text),
+            $newDotSize > 0 ? str_repeat('.', $newDotSize) : '',
+            strtoupper($progress),
         ));
         $this->newLine();
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Progress Block element wasn't ready for long texts;

![image](https://user-images.githubusercontent.com/1838187/189552363-5c739357-f979-4062-bbb6-7473afb94769.png)

### AFTER - What is happening after this PR?

It is!

<img width="632" alt="image" src="https://user-images.githubusercontent.com/1838187/189552375-6d4310ce-67a5-491b-a04e-f920b717f8cb.png">

And it supports long texts, multiline, if it ever gonna happen 🤷‍♂️

<img width="331" alt="image" src="https://user-images.githubusercontent.com/1838187/189552428-62d998ac-6a9d-4a75-b2db-e0aa79a9f0fa.png">


### How can we test the before & after?

Just resize the window to a small width, and run `php artisan backpack:crud test`.
