### PR TITLE
Allow intermediate level deletion on filtered reorder

### DIFF
--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -72,7 +72,7 @@
                     <?php
                     $all_entries = collect($entries->all())->sortBy('lft')->keyBy($crud->getModel()->getKeyName());
                     $root_entries = $all_entries->filter(function ($item) use ($all_entries) {
-                        return $item->parent_id == 0 || !$all_entries->has($item->parent_id);
+                        return $item->parent_id == 0 || ! $all_entries->has($item->parent_id);
                     });
                     foreach ($root_entries as $key => $entry) {
                         $root_entries[$key] = tree_element($entry, $key, $all_entries, $crud);

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -71,8 +71,8 @@
                 <ol class="sortable mt-0">
                     <?php
                     $all_entries = collect($entries->all())->sortBy('lft')->keyBy($crud->getModel()->getKeyName());
-                    $root_entries = $all_entries->filter(function ($item) {
-                        return $item->parent_id == 0;
+                    $root_entries = $all_entries->filter(function ($item) use ($all_entries) {
+                        return $item->parent_id == 0 || !$all_entries->has($item->parent_id);
                     });
                     foreach ($root_entries as $key => $entry) {
                         $root_entries[$key] = tree_element($entry, $key, $all_entries, $crud);


### PR DESCRIPTION
## WHY
When a middle element is deleted, the ordering stops working properly.

### BEFORE - What was wrong? What was happening before this PR?

Once a middle element remains orphan it's not available in the reorder view even though it should still be reordered.

https://user-images.githubusercontent.com/12816305/214054827-b4643fea-1b49-4d0c-b619-feba9a28a319.mp4


### AFTER - What is happening after this PR?

Now once a middle element with child is deleted, the component still allows the reorder it's own orphans.


https://user-images.githubusercontent.com/12816305/214055099-7f946993-b466-447a-bb96-9e9e716a5664.mp4

## HOW

### How did you achieve that, in technical terms?

I achieved that by setting the orphan elements as root.


### Is it a breaking change?

It might break some highly customized applications.


### How can we test the before & after?

It can be tested by creating a reorderable nested structure filtered by a one to many relationship.

