### PR TITLE
Add password field support for default value

### DIFF
--- a/src/resources/views/crud/fields/password.blade.php
+++ b/src/resources/views/crud/fields/password.blade.php
@@ -13,7 +13,7 @@
     <input
     	type="password"
     	name="{{ $field['name'] }}"
-        value="{{ old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '' }}"
+        value="{{ $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::fields.inc.attributes')
     	>
 

--- a/src/resources/views/crud/fields/password.blade.php
+++ b/src/resources/views/crud/fields/password.blade.php
@@ -13,6 +13,7 @@
     <input
     	type="password"
     	name="{{ $field['name'] }}"
+        value="{{ old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '' }}"
         @include('crud::fields.inc.attributes')
     	>
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Not sure the use case for this, but it was asked [here](https://github.com/Laravel-Backpack/ideas/issues/103).
Password was the only field that didn't support a default value.

### AFTER - What is happening after this PR?

Password field supports a default value.


## HOW

### How did you achieve that, in technical terms?

Simple added the value tag on the field input.



### Is it a breaking change?

No.


### How can we test the before & after?

Add a password field with a default value. It should now use it if no value (from model) is provided.
