### PR TITLE
Cover another edge case related to query bindings

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -277,7 +277,7 @@ trait Query
 
         try {
             $count = $outerQuery->cursor()->first()->total_rows;
-        }catch(\Exception $e){
+        } catch(\Exception $e) {
             dd($e->getMessage());
         }
     }

--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -255,8 +255,7 @@ trait Query
         // this subquery is the "main crud query" without some properties:
         // - columns : we manually select the "minimum" columns possible from database.
         // - orders/limit/offset because we want the "full query count" where orders don't matter and limit/offset would break the total count
-        $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset'])
-                                ->cloneWithoutBindings(['order']);
+        $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
         // select minimum possible columns for the count
         $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? '*' : $modelTable.'.'.$this->model->getKeyName();
@@ -275,10 +274,6 @@ trait Query
 
         $outerQuery = $outerQuery->fromSub($subQuery, str_replace('.', '_', $modelTable).'_aggregator');
 
-        try {
-            $count = $outerQuery->cursor()->first()->total_rows;
-        } catch(\Exception $e) {
-            dd($e->getMessage());
-        }
+        return $outerQuery->cursor()->first()->total_rows;
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In case you used for example `having` without using the `model key (id)` as the constrain, the query would fail. 

Same when using `union`.

### AFTER - What is happening after this PR?

it works without errors 👍 


## HOW

### How did you achieve that, in technical terms?

In case of a query with `having` or `union` clauses we just use the global column selector. (*) 


### Is it a breaking change?

I don't think so, no.


### How can we test the before & after?
