### PR TITLE
Make Delete operation aware of TrashOperation

### DIFF
--- a/src/app/Http/Controllers/Operations/DeleteOperation.php
+++ b/src/app/Http/Controllers/Operations/DeleteOperation.php
@@ -53,7 +53,7 @@ trait DeleteOperation
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
 
-        $usingSoftDeletes = $this->crud->model->isSoftDeleted() && 
+        $usingSoftDeletes = $this->crud->model->isSoftDeleted() &&
                             (in_array(TrashOperation::class, class_uses_recursive($this)) ||
                             in_array(BulkTrashOperation::class, class_uses_recursive($this)));
 

--- a/src/app/Models/Traits/CrudTrait.php
+++ b/src/app/Models/Traits/CrudTrait.php
@@ -15,4 +15,9 @@ trait CrudTrait
     {
         return true;
     }
+
+    public function isSoftDeleted()
+    {
+        return in_array(\Illuminate\Database\Eloquent\SoftDeletes::class, class_uses_recursive($this));
+    }
 }

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -8,87 +8,85 @@
 @loadOnce('delete_button_script')
 @push('after_scripts') @if (request()->ajax()) @endpush @endif
 <script>
+if (typeof deleteEntry != 'function') {
+	$("[data-button-type=delete]").unbind('click');
 
-	if (typeof deleteEntry != 'function') {
-	  $("[data-button-type=delete]").unbind('click');
-
-	  function deleteEntry(button) {
+	function deleteEntry(button) {
 		// ask for confirmation before deleting an item
 		// e.preventDefault();
 		var route = $(button).attr('data-route');
 
 		swal({
-		  title: "{!! trans('backpack::base.warning') !!}",
-		  text: "{!! trans('backpack::crud.delete_confirm') !!}",
-		  icon: "warning",
-		  buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
-		  dangerMode: true,
+			title: "{!! trans('backpack::base.warning') !!}",
+			text: "{!! trans('backpack::crud.delete_confirm') !!}",
+			icon: "warning",
+			buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+			dangerMode: true,
 		}).then((value) => {
 			if (value) {
 				$.ajax({
-			      url: route,
-			      type: 'DELETE',
-			      success: function(result) {
-			          if (result == 1) {
-						  // Redraw the table
-						  if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
-							  // Move to previous page in case of deleting the only item in table
-							  if(crud.table.rows().count() === 1) {
-							    crud.table.page("previous");
-							  }
+					url: route,
+					type: 'DELETE',
+					success: function(result) {
+						if (result == 1) {
+							// Redraw the table
+							if (typeof crud != 'undefined' && typeof crud.table != 'undefined') {
+								// Move to previous page in case of deleting the only item in table
+								if(crud.table.rows().count() === 1) {
+								crud.table.page("previous");
+								}
 
-							  crud.table.draw(false);
-						  }
+								crud.table.draw(false);
+							}
 
-			          	  // Show a success notification bubble
-			              new Noty({
-		                    type: "success",
-		                    text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
-		                  }).show();
+							// Show a success notification bubble
+							new Noty({
+							type: "success",
+							text: "{!! '<strong>'.trans('backpack::crud.delete_confirmation_title').'</strong><br>'.trans('backpack::crud.delete_confirmation_message') !!}"
+							}).show();
 
-			              // Hide the modal, if any
-			              $('.modal').modal('hide');
-			          } else {
-			              // if the result is an array, it means 
-			              // we have notification bubbles to show
-			          	  if (result instanceof Object) {
-			          	  	// trigger one or more bubble notifications 
-			          	  	Object.entries(result).forEach(function(entry, index) {
-			          	  	  var type = entry[0];
-			          	  	  entry[1].forEach(function(message, i) {
-					          	  new Noty({
-				                    type: type,
-				                    text: message
-				                  }).show();
-			          	  	  });
-			          	  	});
-			          	  } else {// Show an error alert
-				              swal({
-				              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-	                            text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
-				              	icon: "error",
-				              	timer: 4000,
-				              	buttons: false,
-				              });
-			          	  }			          	  
-			          }
-			      },
-			      error: function(result) {
-			          // Show an alert with the result
-			          swal({
-		              	title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
-                        text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
-		              	icon: "error",
-		              	timer: 4000,
-		              	buttons: false,
-		              });
-			      }
-			  });
+							// Hide the modal, if any
+							$('.modal').modal('hide');
+						} else {
+							// if the result is an array, it means 
+							// we have notification bubbles to show
+							if (result instanceof Object) {
+							// trigger one or more bubble notifications 
+							Object.entries(result).forEach(function(entry, index) {
+								var type = entry[0];
+								entry[1].forEach(function(message, i) {
+									new Noty({
+									type: type,
+									text: message
+									}).show();
+								});
+							});
+							} else {// Show an error alert
+								swal({
+								title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+								text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+								icon: "error",
+								timer: 4000,
+								buttons: false,
+								});
+							}			          	  
+						}
+					},
+					error: function(result) {
+						// Show an alert with the result
+						swal({
+						title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+						text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+						icon: "error",
+						timer: 4000,
+						buttons: false,
+						});
+					}
+				});
 			}
 		});
-
-      }
 	}
+}
 
 	// make it so that the function above is run after each DataTable draw event
 	// crud.addFunctionToDataTablesDrawEventQueue('deleteEntry');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The delete script didn't take into account if model has SoftDeletes trait.

The `Delete` should be exactly that, "Delete", not "Soft Delete". For soft delete you should use the `TrashOperation` that allow you to soft delete (trash), and restore your models. 

I avoided a breaking change by keeping the same behaviour when trash operation is not present, but when you add trash operation to a crud with delete operation, the delete operation would be the "delete permanently" functionality.

This is needed to work with https://github.com/Laravel-Backpack/PRO/pull/118

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-trash-operation-refactored" &&
cd vendor/backpack/crud && git checkout dev-update-delete-and-bulk-delete-operations &&
cd ../pro && git checkout dev-backpack-trash-refactor &&
cd ../../..
```
