### PR TITLE
Trash Operations for crud

### DIFF
--- a/src/app/Http/Controllers/Operations/TrashOperation.php
+++ b/src/app/Http/Controllers/Operations/TrashOperation.php
@@ -10,9 +10,9 @@ trait TrashOperation
     /**
      * Define which routes are needed for this operation.
      *
-     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
-     * @param string $routeName  Prefix of the route name.
-     * @param string $controller Name of the current CrudController.
+     * @param  string  $segment  Name of the current entity (singular). Used as first URL segment.
+     * @param  string  $routeName  Prefix of the route name.
+     * @param  string  $controller  Name of the current CrudController.
      */
     protected function setupTrashRoutes($segment, $routeName, $controller)
     {
@@ -44,16 +44,15 @@ trait TrashOperation
             $this->crud->addFilter([
                 'type'  => 'simple',
                 'name'  => 'trashed',
-                'label' => 'Trashed'
-              ],
+                'label' => 'Trashed',
+            ],
               false,
-              function() { // if the filter is active
-                $this->crud->query->onlyTrashed();
-                $this->crud->removeAllButtons();
-                CRUD::addButton('line', 'restore', 'view', 'crud::buttons.restore');
-                CRUD::addButton('line', 'delete_permanently', 'view', 'crud::buttons.delete_permanently');
-              } );
-
+              function () { // if the filter is active
+                  $this->crud->query->onlyTrashed();
+                  $this->crud->removeAllButtons();
+                  CRUD::addButton('line', 'restore', 'view', 'crud::buttons.restore');
+                  CRUD::addButton('line', 'delete_permanently', 'view', 'crud::buttons.delete_permanently');
+              });
         });
     }
 
@@ -66,9 +65,9 @@ trait TrashOperation
     public function deletePermanently($id)
     {
         $this->crud->hasAccessOrFail('delete_permanently');
-        
+
         $id = $this->crud->getCurrentEntryId() ?? $id;
-        
+
         return $this->crud->query->onlyTrashed()->find($id)->forceDelete();
     }
 
@@ -83,7 +82,7 @@ trait TrashOperation
         $this->crud->hasAccessOrFail('restore');
 
         $id = $this->crud->getCurrentEntryId() ?? $id;
-        
+
         return $this->crud->query->onlyTrashed()->find($id)->restore();
     }
 }

