### PR TITLE
Display PRO version when available in `backpack:version` command

### DIFF
--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -37,9 +37,9 @@ class Version extends Command
         $this->line('');
 
         $this->comment('### BACKPACK PACKAGE VERSIONS:');
-        foreach(\PackageVersions\Versions::VERSIONS as $package => $version) {
+        foreach (\PackageVersions\Versions::VERSIONS as $package => $version) {
             if (substr($package, 0, 9) == 'backpack/') {
-                $this->line($package.': '.strtok($version,'@'));
+                $this->line($package.': '.strtok($version, '@'));
             }
         }
     }

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -36,14 +36,11 @@ class Version extends Command
         $this->line(\PackageVersions\Versions::getVersion('laravel/framework'));
         $this->line('');
 
-        $this->comment('### BACKPACK CRUD:');
-        $this->line(\PackageVersions\Versions::getVersion('backpack/crud'));
-        $this->line('');
-
-        if (backpack_pro()) {
-            $this->comment('### BACKPACK PRO:');
-            $this->line(\PackageVersions\Versions::getVersion('backpack/pro'));
-            $this->line('');
+        $this->comment('### BACKPACK PACKAGE VERSIONS:');
+        foreach(\PackageVersions\Versions::VERSIONS as $package => $version) {
+            if (substr($package, 0, 9) == 'backpack/') {
+                $this->line($package.': '.strtok($version,'@'));
+            }
         }
     }
 

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -36,9 +36,15 @@ class Version extends Command
         $this->line(\PackageVersions\Versions::getVersion('laravel/framework'));
         $this->line('');
 
-        $this->comment('### BACKPACK VERSION:');
+        $this->comment('### BACKPACK CRUD:');
         $this->line(\PackageVersions\Versions::getVersion('backpack/crud'));
         $this->line('');
+
+        if (backpack_pro()) {
+            $this->comment('### BACKPACK PRO:');
+            $this->line(\PackageVersions\Versions::getVersion('backpack/pro'));
+            $this->line('');
+        }
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We didn't output PRO version in `php artisan backpack:version` command. 

### AFTER - What is happening after this PR?

We do!