### PR TITLE
AuthenticatesSessions contract doesn't exist in L8

### DIFF
--- a/src/app/Http/Middleware/AuthenticateSession.php
+++ b/src/app/Http/Middleware/AuthenticateSession.php
@@ -3,11 +3,7 @@
 namespace Backpack\CRUD\app\Http\Middleware;
 
 if (class_exists('Illuminate\Contracts\Session\Middleware\AuthenticatesSessions', false)) {
-    class AuthenticateSession extends AuthenticateSessionL8 implements \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions
-    {
-    }
-} else {
-    class AuthenticateSession extends AuthenticateSessionL8
+    class AuthenticateSession extends AuthenticateSessionL9
     {
     }
 }

--- a/src/app/Http/Middleware/AuthenticateSession.php
+++ b/src/app/Http/Middleware/AuthenticateSession.php
@@ -2,112 +2,12 @@
 
 namespace Backpack\CRUD\app\Http\Middleware;
 
-use Closure;
-use Illuminate\Auth\AuthenticationException;
-use Illuminate\Contracts\Auth\Factory as AuthFactory;
-use Illuminate\Contracts\Session\Middleware\AuthenticatesSessions;
-
-class AuthenticateSession implements AuthenticatesSessions
-{
-    /**
-     * The authentication factory implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\Factory
-     */
-    protected $auth;
-    protected $user;
-
-    /**
-     * Create a new middleware instance.
-     *
-     * @param  \Illuminate\Contracts\Auth\Factory  $auth
-     * @return void
-     */
-    public function __construct(AuthFactory $auth)
+if (class_exists('Illuminate\Contracts\Session\Middleware\AuthenticatesSessions', false)) {
+    class AuthenticateSession extends AuthenticateSessionL8 implements \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions
     {
-        $this->auth = $auth;
-        $this->user = backpack_user();
     }
-
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
-     */
-    public function handle($request, Closure $next)
+} else {
+    class AuthenticateSession extends AuthenticateSessionL8
     {
-        if (! $request->hasSession() || ! $this->user) {
-            return $next($request);
-        }
-
-        if ($this->guard()->viaRemember()) {
-            $passwordHash = explode('|', $request->cookies->get($this->guard()->getRecallerName()))[2] ?? null;
-
-            if (! $passwordHash || $passwordHash != $this->user->getAuthPassword()) {
-                $this->logout($request);
-            }
-        }
-
-        if (! $request->session()->has('password_hash_'.backpack_guard_name())) {
-            $this->storePasswordHashInSession($request);
-        }
-
-        if ($request->session()->get('password_hash_'.backpack_guard_name()) !== $this->user->getAuthPassword()) {
-            $this->logout($request);
-        }
-
-        return tap($next($request), function () use ($request) {
-            if (! is_null($this->guard()->user())) {
-                $this->storePasswordHashInSession($request);
-            }
-        });
-    }
-
-    /**
-     * Store the user's current password hash in the session.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     */
-    protected function storePasswordHashInSession($request)
-    {
-        if (! $this->user) {
-            return;
-        }
-
-        $request->session()->put([
-            'password_hash_'.backpack_guard_name() => $this->user->getAuthPassword(),
-        ]);
-    }
-
-    /**
-     * Log the user out of the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return void
-     *
-     * @throws \Illuminate\Auth\AuthenticationException
-     */
-    protected function logout($request)
-    {
-        $this->guard()->logoutCurrentDevice();
-
-        $request->session()->flush();
-
-        \Alert::error('Your password was changed in another browser session. Please login again using the new password.')->flash();
-
-        throw new AuthenticationException('Unauthenticated.', [backpack_guard_name()], backpack_url('login'));
-    }
-
-    /**
-     * Get the guard instance that should be used by the middleware.
-     *
-     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard
-     */
-    protected function guard()
-    {
-        return $this->auth;
     }
 }

--- a/src/app/Http/Middleware/AuthenticateSessionL8.php
+++ b/src/app/Http/Middleware/AuthenticateSessionL8.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+
+class AuthenticateSessionL8
+{
+    /**
+     * The authentication factory implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    protected $user;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(AuthFactory $auth)
+    {
+        $this->auth = $auth;
+        $this->user = backpack_user();
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $request->hasSession() || ! $this->user) {
+            return $next($request);
+        }
+
+        if ($this->guard()->viaRemember()) {
+            $passwordHash = explode('|', $request->cookies->get($this->guard()->getRecallerName()))[2] ?? null;
+
+            if (! $passwordHash || $passwordHash != $this->user->getAuthPassword()) {
+                $this->logout($request);
+            }
+        }
+
+        if (! $request->session()->has('password_hash_'.backpack_guard_name())) {
+            $this->storePasswordHashInSession($request);
+        }
+
+        if ($request->session()->get('password_hash_'.backpack_guard_name()) !== $this->user->getAuthPassword()) {
+            $this->logout($request);
+        }
+
+        return tap($next($request), function () use ($request) {
+            if (! is_null($this->guard()->user())) {
+                $this->storePasswordHashInSession($request);
+            }
+        });
+    }
+
+    /**
+     * Store the user's current password hash in the session.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function storePasswordHashInSession($request)
+    {
+        if (! $this->user) {
+            return;
+        }
+
+        $request->session()->put([
+            'password_hash_'.backpack_guard_name() => $this->user->getAuthPassword(),
+        ]);
+    }
+
+    /**
+     * Log the user out of the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    protected function logout($request)
+    {
+        $this->guard()->logoutCurrentDevice();
+
+        $request->session()->flush();
+
+        \Alert::error('Your password was changed in another browser session. Please login again using the new password.')->flash();
+
+        throw new AuthenticationException('Unauthenticated.', [backpack_guard_name()], backpack_url('login'));
+    }
+
+    /**
+     * Get the guard instance that should be used by the middleware.
+     *
+     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard
+     */
+    protected function guard()
+    {
+        return $this->auth;
+    }
+}

--- a/src/app/Http/Middleware/AuthenticateSessionL9.php
+++ b/src/app/Http/Middleware/AuthenticateSessionL9.php
@@ -6,7 +6,7 @@ use Closure;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 
-class AuthenticateSessionL8
+class AuthenticateSessionL9 implements \Illuminate\Contracts\Session\Middleware\AuthenticatesSessions
 {
     /**
      * The authentication factory implementation.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When we updated our session middleware we updated it to the latest Laravel version that has a contract (interface) that's not available in L8. 

That broke our installations on L8, as reported in https://github.com/Laravel-Backpack/CRUD/issues/4848

### AFTER - What is happening after this PR?

We conditionally load the class with or without the interface depending on Laravel version. It's ugly, but it works 😞 

## HOW

### How did you achieve that, in technical terms?

Conditionally load the middlware with or without the interface.

### Is it a breaking change?

No, I don't think so.


### How can we test the before & after?

Try to install L8 with Backpack.