### PR TITLE
fix main application tests

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -163,11 +163,6 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function setupRoutes(Router $router)
     {
-        if (app()->runningUnitTests()) {
-            $this->loadRoutesFrom(__DIR__.'/routes/backpack/testing.php');
-
-            return;
-        }
         // by default, use the routes file provided in vendor
         $routeFilePathInUse = __DIR__.$this->routeFilePath;
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\Tests;
 
 use Backpack\CRUD\BackpackServiceProvider;
+use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 
 abstract class BaseTest extends TestCase
@@ -15,6 +16,16 @@ abstract class BaseTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Route::group([
+            (array) config('backpack.base.web_middleware', 'web'),
+            (array) config('backpack.base.middleware_key', 'admin'),
+            'prefix'     => config('backpack.base.route_prefix', 'admin'),
+        ],
+            function () {
+                Route::crud('users', 'Backpack\CRUD\Tests\Unit\Http\Controllers\UserCrudController');
+            }
+        );
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I introduced the `testing.php` routes file where we planned to group all the CRUD testing routes. 
That created an issue when user is running tests from the "main application" and not the "crud tests".

### AFTER - What is happening after this PR?

It no longer breaks userland tests.


## HOW

### How did you achieve that, in technical terms?

Moved the testing routes inside our setup file. 


### Is it a breaking change?

No


### How can we test the before & after?

Try to run the tests in user land (App/..) before this PR, and they will fail. 

