### PR TITLE
remove the tabler theme as dependency (aka make unit tests run again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,16 @@
 {
     "name": "backpack/crud",
     "type": "library",
-    "description": "Quickly build an admin interfaces using Laravel, CoreUI, Bootstrap and jQuery.",
+    "description": "Quickly build admin interfaces using Laravel, Bootstrap and JavaScript.",
     "keywords": [
         "backpack",
         "base",
         "admin panel for laravel",
         "coreui for laravel",
-        "bootstrap 4 admin panel laravel",
+        "tabler for laravel",
+        "dashboard for laravel",
+        "admin template for laravel",
+        "bootstrap 5 admin panel laravel",
         "laravel admin",
         "CRUD",
         "BREAD",
@@ -34,7 +37,6 @@
     "require": {
         "laravel/framework": "^10.0",
         "prologue/alerts": "^1.0",
-        "backpack/theme-tabler": "dev-main as 1.0.0",
         "backpack/basset": "^0.15.0",
         "creativeorange/gravatar": "~1.0",
         "doctrine/dbal": "^3.0",

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -77,6 +77,13 @@ class Install extends Command
         $process->run();
         $this->closeProgressBlock();
 
+        // Install Backpack Tabler Theme
+        $this->progressBlock('Installing Tabler Theme');
+        $process = new Process(['composer', 'require', 'backpack/theme-tabler:dev-main']);
+        $process->setTimeout(300);
+        $process->run();
+        $this->closeProgressBlock();
+
         // Optional commands
         if (! $this->option('no-interaction')) {
             // Create users


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We couldn't run the unit tests, because CRUD could not be resolved to an installable set of dependencies. That was due to `backpack/crud` requiring `tabler-theme`, which in turn required `backpack/crud`.


### AFTER - What is happening after this PR?

`tabler-theme` is no longer a dependency of `backpack/crud`, but something that gets installed when you run `php artisan backpack:install`. So it becomes a requirement of the main Laravel app, not CRUD. That way:
- if a developer doesn't want or like it... they can remove it entirely;
- if a theme developer wants to add it as a dependency, to fall back to its views, they can do that, without risking too many version conflicts;

## HOW

### How did you achieve that, in technical terms?

Change in `composer.json` and Installation command.


### Is it a breaking change?

Yes. People who install v6, even the alpha one, will now also need to run `php artisan backpack:install`
