### PR TITLE
use field validation directly in getting started tutorial

### DIFF
--- a/src/resources/views/base/inc/getting_started.blade.php
+++ b/src/resources/views/base/inc/getting_started.blade.php
@@ -13,24 +13,16 @@
           <div class="card-body">
             <p>You've already got a model, <code class="text-primary bg-light p-1 rounded">App\Models\User</code>... all Laravel projects do. So <strong>let's create a page to administer users</strong>. We want the admin to Create, Read, Update and Delete them. In Backpack, we call that a <a href="https://backpackforlaravel.com/docs/5.x/crud-basics?ref=getting-started-widget" target="blank">CRUD</a>. And you can easily generate one for an existing Eloquent model, by running:</p>
             <p>
-              <code class="text-primary bg-light p-1 rounded">php artisan backpack:crud user</code>
+              <strong><code class="text-primary bg-light p-1 rounded">php artisan backpack:crud user</code></strong>
             </p>
-            <p>Go ahead, run it in your terminal. You can now click on the new sidebar item (or <a href="{{ backpack_url('user') }}">here</a>) and you'll be able to see the entries in the <code class="text-primary bg-light p-1 rounded">users</code> table. Even though generated CRUDs work out-of-the-box, they might not be <i>exactly</i> what you need. But that's where Backpack shines, in how easy it is to customize.</p>
+            <p>Run that in your terminal and <strong>choose <code class="text-primary bg-light p-1 rounded">field</code> when asked which <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation?ref=getting-started-widget"
+              target="_blank">validation type</a> you'd like</strong>. You can now click on the new sidebar item (or <a href="{{ backpack_url('user') }}">here</a>) and you'll be able to see the entries in the <code class="text-primary bg-light p-1 rounded">users</code> table. Now... even though most generated CRUDs work out-of-the-box, they probably won't be <i>exactly</i> what you need. But that's where Backpack shines, in how easy it is to customize.</p>
 
             <p>To dig a little deeper, <a href="#" data-toggle="collapse" data-target="#customizeUsersCRUD" aria-expanded="true" aria-controls="customizeUsersCRUD">let's make a few changes to the Users CRUD <i class="la la-angle-double-right"></i></a></p>
 
             <div class="collapse" id="customizeUsersCRUD">
               <p><strong>1. When Listing, let's remove the "password" column</strong> - no point in showing the hash. To do that, go to <code class="text-primary bg-light p-1 rounded">UserCrudController::setupListOperation()</code> and remove the line saying <code class="text-primary bg-light p-1 rounded">CRUD::column('password');</code> - easy-peasy, right?</p>
-              <p><strong>2. On Create & Update, let's add validation to forms</strong>. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation?ref=getting-started-widget" target="_blank">multiple ways to add validation (A, B, C)</a>. Let's change the standard <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-formrequests?ref=getting-started-widget" target="_blank">validation using FormRequests</a> (A), to a simpler validation using <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-field-attributes?ref=getting-started-widget" target="_blank">field attributes</a> (C):</p>
-              <ul>
-                <li>to remove the current validation:<br>
-                  <ul>
-                    <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, remove <code class="text-primary bg-light p-1 rounded">use App\Http\Requests\UserRequest;</code> from the top;</li>
-                    <li>inside <code class="text-primary bg-light p-1 rounded">UserCrudController</code>, remove <code class="text-primary bg-light p-1 rounded">CRUD::setValidation(UserRequest::class);</code> from <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>;</li>
-                    <li>delete the <code class="text-primary bg-light p-1 rounded">App\Http\Requests\UserRequest;</code> file;</li>
-                  </ul>
-                </li>
-                <li>a quick way to add validation is to go to <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> and specify validation rules directly on the fields:
+              <p><strong>2. On Create & Update, let's add validation to forms</strong>. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validation?ref=getting-started-widget" target="_blank">multiple ways to add validation</a> but we've already chosen the simplest, <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#validating-fields-using-field-attributes?ref=getting-started-widget" target="_blank">validation using field attributes</a>. Let's go to <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code> and specify our validation rules directly on the fields:
                 <p>
                   <pre class="language-php rounded"><code class="language-php p-1">
     CRUD::field('name')->validationRules('required|min:5');
@@ -38,8 +30,6 @@
     CRUD::field('password')->validationRules('required');
                   </code></pre>
                 </p>
-                </li>
-              </ul>
               <p><strong>3. On Create, let's hash the password.</strong> Currently, if we create a new User, it'll work. But if you look in the database... you'll notice the password is stored in plain text. We don't want that - we want it hashed. There are <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#use-events-in-your-setup-method?ref=getting-started-widget" target="_blank">multiple ways to achieve this too</a>. Let's use Model Events inside <code class="text-primary bg-light p-1 rounded">setupCreateOperation()</code>. Here's how our method could look, when we also tap into the <code class="text-primary bg-light p-1 rounded">creating</code> event, to hash the password:</p>
               <p>
                 <pre class="language-php rounded"><code class="language-php p-1">
@@ -75,7 +65,7 @@
                 </code></pre>
               </p>
               <p>
-                That's it. You have a working Users CRUD. Plus, you've already learned some advanced techniques, like <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#use-events-in-your-setup-method?ref=getting-started-widget" target="_blank">using Model events inside CrudController</a> and <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#b-validating-fields-using-a-rules-array?ref=getting-started-widget" target="_blank">using field-attribute-validation instead of form-request-validation</a>. Of course, this only scratches the surface of what Backpack can do. To really understand how it works, and how you can best use Backpack's features, <strong>we heavily recommend you move on to the next step, and learn the basics.</strong>
+                That's it. You have a working Users CRUD. Plus, you've already learned some advanced techniques, like <a href="https://backpackforlaravel.com/docs/5.x/crud-operation-create#use-events-in-your-setup-method?ref=getting-started-widget" target="_blank">using Model events inside CrudController</a>. Of course, this only scratches the surface of what Backpack can do. To really understand how it works, and how you can best use Backpack's features, <strong>we heavily recommend you move on to the next step, and learn the basics.</strong>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Our getting started tutorial was using Request validation... then instructing people on how to scrap the Request and use field validation.

### AFTER - What is happening after this PR?

It instructs them on how to use the `field` validation from the start. It doesn't do it using `--validation=field` though... I've chosen to answer the prompt. That way... a person who is interested in "more ways of doing stuff" would also have the opportunity to read the prompt and see options we have.

This eliminates 3 steps from creating a working UserCrudController (deleting the Request file, removing the request namespace, removing the request usage in setup methods), so it's a HUGE improvement.

## HOW

### How did you achieve that, in technical terms?

Change text.

### Is it a breaking change?

No.

![CleanShot 2022-12-16 at 11 14 31](https://user-images.githubusercontent.com/1032474/208064521-3ac67f97-0a79-4a18-800f-a79aa150f3d2.png)

