### PR TITLE
Trash & BulkTrash operation trait in CRUD Package

### DIFF
--- a/src/app/Http/Controllers/Operations/BulkTrashOperation.php
+++ b/src/app/Http/Controllers/Operations/BulkTrashOperation.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if (! backpack_pro()) {
+    trait BulkTrashOperation
+    {
+        public function setupBulkTrashOperationDefaults()
+        {
+            throw new BackpackProRequiredException('BulkTrashOperation');
+        }
+    }
+} else {
+    trait BulkTrashOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\BulkTrashOperation;
+    }
+}

--- a/src/app/Http/Controllers/Operations/TrashOperation.php
+++ b/src/app/Http/Controllers/Operations/TrashOperation.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Backpack\CRUD\app\Http\Controllers\Operations;
+
+use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
+
+if (! backpack_pro()) {
+    trait TrashOperation
+    {
+        public function setupTrashOperationDefaults()
+        {
+            throw new BackpackProRequiredException('TrashOperation');
+        }
+    }
+} else {
+    trait TrashOperation
+    {
+        use \Backpack\Pro\Http\Controllers\Operations\TrashOperation;
+    }
+}


### PR DESCRIPTION
## WHY
Trash & BulkTrash operation trait in CRUD Package

- to use same path like other operations
- to check backpack pro for usage