### PR TITLE
Fix for the backpack:install command: add dependency

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 
 class Install extends Command
 {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

[The backpack:install command crashes while installing backpack generators](https://github.com/Laravel-Backpack/CRUD/issues/4730)

### AFTER - What is happening after this PR?

The backpack:install command doesn't crash anymore.


## HOW

### How did you achieve that, in technical terms?

I added the `Symfony\Component\Process\Process` dependency in `src/app/Console/Commands/Install.php`



### Is it a breaking change?

No


### How can we test the before & after?

- Run `php artisan backpack:install` in main. It crashes.
- Run `php artisan backpack:install` in this PR. It doesn't crash.
