### PR TITLE
don't select the column, only count the results

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -314,9 +314,6 @@ trait Query
         // create an "outer" query, the one that is responsible to do the count of the "crud query".
         $outerQuery = $crudQuery->newQuery();
 
-        // in this outer query we will select only one column to be counted.
-        $outerQuery = $outerQuery->select($this->model->getKeyName());
-
         // add the count query in the "outer" query.
         $outerQuery = $outerQuery->selectRaw('count(*) as total_rows');
 


### PR DESCRIPTION
`only_full_group_by` breaks this query if we select the column for counting. 

We don't need the query, it would be sligthly faster on older mysql versions, but it's not worth it since it breaks compatibility with the newer versiosn that bring this option `on` by default.