### PR TITLE
check if property is empty in request

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -97,7 +97,7 @@ trait ListOperation
 
         // if show entry count is disabled we use the "simplePagination" technique to move between pages.
         if ($this->crud->getOperationSetting('showEntryCount')) {
-            $totalEntryCount = (int) (empty(request()->get('totalEntryCount')) ? $this->crud->getTotalQueryCount() : request()->get('totalEntryCount'));
+            $totalEntryCount = (int) (request()->get('totalEntryCount') ?: $this->crud->getTotalQueryCount());
             $filteredEntryCount = $this->crud->getFilteredQueryCount() ?? $totalEntryCount;
         } else {
             $totalEntryCount = $length;

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -97,7 +97,7 @@ trait ListOperation
 
         // if show entry count is disabled we use the "simplePagination" technique to move between pages.
         if ($this->crud->getOperationSetting('showEntryCount')) {
-            $totalEntryCount = (int) (request()->get('totalEntryCount') ?? $this->crud->getTotalQueryCount());
+            $totalEntryCount = (int) (empty(request()->get('totalEntryCount')) ? $this->crud->getTotalQueryCount() : request()->get('totalEntryCount'));
             $filteredEntryCount = $this->crud->getFilteredQueryCount() ?? $totalEntryCount;
         } else {
             $totalEntryCount = $length;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were only covering the case where empty strings would be converted to `null` by using Laravel `ConvertEmptyStringsToNull` middleware. 

As reported in https://github.com/Laravel-Backpack/CRUD/issues/4727 , disabling that middleware had side effects on our pagination because the null coalescing operator does not understand empty the same as null.

### AFTER - What is happening after this PR?

we use `empty()` so that we cover empty strings or null values.

### How can we test the before & after?

Enable/disable the middleware and test the ListOperation
