### PR TITLE
fix newQueryWithoutScopes() error

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -246,7 +246,7 @@ trait Query
         // so we just store them and re-use them in the sub-query too.
         $expressionColumns = [];
 
-        foreach ($crudQuery->columns as $column) {
+        foreach ($crudQuery->columns ?? [] as $column) {
             if (! is_string($column) && is_a($column, 'Illuminate\Database\Query\Expression')) {
                 $expressionColumns[] = $column;
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If you wanted to clear the query scopes with ``` $this->crud->query = $this->crud->model->newQueryWithoutScopes() ``` it would throw an error on Query.php trait.

![image](https://user-images.githubusercontent.com/3352723/214097983-980ff94a-600c-4491-9493-9998d6447cf1.png)

### AFTER - What is happening after this PR?

newQueryWithoutScopes is working like it should


## HOW

### How did you achieve that, in technical terms?

just declared an empty array on ``` foreach($crudQuery->columns ?? [] as $column) ``` if it doesn't exists.



### Is it a breaking change?

no

