### PR TITLE
Don't exclude raw expression columns

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -246,8 +246,8 @@ trait Query
         // so we just store them and re-use them in the sub-query too.
         $expressionColumns = [];
 
-        foreach($crudQuery->columns as $column) {
-            if(!is_string($column) && is_a($column, 'Illuminate\Database\Query\Expression')) {
+        foreach ($crudQuery->columns as $column) {
+            if (! is_string($column) && is_a($column, 'Illuminate\Database\Query\Expression')) {
                 $expressionColumns[] = $column;
             }
         }
@@ -261,11 +261,11 @@ trait Query
         $subQuery->select($modelTable.'.'.$this->model->getKeyName());
 
         // in case there are raw expressions we need to add them too.
-        foreach($expressionColumns as $expression) {
+        foreach ($expressionColumns as $expression) {
             $subQuery->selectRaw($expression);
         }
-        
-        $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.','_',$modelTable).'_aggregator');
+
+        $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.', '_', $modelTable).'_aggregator');
 
         return $outerQuery->cursor()->first()->total_rows;
     }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -242,13 +242,30 @@ trait Query
         // add the count query in the "outer" query.
         $outerQuery = $outerQuery->selectRaw('count(*) as total_rows');
 
+        // Expression columns are hand-written by developers in ->selectRaw() and we can't exclude those statements reliably
+        // so we just store them and re-use them in the sub-query too.
+        $expressionColumns = [];
+
+        foreach($crudQuery->columns as $column) {
+            if(!is_string($column) && is_a($column, 'Illuminate\Database\Query\Expression')) {
+                $expressionColumns[] = $column;
+            }
+        }
         // add the subquery from where the "outer query" will count the results.
         // this subquery is the "main crud query" without some properties:
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
-        $outerQuery = $outerQuery->fromSub($subQuery->select($modelTable.'.'.$this->model->getKeyName()), str_replace('.', '_', $modelTable).'_aggregator');
+        // select only one column for the count
+        $subQuery->select($modelTable.'.'.$this->model->getKeyName());
+
+        // in case there are raw expressions we need to add them too.
+        foreach($expressionColumns as $expression) {
+            $subQuery->selectRaw($expression);
+        }
+        
+        $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.','_',$modelTable).'_aggregator');
 
         return $outerQuery->cursor()->first()->total_rows;
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Apart from `where` constrains there is also `having` constrains. The later can be applied on the result of expressions like aliases, sum, avg etc while where can't.

```php
static::addGlobalScope('withPrice', function($query) {
    return $query->selectRaw('price as my_price')->having('my_price', '>', 20); //you can't replace having with where on the alias column.
});
```

### AFTER - What is happening after this PR?

We still exclude all columns except the ones that are raw expressions. Sometimes it could be an expression that we could remove, others like in the example I gave can't be excluded otherwise the `having` wouldn't have the column available. Given the complexity involved in parsing expressions to see if it's one that we could remove we are better just letting all raw expressions go through. Majority of time that's what needs to be done anyway. 


## HOW

### How did you achieve that, in technical terms?

We store the expression columns before cloning the query without columns. We then manually re-add the expression columns along with the column we select for the count.

### Is it a breaking change?

No


### How can we test the before & after?

Go to Product.php model on demo, add:
```php
protected static function boot() {
        parent::boot();
        static::addGlobalScope('withPrice', function($query) {
            return $query->selectRaw('price as my_price')->having('my_price', '>', 20);
        });
    }
```

Try to load the list view. 
