### PR TITLE
[Bugfix] Cast value to int for switch field

### DIFF
--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -18,7 +18,7 @@
             <input
                 type="hidden"
                 name="{{ $field['name'] }}"
-                value="{{ $field['value'] }}" />
+                value="{{ (int) $field['value'] }}" />
             <input
                 type="checkbox"
                 data-init-function="bpFieldInitSwitch"


### PR DESCRIPTION
## WHY

Switch appears to be checked for `false` value

### BEFORE - What was wrong? What was happening before this PR?

Boolean value `false` is casted as an empty string for the hidden input

### AFTER - What is happening after this PR?

Cast the value to int to properly display the switch.


## HOW

### Is it a breaking change?

No


### How can we test the before & after?

Cast an attribute to boolean and setup the switch field, for both `false` and `true` values, the switch always appears as it's checked.
