### PR TITLE
[Feature] Use dropdown for actions column on List operation

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -318,6 +318,17 @@ trait Columns
     }
 
     /**
+     * Set actions column as dropdown
+     * in the CRUD table view.
+     */
+    public function displayActionsColumnAsDropdown(): self
+    {
+        $this->setOperationSetting('actionsColumnAsDropdown', true);
+
+        return $this;
+    }
+
+    /**
      * Check if a column exists, by any given attribute.
      *
      * @param  string  $attribute  Attribute name on that column definition array.

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -318,17 +318,6 @@ trait Columns
     }
 
     /**
-     * Set actions column as dropdown
-     * in the CRUD table view.
-     */
-    public function displayActionsColumnAsDropdown(): self
-    {
-        $this->setOperationSetting('actionsColumnAsDropdown', true);
-
-        return $this;
-    }
-
-    /**
      * Check if a column exists, by any given attribute.
      *
      * @param  string  $attribute  Attribute name on that column definition array.

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -47,7 +47,7 @@ return [
     'actionsColumnPriority' => 1,
 
     // Nest action buttons within a dropdown in actions column
-    'actionsColumnAsDropdown' => false,
+    'lineButtonsAsDropdown' => false,
 
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -46,6 +46,9 @@ return [
     // - 4 - less important than most columns
     'actionsColumnPriority' => 1,
 
+    // Nest action buttons within a dropdown in actions column
+    'actionsColumnAsDropdown' => false,
+
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)
     // that allows the user to erase local storage for that datatable,

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -359,24 +359,23 @@
             crud.executeFunctionByName(functionName);
          });
           @if($crud->getOperationSetting('actionsColumnAsDropdown'))
-          // Get last column
-          $('#crudTable').find('td:last-child').map((index, el) => {
-              const actionButtons = $(el).find('a.btn.btn-link');
-              if (actionButtons.length === 0) {
-                  // This might not be the action column
-                  return;
-              }
-              // Wrap the cell with the component needed for the dropdown
-              const cell = $(el);
-              cell.wrapInner('<div class="nav-item dropdown"></div>');
-              cell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
-              // Prepare buttons as dropdown items
-              actionButtons.map((index, action) => {
-                  $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
-                  $(action).find('i').addClass('me-2 text-primary');
+          // Get action column
+          const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
+          if (actionColumnIndex !== -1) {
+              $('#crudTable tr').each(function (i, tr) {
+                  const actionCell = $(tr).find('td').eq(actionColumnIndex);
+                  const actionButtons = $(actionCell).find('a.btn.btn-link');
+                  // Wrap the cell with the component needed for the dropdown
+                  actionCell.wrapInner('<div class="nav-item dropdown"></div>');
+                  actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+                  // Prepare buttons as dropdown items
+                  actionButtons.map((index, action) => {
+                      $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
+                      $(action).find('i').addClass('me-2 text-primary');
+                  });
+                  actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
               });
-              cell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
-          });
+          }
           @endif
       }).dataTable();
 

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -358,7 +358,27 @@
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
-      } ).dataTable();
+          @if($crud->getOperationSetting('actionsColumnAsDropdown'))
+          // Get last column
+          $('#crudTable').find('td:last-child').map((index, el) => {
+              const actionButtons = $(el).find('a.btn.btn-link');
+              if (actionButtons.length === 0) {
+                  // This might not be the action column
+                  return;
+              }
+              // Wrap the cell with the component needed for the dropdown
+              const cell = $(el);
+              cell.wrapInner('<div class="nav-item dropdown"></div>');
+              cell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+              // Prepare buttons as dropdown items
+              actionButtons.map((index, action) => {
+                  $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
+                  $(action).find('i').addClass('me-2 text-primary');
+              });
+              cell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+          });
+          @endif
+      }).dataTable();
 
       // when datatables-colvis (column visibility) is toggled
       // rebuild the datatable using the datatable-responsive plugin

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -358,7 +358,7 @@
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
-          @if($crud->getOperationSetting('actionsColumnAsDropdown'))
+          @if($crud->getOperationSetting('lineButtonsAsDropdown'))
           // Get action column
           const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
           if (actionColumnIndex !== -1) {

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -110,6 +110,7 @@
                   <th data-orderable="false"
                       data-priority="{{ $crud->getActionsColumnPriority() }}"
                       data-visible-in-export="false"
+                      data-action-column="true"
                       >{{ trans('backpack::crud.actions') }}</th>
                 @endif
               </tr>


### PR DESCRIPTION
# Feature Request

### What's the feature you think Backpack should have?

As devs add more and more inline operations, the actions column gets crowded quickly. It would be great to have a dropdown button that groups all actions and displays them in a compact way.

### Have you already implemented a prototype solution, for your own project?

I did something for my projects, but I don't think it can be used here. Short answer, no :)

### Do you see this as a core feature or an add-on?

Just an improvement.

![dropdown](https://user-images.githubusercontent.com/33960976/228809544-0d5a0d94-9195-4f45-9e20-e9ea32932f49.png)