### PR TITLE
add `backpack:publish-assets` command that publishes CSS and JS assets

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -17,6 +17,7 @@ class BackpackServiceProvider extends ServiceProvider
         \Backpack\CRUD\app\Console\Commands\Install::class,
         \Backpack\CRUD\app\Console\Commands\AddSidebarContent::class,
         \Backpack\CRUD\app\Console\Commands\AddCustomRouteContent::class,
+        \Backpack\CRUD\app\Console\Commands\Update::class,
         \Backpack\CRUD\app\Console\Commands\Version::class,
         \Backpack\CRUD\app\Console\Commands\CreateUser::class,
         \Backpack\CRUD\app\Console\Commands\PublishBackpackMiddleware::class,

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -17,7 +17,7 @@ class BackpackServiceProvider extends ServiceProvider
         \Backpack\CRUD\app\Console\Commands\Install::class,
         \Backpack\CRUD\app\Console\Commands\AddSidebarContent::class,
         \Backpack\CRUD\app\Console\Commands\AddCustomRouteContent::class,
-        \Backpack\CRUD\app\Console\Commands\Update::class,
+        \Backpack\CRUD\app\Console\Commands\PublishAssets::class,
         \Backpack\CRUD\app\Console\Commands\Version::class,
         \Backpack\CRUD\app\Console\Commands\CreateUser::class,
         \Backpack\CRUD\app\Console\Commands\PublishBackpackMiddleware::class,

--- a/src/app/Console/Commands/PublishAssets.php
+++ b/src/app/Console/Commands/PublishAssets.php
@@ -42,7 +42,7 @@ class PublishAssets extends Command
     {
         $process = new Process($command, null, null, null, 60, null);
         $process->run(function ($type, $buffer) {
-            $this->line($buffer);     
+            $this->line($buffer);
         });
 
         // executes after the command finishes

--- a/src/app/Console/Commands/PublishAssets.php
+++ b/src/app/Console/Commands/PublishAssets.php
@@ -42,11 +42,7 @@ class PublishAssets extends Command
     {
         $process = new Process($command, null, null, null, 60, null);
         $process->run(function ($type, $buffer) {
-            if (Process::ERR === $type) {
-                $this->line($buffer);
-            } else {
-                $this->line($buffer);
-            }
+            $this->line($buffer);     
         });
 
         // executes after the command finishes

--- a/src/app/Console/Commands/PublishAssets.php
+++ b/src/app/Console/Commands/PublishAssets.php
@@ -6,14 +6,14 @@ use Illuminate\Console\Command;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class Update extends Command
+class PublishAssets extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:update';
+    protected $signature = 'backpack:publish-assets';
 
     /**
      * The console command description.

--- a/src/app/Console/Commands/Update.php
+++ b/src/app/Console/Commands/Update.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class Update extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:update';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish new CSS and JS assets (will override existing ones).';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->runConsoleCommand(['php', 'artisan', 'vendor:publish', '--provider=Backpack\CRUD\BackpackServiceProvider', '--tag=public', '--force']);
+    }
+
+    /**
+     * Run a shell command in a separate process.
+     *
+     * @param  string  $command  Text to be executed.
+     * @return void
+     */
+    private function runConsoleCommand($command)
+    {
+        $process = new Process($command, null, null, null, 60, null);
+        $process->run(function ($type, $buffer) {
+            if (Process::ERR === $type) {
+                $this->line($buffer);
+            } else {
+                $this->line($buffer);
+            }
+        });
+
+        // executes after the command finishes
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In order to publish the CSS and JS assets you had to google how to do it, in order to copy-paste this:

```bash
php artisan vendor:publish --provider="Backpack\CRUD\BackpackServiceProvider" --tag=”public” --force
```

### AFTER - What is happening after this PR?

You can do the above using:

```bash
php artisan backpack:update
```

## HOW

### How did you achieve that, in technical terms?

Quickly put together a new command that does it.


### Is it a breaking change?

No. But the command name is pretty general.

### How can we test the before & after?

Do `php artisan backpack:update` and it should do the same thing as the other command (publish CRUD assets).
