### PR TITLE
Add PHP 8.2 to test matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
             # run all combinations of the following, to make sure they're working together
             matrix:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
-                php: [7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1, 8.2]
                 dbal: [^2.5, ^3.0]
                 laravel: [8.*, 9.*]
                 phpunit: [8.*, 9.*]


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Not testing against PHP 8.2

### AFTER - What is happening after this PR?

Tests run against PHP 8.2 too. PHP 8.2 has been out for some time and I'm looking to upgrade my sites to it. It will be helpful if the packages I use tests against PHP 8.2 too


## HOW

### How did you achieve that, in technical terms?

Add 8.2 to the test matrix in testing.yml

### Is it a breaking change?

No, other than revealing potential new issues caused by PHP 8.2

### How can we test the before & after?

It will automatically be run in future PRs
