### PR TITLE
[Bug] Missing query bindings lead to error when using `withCount` in the query. 

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -257,6 +257,9 @@ trait Query
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
+        // re-set the previous query bindings 
+        $subQuery->setBindings($crudQuery->getRawBindings());
+        
         // select only one column for the count
         $subQuery->select($modelTable.'.'.$this->model->getKeyName());
 

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -257,9 +257,9 @@ trait Query
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
-        // re-set the previous query bindings 
+        // re-set the previous query bindings
         $subQuery->setBindings($crudQuery->getRawBindings());
-        
+
         // select only one column for the count
         $subQuery->select($modelTable.'.'.$this->model->getKeyName());
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When dealing with subqueries, the bindings were not beeing applied and that lead to errors like: https://github.com/Laravel-Backpack/PermissionManager/issues/316

### AFTER - What is happening after this PR?

We re-apply the binds in the query.


## HOW

### How did you achieve that, in technical terms?

Using `->setBindings` on the cloned query.



### Is it a breaking change?

I don't think so.


### How can we test the before & after?

Try load the `admin/role` in demo without this branch (it has a `->withCount()` query builder) and that breaks the query parameter if we don't re-apply the bindings.
