### PR TITLE
add total query property to CrudPanel object

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -71,9 +71,6 @@ trait ListOperation
     {
         $this->crud->hasAccessOrFail('list');
 
-        // how many total entries there is applying the controller/model constrains, before any filtering or search
-        $this->crud->setOperationSetting('totalEntryCount', $this->crud->getTotalEntryCount($this->crud->getRequest()));
-
         $this->crud->applyUnappliedFilters();
 
         $start = (int) request()->input('start');
@@ -100,14 +97,15 @@ trait ListOperation
 
         // if show entry count is disabled we use the "simplePagination" technique to move between pages.
         if ($this->crud->getOperationSetting('showEntryCount')) {
-            // after filters, search etc are applied, do the query count again
+            $totalEntryCount = (int) (request()->get('totalEntryCount') ?? $this->crud->getTotalEntryCount());
             $filteredEntryCount = $this->crud->performQueryEntryCount();
         } else {
-            $this->crud->setOperationSetting('totalEntryCount', $length);
+            $totalEntryCount = $length;
             $filteredEntryCount = $entries->count() < $length ? 0 : $length + $start + 1;
         }
 
-        $totalEntryCount = $this->crud->getOperationSetting('totalEntryCount');
+        // store the totalEntryCount in CrudPanel so that multiple blade files can access it
+        $this->crud->setOperationSetting('totalEntryCount', $totalEntryCount);
 
         return $this->crud->getEntriesAsJsonForDatatables($entries, $totalEntryCount, $filteredEntryCount, $start);
     }

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -101,9 +101,6 @@ class CrudFilter
      */
     public function apply($input = null)
     {
-        // before applying filters, store the base query count (query before any filters are applied)
-        $this->crud()->setOperationSetting('totalEntryCount', $this->crud()->getTotalEntryCount($this->crud()->getRequest()));
-
         // mark the field as already applied
         $this->applied(true);
 

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -113,7 +113,7 @@ class CrudPanel
         }
 
         $this->model = new $model_namespace();
-        $this->query = $this->model->select('*');
+        $this->query = $this->totalQuery = $this->model->select('*');
         $this->entry = null;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -3,13 +3,15 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
 trait Query
 {
     /** @var Builder */
     public $query;
+
+    /** @var Builder */
+    public $totalQuery;
 
     // ----------------
     // ADVANCED QUERIES
@@ -220,18 +222,16 @@ trait Query
     /**
      * Get the query count without any filters or search applied.
      *
-     * @param  Request  $request
      * @return int
      */
-    public function getTotalEntryCount(Request $request)
+    public function getTotalEntryCount()
     {
         if (! $this->getOperationSetting('showEntryCount')) {
             return 0;
         }
 
-        return  (int) ($request->get('totalEntryCount') ??
-                $this->getOperationSetting('totalEntryCount') ??
-                $this->performQueryEntryCount());
+        return  $this->getOperationSetting('totalEntryCount') ??
+                $this->performQueryEntryCount();
     }
 
     /**
@@ -251,7 +251,7 @@ trait Query
      */
     protected function getEntryCount()
     {
-        $crudQuery = $this->query->toBase()->clone();
+        $crudQuery = $this->totalQuery->toBase()->clone();
         $crudQueryColumns = $this->getQueryColumnsFromWheres($crudQuery);
 
         // merge the model key in the columns array if needed


### PR DESCRIPTION
Points to https://github.com/Laravel-Backpack/CRUD/pull/4502 - and solves the problems we highlighted there.

### TODO

- [ ] 🔴 test test test
- [ ] 🔴 add `$this->crud->addBaseClause();` that would work similarly to `addClause()` but change the query for both `query` and `totalQuery`
- [ ] 🔵 see if `addClause()` and `addBaseClause()` support passing a closure

ideally:
```
$this->crud->addClause(function($query) {
    return $query->where('active', 1);
});
```