### PR TITLE
Fix Reorder When Page is RTL

### DIFF
--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -89,135 +89,135 @@ function tree_element($entry, $key, $all_entries, $crud)
 
 
 @section('after_styles')
-<style>
-    .ui-sortable .placeholder {
-      outline: 1px dashed #4183C4;
-      /*-webkit-border-radius: 3px;
-      -moz-border-radius: 3px;
-      border-radius: 3px;
-      margin: -1px;*/
-    }
+    <style>
+        .ui-sortable .placeholder {
+            outline: 1px dashed #4183C4;
+            /*-webkit-border-radius: 3px;
+            -moz-border-radius: 3px;
+            border-radius: 3px;
+            margin: -1px;*/
+        }
 
-    .ui-sortable .mjs-nestedSortable-error {
-      background: #fbe3e4;
-      border-color: transparent;
-    }
+        .ui-sortable .mjs-nestedSortable-error {
+            background: #fbe3e4;
+            border-color: transparent;
+        }
 
-    .ui-sortable ol {
-      margin: 0;
-      padding: 0;
-      padding-left: 30px;
-    }
+        .ui-sortable ol {
+            margin: 0;
+            padding: 0;
+            padding-left: 30px;
+        }
 
-    ol.sortable, ol.sortable ol {
-      margin: 0 0 0 25px;
-      padding: 0;
-      list-style-type: none;
-    }
+        ol.sortable, ol.sortable ol {
+            margin: 0 0 0 25px;
+            padding: 0;
+            list-style-type: none;
+        }
 
-    ol.sortable {
-      margin: 2em 0;
-    }
+        ol.sortable {
+            margin: 2em 0;
+        }
 
-    .sortable li {
-      margin: 5px 0 0 0;
-      padding: 0;
-    }
+        .sortable li {
+            margin: 5px 0 0 0;
+            padding: 0;
+        }
 
-    .sortable li div  {
-      border: 1px solid #ddd;
-      -webkit-border-radius: 3px;
-      -moz-border-radius: 3px;
-      border-radius: 3px;
-      padding: 6px;
-      margin: 0;
-      cursor: move;
-      background-color: #f4f4f4;
-      color: #444;
-      border-color: #00acd6;
-    }
+        .sortable li div  {
+            border: 1px solid #ddd;
+            -webkit-border-radius: 3px;
+            -moz-border-radius: 3px;
+            border-radius: 3px;
+            padding: 6px;
+            margin: 0;
+            cursor: move;
+            background-color: #f4f4f4;
+            color: #444;
+            border-color: #00acd6;
+        }
 
-    .sortable li.mjs-nestedSortable-branch div {
-      /*background-color: #00c0ef;*/
-      /*border-color: #00acd6;*/
-    }
+        .sortable li.mjs-nestedSortable-branch div {
+            /*background-color: #00c0ef;*/
+            /*border-color: #00acd6;*/
+        }
 
-    .sortable li.mjs-nestedSortable-leaf div {
-      /*background-color: #00c0ef;*/
-      border: 1px solid #ddd;
-    }
+        .sortable li.mjs-nestedSortable-leaf div {
+            /*background-color: #00c0ef;*/
+            border: 1px solid #ddd;
+        }
 
-    li.mjs-nestedSortable-collapsed.mjs-nestedSortable-hovering div {
-      border-color: #999;
-      background: #fafafa;
-    }
+        li.mjs-nestedSortable-collapsed.mjs-nestedSortable-hovering div {
+            border-color: #999;
+            background: #fafafa;
+        }
 
-    .ui-sortable .disclose {
-      cursor: pointer;
-      width: 10px;
-      display: none;
-    }
+        .ui-sortable .disclose {
+            cursor: pointer;
+            width: 10px;
+            display: none;
+        }
 
-    .sortable li.mjs-nestedSortable-collapsed > ol {
-      display: none;
-    }
+        .sortable li.mjs-nestedSortable-collapsed > ol {
+            display: none;
+        }
 
-    .sortable li.mjs-nestedSortable-branch > div > .disclose {
-      display: inline-block;
-    }
+        .sortable li.mjs-nestedSortable-branch > div > .disclose {
+            display: inline-block;
+        }
 
-    .sortable li.mjs-nestedSortable-collapsed > div > .disclose > span:before {
-      content: '+ ';
-    }
+        .sortable li.mjs-nestedSortable-collapsed > div > .disclose > span:before {
+            content: '+ ';
+        }
 
