### PR TITLE
Fix subfields check in Update operation

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -167,7 +167,7 @@ trait Update
                 }
 
                 // when subfields exists developer used the repeatable interface to manage this relation
-                if ($field['subfields']) {
+                if (isset($field['subfields'])) {
                     return [$this->getSubfieldsValues($field['subfields'], $model)];
                 }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fix for https://github.com/Laravel-Backpack/CRUD/issues/5002

Checking for the existence of subfields in the Update operation is not strict enough.

### AFTER - What is happening after this PR?

This PR uses `isset()` to check the array key existence and hence solves the bug.

## HOW

### Is it a breaking change?

No

### How can we test the before & after?

By adding a field within a CRUD with the following configuration: 

```php
$this->crud->addField([
    'label' => 'Category', 
    'type' => 'select', 
    'name' => 'category_id', 
    'entity' => 'category', 
    'attribute' => 'category_name', 
    'model' => 'App\Models\Category'
]);
```