### PR TITLE
add CrudField function to get all fields on page - `crud.allFields()`

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -184,5 +184,14 @@
 
         // Create all fields from a given name list
         fields: names => names.map(window.crud.field),
+        
+        // Get all fields from the current page
+        allFields: () => {
+            let fields = [];
+            $('form [bp-field-name]').each(function() {
+                fields.push(new CrudField($(this).attr('bp-field-name')));
+            });
+            return fields;
+        },
     };
 </script>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When working on https://github.com/Laravel-Backpack/community-forum/issues/206#issuecomment-1455129958 I realised 
we have no way of getting ALL fields on page.

### AFTER - What is happening after this PR?

We do, we have `crud.allFields()` which returns the same as if you passed an array with all the fields you want to `crud.fields()`


## HOW

### How did you achieve that, in technical terms?

jQuery, but should be refactored to JS if we decide to do it.

### Is it a breaking change?

Non-breaking.


### How can we test the before & after?

Inside any CRUD Create/Update operation, you can do 
- `crud.allFields()` to select all fields;
- `crud.allFields().forEach(field => { field.hide(); });` to hide all fields in a form;
