### PR TITLE
Fix CrudFilter initialization from static class method.

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -169,7 +169,8 @@ class CrudFilter
      */
     public static function name($name)
     {
-        return new static(compact('name'), null, null, null);
+        $filter = new static(compact('name'), null, null, null);
+        return $filter->save();
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -170,6 +170,7 @@ class CrudFilter
     public static function name($name)
     {
         $filter = new static(compact('name'), null, null, null);
+
         return $filter->save();
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

`CrudFilter` had kind of the same initialization problem as `CrudButton`. 

Doing `CrudFilter::name('some_filter')` wouldn't add the filter to the `CrudPanel` object, while `CrudFilter::name('some_filter')->label('some_label')` would. 

The difference is that in `->label()` we call `save()` but in `name()` we just return an instance of the `CrudFilter`.

### AFTER - What is happening after this PR?

Doing `CrudFilter::name('some_filter')` will add the filter to the collection.


## HOW

### How did you achieve that, in technical terms?

I called `save` in the `name()` function. 



### Is it a breaking change?

I don't think so, I think this was a mistake and not properly identified because usually you don't define only the filter name.


### How can we test the before & after?

See the example in `BEFORE` section.
