### PR TITLE
check if pro is enable before using table field

### DIFF
--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -158,7 +158,7 @@ trait AutoSet
                 return 'time';
 
             case 'json':
-                return 'table';
+                return backpack_pro() ? 'table' : 'text';
 
             default:
                 return 'text';

--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -158,7 +158,7 @@ trait AutoSet
                 return 'time';
 
             case 'json':
-                return backpack_pro() ? 'table' : 'text';
+                return backpack_pro() ? 'table' : 'textarea';
 
             default:
                 return 'text';


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4694 

`json` database fields would use `table` (pro) by default. 

### AFTER - What is happening after this PR?

We check if pro is enabled, if not we use text field.

### Is it a breaking change?

No

