### PR TITLE
Code coverage reporter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,5 +78,5 @@ jobs:
         if: ${{ success() }}
         with:
           force: true
-          github_token: ${{ secrets.MY_TOKEN }}
+          github_token: ${{ secrets.COVERAGE_TOKEN }}
           branch: coverage-badge-dont-delete

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,82 @@
+name: Generate Code Coverage Report
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  test:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    name: PHP setup
+    steps:
+      
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            ref: main
+            fetch-depth: 0
+      - name: Install SQLite 3
+        run: |
+          sudo apt-get update
+          sudo apt-get install sqlite3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv, xdebug
+          coverage: xdebug
+          tools: composer:v2
+      - name: Install dependencies
+        run: |
+            composer require "laravel/framework:^9.0" "phpunit/phpunit:^9.0" "doctrine/dbal:^3.0" --no-interaction --no-update --no-suggest
+            composer update --prefer-dist --no-interaction
+      - name: Execute tests
+        run: vendor/bin/phpunit --coverage-clover coverage.xml
+      - name: Check test coverage
+        id: test-coverage
+        uses: johanvanhelden/gha-clover-test-coverage-check@v1
+        with:
+          percentage: "1"
+          filename: coverage.xml
+          metric: elements
+          rounded-precision: 2
+      - name: Generate the badge SVG image
+        uses: emibcn/badge-action@v1
+        id: badge
+        with:
+          label: Coverage
+          status: ${{ steps.test-coverage.outputs.coverage-rounded-display }}
+          path: ./test-coverage.svg
+          color: ${{ steps.test-coverage.outputs.coverage > 90 && 'green'              ||
+            steps.test-coverage.outputs.coverage > 80 && 'yellow,green'       ||
+            steps.test-coverage.outputs.coverage > 70 && 'yellow'             ||
+            steps.test-coverage.outputs.coverage > 60 && 'orange,yellow'      ||
+            steps.test-coverage.outputs.coverage > 50 && 'orange'             ||
+            steps.test-coverage.outputs.coverage > 40 && 'red,orange'         ||
+            steps.test-coverage.outputs.coverage > 30 && 'red,red,orange'     ||
+            steps.test-coverage.outputs.coverage > 20 && 'red,red,red,orange' ||
+            'red' }}
+      - name: Upload badge as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: badge
+          path: test-coverage.svg
+          if-no-files-found: error
+      - name: Commit badge
+        continue-on-error: true
+        env:
+          BADGE: test-coverage.svg
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add "${BADGE}"
+          git commit -m "Update Coverage Badge"
+      - name: Push badge commit
+        uses: ad-m/github-push-action@master
+        if: ${{ success() }}
+        with:
+          force: true
+          github_token: ${{ secrets.MY_TOKEN }}
+          branch: coverage-badge-dont-delete

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
         uses: emibcn/badge-action@v1
         id: badge
         with:
-          label: Coverage
+          label: coverage
           status: ${{ steps.test-coverage.outputs.coverage-rounded-display }}
           path: ./test-coverage.svg
           color: ${{ steps.test-coverage.outputs.coverage > 90 && 'green'              ||

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud" title="Quality Score"><img src="https://img.shields.io/scrutinizer/g/laravel-backpack/crud.svg?style=flat-square"></a>
     <a href="https://travis-ci.org/Laravel-Backpack/CRUD" title="Build Status"><img src="https://img.shields.io/travis/Laravel-Backpack/CRUD/master.svg?style=flat-square"></a>
     <a href="https://styleci.io/repos/53581270" title="Style CI"><img src="https://styleci.io/repos/53581270/shield"></a>
-    <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud/code-structure" title="Coverage Status"><img src="https://img.shields.io/scrutinizer/coverage/g/laravel-backpack/crud.svg?style=flat-square"></a>
+    <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud/code-structure" title="Coverage Status"><img src="https://raw.githubusercontent.com/backpack/CRUD/coverage-badge-dont-delete/test-coverage.svg"></a>
     <a href="LICENSE.md" title="Software License"><img src="https://img.shields.io/github/license/laravel-backpack/crud?style=flat-square"></a>
     <a href="https://github.com/the-whole-fruit/manifesto"><img src="https://img.shields.io/badge/writing%20standard-the%20whole%20fruit-brightgreen?style=flat-square" title="We believe writing good code is not only about writing good code. It’s also about the words around it. We aims to deliver both: code and words."></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud" title="Quality Score"><img src="https://img.shields.io/scrutinizer/g/laravel-backpack/crud.svg?style=flat-square"></a>
     <a href="https://travis-ci.org/Laravel-Backpack/CRUD" title="Build Status"><img src="https://img.shields.io/travis/Laravel-Backpack/CRUD/master.svg?style=flat-square"></a>
     <a href="https://styleci.io/repos/53581270" title="Style CI"><img src="https://styleci.io/repos/53581270/shield"></a>
-    <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud/code-structure" title="Coverage Status"><img src="https://raw.githubusercontent.com/backpack/CRUD/coverage-badge-dont-delete/test-coverage.svg"></a>
+    <a href="https://scrutinizer-ci.com/g/laravel-backpack/crud/code-structure" title="Coverage Status"><img src="https://raw.githubusercontent.com/laravel-backpack/CRUD/coverage-badge-dont-delete/test-coverage.svg"></a>
     <a href="LICENSE.md" title="Software License"><img src="https://img.shields.io/github/license/laravel-backpack/crud?style=flat-square"></a>
     <a href="https://github.com/the-whole-fruit/manifesto"><img src="https://img.shields.io/badge/writing%20standard-the%20whole%20fruit-brightgreen?style=flat-square" title="We believe writing good code is not only about writing good code. It’s also about the words around it. We aims to deliver both: code and words."></a>
 </p>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We used an external tool for this. Eventually given the amount of builds we do, we endup in the paid tiers and that's not acceptable only for this metric. 

### AFTER - What is happening after this PR?

Combining tricks from multiple actions I was able to generate the badge and the code report without using any external dependencies (only github ... but if github is down I am pretty sure we are not pushing any work 🙃 )


## HOW

### How did you achieve that, in technical terms?

So basically we run the tests generating the clover report, we then analyse the report and use a js script to generate an svg badge. We then upload the badge to a specific branch to don't polute master with badge commits. We then use that branch image to display the badge. 


## SETUP BEFORE MERGE - for @tabacitu 

Hey @tabacitu so here is what you should do in order for this to work. 
1 - Create a new personal token and add it as a secret in the `Backpack/CRUD` repository. The name of the secret should be: `COVERAGE_TOKEN`

2 -Create an orphan branch -> Steps:
```bash
git checkout main
git checkout --orphan coverage-badge-dont-delete

# IF this command fails, please see troubleshooting below 
git rm --cached $(git ls-files)

echo '# Branch to store the coverage badge' > README.md
git add README.md
git commit -m 'Add readme to badges branch'
git push origin coverage-badge-dont-delete
``` 

In case that command fail, replace it with:
```bash
for f in $(git ls-files); do git rm --cached "$f"; done
```

Everything should be fine by now. 
Please take into consideration that the secret name and branch name are hardcoded in the script so they should match exactly what I've written in the setup docs. 