### PR TITLE
Fix query binding order

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -256,7 +256,7 @@ trait Query
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
-        
+
         // select only one column for the count
         $subQuery->select($modelTable.'.'.$this->model->getKeyName());
 
@@ -266,9 +266,9 @@ trait Query
         }
 
         // re-set the previous query bindings
-        foreach ($crudQuery->getRawBindings() as $type => $binding) {  
+        foreach ($crudQuery->getRawBindings() as $type => $binding) {
             $subQuery->setBindings($binding, $type);
-        } 
+        }
 
         $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.', '_', $modelTable).'_aggregator');
 

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -256,12 +256,7 @@ trait Query
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
-
-        // re-set the previous query bindings
-        foreach ($crudQuery->getRawBindings() as $type => $binding) {
-            $subQuery->setBindings($binding, $type);
-        }
-
+        
         // select only one column for the count
         $subQuery->select($modelTable.'.'.$this->model->getKeyName());
 
@@ -269,6 +264,11 @@ trait Query
         foreach ($expressionColumns as $expression) {
             $subQuery->selectRaw($expression);
         }
+
+        // re-set the previous query bindings
+        foreach ($crudQuery->getRawBindings() as $type => $binding) {  
+            $subQuery->setBindings($binding, $type);
+        } 
 
         $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.', '_', $modelTable).'_aggregator');
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Bidings were set before expression columns. That's a no-no.

### AFTER - What is happening after this PR?

We set them after the final query is built.

## HOW

### How did you achieve that, in technical terms?

Move them down in the function lifecycle.



### Is it a breaking change?

Absolutely NOT, I don't think so, if it's a BC it's a small one. 🙃 


### How can we test the before & after?

Load RolesCrud list page. 
