### PR TITLE
Replace likely typo getCleanFields() with getCleanStateFields(); fixes #4765

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -162,7 +162,7 @@ trait Fields
             return false;
         }
 
-        $firstField = array_keys(array_slice($this->getCleanFields(), 0, 1))[0];
+        $firstField = array_keys(array_slice($this->getCleanStateFields(), 0, 1))[0];
         $this->beforeField($firstField);
     }
 


### PR DESCRIPTION
On making a field the first, the following error occurs:

`Method Backpack\CRUD\app\Library\CrudPanel\CrudPanel::getCleanFields does not exist.`