### PR TITLE
[V6] Small adjustments on fields

### DIFF
--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -12,7 +12,7 @@
     {{-- Translatable icon --}}
     @include('crud::fields.inc.translatable_icon')
 
-    <div class="d-inline-flex">
+    <div class="d-inline-flex align-items-center">
         {{-- Switch --}}
         <label class="form-switch switch switch-sm switch-label switch-pill switch-{{ $field['color'] }} mb-0" style="--bg-color: {{ $field['color'] }};">
             <input

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -234,7 +234,7 @@
               "thousands":      "{{ trans('backpack::crud.thousands') }}",
               "lengthMenu":     "{{ trans('backpack::crud.lengthMenu') }}",
               "loadingRecords": "{{ trans('backpack::crud.loadingRecords') }}",
-              "processing":     "<img src='{{ asset('storage/bassets/vendor/backpack/crud/src/resources/assets/img/spinner.svg') }}' alt='{{ trans('backpack::crud.processing') }}'>",
+              "processing":     "<img src='{{ asset('storage/basset/vendor/backpack/crud/src/resources/assets/img/spinner.svg') }}' alt='{{ trans('backpack::crud.processing') }}'>",
               "search": "_INPUT_",
               "searchPlaceholder": "{{ trans('backpack::crud.search') }}...",
               "zeroRecords":    "{{ trans('backpack::crud.zeroRecords') }}",


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The spinner was not showing on tables and switch field was not displayed properly.

### AFTER - What is happening after this PR?

The spinner is showing!


## HOW

### How did you achieve that, in technical terms?

Well, we use `basset` now instead of `bassets`, so changing that did the trick.
For the switch field, just adjust its alignment.


### Is it a breaking change?

No.