-    .sortable li.mjs-nestedSortable-expanded > div > .disclose > span:before {
-      content: '- ';
-    }
+        .sortable li.mjs-nestedSortable-expanded > div > .disclose > span:before {
+            content: '- ';
+        }
 
-    .ui-sortable h1 {
-      font-size: 2em;
-      margin-bottom: 0;
-    }
+        .ui-sortable h1 {
+            font-size: 2em;
+            margin-bottom: 0;
+        }
 
-    .ui-sortable h2 {
-      font-size: 1.2em;
-      font-weight: normal;
-      font-style: italic;
-      margin-top: .2em;
-      margin-bottom: 1.5em;
-    }
+        .ui-sortable h2 {
+            font-size: 1.2em;
+            font-weight: normal;
+            font-style: italic;
+            margin-top: .2em;
+            margin-bottom: 1.5em;
+        }
 
-    .ui-sortable h3 {
-      font-size: 1em;
-      margin: 1em 0 .3em;;
-    }
+        .ui-sortable h3 {
+            font-size: 1em;
+            margin: 1em 0 .3em;;
+        }
 
-    .ui-sortable p, .ui-sortable ol, .ui-sortable ul, .ui-sortable pre, .ui-sortable form {
-      margin-top: 0;
-      margin-bottom: 1em;
-    }
+        .ui-sortable p, .ui-sortable ol, .ui-sortable ul, .ui-sortable pre, .ui-sortable form {
+            margin-top: 0;
+            margin-bottom: 1em;
+        }
 
-    .ui-sortable dl {
-      margin: 0;
-    }
+        .ui-sortable dl {
+            margin: 0;
+        }
 
-    .ui-sortable dd {
-      margin: 0;
-      padding: 0 0 0 1.5em;
-    }
+        .ui-sortable dd {
+            margin: 0;
+            padding: 0 0 0 1.5em;
+        }
 
-    .ui-sortable code {
-      background: #e5e5e5;
-    }
+        .ui-sortable code {
+            background: #e5e5e5;
+        }
 
-    .ui-sortable input {
-      vertical-align: text-bottom;
-    }
+        .ui-sortable input {
+            vertical-align: text-bottom;
+        }
 
-    .ui-sortable .notice {
-      color: #c33;
-    }
-</style>
+        .ui-sortable .notice {
+            color: #c33;
+        }
+    </style>
 @endsection
 
 @section('after_scripts')
@@ -226,7 +226,10 @@ function tree_element($entry, $key, $all_entries, $crud)
 
 <script type="text/javascript">
     jQuery(document).ready(function($) {
-
+    var isRtl = ($('html').attr('dir') == 'rtl') ? true : false;
+    if(isRtl) {
+        $( " <style> .ui-sortable ol {margin: 0;padding: 0;padding-right: 30px;}ol.sortable, ol.sortable ol {margin: 0 25px 0 0;padding: 0;list-style-type: none;}.ui-sortable dd {margin: 0;padding: 0 1.5em 0 0;}</style>" ).appendTo( "head" )
+    }
     // initialize the nested sortable plugin
     $('.sortable').nestedSortable({
         forcePlaceholderSize: true,
@@ -237,10 +240,10 @@ function tree_element($entry, $key, $all_entries, $crud)
         placeholder: 'placeholder',
         revert: 250,
         tabSize: 25,
+        rtl: isRtl,
         tolerance: 'pointer',
         toleranceElement: '> div',
         maxLevels: {{ $crud->get('reorder.max_level') ?? 3 }},
-
         isTree: true,
         expandOnHover: 700,
         startCollapsed: false


### PR DESCRIPTION
## WHY
Fix RTL Problem With Reorder Sort

### BEFORE - What was wrong? What was happening before this PR?

it was not working fine when the page was rtl 

### AFTER - What is happening after this PR?

work fine depending on the HTML tag dir


## HOW
so there's a method called RTL in nestedSortable() that allow RTL and it detects if dir is RTL from HTML dir attribute 

### How did you achieve that, in technical terms?

- check page dir via ``` $('html').attr('dir') == 'rtl') ```
- if it true it wilis l saved at ```isRtl```
- if isRtl is true will inject some CSS to fix some indentation issues
- add rtl to ``` nestedSortable() ``` with ```isRtl``` var



### Is it a breaking change?

no


### How can we test the before & after?

![ice_video_20220918-073655](https://user-images.githubusercontent.com/23424932/190887495-c02dbc18-e30b-43d4-a55e-5bd83cd86a67.gif)

