### PR TITLE
Register Password to be min 8 to match ResetPassword and laravel default

### DIFF
--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -56,7 +56,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name'                             => 'required|max:255',
             backpack_authentication_column()   => 'required|'.$email_validation.'max:255|unique:'.$users_table,
-            'password'                         => 'required|min:6|confirmed',
+            'password'                         => 'required|min:8|confirmed',
         ]);
     }
 


### PR DESCRIPTION
Laravel 10 and Backpack 6 is very near, so I thought I revive this old issue. Only bump the password min from 6 to 8, nothing about Password::defaults() or how the config rules should be like, be it in config file or ServiceProvider

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Backpack Register password minimum is 6, but ResetPassword in Backpack and Laravel Default is Min 8. This is not consistent. NIST also recommends password to be minimum length 8


### AFTER - What is happening after this PR?

Backpack Register Controller password minimum to be min length 8 to match Reset Password and Laravel Default

## HOW

### How did you achieve that, in technical terms?

Update the validation Rule

### Is it a breaking change?

Well Laravel 10 is and backpack 6 is coming, I doubt new users registering will ever realise min password length has increased by 2 characters too.


### How can we test the before & after?

Try and register with a password less than 8 characters?
