### PR TITLE
[HOT-FIX] use table name when selecting the column

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Str;
 
 trait Query
 {
@@ -247,9 +246,9 @@ trait Query
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
-       
+
         $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), $modelTable.'_aggregator');
-        
+
         return $outerQuery->cursor()->first()->total_rows;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -221,17 +221,17 @@ trait Query
                 // case it's a basic where, we just want to select that column.
                 case 'Basic':
                     $wheresColumns[] = $where['column'];
-                break;
-                // when it's a nested query we will get the columns that link
-                // to the main table from the nested query wheres.
+                    break;
+                    // when it's a nested query we will get the columns that link
+                    // to the main table from the nested query wheres.
                 case 'Nested':
                     $wheresColumns = $nested ?: array_merge($wheresColumns, $this->getNestedQueryColumns($where['query']));
-                break;
-                // when Column get the "first" key that represent the base table column to link with
+                    break;
+                    // when Column get the "first" key that represent the base table column to link with
                 case 'Column':
                     $wheresColumns[] = $where['first'];
-                break;
-                // in case of Exists, we will find in the subquery the query type Column where it links to the main table
+                    break;
+                    // in case of Exists, we will find in the subquery the query type Column where it links to the main table
                 case 'Exists':
                     $wheres = $where['query']->wheres;
                     foreach ($wheres as $subWhere) {
@@ -239,7 +239,7 @@ trait Query
                             $wheresColumns[] = $subWhere['first'];
                         }
                     }
-                break;
+                    break;
             }
         }
 
@@ -323,7 +323,7 @@ trait Query
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
-        $outerQuery = $outerQuery->fromSub($subQuery->select($this->model->getKeyName()), $this->model->getTableWithPrefix());
+        $outerQuery = $outerQuery->fromSub($subQuery->select($this->model->getTableWithPrefix().'.'.$this->model->getKeyName()), $this->model->getTableWithPrefix().'_aggregator');
 
         return $outerQuery->cursor()->first()->total_rows;
     }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -184,69 +184,6 @@ trait Query
     }
 
     /**
-     * Return the nested query columns.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return array
-     */
-    private function getNestedQueryColumns($query)
-    {
-        return $this->getQueryColumnsFromWheres($query, true);
-    }
-
-    /**
-     * We want to select the minimum possible columns respecting the clauses in the query, so that the count is accurate.
-     * for that to happen we will traverse the query `wheres` (Basic, Exists, Nested or Column) to get the correct
-     * column that we need to select in the main model for that "sub query" to work.
-     *
-     * For example a base query of: `SELECT * FROM table WHERE (someColumn, smtValue)`, we would return only the `someColumn`
-     * with the objective of replacing the `*` for the specific columns needed, avoiding the selection of
-     * columns that would not have impact in the counting process.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  bool  $nested  used to prevent multiple level nesting as we only need the first level columns
-     * @return array
-     */
-    private function getQueryColumnsFromWheres($query, $nested = false)
-    {
-        // if there is a raw where we are better not touching the columns, otherwise we
-        // would need to parse the raw sql wheres and that can get messy very quick.
-        if (in_array('raw', array_column($query->wheres, 'type'))) {
-            return $query->columns;
-        }
-
-        $wheresColumns = [];
-        foreach ($query->wheres as $where) {
-            switch ($where['type']) {
-                // case it's a basic where, we just want to select that column.
-                case 'Basic':
-                    $wheresColumns[] = $where['column'];
-                    break;
-                    // when it's a nested query we will get the columns that link
-                    // to the main table from the nested query wheres.
-                case 'Nested':
-                    $wheresColumns = $nested ?: array_merge($wheresColumns, $this->getNestedQueryColumns($where['query']));
-                    break;
-                    // when Column get the "first" key that represent the base table column to link with
-                case 'Column':
-                    $wheresColumns[] = $where['first'];
-                    break;
-                    // in case of Exists, we will find in the subquery the query type Column where it links to the main table
-                case 'Exists':
-                    $wheres = $where['query']->wheres;
-                    foreach ($wheres as $subWhere) {
-                        if ($subWhere['type'] === 'Column') {
-                            $wheresColumns[] = $subWhere['first'];
-                        }
-                    }
-                    break;
-            }
-        }
-
-        return $wheresColumns;
-    }
-
-    /**
      * Get the entries count from `totalQuery`.
      *
      * @return int
@@ -297,19 +234,7 @@ trait Query
         }
 
         $crudQuery = $query->toBase()->clone();
-        $crudQueryColumns = $this->getQueryColumnsFromWheres($crudQuery);
-
-        // merge the model key in the columns array if needed
-        $crudQueryColumns = $this->addModelKeyToColumnsArray($crudQueryColumns);
-
-        // remove table prefix from select columns
-        $crudQueryColumns = array_map(function ($item) {
-            return Str::afterLast($item, '.');
-        }, $crudQueryColumns);
-
-        // remove possible column name duplicates (when using the column name in combination with table.column name in some other constrain
-        // for example `where('table.column', smt') and in other place where('column', 'smt').
-        $crudQueryColumns = array_unique($crudQueryColumns);
+        $modelTable = $this->model->getTableWithPrefix();
 
         // create an "outer" query, the one that is responsible to do the count of the "crud query".
         $outerQuery = $crudQuery->newQuery();
@@ -322,25 +247,9 @@ trait Query
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
-
-        $outerQuery = $outerQuery->fromSub($subQuery->select($this->model->getTableWithPrefix().'.'.$this->model->getKeyName()), $this->model->getTableWithPrefix().'_aggregator');
-
+       
+        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), $modelTable.'_aggregator');
+        
         return $outerQuery->cursor()->first()->total_rows;
-    }
-
-    /**
-     * Adds the model key into the selection columns array.
-     * When using `*` as column selector it's assumed the model key would be selected.
-     *
-     * @param  array  $columns
-     * @return array
-     */
-    private function addModelKeyToColumnsArray(array $columns)
-    {
-        if (! in_array($this->model->getKeyName(), $columns) && ! in_array('*', $columns)) {
-            return array_merge($columns, [$this->model->getKeyName()]);
-        }
-
-        return $columns;
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4720

When using joining tables, the fact that we don't use the specific table name prefixing the column could make the column ambiguous when selecting.  

### AFTER - What is happening after this PR?

We use the table to prefix the column selection. eg: `table.column`. 

Removed unused code. 
