### PR TITLE
Deprecation notice on passing null to str_replace

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -96,7 +96,11 @@ class CrudController extends Controller
     protected function setupConfigurationForCurrentOperation()
     {
         $operationName = $this->crud->getCurrentOperation();
-        $setupClassName = 'setup'.Str::studly($operationName ?? '').'Operation';
+        if (!$operationName) {
+            return;
+        }
+        
+        $setupClassName = 'setup'.Str::studly($operationName).'Operation';
 
         /*
          * FIRST, run all Operation Closures for this operation.

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -96,8 +96,7 @@ class CrudController extends Controller
     protected function setupConfigurationForCurrentOperation()
     {
         $operationName = $this->crud->getCurrentOperation();
-
-        $setupClassName = 'setup'.Str::studly($operationName).'Operation';
+        $setupClassName = 'setup'.Str::studly($operationName ?? '').'Operation';
 
         /*
          * FIRST, run all Operation Closures for this operation.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Passing null to a later on str_replace $subject generates a deprecation notice.

### AFTER - What is happening after this PR?

No deprecation notice


## HOW

### How did you achieve that, in technical terms?

Prevented passing null to Str::studly, which it does not accept according to it's docs.

### Is it a breaking change?

No

### How can we test the before & after?

Test by passing a null on Str::studly even in tinker in php 8.1 and you will recieve a deprecation notice if they are enabled in your settings.
