### PR TITLE
Fix attribute infering

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -368,10 +368,10 @@ trait Relationships
      */
     private function isAttributeInRelationString($relationString)
     {
-        if(! str_contains($relationString, '.')) {
+        if (! str_contains($relationString, '.')) {
             return false;
         }
-        
+
         $parts = explode('.', $relationString);
 
         $model = $this->model;

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -368,6 +368,10 @@ trait Relationships
      */
     private function isAttributeInRelationString($relationString)
     {
+        if(! str_contains($relationString, '.')) {
+            return false;
+        }
+        
         $parts = explode('.', $relationString);
 
         $model = $this->model;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

https://github.com/Laravel-Backpack/CRUD/issues/4726 

I broke it 😞 

### AFTER - What is happening after this PR?

I fixed it! 🙃 


## HOW

### How did you achieve that, in technical terms?

The attribute can only be specified after the dot, no dot, no fun!

