### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,8 +12,6 @@ on:
 permissions: {}
 jobs:
   add-to-project:
-    permissions:
-      repository-projects: write # to add to projects (actions/add-to-project)
     name: Add new bugs and PRs to This Week project
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,8 +9,11 @@ on:
     types:
       - opened
 
+permissions: {}
 jobs:
   add-to-project:
+    permissions:
+      repository-projects: write # to add to projects (actions/add-to-project)
     name: Add new bugs and PRs to This Week project
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,9 @@ on:
     schedule:
         - cron: '0 0 * * *'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.