### PR TITLE
[WIP] valid array instead of upload

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -2,7 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
-use Backpack\CRUD\app\Library\Uploaders\Validation\ValidBackpackUpload;
+use Backpack\CRUD\app\Library\Uploaders\Validation\ValidArray;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
 
@@ -185,7 +185,7 @@ trait Validation
                     $validationRules = explode('|', $validationRules);
                 }
                 foreach ($validationRules as $rule) {
-                    if (is_a($rule, ValidBackpackUpload::class, true)) {
+                    if (is_a($rule, ValidArray::class, true)) {
                         foreach ($rule->arrayRules as $arrayRule) {
                             $key = $this->checkIfRuleIsRequired($key, $arrayRule);
                             if ($key) {

--- a/src/app/Library/Uploaders/Validation/ValidUploadMultiple.php
+++ b/src/app/Library/Uploaders/Validation/ValidUploadMultiple.php
@@ -5,7 +5,7 @@ namespace Backpack\CRUD\app\Library\Uploaders\Validation;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade;
 use Closure;
 
-class ValidUploadMultiple extends ValidBackpackUpload
+class ValidUploadMultiple extends ValidArray
 {
     /**
      * Run the validation rule.
@@ -54,13 +54,13 @@ class ValidUploadMultiple extends ValidBackpackUpload
 
             $this->validateArrayData($attribute, $fail, $data);
 
-            $this->validateFiles($attribute, $value, $fail);
+            $this->validateItems($attribute, $value, $fail);
 
             return;
         }
 
         $this->validateArrayData($attribute, $fail);
 
-        $this->validateFiles($attribute, $value, $fail);
+        $this->validateItems($attribute, $value, $fail);
     }
 }


### PR DESCRIPTION
So this changes the `ValidBackpackUpload` to a more generic `ValidArray` rule. 

This rule can be used by uploads, but also by other arrayable items like `repeatable`. 

So you theoretically could validate your repeatable like this: (probably still need some changes to accomodate the full syntax but ...)
```php
'attachments' => [ValidArray::make()
       ->arrayRules('min:1|max:3')
       ->itemRules([
                  'title' => 'required|min:10', 
                  'file' => [File::types(['pdf'])->max(2048)]
        )
],
// or we can create a syntax sugar with some regex for repeatable fields like:

class ValidRepeatable extends ValidArray {}

'repeatable' => [ValidRepeatable::make()
       ->arrayRules('min:1|max:3')
       ->ruleTitle('required|min:10')
       ->ruleFile( [File::types(['pdf'])->max(2048)])
      ->ruleOtherField()
```