### PR TITLE
add nl2br option for textarea column

### DIFF
--- a/src/resources/views/crud/columns/textarea.blade.php
+++ b/src/resources/views/crud/columns/textarea.blade.php
@@ -5,13 +5,14 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['text'] = $column['default'] ?? '-';
+    $column['nl2br'] = $column['nl2br'] ?? false;
 
     if($column['value'] instanceof \Closure) {
         $column['value'] = $column['value']($entry);
     }
 
     if(!empty($column['value'])) {
-        $column['text'] = $column['prefix'].$column['value'].$column['suffix'];
+        $column['text'] = $column['prefix'].$column['nl2br'] ? nl2br($column['value']) : $column['value'].$column['suffix'];
     }
 @endphp
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I missed multiple times a simpler way to break lines of a textarea content

### AFTER - What is happening after this PR?

Now, if you have a textarea column, you can set the option `'nl2br' => true` to do so. Like
```php
[
    'name' => 'message',
    'type' => 'textarea',
    'escaped' => false,
    'nl2br' => true
]
```

## HOW

### How did you achieve that, in technical terms?

Added if clause in the column text generation



### Is it a breaking change?

No


### How can we test the before & after?

Change the nl2br (boolean) option on a textarea column
