### PR TITLE
optimizations for query count

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -98,7 +98,9 @@ trait ListOperation
         // if show entry count is disabled we use the "simplePagination" technique to move between pages.
         if ($this->crud->getOperationSetting('showEntryCount')) {
             $totalEntryCount = (int) (request()->get('totalEntryCount') ?? $this->crud->getTotalQueryCount());
-            $filteredEntryCount = $this->crud->getQueryCount();
+            // check if the filtered query is different from total query, in case they are the same, skip the count
+            $filteredQuery = $this->crud->query->toBase()->cloneWithout(['orders', 'limit', 'offset']);
+            $filteredEntryCount = $filteredQuery->toSql() === $this->crud->totalQuery->toSql() ? $totalEntryCount : $this->crud->getQueryCount();
         } else {
             $totalEntryCount = $length;
             $filteredEntryCount = $entries->count() < $length ? 0 : $length + $start + 1;

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -297,9 +297,6 @@ trait Query
         // create an "outer" query, the one that is responsible to do the count of the "crud query".
         $outerQuery = $crudQuery->newQuery();
 
-        // in this outer query we will select only one column to be counted.
-        $outerQuery = $outerQuery->select($this->model->getKeyName());
-
         // add the count query in the "outer" query.
         $outerQuery = $outerQuery->selectRaw("count('".$this->model->getKeyName()."') as total_rows");
 
@@ -310,7 +307,7 @@ trait Query
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
         $outerQuery = $outerQuery->fromSub($subQuery->select($crudQueryColumns), $this->model->getTableWithPrefix());
 
-        return $outerQuery->cursor()->first()->total_rows;
+        return $outerQuery->first()->total_rows;
     }
 
     /**


### PR DESCRIPTION
- do not do the filtered query if the filtered query is the same as the total query
- don't select the id, return only count
- no need for lazyloading if we are returning only one record

down from 7~8s to 3s with 4.000.000 rows.

