### PR TITLE
V6 move UI configs to separate file

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -227,6 +227,7 @@ class BackpackServiceProvider extends ServiceProvider
         // use the vendor configuration file as fallback
         $this->mergeConfigFrom(__DIR__.'/config/backpack/crud.php', 'backpack.crud');
         $this->mergeConfigFrom(__DIR__.'/config/backpack/base.php', 'backpack.base');
+        $this->mergeConfigFrom(__DIR__.'/config/backpack/ui.php', 'backpack.ui');
         $this->mergeConfigsFromDirectory('operations');
 
         // add the root disk to filesystem configuration

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -4,143 +4,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Look & feel customizations
+    | Theme (User Interface)
     |--------------------------------------------------------------------------
-    |
-    | Make it yours.
-    |
     */
+    // Change the view namespace in order to load a different theme than the one Backpack provides.
+    // You can create child themes yourself, by creating a view folder anywhere in your resources/views
+    // and choosing that view_namespace instead of the default one. Backpack will load a file from there
+    // if it exists, otherwise it will load it from the default namespace ("backpack::").
 
-    // Date & Datetime Format Syntax: https://carbon.nesbot.com/docs/#api-localization
-    'default_date_format'     => 'D MMM YYYY',
-    'default_datetime_format' => 'D MMM YYYY, HH:mm',
+    'view_namespace' => 'backpack::',
 
-    // Direction, according to language
-    // (left-to-right vs right-to-left)
-    'html_direction' => 'ltr',
+    // EXAMPLE: if you create a new folder in resources/views/vendor/myname/mypackage,
+    // your namespace would be the one below. IMPORTANT: in this case the namespace ends with a dot.
+    // 'view_namespace' => 'vendor.myname.mypackage.',
 
