### PR TITLE
[v6] Use basset block directive in FREE fields

### DIFF
--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -5,6 +5,7 @@
 {{-- Button Javascript --}}
 {{-- - used right away in AJAX operations (ex: List) --}}
 {{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+{{-- - cannot use bassetBlock here, because of inline PHP that we WANT rendered (ability to change lang) --}}
 @loadOnce('delete_button_script')
 @push('after_scripts') @if (request()->ajax()) @endpush @endif
 <script>

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -5,9 +5,8 @@
 {{-- Button Javascript --}}
 {{-- - used right away in AJAX operations (ex: List) --}}
 {{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
-{{-- - cannot use bassetBlock here, because of inline PHP that we WANT rendered (ability to change lang) --}}
-@loadOnce('delete_button_script')
 @push('after_scripts') @if (request()->ajax()) @endpush @endif
+@bassetBlock('backpack/crud/buttons/delete-button-'.app()->getLocale().'.js')
 <script>
 
 	if (typeof deleteEntry != 'function') {
@@ -94,5 +93,5 @@
 	// make it so that the function above is run after each DataTable draw event
 	// crud.addFunctionToDataTablesDrawEventQueue('deleteEntry');
 </script>
+@endBassetBlock
 @if (!request()->ajax()) @endpush @endif
-@endLoadOnce

--- a/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
+++ b/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
@@ -7,7 +7,7 @@
         <input type="checkbox" class="crud_bulk_actions_line_checkbox" data-primary-key-value="{{ $entry->getKey() }}">
     </span>
 
-    @loadOnce('bpFieldInitCheckboxScript')
+    @bassetBlock('backpack/crud/operations/list/bulk-actions-checkbox.js')
     <script>
     if (typeof addOrRemoveCrudCheckedItem !== 'function') {
         function addOrRemoveCrudCheckedItem(element) {
@@ -123,5 +123,5 @@
     crud.addFunctionToDataTablesDrawEventQueue('addBulkActionMainCheckboxesFunctionality');
     crud.addFunctionToDataTablesDrawEventQueue('enableOrDisableBulkButtons');
     </script>
-    @endLoadOnce
+    @endBassetBlock
 @endif

--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -33,7 +33,7 @@
 
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
     @push('crud_fields_scripts')
-        @loadOnce('bpFieldInitCheckbox')
+        @bassetBlock('backpack/crud/fields/checkbox-field.js')
         <script>
             function bpFieldInitCheckbox(element) {
                 var hidden_element = element.siblings('input[type=hidden]');
@@ -72,7 +72,7 @@
                 })
             }
         </script>
-        @endLoadOnce
+        @endBassetBlock
     @endpush
 
 {{-- End of Extra CSS and JS --}}

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -55,7 +55,7 @@
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
     {{-- FIELD JS - will be loaded in the after_scripts section --}}
     @push('crud_fields_scripts')
-        @loadOnce('bpFieldInitChecklist')
+        @bassetBlock('backpack/crud/fields/checklist-field.js')
         <script>
             function bpFieldInitChecklist(element) {
                 var hidden_input = element.find('input[type=hidden]');
@@ -100,7 +100,7 @@
 
             }
         </script>
-        @endLoadOnce
+        @endBassetBlock
     @endpush
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}

--- a/src/resources/views/crud/fields/checklist_dependency.blade.php
+++ b/src/resources/views/crud/fields/checklist_dependency.blade.php
@@ -187,16 +187,14 @@
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
 
-@push('crud_fields_scripts')
-    <script>
-        var  {{ $field['field_unique_name'] }} = {!! $dependencyJson !!};
-    </script>
-@endpush
-
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
+  <script>
+      var  {{ $field['field_unique_name'] }} = {!! $dependencyJson !!};
+  </script>
+
   {{-- include checklist_dependency js --}}
-  @loadOnce('bpFieldInitChecklistDependencyElement')
+  @bassetBlock('backpack/crud/fields/checklist-dependency-field.js')
     <script>
       function bpFieldInitChecklistDependencyElement(element) {
 
@@ -311,7 +309,7 @@
 
       }
     </script>
-  @endLoadOnce
+  @endBassetBlock
 @endpush
 {{-- End of Extra CSS and JS --}}
 {{-- ########################################## --}}

--- a/src/resources/views/crud/fields/radio.blade.php
+++ b/src/resources/views/crud/fields/radio.blade.php
@@ -49,9 +49,13 @@
 
 @include('crud::fields.inc.wrapper_end')
 
-    {{-- FIELD JS - will be loaded in the after_scripts section --}}
-    @push('crud_fields_scripts')
-    @loadOnce('bpFieldInitRadioElement')
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+
+{{-- FIELD JS - will be loaded in the after_scripts section --}}
+@push('crud_fields_scripts')
+    @bassetBlock('backpack/crud/fields/radio-field.js')
     <script>
         function bpFieldInitRadioElement(element) {
             var hiddenInput = element.find('input[type=hidden]');
@@ -88,5 +92,7 @@
             element.find('input[type=radio][value="'+value+'"]').prop('checked', true);
         }
     </script>
-    @endLoadOnce
-    @endpush
+    @endBassetBlock
+@endpush
+{{-- End of Extra CSS and JS --}}
+{{-- ########################################## --}}

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -28,29 +28,30 @@
 {{-- Extra CSS and JS for this particular field --}}
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
 
-    {{-- FIELD CSS - will be loaded in the after_styles section --}}
+{{-- FIELD CSS - will be loaded in the after_styles section --}}
 @push('crud_fields_styles')
     {{-- include summernote css --}}
     @basset('https://unpkg.com/summernote@0.8.20/dist/summernote-bs4.min.css')
     @basset('https://unpkg.com/summernote@0.8.20/dist/font/summernote.woff2', false)
-    @loadOnce('summernoteCss')
+    @bassetBlock('backpack/crud/fields/checklist-field.css')
     <style type="text/css">
         .note-editor.note-frame .note-status-output, .note-editor.note-airframe .note-status-output {
                 height: auto;
         }
     </style>
-    @endLoadOnce
+    @endBassetBlock
 @endpush
+
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
     {{-- include summernote js --}}
     @basset('https://unpkg.com/summernote@0.8.20/dist/summernote.min.js')
-    @loadOnce('bpFieldInitSummernoteElement')
+    @bassetBlock('backpack/crud/fields/summernote-field.js')
     <script>
         function bpFieldInitSummernoteElement(element) {
              var summernoteOptions = element.data('options');
 
-            let summernotCallbacks = { 
+            let summernotCallbacks = {
                 onChange: function(contents, $editable) {
                     element.val(contents).trigger('change');
                 }
@@ -63,13 +64,13 @@
             element.on('CrudField:enable', function(e) {
                 element.summernote('enable');
             });
-            
+
             summernoteOptions['callbacks'] = summernotCallbacks;
-            
-            element.summernote(summernoteOptions); 
+
+            element.summernote(summernoteOptions);
         }
     </script>
-    @endLoadOnce
+    @endBassetBlock
 @endpush
 
 {{-- End of Extra CSS and JS --}}

--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -50,7 +50,7 @@
 
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
-    @loadOnce('bpFieldInitSwitchScript')
+    @bassetBlock('backpack/crud/fields/switch-field.js')
     <script>
         function bpFieldInitSwitch($element) {
             let element = $element[0];
@@ -79,17 +79,17 @@
             });
         }
     </script>
-    @endLoadOnce
+    @endBassetBlock
 @endpush
 
 @push('crud_fields_styles')
-    @loadOnce('bpFieldInitSwitchStyle')
+    @bassetBlock('backpack/crud/fields/switch-field.css')
     <style>
         .switch-input:checked+.switch-slider {
             background-color: var(--bg-color);
         }
     </style>
-    @endLoadOnce
+    @endBassetBlock
 @endpush
 
 {{-- End of Extra CSS and JS --}}

--- a/src/resources/views/crud/fields/upload.blade.php
+++ b/src/resources/views/crud/fields/upload.blade.php
@@ -51,7 +51,7 @@
 {{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
 
 @push('crud_fields_styles')
-  @loadOnce('upload_field_styles')
+  @bassetBlock('backpack/crud/fields/upload-field.css')
     <style type="text/css">
         .existing-file {
             border: 1px solid rgba(0,40,100,.12);
@@ -132,11 +132,11 @@
           border-radius: 0 0.25rem 0.25rem 0;
         }
     </style>
-  @endLoadOnce
+  @endBassetBlock
 @endpush
 
 @push('crud_fields_scripts')
-  @loadOnce('bpFieldInitUploadElement')
+  @bassetBlock('backpack/crud/fields/upload-field.js')
     <script>
         function bpFieldInitUploadElement(element) {
             var fileInput = element.find(".file_input");
@@ -169,9 +169,9 @@
 
             element.on('CrudField:disable', function(e) {
               element.children('.backstrap-file').find('input').prop('disabled', 'disabled');
-              
+
               let $deleteButton = element.children('.existing-file').children('a.file_clear_button');
-              
+
               if($deleteButton.length > 0) {
                 $deleteButton.on('click.prevent', function(e) {
                     e.stopImmediatePropagation();
@@ -189,5 +189,5 @@
 
         }
     </script>
-  @endLoadOnce
+  @endBassetBlock
 @endpush

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -56,7 +56,7 @@
 {{-- ########################################## --}}
 {{-- Extra CSS and JS for this particular field --}}
 	@push('crud_fields_styles')
-	@loadOnce('upload_field_styles')
+	@bassetBlock('backpack/crud/fields/upload-multiple-field.css')
 	<style type="text/css">
 		.existing-file {
 			border: 1px solid rgba(0,40,100,.12);
@@ -137,10 +137,11 @@
 			border-radius: 0 0.25rem 0.25rem 0;
 		}
 	</style>
-	@endLoadOnce
+	@endBassetBlock
 	@endpush
+
     @push('crud_fields_scripts')
-    	@loadOnce('bpFieldInitUploadMultipleElement')
+    	@bassetBlock('backpack/crud/fields/upload-multiple-field.js')
         <script>
         	function bpFieldInitUploadMultipleElement(element) {
         		var fieldName = element.attr('data-field-name');
@@ -199,5 +200,5 @@
 				});
         	}
         </script>
-        @endLoadOnce
+        @endBassetBlock
     @endpush


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some FREE fields were still use `@loadOnce` instead of the new `@bassetBlock`

### AFTER - What is happening after this PR?

All fields are using `@bassetBlock` instead, which is not only loading it once... but also MOVING that bit of CSS/JS to a file, and afterwards load it from there. This has two benefits:
- (1) it cleans up the output (no more inline CSS and JS because of the fields)
- (2) caching; because it's a JS/CSS file, the browser can cache it, so it SHOULD be faster (haven't benchmarked);

Just look at how clean the directory looks, with all the CSS and JS that used to be inline:
<img width="831" alt="CleanShot 2023-02-21 at 10 01 20@2x" src="https://user-images.githubusercontent.com/1032474/220283810-45c91639-1bd2-4fd7-a6d3-d0f16efa9817.png">

But wait till we do the same with the PRO repo 🤯 Over there, all fields have some sort of inline JS or CSS. So all of that will get moved to files.

## HOW

### How did you achieve that, in technical terms?

Manually replaced ALMOST all ocurrences.

### Is it a breaking change?

For v5? Yes.
For v6? Not if you're using the `bassets` branch of DigitallyHappy/Assets, no.