### PR TITLE
switch anchors for buttons

### DIFF
--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -16,7 +16,7 @@
                 <button id="btnGroupDrop1" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="caret"></span><span class="sr-only">&#x25BC;</span></button>
                 <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
                     @foreach( $saveAction['options'] as $value => $label)
-                    <a class="dropdown-item" href="javascript:void(0);" data-value="{{ $value }}">{{ $label }}</a>
+                    <button type="submit" class="dropdown-item" data-value="{{ $value }}">{{ $label }}</a>
                     @endforeach
                 </div>
             @endif


### PR DESCRIPTION
This points to phone-field branch. 

Phone field was not properly working when choosing an action from the dropdown because the anchors used `javascript:void(0)` and the plugin relies on the form submit event to properly work. The "main save button" is a "button type submit" so it worked fine when not choosing a different save action. 