### PR TITLE
QueryBuilder automatically add table prefix

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -233,7 +233,8 @@ trait Query
         }
 
         $crudQuery = $query->toBase()->clone();
-        $modelTable = $this->model->getTableWithPrefix();
+
+        $modelTable = $this->model->getTable();
 
         // create an "outer" query, the one that is responsible to do the count of the "crud query".
         $outerQuery = $crudQuery->newQuery();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4753

We were manually adding the table prefix into the query, and `QueryBuilder` already does this by default, so we endup with duplicated table prefixes. 

### AFTER - What is happening after this PR?

We just give QueryBuilder the table name, and he will be responsible for adding the prefix.