-    // ----
-    // HEAD
-    // ----
-
-    // Project name. Shown in the window title.
-    'project_name' => 'Backpack Admin Panel',
-
-    // When clicking on the admin panel's top-left logo/name,
-    // where should the user be redirected?
-    // The string below will be passed through the url() helper.
-    // - default: '' (project root)
-    // - alternative: 'admin' (the admin's dashboard)
-    'home_link' => '',
-
-    // Content of the HTML meta robots tag to prevent indexing and link following
-    'meta_robots_content' => 'noindex, nofollow',
-
-    // ---------
-    // DASHBOARD
-    // ---------
-
-    // Show "Getting Started with Backpack" info block?
-    'show_getting_started' => env('APP_ENV') == 'local',
-
-    // ------
-    // STYLES
-    // ------
-
-    // CSS files that are loaded in all pages, using Laravel's asset() helper
-    'styles' => [
-        // 'styles/example.css',
-        // 'https://some-cdn.com/example.css',
+    // Tell Backpack to look in more places for component views (like widgets)
+    'component_view_namespaces' => [
+        'widgets' => [
+            'backpack::widgets', // falls back to 'resources/views/vendor/backpack/base/widgets'
+        ],
     ],
-
-    // CSS files that are loaded in all pages, using Laravel's mix() helper
-    'mix_styles' => [ // file_path => manifest_directory_path
-        // 'css/app.css' => '',
-    ],
-
-    // CSS files that are loaded in all pages, using Laravel's @vite() helper
-    // Please note that support for Vite was added in Laravel 9.19. Earlier versions are not able to use this feature.
-    'vite_styles' => [ // resource file_path
-        // 'resources/css/app.css' => '',
-    ],
-
-    // ------
-    // HEADER
-    // ------
-
-    // Menu logo. You can replace this with an <img> tag if you have a logo.
-    'project_logo'   => '<b>Back</b>pack',
-
-    // Show / hide breadcrumbs on admin panel pages.
-    'breadcrumbs' => true,
-
-    // Horizontal navbar classes. Helps make the admin panel look similar to your project's design.
-    'header_class' => 'app-header bg-light border-0 navbar',
-    // For background colors use: bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
-    // For links to be visible on different background colors use: "navbar-dark", "navbar-light", "navbar-color"
-
-    // ----
-    // BODY
-    // ----
-
-    // Body element classes.
-    'body_class' => 'app aside-menu-fixed sidebar-lg-show',
-    // Try sidebar-hidden, sidebar-fixed, sidebar-compact, sidebar-lg-show
-
-    // Sidebar element classes.
-    'sidebar_class' => 'sidebar sidebar-pills bg-light',
-    // Remove "sidebar-transparent" for standard sidebar look
-    // Try "sidebar-light" or "sidebar-dark" for dark/light links
-    // You can also add a background class like bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
-
-    // ------
-    // FOOTER
-    // ------
-
-    // Footer element classes.
-    'footer_class' => 'app-footer d-print-none',
-    // hide it with d-none
-    // change background color with bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
-
-    // Developer or company name. Shown in footer.
-    'developer_name' => 'Cristian Tabacitu',
-
-    // Developer website. Link in footer. Type false if you want to hide it.
-    'developer_link' => 'http://tabacitu.ro',
-
-    // Show powered by Laravel Backpack in the footer? true/false
-    'show_powered_by' => true,
-
-    // -------
-    // SCRIPTS
-    // -------
-
-    // JS files that are loaded in all pages, using Laravel's asset() helper
-    'scripts' => [
-        // 'js/example.js',
-        // 'https://unpkg.com/vue@2.4.4/dist/vue.min.js',
-        // 'https://unpkg.com/react@16/umd/react.production.min.js',
-        // 'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
-    ],
-
-    // JS files that are loaded in all pages, using Laravel's mix() helper
-    'mix_scripts' => [ // file_path => manifest_directory_path
-        // 'js/app.js' => '',
-    ],
-
-    // JS files that are loaded in all pages, using Laravel's @vite() helper
-    'vite_scripts' => [ // resource file_path
-        // 'resources/js/app.js',
-    ],
-
-    // -------------
-    // CACHE-BUSTING
-    // -------------
-
-    // All JS and CSS assets defined above have this string appended as query string (?v=string).
-    // If you want to manually trigger cachebusting for all styles and scripts,
-    // append or prepend something to the string below, so that it's different.
-    'cachebusting_string' => \PackageVersions\Versions::getVersion('backpack/crud'),
 
     /*
     |--------------------------------------------------------------------------
@@ -274,29 +157,6 @@ return [
     // Gravatar fallback options are 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'
     // 'blank' will keep the generic image with the user first letter
     'gravatar_fallback' => 'blank',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Theme (User Interface)
-    |--------------------------------------------------------------------------
-    */
-    // Change the view namespace in order to load a different theme than the one Backpack provides.
-    // You can create child themes yourself, by creating a view folder anywhere in your resources/views
-    // and choosing that view_namespace instead of the default one. Backpack will load a file from there
-    // if it exists, otherwise it will load it from the default namespace ("backpack::").
-
-    'view_namespace' => 'backpack::',
-
-    // EXAMPLE: if you create a new folder in resources/views/vendor/myname/mypackage,
-    // your namespace would be the one below. IMPORTANT: in this case the namespace ends with a dot.
-    // 'view_namespace' => 'vendor.myname.mypackage.',
-
-    // Tell Backpack to look in more places for component views (like widgets)
-    'component_view_namespaces' => [
-        'widgets' => [
-            'backpack::widgets', // falls back to 'resources/views/vendor/backpack/base/widgets'
-        ],
-    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -1,0 +1,115 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Look & feel customizations
+    |--------------------------------------------------------------------------
+    |
+    | To make the UI feel yours.
+    |
+    | Note that values set here might be overriden by theme config files
+    | (eg. config/backpack/theme-tabler.php) when that theme is in use.
+    |
+    */
+
+    // Date & Datetime Format Syntax: https://carbon.nesbot.com/docs/#api-localization
+    'default_date_format'     => 'D MMM YYYY',
+    'default_datetime_format' => 'D MMM YYYY, HH:mm',
+
+    // Direction, according to language
+    // (left-to-right vs right-to-left)
+    'html_direction' => 'ltr',
+
+    // ----
+    // HEAD
+    // ----
+
+    // Project name - shown in the window title
+    'project_name' => 'Backpack Admin Panel',
+
+    // Content of the HTML meta robots tag to prevent indexing and link following
+    'meta_robots_content' => 'noindex, nofollow',
+
+    // ------
+    // HEADER
+    // ------
+
+    // When clicking on the admin panel's top-left logo/name,
+    // where should the user be redirected?
+    // The string below will be passed through the url() helper.
+    // - default: '' (project root)
+    // - alternative: 'admin' (the admin's dashboard)
+    'home_link' => '',
+
+    // Menu logo. You can replace this with an <img> tag if you have a logo.
+    'project_logo'   => '<b>Back</b>pack',
+
+    // Show / hide breadcrumbs on admin panel pages.
+    'breadcrumbs' => true,
+
+    // ------
+    // FOOTER
+    // ------
+
+    // Developer or company name. Shown in footer.
+    'developer_name' => 'Cristian Tabacitu',
+
+    // Developer website. Link in footer. Type false if you want to hide it.
+    'developer_link' => 'http://tabacitu.ro',
+
+    // Show powered by Laravel Backpack in the footer? true/false
+    'show_powered_by' => true,
+
+    // ---------
+    // DASHBOARD
+    // ---------
+
+    // Show "Getting Started with Backpack" info block?
+    'show_getting_started' => env('APP_ENV') == 'local',
+
+    // -------------
+    // GLOBAL STYLES
+    // -------------
+
+    // CSS files that are loaded in all pages, using Laravel's asset() helper
+    'styles' => [
+        // 'styles/example.css',
+        // 'https://some-cdn.com/example.css',
+    ],
+
+    // CSS files that are loaded in all pages, using Laravel's mix() helper
+    'mix_styles' => [ // file_path => manifest_directory_path
+        // 'css/app.css' => '',
+    ],
+
+    // CSS files that are loaded in all pages, using Laravel's @vite() helper
+    // Please note that support for Vite was added in Laravel 9.19. Earlier versions are not able to use this feature.
+    'vite_styles' => [ // resource file_path
+        // 'resources/css/app.css' => '',
+    ],
+
+    // --------------
+    // GLOBAL SCRIPTS
+    // --------------
+
+    // JS files that are loaded in all pages, using Laravel's asset() helper
+    'scripts' => [
+        // 'js/example.js',
+        // 'https://unpkg.com/vue@2.4.4/dist/vue.min.js',
+        // 'https://unpkg.com/react@16/umd/react.production.min.js',
+        // 'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
+    ],
+
+    // JS files that are loaded in all pages, using Laravel's mix() helper
+    'mix_scripts' => [ // file_path => manifest_directory_path
+        // 'js/app.js' => '',
+    ],
+
+    // JS files that are loaded in all pages, using Laravel's @vite() helper
+    'vite_scripts' => [ // resource file_path
+        // 'resources/js/app.js',
+    ],
+
+];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -241,12 +241,20 @@ if (! function_exists('backpack_theme_config')) {
      * @param string
      * @return string
      */
-    function backpack_theme_config($string)
+    function backpack_theme_config($key)
     {
-        $key = config('backpack.base.view_namespace').$string;
-        $key = str_replace('::', '.', $key);
+        $namespacedKey = config('backpack.base.view_namespace').$key;
+        $namespacedKey = str_replace('::', '.', $namespacedKey);
 
-        return config($key);
+        // if the config exists in the theme config file, use it
+        if (config()->has($namespacedKey)) {
+            return config($namespacedKey);
+        }
+
+        // if not, fall back to a general config/backpack/theme.php file
+        $namespacedKey = 'backpack.ui.'.$key;
+
+        return config($namespacedKey);
     }
 }
 

--- a/src/resources/views/crud/columns/date.blade.php
+++ b/src/resources/views/crud/columns/date.blade.php
@@ -4,7 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['format'] = $column['format'] ?? config('backpack.base.default_date_format');
+    $column['format'] = $column['format'] ?? backpack_theme_config('default_date_format');
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {

--- a/src/resources/views/crud/columns/datetime.blade.php
+++ b/src/resources/views/crud/columns/datetime.blade.php
@@ -4,7 +4,7 @@
     $column['escaped'] = $column['escaped'] ?? true;
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
-    $column['format'] = $column['format'] ?? config('backpack.base.default_datetime_format');
+    $column['format'] = $column['format'] ?? backpack_theme_config('default_datetime_format');
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Our `config/backpack/base.php` file was bloated by a bunch of configs that didn't relate to CRUD itself... they related to the UI. And since that whole UI was moved into separate packages (as themes)... they didn't really make sense inside a `config/backpack/base.php` file...

In addition... themes might want to override some of the configs. And we didn't provide a way for them to do that.

### AFTER - What is happening after this PR?

I have separated all the UI-related configs to a different file, `config/backpack/ui.php`. EVERYTHING is kept the same way it was in `base.php`, for easier upgrades, EXCEPT for the CSS classes. Those have been moved:
- from `header_class` to `classes.header`
- from `body_class` to `classes.body`
- from `footer_class` to `classes.footer`
- from `sidebar_class` to `classes.sidebar`

But that's actually not done HERE, in this PR. It's done in the PR to the CoreUIv2 theme. By default, `ui.php` provides no classes, because it provides no interface.

## HOW

### How did you achieve that, in technical terms?

- moved the configs from `base.php` to `ui.php`
- made sure that `ui.php` config file is registered
- made `backpack_theme_config()` fall back to `ui.php` if that key isn't found in the theme config file

### Is it a breaking change?

Yup
