### PR TITLE
Fix for Laravel 10 new password_reset_tokens table

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -260,7 +260,7 @@ class BackpackServiceProvider extends ServiceProvider
         [
             'backpack' => [
                 'provider'  => 'backpack',
-                'table'     => 'password_resets',
+                'table'     => config('backpack.base.password_resets_table') ?? config('auth.passwords.users.table'),
                 'expire'    => config('backpack.base.password_recovery_token_expiration', 60),
                 'throttle'  => config('backpack.base.password_recovery_throttle_notifications'),
             ],

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -258,7 +258,7 @@ class BackpackServiceProvider extends ServiceProvider
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
 
-        $firstBrokerTable = collect($laravelAuthPasswordBrokers)
+        $backpackPasswordBrokerTable = app()->version() < 10 ? 'password_resets' : collect($laravelAuthPasswordBrokers)
                                 ->filter(function ($item) {
                                     return isset($item['table']);
                                 })->first()['table'];
@@ -267,7 +267,7 @@ class BackpackServiceProvider extends ServiceProvider
         [
             'backpack' => [
                 'provider'  => 'backpack',
-                'table'     => config('backpack.base.password_resets_table') ?? $firstBrokerTable,
+                'table'     => config('backpack.base.password_resets_table') ?? $backpackPasswordBrokerTable,
                 'expire'    => config('backpack.base.password_recovery_token_expiration', 60),
                 'throttle'  => config('backpack.base.password_recovery_throttle_notifications'),
             ],

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -256,11 +256,18 @@ class BackpackServiceProvider extends ServiceProvider
         ];
 
         // add the backpack_users password broker to the configuration
-        app()->config['auth.passwords'] = app()->config['auth.passwords'] +
+        $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
+
+        $firstBrokerTable = collect($laravelAuthPasswordBrokers)
+                                ->filter(function ($item) {
+                                    return isset($item['table']);
+                                })->first()['table'];
+
+        app()->config['auth.passwords'] = $laravelAuthPasswordBrokers +
         [
             'backpack' => [
                 'provider'  => 'backpack',
-                'table'     => config('backpack.base.password_resets_table') ?? config('auth.passwords.users.table'),
+                'table'     => config('backpack.base.password_resets_table') ?? $firstBrokerTable,
                 'expire'    => config('backpack.base.password_recovery_token_expiration', 60),
                 'throttle'  => config('backpack.base.password_recovery_throttle_notifications'),
             ],

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -258,10 +258,7 @@ class BackpackServiceProvider extends ServiceProvider
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
 
-        $backpackPasswordBrokerTable = app()->version() < 10 ? 'password_resets' : collect($laravelAuthPasswordBrokers)
-                                ->filter(function ($item) {
-                                    return isset($item['table']);
-                                })->first()['table'];
+        $backpackPasswordBrokerTable = app()->version() < 10 ? 'password_resets' : current($laravelAuthPasswordBrokers)['table'];
 
         app()->config['auth.passwords'] = $laravelAuthPasswordBrokers +
         [

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -258,13 +258,15 @@ class BackpackServiceProvider extends ServiceProvider
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
 
-        $backpackPasswordBrokerTable = app()->version() < 10 ? 'password_resets' : current($laravelAuthPasswordBrokers)['table'];
+        $backpackPasswordBrokerTable = config('backpack.base.password_resets_table') ??
+                                        config('auth.passwords.users.table') ??
+                                        current($laravelAuthPasswordBrokers)['table'];
 
         app()->config['auth.passwords'] = $laravelAuthPasswordBrokers +
         [
             'backpack' => [
                 'provider'  => 'backpack',
-                'table'     => config('backpack.base.password_resets_table') ?? $backpackPasswordBrokerTable,
+                'table'     => $backpackPasswordBrokerTable,
                 'expire'    => config('backpack.base.password_recovery_token_expiration', 60),
                 'throttle'  => config('backpack.base.password_recovery_throttle_notifications'),
             ],


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fix for #4979.
Laravel 10 uses a new name for `password_resets` table » `password_reset_tokens`.

### AFTER - What is happening after this PR?

This PR makes backpack load the table name for password reset from laravel config.
It allows developers to set the table name on backpack config, if they want to. By default it fallback to laravel config.

### Is it a breaking change?

No 🎉
This was never possible to config, so it shouldn't break any project.

### How can we test the before & after?

1) This can be tested in current Laravel 10 projects that were migrated from old Laravel 9 installations, like Backpack demo.
2) To test with new Laravel 10 table name, probably only by creating a new laravel 10 + backpack project.