### PR TITLE
Fix to allow export of input/select

### DIFF
--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -18,7 +18,7 @@
             .replace(/<!\-\-.*?\-\->/g, '')
             .replace(/<[^>]*>/g, '')
             .replace(/^\s+|\s+$/g, '')
-            .replace(/\n/g, ' ');
+            .replace(/[\n|\r]/g, ' ');
     };
 
     let dataTablesExportFormat = {

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -18,6 +18,8 @@
             .replace(/<!\-\-.*?\-\->/g, '')
             .replace(/<[^>]*>/g, '')
             .replace(/^\s+|\s+$/g, '')
+            .replace(/\s+([,.;:!\?])/g, '$1')
+            .replace(/\s+/g, ' ')
             .replace(/[\n|\r]/g, ' ');
     };
 

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -8,6 +8,27 @@
   <script src="//cdn.datatables.net/buttons/1.5.6/js/buttons.print.min.js" type="text/javascript"></script>
   <script src="//cdn.datatables.net/buttons/1.5.6/js/buttons.colVis.min.js" type="text/javascript"></script>
   <script>
+    let dataTablesExportStrip = text => {
+        if ( typeof text !== 'string' ) {
+            return text;
+        }
+
+        return text
+            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+            .replace(/<!\-\-.*?\-\->/g, '')
+            .replace(/<[^>]*>/g, '')
+            .replace(/^\s+|\s+$/g, '')
+            .replace(/\n/g, ' ');
+    };
+
+    let dataTablesExportFormat = {
+        body: (data, row, column, node) => 
+            node.querySelector('input[type*="text"]')?.value ??
+            node.querySelector('input[type*="checkbox"]')?.checked ??
+            node.querySelector('select')?.selectedOptions[0]?.value ??
+            dataTablesExportStrip(data),
+    };
+
     window.crud.dataTableConfiguration.buttons = [
         @if($crud->get('list.showExportButton'))
         {
@@ -22,7 +43,8 @@
                         columns: function ( idx, data, node ) {
                             var $column = crud.table.column( idx );
                                 return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        }
+                        },
+                        format: dataTablesExportFormat,
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -37,7 +59,8 @@
                         columns: function ( idx, data, node ) {
                             var $column = crud.table.column( idx );
                                 return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        }
+                        },
+                        format: dataTablesExportFormat,
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -52,7 +75,8 @@
                         columns: function ( idx, data, node ) {
                             var $column = crud.table.column( idx );
                                 return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        }
+                        },
+                        format: dataTablesExportFormat,
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);
@@ -67,7 +91,8 @@
                         columns: function ( idx, data, node ) {
                             var $column = crud.table.column( idx );
                                 return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        }
+                        },
+                        format: dataTablesExportFormat,
                     },
                     orientation: 'landscape',
                     action: function(e, dt, button, config) {
@@ -83,7 +108,8 @@
                         columns: function ( idx, data, node ) {
                             var $column = crud.table.column( idx );
                                 return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        }
+                        },
+                        format: dataTablesExportFormat,
                     },
                     action: function(e, dt, button, config) {
                         crud.responsiveToggle(dt);


### PR DESCRIPTION
_AKA Editable Columns export._

This is a fix for https://github.com/Laravel-Backpack/CRUD/issues/4576.

---

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Datatables does not process inputs, only texts.
**And that is an issue for Editable Columns.**

### AFTER - What is happening after this PR?

The `<input>` and `<select>` are exported.
In particularly, **Editable Text**, **Editable Checkbox** and **Editable Select**.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/1838187/189784744-83c250bf-fe20-4080-b2be-7e1604a7a518.png">


## HOW

### How did you achieve that, in technical terms?

To allow the usage of input values instead of parsing the text of the cell, DataTables force us to override `buttons.exportOptions.format`, in DataTables core, inside that function it's the strip text method (exactly here: https://github.com/DataTables/Buttons/blob/4359f3568de9df6659c5170e18bdd48120ba18ff/js/dataTables.buttons.js#L2015)

So to override it, I had to copy the function to backpack side. This isn't good, but it was the only way (it's the `dataTablesExportStrip` function btw).

### Is it a breaking change?

I think it isn't 🙏
	
### How can we test the before & after?

Go to `/admin/editable-monster`, and export anything.
