### PR TITLE
Validates user connection on backpack install

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -96,12 +96,20 @@ class Install extends Command
         $userClass = config('backpack.base.user_model_fqn', 'App\Models\User');
         $userModel = new $userClass();
 
-        // Count current users
-        $currentUsers = $userModel->count();
-
         $this->newLine();
         $this->infoBlock('Creating an admin:', 'Step 2');
         $this->note('Quickly jump in your admin panel, using the email & password you choose here.');
+
+        // Test User Model DB Connection
+        try {
+            $userModel->getConnection()->getPdo();
+        } catch (\Throwable $e) {
+            $this->note('Error accessing the database, make sure the User Model has a valid DB connection.', 'red');
+            return;
+        }
+
+        // Count current users
+        $currentUsers = $userModel->count();
         $this->note(sprintf('Currently there %s in the <fg=blue>%s</> table.', trans_choice("{0} are <fg=blue>no users</>|{1} is <fg=blue>1 user</>|[2,*] are <fg=blue>$currentUsers users</>", $currentUsers), $userModel->getTable()));
 
         $total = 0;

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -8,7 +8,6 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
 class Install extends Command
 {
@@ -77,11 +76,14 @@ class Install extends Command
         $process->run();
         $this->closeProgressBlock();
 
-        // Create users
-        $this->createUsers();
+        // Optional commands
+        if (! $this->option('no-interaction')) {
+            // Create users
+            $this->createUsers();
 
-        // Addons
-        $this->installAddons();
+            // Addons
+            $this->installAddons();
+        }
 
         // Done
         $url = Str::of(config('app.url'))->finish('/')->append('admin/');

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -105,6 +105,7 @@ class Install extends Command
             $userModel->getConnection()->getPdo();
         } catch (\Throwable $e) {
             $this->note('Error accessing the database, make sure the User Model has a valid DB connection.', 'red');
+
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/Laravel-Backpack/CRUD/issues/4663.

>**Note**
> **Why I think this PR is necessary, and it's not necessary to remove the user counting info line.**
> 
> Regarding the reported error on https://github.com/Laravel-Backpack/CRUD/issues/4663, it broke on user counting, but it would broke on user insert any way 🤷‍♂️
> To remove the info line would not solve the issue.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Backpack installation could break because of wrong database configurations.

### AFTER - What is happening after this PR?

This validates the User Model DB connection before performing any action on it.

### Is it a breaking change?

No 🙌


### How can we test the before & after?

I set an invalid connection on User model to test this 👌

`app\Models\User.php`
```php
protected $connection = 'mysql2';
```

`config\database.php`
```php
'mysql2' => [
    ...
    'port' => 1234, // enough to break the connection
```

### Result

<img width="540" alt="image" src="https://user-images.githubusercontent.com/1838187/190832033-e6581696-9b33-4397-9988-fb103a79e287.png">
