### PR TITLE
[v6] UI fallback for views too

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -46,7 +46,8 @@ class BackpackServiceProvider extends ServiceProvider
      */
     public function boot(Router $router)
     {
-        $this->loadViewsWithFallbacks();
+        $this->loadViewsWithFallbacks('crud');
+        $this->loadViewsWithFallbacks('ui', 'backpack.ui');
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
         $this->loadConfigs();
         $this->registerMiddlewareGroup($this->app->router);
@@ -194,16 +195,18 @@ class BackpackServiceProvider extends ServiceProvider
         }
     }
 
-    public function loadViewsWithFallbacks()
+    public function loadViewsWithFallbacks($dir, $namespace = null)
     {
-        $customCrudFolder = resource_path('views/vendor/backpack/crud');
+        $customFolder = resource_path('views/vendor/backpack/' . $dir);
+        $vendorFolder = realpath(__DIR__ . '/resources/views/' . $dir);
+        $namespace = $namespace ?? $dir;
 
-        // - first the published/overwritten views (in case they have any changes)
-        if (file_exists($customCrudFolder)) {
-            $this->loadViewsFrom($customCrudFolder, 'crud');
+        // first the published/overwritten views (in case they have any changes)
+        if (file_exists($customFolder)) {
+            $this->loadViewsFrom($customFolder, $namespace);
         }
-        // - then the stock views that come with the package, in case a published view might be missing
-        $this->loadViewsFrom(realpath(__DIR__.'/resources/views/crud'), 'crud');
+        // then the stock views that come with the package, in case a published view might be missing
+        $this->loadViewsFrom($vendorFolder, $namespace);
     }
 
     protected function mergeConfigsFromDirectory($dir)

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -197,8 +197,8 @@ class BackpackServiceProvider extends ServiceProvider
 
     public function loadViewsWithFallbacks($dir, $namespace = null)
     {
-        $customFolder = resource_path('views/vendor/backpack/' . $dir);
-        $vendorFolder = realpath(__DIR__ . '/resources/views/' . $dir);
+        $customFolder = resource_path('views/vendor/backpack/'.$dir);
+        $vendorFolder = realpath(__DIR__.'/resources/views/'.$dir);
         $namespace = $namespace ?? $dir;
 
         // first the published/overwritten views (in case they have any changes)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -226,28 +226,28 @@ if (! function_exists('mb_ucfirst')) {
 
 if (! function_exists('backpack_view')) {
     /**
-     * Returns a new displayable view based on the configured backpack view namespace.
-     * If that view doesn't exist, it will load the one from the original theme.
+     * Returns a new displayable view path, based on the configured backpack view namespace.
+     * If that view doesn't exist, it falls back to the fallback namespace.
+     * If that view doesn't exist, it falls back to the one from the Backpack UI directory.
      *
      * @param string (see config/backpack/base.php)
      * @return string
      */
     function backpack_view($view)
     {
-        $theme = config('backpack.ui.view_namespace');
-        $fallbackTheme = backpack_theme_config('view_namespace_fallback');
+        $viewPaths = [
+            config('backpack.ui.view_namespace') . $view,
+            backpack_theme_config('view_namespace_fallback') . $view,
+            'backpack.ui::' . $view,
+        ];
 
-        if (is_null($theme)) {
-            $theme = $fallbackTheme;
+        foreach ($viewPaths as $view) {
+            if (view()->exists($view)) {
+                return $view;
+            }
         }
 
-        $returnView = $theme.$view;
-
-        if (! view()->exists($returnView)) {
-            $returnView = $fallbackTheme.$view;
-        }
-
-        return $returnView;
+        dd('Could not find Backpack view ['.$view.'] in theme namespace, fallback namespace nor UI namespace.');
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Log;
+
 if (! function_exists('backpack_url')) {
     /**
      * Appends the configured backpack prefix and returns
@@ -269,12 +271,22 @@ if (! function_exists('backpack_theme_config')) {
 
         // if not, fall back to a general the config in the fallback theme
         $namespacedKey = config('backpack.ui.view_namespace_fallback').$key;
+        $namespacedKey = str_replace('::', '.', $namespacedKey);
 
         if (config()->has($namespacedKey)) {
             return config($namespacedKey);
         }
 
-        return config('backpack.ui.'.$key);
+        // if not, fall back to the config in ui
+        $namespacedKey = 'backpack.ui.' . $key;
+
+        if (config()->has($namespacedKey)) {
+            return config($namespacedKey);
+        }
+
+        Log::error('Could not find config key: ' . $key . '. Neither in the Backpack theme, nor in the fallback theme, nor in ui.');
+
+        return null;
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -236,9 +236,9 @@ if (! function_exists('backpack_view')) {
     function backpack_view($view)
     {
         $viewPaths = [
-            config('backpack.ui.view_namespace') . $view,
-            backpack_theme_config('view_namespace_fallback') . $view,
-            'backpack.ui::' . $view,
+            config('backpack.ui.view_namespace').$view,
+            backpack_theme_config('view_namespace_fallback').$view,
+            'backpack.ui::'.$view,
         ];
 
         foreach ($viewPaths as $view) {
@@ -278,13 +278,13 @@ if (! function_exists('backpack_theme_config')) {
         }
 
         // if not, fall back to the config in ui
-        $namespacedKey = 'backpack.ui.' . $key;
+        $namespacedKey = 'backpack.ui.'.$key;
 
         if (config()->has($namespacedKey)) {
             return config($namespacedKey);
         }
 
-        Log::error('Could not find config key: ' . $key . '. Neither in the Backpack theme, nor in the fallback theme, nor in ui.');
+        Log::error('Could not find config key: '.$key.'. Neither in the Backpack theme, nor in the fallback theme, nor in ui.');
 
         return null;
     }

--- a/src/resources/views/ui/inc/menu_items.blade.php
+++ b/src/resources/views/ui/inc/menu_items.blade.php
@@ -1,2 +1,2 @@
-{{-- This file is used to store sidebar items, inside the Backpack admin panel --}}
+{{-- This file is used for menu items by any Backpack v6 theme --}}
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('dashboard') }}"><i class="la la-home nav-icon"></i> {{ trans('backpack::base.dashboard') }}</a></li>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We had no way for CRUD to provide views that were used across themes. See https://github.com/Laravel-Backpack/CRUD/issues/5033 which this PR fixes.

### AFTER - What is happening after this PR?

We do.


## HOW

### How did you achieve that, in technical terms?

- the `backpack_view()` helper now looks to the `ui` directory as a last resort
