### PR TITLE
add configuration option to token expiration time

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -30,8 +30,10 @@ class BackpackServiceProvider extends ServiceProvider
 
     // Indicates if loading of the provider is deferred.
     protected $defer = false;
+
     // Where the route file lives, both inside the package and in the app (if overwritten).
     public $routeFilePath = '/routes/backpack/base.php';
+
     // Where custom routes can be written, and will be registered by Backpack.
     public $customRoutesFilePath = '/routes/backpack/custom.php';
 
@@ -40,7 +42,7 @@ class BackpackServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot(\Illuminate\Routing\Router $router)
+    public function boot(Router $router)
     {
         $this->loadViewsWithFallbacks();
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
@@ -259,8 +261,8 @@ class BackpackServiceProvider extends ServiceProvider
             'backpack' => [
                 'provider'  => 'backpack',
                 'table'     => 'password_resets',
-                'expire'   => 60,
-                'throttle' => config('backpack.base.password_recovery_throttle_notifications'),
+                'expire'    => config('backpack.base.password_recovery_token_expiration', 60),
+                'throttle'  => config('backpack.base.password_recovery_throttle_notifications'),
             ],
         ];
 

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -236,6 +236,11 @@ return [
     // password reset, before they can try again for the same email?
     'password_recovery_throttle_notifications' => 600, // time in seconds
 
+    // How much time should the token sent to user email be considered valid?
+    // After this time expires, user need to request a new reset token
+    // for the given email account.
+    'password_recovery_token_expiration' => 60, // time in minutes
+
     // Backpack will prevent an IP from trying to reset the password too many times,
     // so that a malicious actor cannot try too many emails, too see if they have
     // accounts or to increase the AWS/SendGrid/etc bill.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Can't configure the default of 60 minutes for the token expiration time.

### AFTER - What is happening after this PR?

You can configure it


## HOW

### How did you achieve that, in technical terms?

Added a configuration option



### Is it a breaking change?

NO


### How can we test the before & after?

I think it only makes sense to test the after. Change the configuration and test the expiration time. 
