### PR TITLE
Fix old reference to Digitally Happy Assets

### DIFF
--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -46,7 +46,7 @@
 		      	@include('crud::form_content', [ 'fields' => $crud->fields(), 'action' => 'create' ])
 		      @endif
                 {{-- This makes sure that all field assets are loaded. --}}
-                <div class="d-none" id="parentLoadedAssets">{{ json_encode(Assets::loaded()) }}</div>
+                <div class="d-none" id="parentLoadedAssets">{{ json_encode(Basset::loaded()) }}</div>
 	          @include('crud::inc.form_save_buttons')
 		  </form>
 	</div>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -62,7 +62,7 @@
 		      	@include('crud::form_content', ['fields' => $crud->fields(), 'action' => 'edit'])
               @endif
               {{-- This makes sure that all field assets are loaded. --}}
-            <div class="d-none" id="parentLoadedAssets">{{ json_encode(Assets::loaded()) }}</div>
+            <div class="d-none" id="parentLoadedAssets">{{ json_encode(Basset::loaded()) }}</div>
             @include('crud::inc.form_save_buttons')
 		  </form>
 	</div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was some old references of Digitally Happy Assets

### AFTER - What is happening after this PR?

It uses Bassets now.