### PR TITLE
fix localstorage bug when using datatables on with subdomains

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -136,7 +136,7 @@
             newUrl = params_arr.length ? tmpUrl + "?" + params_arr.join("&") : tmpUrl;
         }
         window.history.pushState({}, '', newUrl);
-        localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url', newUrl);
+        localStorage.setItem('{{ Str::slug(url($crud->getRoute())) }}_list_url', newUrl);
       },
       dataTableConfiguration: {
         bInfo: {{ var_export($crud->getOperationSetting('showEntryCount') ?? true) }},
@@ -189,7 +189,7 @@
 
         stateSaveParams: function(settings, data) {
 
-            localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url_time', data.time);
+            localStorage.setItem('{{ Str::slug(url($crud->getRoute())) }}_list_url_time', data.time);
 
             data.columns.forEach(function(item, index) {
                 var columnHeading = crud.table.columns().header()[index];
@@ -335,7 +335,7 @@
         // so in next requests we know if the length changed by user
         // or by developer in the controller.
         $('#crudTable').on( 'length.dt', function ( e, settings, len ) {
-            localStorage.setItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength', len);
+            localStorage.setItem('DataTables_crudTable_/{{Str::slug(url($crud->getRoute()))}}_pageLength', len);
         });
 
         // make sure AJAX requests include XSRF token
@@ -349,7 +349,7 @@
 
 
         $('#crudTable').on( 'page.dt', function () {
-            localStorage.setItem('page_changed', true);
+            localStorage.setItem('{{Str::slug(url($crud->getRoute()))}}_page_changed', true);
         });
 
       // on DataTable draw event run all functions in the queue


### PR DESCRIPTION
We use Backpack on a project where the dev, staging and production environment are on different subdomains. Setting the e.g _list_url in localstorage with a key based only on the route caused redirects between our environments. The keys should include the subdomain path.

## WHY

### BEFORE - What was wrong? What was happening before this PR?
Install two project instances on subdomains, e.g. www.example.com/first and www.example.com/second

Create a CRUD panel with a list view and add filters.

Go to www.example.com/first/admin/your-crud
Select a filter. You will see that the 'admin_yourcrud_list_url' key is set in localStorage to enable the persistent filters.

Go to www.example.com/second/admin/your-crud
It will redirect back to the persisted url in the localStorage, which is www.example.com/first/admin/your-crud, the incorrect project.

### AFTER - What is happening after this PR?

The keys are subdomain specific and don't interfere with each other anymore


## HOW

### How did you achieve that, in technical terms?

Took the full url as key prefix for the localStorage instead of solely the route