### PR TITLE
account for the possibility that save actions are not defined

### DIFF
--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -47,7 +47,7 @@ trait SaveActions
      */
     public function getSaveActionByOrder($order)
     {
-        return array_filter($this->getOperationSetting('save_actions'), function ($arr) use ($order) {
+        return array_filter($this->getOperationSetting('save_actions') ?? [], function ($arr) use ($order) {
             return $arr['order'] == $order;
         });
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This had been reported in gitter https://flareapp.io/share/dPbXE1A5#F62, but I recall that this had been reported here too, just can't find the issue. 
I was not able to reproduce this, but some people reported that in devtools they get this error when creating a new model and previewing. 

I just now created a new model, and a new migration in devtools and couldn't reproduce it, so it is possible that it's a race condition somewhere. 

But since I've seen this error reported more than once, I think it's wise to assume that sometimes the save actions may be empty and account for that before using `array_filter`. 

### AFTER - What is happening after this PR?

We check for the possibility of save actions beeing undefined at that time and use an empty array to prevent errors in `array_filter()`.

### Is it a breaking change?

No I don't think so.


### How can we test the before & after?

I was not able to reproduce the error, but if you are able, just test it again with this branch and you should get no errors.
