### PR TITLE
fix concurrent access issue with class_alias

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -205,7 +205,8 @@ trait Validation
 
             // create a new anonymous class that will extend the provided developer FormRequest
             // in this class we will merge the FormRequest rules() and messages() with the ones provided by developer in fields.
-            $extendedRequest = new class(new $formRequest, $rules, $messages) extends FormRequest {
+            $extendedRequest = new class(new $formRequest, $rules, $messages) extends FormRequest
+            {
                 private $_originalFormRequest;
 
                 private $_rules;
@@ -216,8 +217,8 @@ trait Validation
                 {
                     parent::__construct();
                     $this->_originalFormRequest = $originalFormRequest;
-                    $this->_rules               = $rules;
-                    $this->_messages            = $messages;
+                    $this->_rules = $rules;
+                    $this->_messages = $messages;
                 }
 
                 public function __call($name, $arguments)
@@ -228,19 +229,23 @@ trait Validation
                     );
                 }
 
-                public function __get($name) {
+                public function __get($name)
+                {
                     return $this->_originalFormRequest->$name;
                 }
 
-                public function __set($name, $value) {
+                public function __set($name, $value)
+                {
                     $this->_originalFormRequest->$name = $value;
                 }
 
-                public function __isset($name) {
+                public function __isset($name)
+                {
                     return isset($this->_originalFormRequest->$name);
                 }
 
-                public function __unset($name) {
+                public function __unset($name)
+                {
                     unset($this->_originalFormRequest->$name);
                 }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We are using Roadrunner with Laravel and Backpack. When two users happen to using the same edit form in Backpack. The following error will happen:

```
Cannot declare class DeveloperProvidedFormRequest, because the name is already in use {"userId":"969bc122-81ac-45ea-ad1d-609a5f79f9b3","exception":"[object] (ErrorException(code: 0): Cannot declare class DeveloperProvidedFormRequest, because the name is already in use at /var/www/application/vendor/backpack/crud/src/app/Library/CrudPanel/Traits/Validation.php:207)
```

### AFTER - What is happening after this PR?

The above error should not happen anymore


## HOW

### How did you achieve that, in technical terms?

I'm using a decorator class which extends a base `FormRequest` class and do some decoration to the original class.

### Is it a breaking change?

No


### How can we test the before & after?

I think existing tests are sufficient
