### PR TITLE
Fix `php artisan backpack:version` command for composer2 installations

### DIFF
--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -37,7 +37,28 @@ class Version extends Command
         $this->line('');
 
         $this->comment('### BACKPACK PACKAGE VERSIONS:');
-        foreach (\PackageVersions\Versions::VERSIONS as $package => $version) {
+
+        if (class_exists(\Composer\InstalledVersions::class, false)) {
+            $this->getPackageVersionsFromComposer2();
+        } else {
+            $this->getPackageVersionsFromComposer1();
+        }
+    }
+
+    private function getPackageVersionsFromComposer2()
+    {
+        $packages = \Composer\InstalledVersions::getInstalledPackages();
+        foreach ($packages as $package) {
+            if (substr($package, 0, 9) == 'backpack/') {
+                $this->line($package.': '.\Composer\InstalledVersions::getPrettyVersion($package));
+            }
+        }
+    }
+
+    private function getPackageVersionsFromComposer1()
+    {
+        $packages = \PackageVersions\Versions::VERSIONS;
+        foreach ($packages as $package => $version) {
             if (substr($package, 0, 9) == 'backpack/') {
                 $this->line($package.': '.strtok($version, '@'));
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were not covering composer2 installations and would return an empty list of installed packages.

### AFTER - What is happening after this PR?

We do show the packages in both versions of composer.


## HOW

### How did you achieve that, in technical terms?

Checking what composer version is installed.



### Is it a breaking change?

I don't think so, no.


### How can we test the before & after?

run `php artisan backpack:version` on a composer v2 installation. 

