### PR TITLE
Improvements on color field

### DIFF
--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -1,21 +1,69 @@
 {{-- html5 color input --}}
+@php
+$value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '';
+@endphp
+
+
 @include('crud::fields.inc.wrapper_start')
     <label>{!! $field['label'] !!}</label>
     @include('crud::fields.inc.translatable_icon')
 
-    @if(isset($field['prefix']) || isset($field['suffix'])) <div class="input-group"> @endif
+    <div class="input-group">
         @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
         <input
-            type="color"
+            type="text"
             name="{{ $field['name'] }}"
-            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            value="{{ $value }}"
+            pattern="#[0-9a-f]{6}"
+            maxlength="7"
+            data-init-function="bpFieldInitColorElement"
             @include('crud::fields.inc.attributes')
-    	>
+        />
+        <div class="input-group-append">
+            <span class="input-group-text">
+                <input
+                    type="color"
+                    value="{{ $value }}"
+                />
+            </span>
+        </div>
         @if(isset($field['suffix'])) <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div> @endif
-    @if(isset($field['prefix']) || isset($field['suffix'])) </div> @endif
+    </div>
 
     {{-- HINT --}}
     @if (isset($field['hint']))
         <p class="help-block">{!! $field['hint'] !!}</p>
     @endif
 @include('crud::fields.inc.wrapper_end')
+
+
+@push('crud_fields_styles')
+    @bassetBlock('backpack/crud/fields/color.css')
+    <style>
+        [bp-field-name="color"] input[type="color"] {
+            background-color: unset;
+            border: 0;
+            width: 1.8rem;
+            height: 1.8rem;
+        }
+        [bp-field-name="color"] .input-group-text {
+            padding: 0 0.4rem;
+        }
+    </style>
+    @endLoaendBassetBlockdOnce
+@endpush
+
+
+@push('crud_fields_scripts')
+    @bassetBlock('backpack/crud/fields/color.js')
+    <script>
+        function bpFieldInitColorElement(element) {
+            let inputText = element[0];
+            let inputColor = inputText.nextElementSibling.querySelector('input');
+
+            inputText.addEventListener('input', () => inputText.value = inputColor.value = '#' + inputText.value.replace(/[^\da-f]/gi, '').toLowerCase());
+            inputColor.addEventListener('input', () => inputText.value = inputColor.value);
+        }
+    </script>
+    @endBassetBlock
+@endpush

--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -50,7 +50,7 @@ $value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['de
             padding: 0 0.4rem;
         }
     </style>
-    @endLoaendBassetBlockdOnce
+    @endBassetBlock
 @endpush
 
 


### PR DESCRIPTION
This PR aims to make the `color` field behaves the same way as `color_picker` that is jquery.

jQuery `color_picker` was abandoned and it's actually no longer necessary since `<input type="color"` is now supported everywhere.