### PR TITLE
make distinction between inline inputs and main form inputs

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -37,7 +37,8 @@
         get activeInput() {
             // get the input/textarea/select that has that field name
             this.$input = $(`input[name="${this.name}"], textarea[name="${this.name}"], select[name="${this.name}"], select[name="${this.name}[]"]`);
-            return this.$input.length === 1 ? this.$input : this.$input.filter(function() { return $(this).closest('[id=inline-create-dialog]').length }) ?? this.$input.first();
+            let possibleInput = this.$input.length === 1 ? this.$input : this.$input.filter(function() { return $(this).closest('[id=inline-create-dialog]').length });
+            return possibleInput.length === 1 ? possibleInput : this.$input.first();
         }
 
         get mainInput() {

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -9,10 +9,8 @@
     class CrudField {
         constructor(name) {
             this.name = name;
-
-            // get the input/textarea/select that has that field name
-            this.$input = $(`input[name="${this.name}"], textarea[name="${this.name}"], select[name="${this.name}"], select[name="${this.name}[]"]`).first();
-
+            // get the current input
+            this.$input = this.activeInput;
             // get the field wraper
             this.wrapper = this.inputWrapper;
 
@@ -34,6 +32,12 @@
 
             return this;
 
+        }
+
+        get activeInput() {
+            // get the input/textarea/select that has that field name
+            this.$input = $(`input[name="${this.name}"], textarea[name="${this.name}"], select[name="${this.name}"], select[name="${this.name}[]"]`);
+            return this.$input.length === 1 ? this.$input : this.$input.filter(function() { return $(this).closest('[id=inline-create-dialog]').length }) ?? this.$input.first();
         }
 
         get mainInput() {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This PR answers the questions in this comment https://github.com/Laravel-Backpack/PRO/pull/90#issuecomment-1251228131

The `CrudField` didn't properly work when there are fields with the same name both in main form and inline form.

### AFTER - What is happening after this PR?

If we found more than one field, we return the field that have `inline-create-dialog` as a parent. 


### Is it a breaking change?

I don't think so, we were explicitly using `.first()` so even if two fields were found we would only get the first one, and we kept that behaviour in this PR.

### How can we test the before & after?

add a widget on ProductCrudController: `Widget::add()->type('script')->inline()->content('assets/js/products/products_create.js');` 

```javascript
// file assets/js/products/products_create.js 
crud.field('name').onChange(field => {
    crud.field('description').input.value = field.value.toString().toLowerCase().trim()
    .normalize('NFD')                // separate accent from letter
    .replace(/[\u0300-\u036f]/g, '') // remove all separated accents
    .replace(/\s+/g, '-')            // replace spaces with -
    .replace(/[^\w\-]+/g, '')        // remove all non-word chars
    .replace(/\-\-+/g, '-')          // replace multiple '-' with single '-';
});
```

You should now see that when you writte on name a slug is generated on description.
Now go to MonsterCrud to create a new monster, and in the `#relationships` tab you have the following field:
![image](https://user-images.githubusercontent.com/7188159/195362036-ac2c22bb-9561-4502-9ae5-f70a4d7f26c9.png)

Go to `+ Add` to InlineCreate a product. 

See that the same behaviour is kept 👍 

This needs https://github.com/Laravel-Backpack/PRO/pull/90

