### PR TITLE
use request set in crud instead of global request instance

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -51,8 +51,8 @@ class CrudFilter
             $this->fallbackLogic = $fallbackLogic;
         }
 
-        if (\Request::has($this->name)) {
-            $this->currentValue = \Request::input($this->name);
+        if ($this->crud()->getRequest()->has($this->name)) {
+            $this->currentValue = $this->crud()->getRequest()->input($this->name);
         }
     }
 
@@ -64,7 +64,7 @@ class CrudFilter
      */
     public function isActive()
     {
-        if (\Request::has($this->name)) {
+        if ($this->crud()->getRequest()->has($this->name)) {
             return true;
         }
 

--- a/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+use Backpack\CRUD\Tests\Unit\Models\User;
 
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Filters

--- a/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
+use Backpack\CRUD\app\Library\CrudPanel\CrudFilter;
 use Backpack\CRUD\Tests\Unit\Models\User;
 
 /**

--- a/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
@@ -33,4 +33,17 @@ class CrudPanelFiltersTest extends BaseCrudPanelTest
         $this->crudPanel->clearFilters();
         $this->assertCount(0, $this->crudPanel->filters());
     }
+
+    public function testItCanCheckIfFilterIsActiveFromRequest()
+    {
+        $this->crudPanel->setModel(User::class);
+        $request = request()->create('/admin/users', 'GET', ['my_custom_filter' => 'foo']);
+        $request->setRouteResolver(function () use ($request) {
+            return (new Route('GET', 'admin/users', ['UserCrudController', 'index']))->bind($request);
+        });
+        $this->crudPanel->setRequest($request);
+
+        $isActive = CrudFilter::name('my_custom_filter')->isActive();
+        $this->assertTrue($isActive);
+    }
 }

--- a/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
 use Backpack\CRUD\Tests\Unit\Models\User;
 
 /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I think this was a leftover from some old refactoring since we are already using the request defined in the CrudPanel in other methods, eg: https://github.com/Laravel-Backpack/CRUD/blob/77f783dd3e65e39a8bae8a0ec41dfc564a2c2c60/src/app/Library/CrudPanel/CrudFilter.php#L111

### AFTER - What is happening after this PR?

I replaced the global request instances for the requests defined in CrudPanel, in the end it would fallback to the global request instance in case a request is not set in CrudPanel.

### Is it a breaking change?

I don't think so no.

### How can we test the before & after?

This is testable if you are manually creating a request instance and attaching it to the CrudPanel. 

```php
        $request = request()->create('/admin/users', 'GET', ['my_custom_filter' => 'foo']);
        $request->setRouteResolver(function () use ($request) {
            return (new Route('GET', 'admin/users', ['UserCrudController', 'index']))->bind($request);
        });
        $this->crudPanel->setRequest($request);
```
The global `\Request` instance has no access to this Request that we set on the CrudPanel. 
