### PR TITLE
Added PHP 7.4 as a min. version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         }
     ],
     "require": {
+        "php": "^7.4|^8.0",
         "laravel/framework": "^9.0|^8.69",
         "prologue/alerts": "^1.0|^0.4",
         "digitallyhappy/assets": "^2.0.1",


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Backpack uses Laravel 8 as a minimum requirement and Laravel 8 has a minimum requirement of PHP 7.3.
Issue https://github.com/Laravel-Backpack/community-forum/issues/399 describes a logic that fails because of arrow function used in the code. Arrow functions are introduced in PHP 7.4 and therefore fail in PHP 7.3.

### AFTER - What is happening after this PR?

After setting the minimum PHP version to 7.4 the issue is resolved, as the user is forced to use PHP version 7.4 instead of 7.3.


## HOW

### How did you achieve that, in technical terms?

Added `"php": "^7.4|^8.0"` as `required` in `composer.json`.



### Is it a breaking change?

It could be a breaking change for 0.7% of the users that use PHP 7.3 (according to the stats provided by Pedro in the linked issue)/


### How can we test the before & after?

1. Do a fresh installation of latest Backpack version under PHP 7.3 - artisan will fail after the installation
2. Do a fresh installation of latest Backpack version under PHP 7.4 - artisan will work after the installation 

## NOTES

### Possible non-breaking-change approach

Instead of increasing the minimum requirement for the PHP version we could rewrite the arrow function to an anonymous function. Then there will be no need to touch `composer.json` and it will work also under PHP 7.3. I am not sure if there are any similar (arrow function) cases or other issues in the codebase. Not sure if it is a viable option.