### PR TITLE
[BUG-FIX] backpack_form_input() handle multiple inputs 

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -65,6 +65,13 @@ if (! function_exists('backpack_form_input')) {
                 continue;
             }
 
+            $isMultiple = substr($row['name'], -2, 2) === '[]';
+           
+            if($isMultiple && substr_count($row['name'], '[') === 1) {
+                $result[substr($row['name'], 0, -2)][] = $row['value'];
+                continue;
+            }
+
             // dot notation fields
             if (substr_count($row['name'], '[') === 1) {
                 // start in the first occurence since it's HasOne/MorphOne with dot notation (address[street] in request) to get the input name (address)
@@ -87,11 +94,20 @@ if (! function_exists('backpack_form_input')) {
             $parentInputName = substr($row['name'], 0, strpos($row['name'], '['));
 
             if (isset($repeatableRowKey)) {
+                if($isMultiple) {
+                    $result[$parentInputName][$repeatableRowKey][$inputName][] = $row['value'];
+                    continue;
+                }
+
                 $result[$parentInputName][$repeatableRowKey][$inputName] = $row['value'];
 
                 continue;
             }
 
+            if($isMultiple) {
+                $result[$parentInputName][$inputName][] = $row['value'];
+                continue;
+            }
             $result[$parentInputName][$inputName] = $row['value'];
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -66,8 +66,8 @@ if (! function_exists('backpack_form_input')) {
             }
 
             $isMultiple = substr($row['name'], -2, 2) === '[]';
-           
-            if($isMultiple && substr_count($row['name'], '[') === 1) {
+
+            if ($isMultiple && substr_count($row['name'], '[') === 1) {
                 $result[substr($row['name'], 0, -2)][] = $row['value'];
                 continue;
             }
@@ -94,7 +94,7 @@ if (! function_exists('backpack_form_input')) {
             $parentInputName = substr($row['name'], 0, strpos($row['name'], '['));
 
             if (isset($repeatableRowKey)) {
-                if($isMultiple) {
+                if ($isMultiple) {
                     $result[$parentInputName][$repeatableRowKey][$inputName][] = $row['value'];
                     continue;
                 }
@@ -104,7 +104,7 @@ if (! function_exists('backpack_form_input')) {
                 continue;
             }
 
-            if($isMultiple) {
+            if ($isMultiple) {
                 $result[$parentInputName][$inputName][] = $row['value'];
                 continue;
             }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4960 . Multiple fields whose names ended with `[]` were not properly treated and mistakenly identified as relationships/repeatable fields.

### AFTER - What is happening after this PR?

We properly handle fields that end with `[]` AKA array inputs.

## HOW

### How did you achieve that, in technical terms?

Added check for field name patterns ending with `[]`

### Is it a breaking change?

I don't think so, no

### How can we test the before & after?

Described [here on how to reproduce](https://github.com/Laravel-Backpack/CRUD/issues/4960#issuecomment-1455162431).
