### PR TITLE
fix ternary and indent comments/breaks properly

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -218,28 +218,34 @@ trait Query
         $wheresColumns = [];
         foreach ($query->wheres as $where) {
             switch ($where['type']) {
-                // case it's a basic where, we just want to select that column.
                 case 'Basic':
+                    // case it's a basic where, we just want to select that column.
                     $wheresColumns[] = $where['column'];
-                break;
-                // when it's a nested query we will get the columns that link
-                // to the main table from the nested query wheres.
+                    
+                    break;
                 case 'Nested':
-                    $wheresColumns = $nested ?: array_merge($wheresColumns, $this->getNestedQueryColumns($where['query']));
-                break;
-                // when Column get the "first" key that represent the base table column to link with
+                    // when it's a nested query we will get the columns that link
+                    // to the main table from the nested query wheres.
+                    if ($nested) {
+                        $wheresColumns = array_merge($wheresColumns, $this->getNestedQueryColumns($where['query']));
+                    }
+                    
+                    break;
                 case 'Column':
+                    // when Column get the "first" key that represent the base table column to link with
                     $wheresColumns[] = $where['first'];
-                break;
-                // in case of Exists, we will find in the subquery the query type Column where it links to the main table
+                    
+                    break;
                 case 'Exists':
+                    // in case of Exists, we will find in the subquery the query type Column where it links to the main table
                     $wheres = $where['query']->wheres;
                     foreach ($wheres as $subWhere) {
                         if ($subWhere['type'] === 'Column') {
                             $wheresColumns[] = $subWhere['first'];
                         }
                     }
-                break;
+                    
+                    break;
             }
         }
 


### PR DESCRIPTION
## WHY
`$wheresColumns = $nested ?: array_merge()` is the same as `$whereColumns = $nested ? $nested : array_merge()`, which means that `$whereColumns` can end up being `true`.

More in #4722 

This only happens when `$nested` is true, so only happens for multiple levels of recursion of nested where queries in the CrudController's `setup()`

### BEFORE - What was wrong? What was happening before this PR?
CrudControllers which have nested `where()`s as part of their `setup()` were not loading

### AFTER - What is happening after this PR?
They now load 🥳 

## HOW

### How did you achieve that, in technical terms?
Replaced `$whereColumns = ?: $nested` with `if ($nested) {`

### Is it a breaking change?
Nope


### How can we test the before & after?
Try to load a CrudController which has nested `where()` statements as part of `$this->crud->query` object.
