### PR TITLE
[Bugfix] Fixed inconsistent behavior in `enum` field

### DIFF
--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -15,18 +15,9 @@
             return array_combine($options, $options);
         }
 
-        // developer can provide the enum class so that we extract the available options from it
-        if(isset($field['enum_class'])) {
-            if($field['enum_class'] instanceof \BackedEnum) {
-                $options = array_column($field['enum_class']::cases(), 'value', 'name');
-            }
-            $options = array_column($field['enum_class']::cases(), 'name');
-            $options = array_combine($options, $options);
-        }
-
-        // check for model casting, in this case it must be a BakedEnum to work with Laravel casting
-        $possibleEnumCast = (new $entity_model)->getCasts()[$field['name']] ?? false;
-        if(!isset($options) && $possibleEnumCast && class_exists($possibleEnumCast)) {
+        // check for model casting, in this case it must be a BackedEnum to work with Laravel casting
+        $possibleEnumCast = $field['enum_class'] ?? ((new $entity_model)->getCasts()[$field['name']] ?? false);
+        if($possibleEnumCast && class_exists($possibleEnumCast)) {
             $field['enum_class'] = $possibleEnumCast;
             $options = array_column($possibleEnumCast::cases(), 'name', 'value');
         }


### PR DESCRIPTION
## WHY

Inconsistent behavior when providing `enum_class`

### BEFORE - What was wrong? What was happening before this PR?

Providing `enum_class` will output options in this format [$enumName => $enumName] since "$field['enum_class'] instanceof \BackedEnum" will always return false.

### AFTER - What is happening after this PR?

Providing `enum_class` will behave the same as taking the enum class from the model


## HOW

### How did you achieve that, in technical terms?

-


### Is it a breaking change?

No


### How can we test the before & after?

Cast an attribute to an Enum and setup the field with 'enum_class' => Enum::class and without
