### PR TITLE
Add URL Column Type

### DIFF
--- a/src/resources/views/crud/columns/url.blade.php
+++ b/src/resources/views/crud/columns/url.blade.php
@@ -1,0 +1,20 @@
+{{-- regular object attribute --}}
+@php
+    $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
+    $column['limit'] = $column['limit'] ?? 32;
+    $column['text'] = $column['default'] ?? '-';
+
+    if(is_array($column['value'])) {
+        $column['value'] = json_encode($column['value']);
+    }
+
+    if(!empty($column['value'])) {
+        $column['text'] = '<a href="'.$column['value'].'" target="_blank">'.Str::limit($column['value'], $column['limit'], '…').'</a>';
+    }
+@endphp
+
+<span>
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+    {!! $column['text'] !!}
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+</span>


### PR DESCRIPTION
## WHY
Allow Enduser to preview URL in the right format " clickable "

### BEFORE - What was wrong? What was happening before this PR?
there was no URL column type so it was shown as TEXT
![image](https://user-images.githubusercontent.com/23424932/218249192-1e9ffc84-6cd2-4c10-add9-c58c6eaedb4a.png)

### AFTER - What is happening after this PR?
the URL is shown in the right way " Clickable URL " And Allow limit just In case URL is too long it automatic trimmed in view 
![image](https://user-images.githubusercontent.com/23424932/218249220-c3721903-62df-4d31-959b-e60e59c44594.png)


## HOW

### How did you achieve that, in technical terms?
By Duplicate Text Column and editing it by adding `a` tag with escaped False to show the URL in the right way



### Is it a breaking change?
No


### How can we test the before & after?
Image Above

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
No
