### PR TITLE
use reflection to work with php enum classes

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -192,14 +192,13 @@ trait ColumnsProtectedMethods
 
             // if the first part of the string exists as method in the model
             if (method_exists($this->model, $possibleMethodName)) {
-
                 // check model method for possibility of being a relationship
                 $column['entity'] = $this->modelMethodIsRelationship($this->model, $possibleMethodName) ? $column['name'] : false;
 
                 if ($column['entity']) {
                     // if the user setup the attribute in relation string, we are not going to infer that attribute from model
                     // instead we get the defined attribute by the user.
-                    if ($this->isAttributeInRelationString($column['entity'])) {
+                    if ($this->isAttributeInRelationString($column)) {
                         $column['attribute'] = $column['attribute'] ?? Str::afterLast($column['entity'], '.');
                     }
                 }
@@ -210,8 +209,7 @@ trait ColumnsProtectedMethods
 
         // if there's a method on the model with this name
         if (method_exists($this->model, $column['name'])) {
-
-             // check model method for possibility of being a relationship
+            // check model method for possibility of being a relationship
             $column['entity'] = $this->modelMethodIsRelationship($this->model, $column['name']);
 
             return $column;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -292,7 +292,7 @@ trait FieldsProtectedMethods
                 $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
                 $subfield['baseEntity'] = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$currentEntity : $currentEntity;
                 $subfield['baseFieldName'] = is_array($subfield['name']) ? implode(',', $subfield['name']) : $subfield['name'];
-                $subfield['baseFieldName'] = str()->afterLast($subfield['baseFieldName'], '.');
+                $subfield['baseFieldName'] = Str::afterLast($subfield['baseFieldName'], '.');
             }
 
             $field['subfields'][$key] = $this->makeSureFieldHasNecessaryAttributes($subfield);

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -132,7 +132,7 @@ trait FieldsProtectedMethods
      */
     protected function makeSureFieldHasEntity($field)
     {
-        $model = isset($field['baseModel']) ? app($field['baseModel']) : $this->model;
+        $model = isset($field['baseModel']) ? (new $field['baseModel']) : $this->model;
 
         if (isset($field['entity'])) {
             return $field;
@@ -184,7 +184,7 @@ trait FieldsProtectedMethods
         if ($field['entity']) {
             // if the user setup the attribute in relation string, we are not going to infer that attribute from model
             // instead we get the defined attribute by the user.
-            if ($this->isAttributeInRelationString($field['entity'])) {
+            if ($this->isAttributeInRelationString($field)) {
                 $field['attribute'] = $field['attribute'] ?? Str::afterLast($field['entity'], '.');
 
                 return $field;
@@ -291,6 +291,8 @@ trait FieldsProtectedMethods
                 $currentEntity = $subfield['baseEntity'] ?? $field['entity'];
                 $subfield['baseModel'] = $subfield['baseModel'] ?? $field['model'];
                 $subfield['baseEntity'] = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$currentEntity : $currentEntity;
+                $subfield['baseFieldName'] = is_array($subfield['name']) ? implode(',', $subfield['name']) : $subfield['name'];
+                $subfield['baseFieldName'] = str()->afterLast($subfield['baseFieldName'], '.');
             }
 
             $field['subfields'][$key] = $this->makeSureFieldHasNecessaryAttributes($subfield);
@@ -314,7 +316,7 @@ trait FieldsProtectedMethods
                         'name' => $relationInstance->getRelated()->getKeyName(),
                         'type' => 'hidden',
                     ]);
-                break;
+                    break;
             }
         }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -374,7 +374,9 @@ trait Relationships
 
         $parts = explode('.', $field['entity']);
 
-        $model = new ($field['baseModel'] ?? $this->model);
+        $model = $field['baseModel'] ?? $this->model;
+
+        $model = new $model;
 
         // here we are going to iterate through all relation parts to check
         // if the attribute is present in the relation string.

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -374,7 +374,7 @@ trait Relationships
 
         $parts = explode('.', $field['entity']);
 
-        $model = new $field['baseModel'] ?? $this->model;
+        $model = new ($field['baseModel'] ?? $this->model);
 
         // here we are going to iterate through all relation parts to check
         // if the attribute is present in the relation string.

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -363,18 +363,18 @@ trait Relationships
      * Check if it's possible that attribute is in the relation string when
      * the last part of the string is not a method on the chained relations.
      *
-     * @param  string  $relationString
+     * @param  array  $field
      * @return bool
      */
-    private function isAttributeInRelationString($relationString)
+    private function isAttributeInRelationString($field)
     {
-        if (! str_contains($relationString, '.')) {
+        if (! str_contains($field['entity'], '.')) {
             return false;
         }
 
-        $parts = explode('.', $relationString);
+        $parts = explode('.', $field['entity']);
 
-        $model = $this->model;
+        $model = new $field['baseModel'] ?? $this->model;
 
         // here we are going to iterate through all relation parts to check
         // if the attribute is present in the relation string.

--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -1,9 +1,11 @@
 {{-- enum --}}
 @php
-    $entity_model = $field['model'] ?? $crud->model;
+    $entity_model = $field['model'] ?? $field['baseModel'] ?? $crud->model;
+
     $field['value'] = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
 
     $possible_values = (function() use ($entity_model, $field) {
+        $fieldName = $field['baseFieldName'] ?? $field['name'];
         // if developer provided the options, use them, no ned to guess.
         if(isset($field['options'])) {
             return $field['options'];
@@ -11,7 +13,7 @@
 
         // if we are in a PHP version where PHP enums are not available, it can only be a database enum
         if(! function_exists('enum_exists')) {
-            $options = $entity_model::getPossibleEnumValues($field['name']);
+            $options = $entity_model::getPossibleEnumValues($fieldName);
             return array_combine($options, $options);
         }
 
@@ -20,7 +22,7 @@
 
         if(! $enumClassReflection) {
             // check for model casting
-            $possibleEnumCast = (new $entity_model)->getCasts()[$field['name']] ?? false;
+            $possibleEnumCast = (new $entity_model)->getCasts()[$fieldName] ?? false;
             if($possibleEnumCast && class_exists($possibleEnumCast)) {
                 $enumClassReflection = new \ReflectionEnum($possibleEnumCast);
             }


### PR DESCRIPTION
Make the enum field consistent by always using `ReflectionEnum` on PHP Enums. 

Removes a bit of dead code reported in https://github.com/Laravel-Backpack/CRUD/pull/4735

The code is now more readable and removed the corners in `Backed` vs `Unit` enums. 