### PR TITLE
fix how to contribute tutorial link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you have a solution for it and want to help, you can submit a Pull Request. T
 - you'll become one of the Backpack contributors; [welcome to the party! :-)](https://media.giphy.com/media/l0MYt5jPR6QX5pnqM/giphy.gif);
 - you'll not just be helping yourself and the maintainers of Backpack, you'd be helping thousants of Backpack developers;
 
-If you've never submitted a PR before, don't worry, it's not that difficult. Read [this tutoral](https://mattstauffer.co/blog/how-to-contribute-to-an-open-source-github-project-using-your-own-fork) and the rules above. I promise, you'll enjoy sending PRs after a while :-)
+If you've never submitted a PR before, don't worry, it's not that difficult. Read [this tutoral](https://mattstauffer.com/blog/how-to-contribute-to-an-open-source-github-project-using-your-own-fork) and the rules above. I promise, you'll enjoy sending PRs after a while :-)
 
 
 # Want to help out?


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The link was wrong.

### AFTER - What is happening after this PR?

The link is right!


## HOW

### How did you achieve that, in technical terms?

Went to github interface and changed it! You got me, I was lazy!



### Is it a breaking change?

Negative!


### How can we test the before & after?

Try to click the link in the main branch it will fail. It will work on this branch! 👍 
