### PR TITLE
provide a fallback view namespace for themes

### DIFF
--- a/src/ViewNamespaces.php
+++ b/src/ViewNamespaces.php
@@ -57,7 +57,7 @@ class ViewNamespaces
     {
         return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ??
             [config('backpack.ui.view_namespace').$domain] ??
-            [config('backpack.ui.view_namespace_fallback') . $domain];
+            [config('backpack.ui.view_namespace_fallback').$domain];
     }
 
     /**

--- a/src/ViewNamespaces.php
+++ b/src/ViewNamespaces.php
@@ -56,7 +56,8 @@ class ViewNamespaces
     private static function getFromConfigFor(string $domain, $customConfigKey = null)
     {
         return config($customConfigKey ?? 'backpack.crud.view_namespaces.'.$domain) ??
-            [config('backpack.base.view_namespace').$domain];
+            [config('backpack.ui.view_namespace').$domain] ??
+            [config('backpack.ui.view_namespace_fallback') . $domain];
     }
 
     /**

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -159,7 +159,7 @@ class Widget extends Fluent
         $type = $this->type;
         $paths = array_map(function ($item) use ($type) {
             return $item.'.'.$type;
-        }, ViewNamespaces::getWithFallbackFor('widgets', 'backpack.base.component_view_namespaces.widgets'));
+        }, ViewNamespaces::getWithFallbackFor('widgets', 'backpack.ui.component_view_namespaces.widgets'));
 
         foreach ($paths as $path) {
             if (view()->exists($path)) {

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -4,32 +4,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Theme (User Interface)
-    |--------------------------------------------------------------------------
-    */
-    // Change the view namespace in order to load a different theme than the one Backpack provides.
-    // You can create child themes yourself, by creating a view folder anywhere in your resources/views
-    // and choosing that view_namespace instead of the default one. Backpack will load a file from there
-    // if it exists, otherwise it will load it from the fallback namespace.
-
-    'view_namespace' => env('BACKPACK_THEME', 'backpack.theme-tabler').'::',
-
-    // When a view doesn't exist in the current theme, fall back to:
-    'view_namespace_fallback' => 'backpack.theme-tabler::',
-
-    // EXAMPLE: if you create a new folder in resources/views/vendor/myname/mypackage,
-    // your namespace would be the one below. IMPORTANT: in this case the namespace ends with a dot.
-    // 'view_namespace' => 'vendor.myname.mypackage.',
-
-    // Tell Backpack to look in more places for component views (like widgets)
-    'component_view_namespaces' => [
-        'widgets' => [
-            'backpack::widgets', // falls back to 'resources/views/vendor/backpack/base/widgets'
-        ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Registration Open
     |--------------------------------------------------------------------------
     |

--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Theme (User Interface)
+    |--------------------------------------------------------------------------
+    */
+    // Change the view namespace in order to load a different theme than the one Backpack provides.
+    // You can create child themes yourself, by creating a view folder anywhere in your resources/views
+    // and choosing that view_namespace instead of the default one. Backpack will load a file from there
+    // if it exists, otherwise it will load it from the fallback namespace.
+
+    'view_namespace' => 'backpack.theme-tabler::',
+    'view_namespace_fallback' => 'backpack.theme-tabler::',
+
+    /*
+    |--------------------------------------------------------------------------
     | Look & feel customizations
     |--------------------------------------------------------------------------
     |

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -252,14 +252,14 @@ if (! function_exists('backpack_theme_config')) {
         }
 
         // if not, fall back to a general the config in the fallback theme
-        $namespacedKey = config('backpack.ui.view_namespace_fallback') . $key;
+        $namespacedKey = config('backpack.ui.view_namespace_fallback').$key;
         $namespacedKey = str_replace('::', '.', $namespacedKey);
 
         if (config()->has($namespacedKey)) {
             return config($namespacedKey);
         }
 
-        return config('backpack.ui.' . $key);
+        return config('backpack.ui.'.$key);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -216,8 +216,8 @@ if (! function_exists('backpack_view')) {
      */
     function backpack_view($view)
     {
-        $theme = config('backpack.base.view_namespace');
-        $fallbackTheme = config('backpack.base.view_namespace_fallback');
+        $theme = config('backpack.ui.view_namespace');
+        $fallbackTheme = backpack_theme_config('view_namespace_fallback');
 
         if (is_null($theme)) {
             $theme = $fallbackTheme;
@@ -243,7 +243,7 @@ if (! function_exists('backpack_theme_config')) {
      */
     function backpack_theme_config($key)
     {
-        $namespacedKey = config('backpack.base.view_namespace').$key;
+        $namespacedKey = config('backpack.ui.view_namespace').$key;
         $namespacedKey = str_replace('::', '.', $namespacedKey);
 
         // if the config exists in the theme config file, use it
@@ -252,7 +252,7 @@ if (! function_exists('backpack_theme_config')) {
         }
 
         // if not, fall back to a general the config in the fallback theme
-        $namespacedKey = config('backpack.base.view_namespace_fallback') . $key;
+        $namespacedKey = config('backpack.ui.view_namespace_fallback') . $key;
         $namespacedKey = str_replace('::', '.', $namespacedKey);
 
         if (config()->has($namespacedKey)) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When you wanted to create a new theme... you couldn't re-use files from a different theme. You had to create ALL NEEDED FILES. Which.. isn't practical.

Rephrased... we had a one-theme system. But we wanted a parent-child theme system.

### AFTER - What is happening after this PR?

We define two view namespaces:
```php
    'view_namespace' => 'backpack.theme-tabler::',
    'view_namespace_fallback' => 'backpack.theme-tabler::',
```

This is done in `config/ui.php`, which means... it can also be overridden by the theme 🤯

That means a new theme, say `theme-custom` can require `theme-tabler` and just provide a few more files, that are different... as long as it specifies in its config file that the `view_namespace_fallback` should be `backpack.theme-tabler::`

## HOW

### How did you achieve that, in technical terms?

- moved view namespace configs from `config/base.php` to `ui.php`;
- added new `view_namespace_fallback` config which is used in the helpers that need it;

### Is it a breaking change?

Yes. Because we moved the config from `base` to `ui`. That's where you should define your theme now.
