### PR TITLE
revert model_function column 

### DIFF
--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -1,19 +1,7 @@
 {{-- custom return value --}}
 @php
-    $column['value'] = $column['value'] ?? $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
+    $column['value'] = $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 32;
-    $column['prefix'] = $column['prefix'] ?? '';
-    $column['suffix'] = $column['suffix'] ?? '';
-    $column['text'] = $column['default'] ?? '-';
-
-    if($column['value'] instanceof \Closure) {
-        $column['value'] = $column['value']($entry);
-    }
-
-    if(!empty($column['value'])) {
-        $column['text'] = $column['prefix'].Str::limit($column['value'], $column['limit'], "…").$column['suffix'];
-    }
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 999;
+    $column['limit'] = $column['limit'] ?? 40;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -2,6 +2,14 @@
 @php
     $column['value'] = $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
     $column['escaped'] = $column['escaped'] ?? true;
+    $column['limit'] = $column['limit'] ?? 999;
+    $column['prefix'] = $column['prefix'] ?? '';
+    $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = $column['default'] ?? '-';
+
+    if(!empty($column['value'])) {
+        $column['text'] = $column['prefix'].Str::limit($column['value'], $column['limit'], "…").$column['suffix'];
+    }
 @endphp
 
 <span>

--- a/src/resources/views/crud/columns/model_function.blade.php
+++ b/src/resources/views/crud/columns/model_function.blade.php
@@ -2,7 +2,7 @@
 @php
     $column['value'] = $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));
     $column['escaped'] = $column['escaped'] ?? true;
-    $column['limit'] = $column['limit'] ?? 40;
+    $column['limit'] = $column['limit'] ?? 32;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';


### PR DESCRIPTION
We broke `model_function` column here: https://github.com/Laravel-Backpack/CRUD/pull/3936
We added `$column['value'] = >>> $column['value'] ?? <<< $entry->{$column['function_name']}(...($column['function_parameters'] ?? []));` and guess what happens if your column name is a real colum in database that has value ? Yes, **the model function never runs**. 
