### PR TITLE
Correctly use values of backed enums for options (#4929)

### DIFF
--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -18,7 +18,7 @@
         }
 
         // developer can provide the enum class so that we extract the available options from it
-        $enumClassReflection = isset($field['enum_class']) ? new \ReflectionEnum($field['enum_class']) : false;              
+        $enumClassReflection = isset($field['enum_class']) ? new \ReflectionEnum($field['enum_class']) : false;
 
         if(! $enumClassReflection) {
             // check for model casting
@@ -27,12 +27,12 @@
                 $enumClassReflection = new \ReflectionEnum($possibleEnumCast);
             }
         }
-        
+
         if($enumClassReflection) {
             $options = array_map(function($item) use ($enumClassReflection) {
                 return $enumClassReflection->isBacked() ? [$item->getBackingValue() => $item->name] : $item->name;
             },$enumClassReflection->getCases());
-            $options = is_multidimensional_array($options) ? array_merge(...$options) : array_combine($options, $options);
+            $options = is_multidimensional_array($options) ? array_replace(...$options) : array_combine($options, $options);
         }
 
         if(isset($field['enum_function']) && isset($options)) {
@@ -54,7 +54,7 @@
         $options = $entity_model::getPossibleEnumValues($field['name']);
         return array_combine($options, $options);
     })();
-    
+
 
     if(function_exists('enum_exists') && !empty($field['value']) && $field['value'] instanceof \UnitEnum)  {
         $field['value'] = $field['value'] instanceof \BackedEnum ? $field['value']->value : $field['value']->name;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Detailed description can be found in #4929.
The values of backed enums were discarded and regular array keys were used to build the options for the HTML select. This resulted incorrect values for the enums being passed to the controller when saving the entry. In my case PHP complained because `0` was not an option available in my enum.

### AFTER - What is happening after this PR?

The HTML select has options with values correctly set with the corresponding values of the enum.

## HOW

### How did you achieve that, in technical terms?

From a technical side, a change was needed to preserve the array keys of the $options array that was built with the values of a backed enum.

Those are the option arrays for the two enum types before they are flattened in the enum.blade.php:

SimplePriority::class
```php
array:3 [
  0 => "LOW"
  1 => "MEDIUM"
  2 => "HIGH"
]
```

Priority::class
```php
array:3 [
  0 => array:1 [
    10 => "Low"
  ]
  1 => array:1 [
    20 => "Medium"
  ]
  2 => array:1 [
    30 => "High"
  ]
]
```

When I replace `array_merge(...$options)` with `array_replace(...$options)`, I get the correct resulting array with the enum values as the array keys:

```php
array:3 [
  10 => "Low"
  20 => "Medium"
  30 => "High"
]
```



### Is it a breaking change?

I assume it's not, because backed enums likely never worked correctly before. But of course, I am not sure about this.


### How can we test the before & after?

Set up a backed enum (see #4929) and used it to configure a field. The resulting HTML will likely have option values like array keys (0,1,2,3,...).
When checking out this fix, the resulting HTML should produce options with the values of your enum (10,20,30,...).
