### PR TITLE
Adds a schema check before attempting to get the columns

### DIFF
--- a/src/app/Library/Database/TableSchema.php
+++ b/src/app/Library/Database/TableSchema.php
@@ -20,10 +20,10 @@ class TableSchema
     public function getColumnsNames()
     {
         return array_values(
-                array_map(function ($item) {
-                    return $item->getName();
-                }, $this->getColumns())
-            );
+            array_map(function ($item) {
+                return $item->getName();
+            }, $this->getColumns())
+        );
     }
 
     /**
@@ -116,6 +116,10 @@ class TableSchema
      */
     public function getColumns()
     {
+        if (! $this->schemaExists()) {
+            return [];
+        }
+
         return $this->schema->getColumns();
     }
 

--- a/src/app/Models/Traits/HasRelationshipFields.php
+++ b/src/app/Models/Traits/HasRelationshipFields.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\DB;
 */
 trait HasRelationshipFields
 {
+    protected static $schema;
+
     /**
      * Register aditional types in doctrine schema manager for the current connection.
      *
@@ -127,9 +129,14 @@ trait HasRelationshipFields
 
     public static function getDbTableSchema()
     {
-        [$connection, $table] = self::getConnectionAndTable();
+        if (self::$schema) {
+            return self::$schema;
+        }
 
-        return new TableSchema($connection->getName(), $table);
+        [$connection, $table] = self::getConnectionAndTable();
+        self::$schema = new TableSchema($connection->getName(), $table);
+
+        return self::$schema;
     }
 
     private static function isSqlConnection()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It could raise errors while there is no schema for the table. We use it everywhere, I forgot about it here.