### PR TITLE
Add method to get widget attributes

### DIFF
--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -50,8 +50,8 @@ class Widget extends Fluent
 
     /**
      * Return the widget attribute value or null when attribute does not exist.
-     * 
-     * @param string $attribute
+     *
+     * @param  string  $attribute
      * @return mixed
      */
     public function getAttribute(string $attribute)

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -49,7 +49,7 @@ class Widget extends Fluent
     }
 
     /**
-     * Return the widget attribute value or null when attribute does not exist.
+     * Return the widget attribute value or null when it doesn't exist.
      *
      * @param  string  $attribute
      * @return mixed
@@ -57,6 +57,17 @@ class Widget extends Fluent
     public function getAttribute(string $attribute)
     {
         return $this->attributes[$attribute] ?? null;
+    }
+
+    /**
+     * Check if widget has the attribute.
+     *
+     * @param  string  $attribute
+     * @return bool
+     */
+    public function hasAttribute(string $attribute)
+    {
+        return array_key_exists($attribute, $this->attributes);
     }
 
     /**

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -49,6 +49,17 @@ class Widget extends Fluent
     }
 
     /**
+     * Return the widget attribute value or null when attribute does not exist.
+     * 
+     * @param string $attribute
+     * @return mixed
+     */
+    public function getAttribute(string $attribute)
+    {
+        return $this->attributes[$attribute] ?? null;
+    }
+
+    /**
      * This method allows one to creat a widget without attaching it to any 'real'
      * widget section, by moving it to a 'hidden' section.
      *


### PR DESCRIPTION
`Widget` attributes are a protected property. 

We needed an acessor. I build the accessor. 

debatable `get` vs `getAttribute`. For me `get` seems more like to `get a widget` than `get an attribute of the widget` .. so `getAttribute` for me 🙏 