### PR TITLE
BUG-FIX: Set limit on select_multiple column

### DIFF
--- a/src/resources/views/crud/columns/select_multiple.blade.php
+++ b/src/resources/views/crud/columns/select_multiple.blade.php
@@ -17,8 +17,8 @@
     }
 
     $column['value'] = $column['value']
-        ->each(function($value) use ($column) {
-            $value = Str::limit($value, $column['limit'], '…');
+        ->map(function($value) use ($column) {
+            return Str::limit($value, $column['limit'], '…');
         })
         ->toArray();
 @endphp


### PR DESCRIPTION
## WHY
Setting a limit in select_multipe column did not work. This PR is fixing it.

### BEFORE - What was wrong? What was happening before this PR?
Using each in this case and setting `$value ` will do nothing. The value in the array will not be changes.

### AFTER - What is happening after this PR?
 Map will return a new array with the correct, and now limited strings.

### Is it a breaking change?
No, but if someone set a limit it was not working before, but now it will. But maybe unnoticed.


### How can we test the before & after?
Setting a limit on a select multiple column.
