### PR TITLE
Add methods into view namespaces to avoid BC

### DIFF
--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -23,4 +23,14 @@ trait HasViewNamespaces
     {
         ViewNamespaces::addFor($domain, $viewNamespace);
     }
+
+    public function getViewNamespacesFor(string $domain)
+    {
+        ViewNamespaces::getFor($domain);
+    }
+
+    public function  getViewNamespacesWithFallbackFor(string $domain, string $viewNamespacesFromConfigKey)
+    {
+        ViewNamespaces::getWithFallbackFor($domain, $viewNamespacesFromConfigKey);
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
+++ b/src/app/Library/CrudPanel/Traits/HasViewNamespaces.php
@@ -29,7 +29,7 @@ trait HasViewNamespaces
         ViewNamespaces::getFor($domain);
     }
 
-    public function  getViewNamespacesWithFallbackFor(string $domain, string $viewNamespacesFromConfigKey)
+    public function getViewNamespacesWithFallbackFor(string $domain, string $viewNamespacesFromConfigKey)
     {
         ViewNamespaces::getWithFallbackFor($domain, $viewNamespacesFromConfigKey);
     }


### PR DESCRIPTION
Add the rest of the public methods that we had in `HasViewNamespaces` to avoid BC.