### PR TITLE
Add config for backpack_email_column

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -275,8 +275,8 @@ return [
     'authentication_column'      => 'email',
     'authentication_column_name' => 'Email',
 
-    // As default backpack will use email column as username
-    // If we change email column as "authentication_column", then we can set email column here to not break recovery password and keep working route:list
+    // Backpack assumes that your "database email column" for operations like Login and Register is called "email".
+    // If your database email column have a different name, you can configure it here. Eg: `user_mail`
     'email_column' => 'email',
 
     // The guard that protects the Backpack admin panel.

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -275,6 +275,10 @@ return [
     'authentication_column'      => 'email',
     'authentication_column_name' => 'Email',
 
+    // As default backpack will use email column as username
+    // If we change email column as "authentication_column", then we can set email column here to not break recovery password and keep working route:list
+    'email_column' => 'email',
+
     // The guard that protects the Backpack admin panel.
     // If null, the config.auth.defaults.guard value will be used.
     'guard' => 'backpack',

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -29,6 +29,19 @@ if (! function_exists('backpack_authentication_column')) {
     }
 }
 
+if (! function_exists('backpack_email_column')) {
+    /**
+     * Return the email column name.
+     * The Laravel default (and Backpack default) is 'email'.
+     *
+     * @return string
+     */
+    function backpack_email_column()
+    {
+        return config('backpack.base.email_column', 'email');
+    }
+}
+
 if (! function_exists('backpack_form_input')) {
     /**
      * Parse the submitted input in request('form') to an usable array.
@@ -95,7 +108,7 @@ if (! function_exists('backpack_users_have_email')) {
         $user_model_fqn = config('backpack.base.user_model_fqn');
         $user = new $user_model_fqn();
 
-        return \Schema::hasColumn($user->getTable(), 'email');
+        return \Schema::hasColumn($user->getTable(), config('backpack.base.email_column') ?? 'email');
     }
 }
 

--- a/src/resources/views/base/auth/login.blade.php
+++ b/src/resources/views/base/auth/login.blade.php
@@ -57,7 +57,7 @@
                     </form>
                 </div>
             </div>
-            @if (backpack_users_have_email() && config('backpack.base.setup_password_recovery_routes', true))
+            @if (backpack_users_have_email() && backpack_email_column() == 'email' && config('backpack.base.setup_password_recovery_routes', true))
                 <div class="text-center"><a href="{{ route('backpack.auth.password.reset') }}">{{ trans('backpack::base.forgot_your_password') }}</a></div>
             @endif
             @if (config('backpack.base.registration_open'))

--- a/src/resources/views/base/auth/register.blade.php
+++ b/src/resources/views/base/auth/register.blade.php
@@ -27,7 +27,7 @@
                             <label class="control-label" for="{{ backpack_authentication_column() }}">{{ config('backpack.base.authentication_column_name') }}</label>
 
                             <div>
-                                <input type="{{ backpack_authentication_column()=='email'?'email':'text'}}" class="form-control{{ $errors->has(backpack_authentication_column()) ? ' is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
+                                <input type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text'}}" class="form-control{{ $errors->has(backpack_authentication_column()) ? ' is-invalid' : '' }}" name="{{ backpack_authentication_column() }}" id="{{ backpack_authentication_column() }}" value="{{ old(backpack_authentication_column()) }}">
 
                                 @if ($errors->has(backpack_authentication_column()))
                                     <span class="invalid-feedback">
@@ -75,7 +75,7 @@
                     </form>
                 </div>
             </div>
-            @if (backpack_users_have_email() && config('backpack.base.setup_password_recovery_routes', true))
+            @if (backpack_users_have_email() && backpack_email_column() == 'email' && config('backpack.base.setup_password_recovery_routes', true))
                 <div class="text-center"><a href="{{ route('backpack.auth.password.reset') }}">{{ trans('backpack::base.forgot_your_password') }}</a></div>
             @endif
             <div class="text-center"><a href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a></div>

--- a/src/resources/views/base/my_account.blade.php
+++ b/src/resources/views/base/my_account.blade.php
@@ -76,7 +76,7 @@
                                     $field = backpack_authentication_column();
                                 @endphp
                                 <label class="required">{{ $label }}</label>
-                                <input required class="form-control" type="{{ backpack_authentication_column()=='email'?'email':'text' }}" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }}">
+                                <input required class="form-control" type="{{ backpack_authentication_column()==backpack_email_column()?'email':'text' }}" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }}">
                             </div>
                         </div>
                     </div>
@@ -89,7 +89,7 @@
 
             </form>
         </div>
-        
+
         {{-- CHANGE PASSWORD FORM --}}
         <div class="col-lg-8">
             <form class="form" action="{{ route('backpack.account.password') }}" method="post">


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If developer set other column not called "email" php artisan route:list will fail, this is a small version of PR https://github.com/Laravel-Backpack/CRUD/pull/4623

### AFTER - What is happening after this PR?

Developer can set any column as login and any as email, but if this last one is not called email will disable recovery password process (because Laravel is hardcode as email column)


## HOW

### How did you achieve that, in technical terms?

Update helper and add new check on recovery links



### Is it a breaking change?

No


### How can we test the before & after?

Change name to email column on user table and set it on base.php
