### PR TITLE
[Bug] Actions Dropdown changes back to line buttons after editable switch is toggled

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -358,9 +358,9 @@
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
-          @if($crud->getOperationSetting('lineButtonsAsDropdown'))
-              formatActionColumnAsDropdown();
-          @endif
+         if ($('#crudTable').data('has-line-buttons-as-dropdown')) {
+          formatActionColumnAsDropdown();
+         }
       }).dataTable();
 
       // when datatables-colvis (column visibility) is toggled

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -359,23 +359,7 @@
             crud.executeFunctionByName(functionName);
          });
           @if($crud->getOperationSetting('lineButtonsAsDropdown'))
-          // Get action column
-          const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
-          if (actionColumnIndex !== -1) {
-              $('#crudTable tr').each(function (i, tr) {
-                  const actionCell = $(tr).find('td').eq(actionColumnIndex);
-                  const actionButtons = $(actionCell).find('a.btn.btn-link');
-                  // Wrap the cell with the component needed for the dropdown
-                  actionCell.wrapInner('<div class="nav-item dropdown"></div>');
-                  actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
-                  // Prepare buttons as dropdown items
-                  actionButtons.map((index, action) => {
-                      $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
-                      $(action).find('i').addClass('me-2 text-primary');
-                  });
-                  actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
-              });
-          }
+              formatActionColumnAsDropdown();
           @endif
       }).dataTable();
 
@@ -415,6 +399,26 @@
       @endif
 
     });
+
+    function formatActionColumnAsDropdown() {
+        // Get action column
+        const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
+        if (actionColumnIndex !== -1) {
+            $('#crudTable tr').each(function (i, tr) {
+                const actionCell = $(tr).find('td').eq(actionColumnIndex);
+                const actionButtons = $(actionCell).find('a.btn.btn-link');
+                // Wrap the cell with the component needed for the dropdown
+                actionCell.wrapInner('<div class="nav-item dropdown"></div>');
+                actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+                // Prepare buttons as dropdown items
+                actionButtons.map((index, action) => {
+                    $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
+                    $(action).find('i').addClass('me-2 text-primary');
+                });
+                actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+            });
+        }
+    }
   </script>
 
   @include('crud::inc.details_row_logic')

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -53,6 +53,7 @@
           data-responsive-table="{{ (int) $crud->getOperationSetting('responsiveTable') }}"
           data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
           data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"
+          data-has-line-buttons-as-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdown') }}"
           cellspacing="0">
             <thead>
               <tr>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The problem is well explained [here](https://github.com/Laravel-Backpack/CRUD/issues/5039).

### AFTER - What is happening after this PR?

The problem is gone.


## HOW

### How did you achieve that, in technical terms?

Moved the logic that adjust the action column into a function that can be called in other places in case the table or any of its given components is re-loaded.

This [PR](https://github.com/Laravel-Backpack/editable-columns/pull/77) on `editable-columns` also is needed.


### Is it a breaking change?

No.


### How can we test the before & after?

Try with and without this branch and the action columns should remain formatted when config(`backpack.list.lineButtonsAsDropdown`) is `true` and an editable column is edited.

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
// editable-columns
git checkout "fix-dropdown-action-buttons"
```
