### PR TITLE
Drop L9 support & other old dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,20 +32,19 @@
         }
     ],
     "require": {
-        "laravel/framework": "^10.0|^9.0|^8.69",
-        "prologue/alerts": "^1.0|^0.4",
+        "laravel/framework": "^10.0",
+        "prologue/alerts": "^1.0",
         "backpack/theme-tabler": "dev-main as 1.0.0",
         "backpack/basset": "dev-main as 0.99.99",
         "creativeorange/gravatar": "~1.0",
-        "composer/package-versions-deprecated": "^1.8",
-        "doctrine/dbal": "^2.5|^3.0",
-        "guzzlehttp/guzzle": "^7.0|^6.3"
+        "doctrine/dbal": "^3.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0|~7.0|~9.0",
-        "scrutinizer/ocular": "~1.7|~1.1",
-        "orchestra/testbench": "^8.0|^7.0|^6.0|^5.0|^4.0|^3.0",
-        "spatie/laravel-translatable": "^4.0|^5.0|^6.0"
+        "phpunit/phpunit": "~10.0|~9.0",
+        "scrutinizer/ocular": "~1.7",
+        "orchestra/testbench": "^8.0",
+        "spatie/laravel-translatable": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Finally! And with it, only support PHP 8.1 🎉 This will make Backpack SO MUCH easier to maintain. 

Along with this change, we can drop support for some other old package versions we're supporting.