### PR TITLE
Add Conditionable trait to support ->when() and ->unless()

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel;
 
+use Illuminate\Support\Traits\Conditionable;
+
 /**
  * Adds fluent syntax to Backpack CRUD Fields.
  *
@@ -34,6 +36,8 @@ namespace Backpack\CRUD\app\Library\CrudPanel;
  */
 class CrudField
 {
+    use Conditionable;
+    
     protected $attributes;
 
     public function __construct($name)


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Nothing

### AFTER - What is happening after this PR?

The Conditionable trait from laravel 8 is added. (Backpack minimum laravel 8 version is higher than when this is added into laravel so it is very safe)

https://www.amitmerchant.com/conditionally-executing-callbacks-conditionable-trait-laravel-8x/

I think this will greatly improve the fluent flexibility and reduce if () clauses as you can chain methods on a conditional basis in a fluent way.


## HOW

### How did you achieve that, in technical terms?

Add the Conditionable trait



### Is it a breaking change?

No


### How can we test the before & after?

Try chaining ->when() or ->unless() method and inside it call other fluent methods conditionally

Feel free to edit this PR and add the Conditionable trait to other classes too (filters, columns.etc), I can add it too if you all want but tell me which classes

I think this is a small change that is a big improvement to developer DX
