### PR TITLE
Update select_multiple.blade.php

### DIFF
--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -1,6 +1,6 @@
 {{-- relationships with pivot table (n-n) --}}
 @php
-    $column['value'] = $column['value'] ?? data_get($entry, $column['name'], []);
+    $column['value'] = $column['value'] ?? data_get($entry, $column['name'], collect([]));
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';


### PR DESCRIPTION
when the item is null it defaults to an array, but then we call functions on that array and it fails

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Empty values would cause a PHP Exception (calling a function on an array)

### AFTER - What is happening after this PR?

Now we are calling our functions on an empty collection


## HOW

### How did you achieve that, in technical terms?

I wrapped the default array with `collect`



### Is it a breaking change?

No


### How can we test the before & after?

Try to add a column to a crud list without a defined "value" and specifically has two levels in the name. So, for example if you have a location model with user models, and the users have phone models, then on the listing page for locations, if the name of the column is user.phone with attribute of name for example - in that scenario if there is no user, then the data_get returns the default value, which we have defined at an empty array

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
