### PR TITLE
Add helper method to viewnamespaces

### DIFF
--- a/src/ViewNamespaces.php
+++ b/src/ViewNamespaces.php
@@ -72,4 +72,19 @@ class ViewNamespaces
 
         return array_unique(array_merge($viewNamespacesFromConfig, self::getFor($domain)));
     }
+
+    /**
+     * This is an helper function that returns the view namespace with the view name appended.
+     * It's usefull to use in blade templates with `@includeFirst(ViewNamespaces::getViewPathsFor('columns', 'some_column'))`.
+     *
+     * @param  string  $domain
+     * @param  string  $viewName
+     * @return array
+     */
+    public static function getViewPathsFor(string $domain, string $viewName)
+    {
+        return array_map(function ($item) use ($viewName) {
+            return $item.'.'.$viewName;
+        }, self::getFor($domain));
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -162,7 +162,7 @@ trait Fields
             return false;
         }
 
-        $firstField = array_keys(array_slice($this->getCleanFields(), 0, 1))[0];
+        $firstField = array_keys(array_slice($this->getCleanStateFields(), 0, 1))[0];
         $this->beforeField($firstField);
     }
 


### PR DESCRIPTION
This adds an helper method to view namespaces that allow us to get the full view path appending the view name to the view namespaces array. 

It's specially helpfull to use in blade templates with: `@includeFirst()`