### PR TITLE
[Feature] Add option to display actions column as dropdown

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -318,6 +318,17 @@ trait Columns
     }
 
     /**
+     * Set actions column as dropdown
+     * in the CRUD table view.
+     */
+    public function displayActionsColumnAsDropdown(): self
+    {
+        $this->setOperationSetting('actionsColumnAsDropdown', true);
+
+        return $this;
+    }
+
+    /**
      * Check if a column exists, by any given attribute.
      *
      * @param  string  $attribute  Attribute name on that column definition array.

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -321,9 +321,9 @@ trait Columns
      * Set actions column as dropdown
      * in the CRUD table view.
      */
-    public function displayActionsColumnAsDropdown(bool $value): self
+    public function displayActionsColumnAsDropdown(): self
     {
-        $this->setOperationSetting('actionsColumnAsDropdown', $value);
+        $this->setOperationSetting('actionsColumnAsDropdown', true);
 
         return $this;
     }

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -321,9 +321,9 @@ trait Columns
      * Set actions column as dropdown
      * in the CRUD table view.
      */
-    public function displayActionsColumnAsDropdown(): self
+    public function displayActionsColumnAsDropdown(bool $value): self
     {
-        $this->setOperationSetting('actionsColumnAsDropdown', true);
+        $this->setOperationSetting('actionsColumnAsDropdown', $value);
 
         return $this;
     }

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -47,7 +47,7 @@ return [
     'actionsColumnPriority' => 1,
 
     // Nest action buttons within a dropdown in actions column
-    'actionsColumnAsDropdown' => true,
+    'actionsColumnAsDropdown' => false,
 
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -46,6 +46,9 @@ return [
     // - 4 - less important than most columns
     'actionsColumnPriority' => 1,
 
+    // Nest action buttons within a dropdown in actions column
+    'actionsColumnAsDropdown' => true,
+
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)
     // that allows the user to erase local storage for that datatable,

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -166,9 +166,9 @@ form .select2.select2-container {
 #crudTable_wrapper table.dataTable tr td:first-child {
     display: flex;
     align-items: center;
-    padding-top: 1rem !important;
-    padding-bottom: 1rem !important;
-    padding-left: 0.6rem !important;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 0.6rem;
 }
 
 #crudTable_wrapper .dt-buttons .dt-button-collection,

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -166,9 +166,9 @@ form .select2.select2-container {
 #crudTable_wrapper table.dataTable tr td:first-child {
     display: flex;
     align-items: center;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    padding-left: 0.6rem;
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+    padding-left: 0.6rem !important;
 }
 
 #crudTable_wrapper .dt-buttons .dt-button-collection,

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -164,7 +164,6 @@ form .select2.select2-container {
 #crudTable_wrapper #crudTable tr td:first-child,
 #crudTable_wrapper table.dataTable tr th:first-child,
 #crudTable_wrapper table.dataTable tr td:first-child {
-    display: flex;
     align-items: center;
     padding-top: 1rem !important;
     padding-bottom: 1rem !important;

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -360,6 +360,20 @@
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
+          @if($crud->getOperationSetting('actionsColumnAsDropdown'))
+          // Transform actions buttons into a dropdown
+          $('#crudTable').find('td:last-child').map((index, el) => {
+              const cell = $(el);
+              const buttons = $(cell).find('a');
+              cell.wrapInner('<div class="nav-item dropdown"></div>');
+              cell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+              buttons.map((index, action) => {
+                  $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
+                  $(action).find('i').addClass('me-2');
+              });
+              cell.prepend('<a class="nav-link dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+          });
+          @endif
       } ).dataTable();
 
       // when datatables-colvis (column visibility) is toggled

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -371,7 +371,7 @@
                   $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                   $(action).find('i').addClass('me-2');
               });
-              cell.prepend('<a class="nav-link dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+              cell.prepend('<a class="btn bg-light dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
           });
           @endif
       } ).dataTable();

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -371,7 +371,7 @@
                   $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                   $(action).find('i').addClass('me-2');
               });
-              cell.prepend('<a class="btn bg-light dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+              cell.prepend('<a class="btn btn-outline-dark bp-action-button dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
           });
           @endif
       } ).dataTable();

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -371,7 +371,7 @@
                   $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                   $(action).find('i').addClass('me-2');
               });
-              cell.prepend('<a class="btn btn-outline-dark bp-action-button dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+              cell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-dark dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
           });
           @endif
       } ).dataTable();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Nothing! [Here](https://github.com/Laravel-Backpack/CRUD/issues/4963) it is well explained.

### AFTER - What is happening after this PR?

Basically... this!

![actions-column-as-dropdown-button](https://user-images.githubusercontent.com/33960976/227874064-b353f995-3935-4883-9f52-ae9b17896835.gif)


## HOW

### How did you achieve that, in technical terms?

Most changes are done in js, `src/resources/views/crud/inc/datatables_logic.blade.php`. A new operation setting is added in order to control it `actionsColumnAsDropdown`, since there might be people nostalgic about the old ways... :)

```
$this->crud->displayActionsColumnAsDropdown(false);
```


### Is it a breaking change?

Nope.


### How can we test the before & after?

Checkout this branch and test if columns can now be displayed as dropdown. Also, `$this->crud->displayActionsColumnAsDropdown(false);` should revert it to the old line stack.