--- a/src/app/Http/Controllers/Operations/TrashOperation.php
+++ b/src/app/Http/Controllers/Operations/TrashOperation.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+use Illuminate\Support\Facades\Route;
+
+trait TrashOperation
+{
+    /**
+     * Define which routes are needed for this operation.
+     *
+     * @param string $segment    Name of the current entity (singular). Used as first URL segment.
+     * @param string $routeName  Prefix of the route name.
+     * @param string $controller Name of the current CrudController.
+     */
+    protected function setupTrashRoutes($segment, $routeName, $controller)
+    {
+        Route::delete($segment.'/{id}/delete-permanently', [
+            'as'        => $routeName.'.delete_permanently',
+            'uses'      => $controller.'@deletePermanently',
+            'operation' => 'delete_permanently',
+        ]);
+        Route::put($segment.'/{id}/restore', [
+            'as'        => $routeName.'.restore',
+            'uses'      => $controller.'@restore',
+            'operation' => 'restore',
+        ]);
+    }
+
+    /**
+     * Add the default settings, buttons, etc that this operation needs.
+     */
+    protected function setupTrashDefaults()
+    {
+        CRUD::allowAccess('restore');
+        CRUD::allowAccess('delete_permanently');
+
+        CRUD::operation('delete_permanently', function () {
+            CRUD::loadDefaultOperationSettingsFromConfig();
+        });
+
+        CRUD::operation('list', function () {
+            $this->crud->addFilter([
+                'type'  => 'simple',
+                'name'  => 'trashed',
+                'label' => 'Trashed'
+              ],
+              false,
+              function() { // if the filter is active
+                $this->crud->query->onlyTrashed();
+                $this->crud->removeAllButtons();
+                CRUD::addButton('line', 'restore', 'view', 'crud::buttons.restore');
+                CRUD::addButton('line', 'delete_permanently', 'view', 'crud::buttons.delete_permanently');
+              } );
+
+        });
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return string
+     */
+    public function deletePermanently($id)
+    {
+        $this->crud->hasAccessOrFail('delete_permanently');
+        
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+        
+        return $this->crud->query->onlyTrashed()->find($id)->forceDelete();
+    }
+
+    /**
+     * Restore the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return string
+     */
+    public function restore($id)
+    {
+        $this->crud->hasAccessOrFail('restore');
+
+        $id = $this->crud->getCurrentEntryId() ?? $id;
+        
+        return $this->crud->query->onlyTrashed()->find($id)->restore();
+    }
+}

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -42,6 +42,8 @@ return [
     'actions'                   => 'Actions',
     'preview'                   => 'Preview',
     'delete'                    => 'Delete',
+    'delete_permanently'        => 'Delete Permanently',
+    'restore'                   => 'Restore',
     'admin'                     => 'Admin',
     'details_row'               => 'This is the details row. Modify as you please.',
     'details_row_loading_error' => 'There was an error loading the details. Please retry.',
@@ -50,13 +52,22 @@ return [
     'clone_failure'             => '<strong>Cloning failed</strong><br>The new entry could not be created. Please try again.',
 
     // Confirmation messages and bubbles
-    'delete_confirm'                              => 'Are you sure you want to delete this item?',
+    'delete_confirm'                              => 'Are you sure you want to delete this item?',    
+    'permanently_delete_confirm'                  => 'Are you sure you want to permanently delete this item?',
     'delete_confirmation_title'                   => 'Item Deleted',
     'delete_confirmation_message'                 => 'The item has been deleted successfully.',
     'delete_confirmation_not_title'               => 'NOT deleted',
     'delete_confirmation_not_message'             => "There's been an error. Your item might not have been deleted.",
     'delete_confirmation_not_deleted_title'       => 'Not deleted',
     'delete_confirmation_not_deleted_message'     => 'Nothing happened. Your item is safe.',
+    
+    'restore_confirm'                             => 'Are you sure you want to restore this item?',
+    'restore_confirmation_title'                   => 'Item Restored',
+    'restore_confirmation_message'                 => 'The item has been restore successfully.',
+    'restore_confirmation_not_title'               => 'NOT restore',
+    'restore_confirmation_not_message'             => "There's been an error. Your item might not have been restored.",
+    'restore_confirmation_not_deleted_title'       => 'Not restored',
+    'restore_confirmation_not_deleted_message'     => 'Nothing happened. Your item is in trash.',
 
     // Bulk actions
     'bulk_no_entries_selected_title'   => 'No entries selected',

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -52,7 +52,7 @@ return [
     'clone_failure'             => '<strong>Cloning failed</strong><br>The new entry could not be created. Please try again.',
 
     // Confirmation messages and bubbles
-    'delete_confirm'                              => 'Are you sure you want to delete this item?',    
+    'delete_confirm'                              => 'Are you sure you want to delete this item?',
     'permanently_delete_confirm'                  => 'Are you sure you want to permanently delete this item?',
     'delete_confirmation_title'                   => 'Item Deleted',
     'delete_confirmation_message'                 => 'The item has been deleted successfully.',
@@ -60,7 +60,7 @@ return [
     'delete_confirmation_not_message'             => "There's been an error. Your item might not have been deleted.",
     'delete_confirmation_not_deleted_title'       => 'Not deleted',
     'delete_confirmation_not_deleted_message'     => 'Nothing happened. Your item is safe.',
-    
+
     'restore_confirm'                             => 'Are you sure you want to restore this item?',
     'restore_confirmation_title'                   => 'Item Restored',
     'restore_confirmation_message'                 => 'The item has been restore successfully.',

--- a/src/resources/views/crud/buttons/delete_permanently.blade.php
+++ b/src/resources/views/crud/buttons/delete_permanently.blade.php
@@ -1,0 +1,95 @@
+@if ($crud->hasAccess('delete_permanently'))
+	<a href="javascript:void(0)" onclick="deleteEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey().'/delete-permanently') }}" class="btn btn-sm btn-link" data-button-type="delete"><i class="la la-trash"></i> {{ trans('backpack::crud.delete_permanently') }}</a>
+@endif
+
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+<script>
+
+	if (typeof deleteEntry != 'function') {
+	  $("[data-button-type=delete]").unbind('click');
+
+	  function deleteEntry(button) {
+		// ask for confirmation before deleting an item
+		// e.preventDefault();
+		var route = $(button).attr('data-route');
+
+		swal({
+		  title: "{!! trans('backpack::base.warning') !!}",
+		  text: "{!! trans('backpack::crud.permanently_delete_confirm') !!}",
+		  icon: "warning",
+		  buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+		  dangerMode: true,
+		}).then((value) => {
+			if (value) {
+				$.ajax({
+			      url: route,
+			      type: 'DELETE',
+			      success: function(result) {
+			          if (result == 1) {
+						  // Redraw the table
+						  if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+							  // Move to previous page in case of deleting the only item in table
+							  if(crud.table.rows().count() === 1) {
+							    crud.table.page("previous");
+							  }
+
+							  crud.table.draw(false);
+						  }
+
+			          	  // Show a success notification bubble
+			              new Noty({
+		                    type: "success",
+		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
+		                  }).show();
+
+			              // Hide the modal, if any
+			              $('.modal').modal('hide');
+			          } else {
+			              // if the result is an array, it means 
+			              // we have notification bubbles to show
+			          	  if (result instanceof Object) {
+			          	  	// trigger one or more bubble notifications 
+			          	  	Object.entries(result).forEach(function(entry, index) {
+			          	  	  var type = entry[0];
+			          	  	  entry[1].forEach(function(message, i) {
+					          	  new Noty({
+				                    type: type,
+				                    text: message
+				                  }).show();
+			          	  	  });
+			          	  	});
+			          	  } else {// Show an error alert
+				              swal({
+				              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+	                            text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+				              	icon: "error",
+				              	timer: 4000,
+				              	buttons: false,
+				              });
+			          	  }			          	  
+			          }
+			      },
+			      error: function(result) {
+			          // Show an alert with the result
+			          swal({
+		              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+                        text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+		              	icon: "error",
+		              	timer: 4000,
+		              	buttons: false,
+		              });
+			      }
+			  });
+			}
+		});
+
+      }
+	}
+
+	// make it so that the function above is run after each DataTable draw event
+	// crud.addFunctionToDataTablesDrawEventQueue('deleteEntry');
+</script>
+@if (!request()->ajax()) @endpush @endif

--- a/src/resources/views/crud/buttons/restore.blade.php
+++ b/src/resources/views/crud/buttons/restore.blade.php
@@ -1,0 +1,93 @@
+@if ($crud->hasAccess('restore'))
+	<a href="javascript:void(0)" onclick="restoreEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey().'/restore') }}" class="btn btn-sm btn-link" data-button-type="restore"><i class="la la-trash-restore"></i> {{ trans('backpack::crud.restore') }}</a>
+@endif
+
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+<script>
+
+	if (typeof restoreEntry != 'function') {
+	  $("[data-button-type=restore]").unbind('click');
+
+	  function restoreEntry(button) {
+		// ask for confirmation before deleting an item
+		// e.preventDefault();
+		var route = $(button).attr('data-route');
+
+		swal({
+		  title: "{!! trans('backpack::base.warning') !!}",
+		  text: "{!! trans('backpack::crud.restore_confirm') !!}",
+		  icon: "warning",
+		  buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.restore') !!}"],
+		  dangerMode: true,
+		}).then((value) => {
+			if (value) {
+				$.ajax({
+			      url: route,
+			      type: 'PUT',
+			      success: function(result) {
+			          if (result == 1) {
+						  // Redraw the table
+						  if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+							  // Move to previous page in case of deleting the only item in table
+							  if(crud.table.rows().count() === 1) {
+							    crud.table.page("previous");
+							  }
+
+							  crud.table.draw(false);
+						  }
+
+			          	  // Show a success notification bubble
+			              new Noty({
+		                    type: "success",
+		                    text: "{!! '<strong>'.trans('backpack::crud.restore_confirmation_title').'</strong><br>'.trans('backpack::crud.restore_confirmation_message') !!}"
+		                  }).show();
+
+			              // Hide the modal, if any
+			              $('.modal').modal('hide');
+			          } else {
+			              // if the result is an array, it means 
+			              // we have notification bubbles to show
+			          	  if (result instanceof Object) {
+			          	  	// trigger one or more bubble notifications 
+			          	  	Object.entries(result).forEach(function(entry, index) {
+			          	  	  var type = entry[0];
+			          	  	  entry[1].forEach(function(message, i) {
+					          	  new Noty({
+				                    type: type,
+				                    text: message
+				                  }).show();
+			          	  	  });
+			          	  	});
+			          	  } else {// Show an error alert
+				              swal({
+				              	title: "{!! trans('backpack::crud.restore_confirmation_not_title') !!}",
+	                            text: "{!! trans('backpack::crud.restore_confirmation_not_message') !!}",
+				              	icon: "error",
+				              	timer: 4000,
+				              	buttons: false,
+				              });
+			          	  }			          	  
+			          }
+			      },
+			      error: function(result) {
+			          // Show an alert with the result
+			          swal({
+		              	title: "{!! trans('backpack::crud.restore_confirmation_not_title') !!}",
+                        text: "{!! trans('backpack::crud.restore_confirmation_not_message') !!}",
+		              	icon: "error",
+		              	timer: 4000,
+		              	buttons: false,
+		              });
+			      }
+			  });
+			}
+		});
+
+      }
+	}
+	
+</script>
+@if (!request()->ajax()) @endpush @endif


### PR DESCRIPTION
## Intro
CRUD Trash with following bin functions:
* View trashed items.
* Permanently delete.
* Restore item.

## HOW 
Using **Filter** and two action **buttons**.

## HOW to use:
`use \Backpack\CRUD\app\Http\Controllers\Operations\TrashOperation;` in CRUD having a model using `SoftDeletes`
