### PR TITLE
[DX] add return types to facade

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanelFacade.php
+++ b/src/app/Library/CrudPanel/CrudPanelFacade.php
@@ -13,17 +13,17 @@ use Illuminate\Support\Facades\Facade;
  * @codeCoverageIgnore
  * Class CrudPanelFacade.
  *
- * @method static setModel($model)
- * @method static setRoute(string $route)
- * @method static setEntityNameStrings(string $singular, string $plural)
- * @method static field(string $name)
- * @method static addField(array $field)
- * @method static addFields(array $fields)
- * @method static column(string $name)
- * @method static addColumn(array $column)
- * @method static addColumns(array $columns)
- * @method static afterColumn(string $targetColumn)
- * @method static setValidation($class)
+ * @method static CrudPanel setModel($model)
+ * @method static CrudPanel setRoute(string $route)
+ * @method static CrudPanel setEntityNameStrings(string $singular, string $plural)
+ * @method static CrudField field(string $name)
+ * @method static CrudPanel addField(array $field)
+ * @method static CrudPanel addFields(array $fields)
+ * @method static CrudColumn column(string $name)
+ * @method static CrudPanel addColumn(array $column)
+ * @method static CrudPanel addColumns(array $columns)
+ * @method static CrudPanel afterColumn(string $targetColumn)
+ * @method static CrudPanel setValidation($class)
  * @mixin CrudPanel
  */
 class CrudPanelFacade extends Facade


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When using the CrudPanel Facade some editors didn't get the proper return type of the underlying class methods. 

![image](https://user-images.githubusercontent.com/7188159/221910929-242ede81-1c83-4b57-883c-7afc36566128.png)


### AFTER - What is happening after this PR?

We provide the return types so they are always properly inferred. 

![image](https://user-images.githubusercontent.com/7188159/221911195-a8df6754-16bb-4cc3-b675-80875ccf58f2.png)


### Is it a breaking change?

Nop
