### PR TITLE
remove DevTools does not support L10 notice in installer

### DIFF
--- a/src/app/Console/Commands/Addons/RequireDevTools.php
+++ b/src/app/Console/Commands/Addons/RequireDevTools.php
@@ -45,15 +45,6 @@ class RequireDevTools extends Command
      */
     public function handle()
     {
-        // Prevent installations in laravel 10 as it wouldn't properly work. Waiting for Blueprint L10 support.
-        if (app()->version() >= 10) {
-            $this->newLine();
-            $this->line(sprintf('Support for Laravel 10 is comming soon. Sorry for the trouble.'), 'fg=red');
-            $this->newLine();
-
-            return;
-        }
-
         // Check if it is installed
         if ($this->isInstalled()) {
             $this->newLine();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Notice

### AFTER - What is happening after this PR?

No notice

