### PR TITLE
Fix alias name for msslq

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -248,7 +248,7 @@ trait Query
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
-        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), str_replace('.','_',$modelTable).'_aggregator');
+        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), str_replace('.', '_', $modelTable).'_aggregator');
 
         return $outerQuery->cursor()->first()->total_rows;
     }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -248,7 +248,7 @@ trait Query
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
-        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), $modelTable.'_aggregator');
+        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), str_replace('.','_',$modelTable).'_aggregator');
 
         return $outerQuery->cursor()->first()->total_rows;
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4760

MsSql uses `schema.table` notation when defining the table in the model, and since we use the table name to create the alias, it would break because if the usage of the `. (dot)` in the alias name.

### AFTER - What is happening after this PR?

We replace the `. (dot)` with `_ (underscore)` so it becomes a valid alias name. 

## HOW

### How did you achieve that, in technical terms?

Using `str_replace`.

### Is it a breaking change?

No


### How can we test the before & after?

Try to run any ListOperation using MsSql db type.
