### PR TITLE
wrap the delete button script in a @loadOnce directive

### DIFF
--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -5,6 +5,7 @@
 {{-- Button Javascript --}}
 {{-- - used right away in AJAX operations (ex: List) --}}
 {{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@loadOnce('delete_button_script')
 @push('after_scripts') @if (request()->ajax()) @endpush @endif
 <script>
 
@@ -93,3 +94,4 @@
 	// crud.addFunctionToDataTablesDrawEventQueue('deleteEntry');
 </script>
 @if (!request()->ajax()) @endpush @endif
+@endLoadOnce


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were echoing the script in every row and all that text adds up on page and make the requests heavier. 

[@jrbe](https://github.com/jrbecart) started a discussion here: https://github.com/Laravel-Backpack/CRUD/discussions/4274

### AFTER - What is happening after this PR?

The script is only loaded once. 


## HOW

### How did you achieve that, in technical terms?

Used the `loadOnce` directive to only load the script once in page. 

### Is it a breaking change?

I don't think so.


### How can we test the before & after?

Test the delete functionality after and before this PR. 
