### PR TITLE
Fix reorder operation error

### DIFF
--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -80,7 +80,7 @@ trait ReorderOperation
     {
         $this->crud->hasAccessOrFail('reorder');
 
-        $all_entries = json_decode(\Request::input('tree'), true);
+        $all_entries = \Request::input('tree');
 
         if (count($all_entries)) {
             $count = $this->crud->updateTreeOrder($all_entries);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Error when trying to save reordered items

### AFTER - What is happening after this PR?

Reorder operation works as expected

## HOW

### How did you achieve that, in technical terms?

Just debug 

### Is it a breaking change?

Its a bug

### How can we test the before & after?

Try to reorder items

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
