### PR TITLE
Replace sidebar content command with menu content

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -197,8 +197,8 @@ class BackpackServiceProvider extends ServiceProvider
 
     public function loadViewsWithFallbacks($dir, $namespace = null)
     {
-        $customFolder = resource_path('views/vendor/backpack/' . $dir);
-        $vendorFolder = realpath(__DIR__ . '/resources/views/' . $dir);
+        $customFolder = resource_path('views/vendor/backpack/'.$dir);
+        $vendorFolder = realpath(__DIR__.'/resources/views/'.$dir);
         $namespace = $namespace ?? $dir;
 
         // first the published/overwritten views (in case they have any changes)

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -17,7 +17,7 @@ class BackpackServiceProvider extends ServiceProvider
 
     protected $commands = [
         \Backpack\CRUD\app\Console\Commands\Install::class,
-        \Backpack\CRUD\app\Console\Commands\AddSidebarContent::class,
+        \Backpack\CRUD\app\Console\Commands\AddMenuContent::class,
         \Backpack\CRUD\app\Console\Commands\AddCustomRouteContent::class,
         \Backpack\CRUD\app\Console\Commands\PublishAssets::class,
         \Backpack\CRUD\app\Console\Commands\Version::class,
@@ -130,7 +130,7 @@ class BackpackServiceProvider extends ServiceProvider
 
         // sidebar content views, which are the only views most people need to overwrite
         $backpack_menu_contents_view = [
-            __DIR__.'/resources/views/ui/inc/sidebar_content.blade.php' => resource_path('views/vendor/backpack/theme-tabler/inc/sidebar_content.blade.php'),
+            __DIR__.'/resources/views/ui/inc/menu_items.blade.php' => resource_path('views/vendor/backpack/ui/inc/menu_items.blade.php'),
         ];
         $backpack_custom_routes_file = [__DIR__.$this->customRoutesFilePath => base_path($this->customRoutesFilePath)];
 

--- a/src/app/Console/Commands/AddMenuContent.php
+++ b/src/app/Console/Commands/AddMenuContent.php
@@ -4,9 +4,8 @@ namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
-class AddSidebarContent extends Command
+class AddMenuContent extends Command
 {
     use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
 
@@ -15,15 +14,15 @@ class AddSidebarContent extends Command
      *
      * @var string
      */
-    protected $signature = 'backpack:add-sidebar-content
-                                {code : HTML/PHP code that shows the sidebar item. Use either single quotes or double quotes. Never both. }';
+    protected $signature = 'backpack:add-menu-content
+                                {code : HTML/PHP code that shows menu items. Use either single quotes or double quotes. Never both. }';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Add HTML/PHP code to the Backpack sidebar_content file';
+    protected $description = 'Add HTML/PHP code to the Backpack menu_items file';
 
     /**
      * Create a new command instance.
@@ -42,20 +41,17 @@ class AddSidebarContent extends Command
      */
     public function handle()
     {
-        $theme_subdirectory = Str::of(config('backpack.ui.view_namespace'))
-                    ->replace('.', '/')
-                    ->replace('::', '');
-        $path = 'resources/views/vendor/'.$theme_subdirectory.'/inc/sidebar_content.blade.php';
+        $path = 'resources/views/vendor/backpack/ui/inc/menu_items.blade.php';
         $disk_name = config('backpack.base.root_disk_name');
         $disk = Storage::disk($disk_name);
         $code = $this->argument('code');
 
-        $this->progressBlock("Adding sidebar entry to <fg=blue>$path</>");
+        $this->progressBlock("Adding menu entry to <fg=blue>$path</>");
 
         // Validate file exists
         if (! $disk->exists($path)) {
             $this->errorProgressBlock();
-            $this->note('The sidebar_content file does not exist. Make sure Backpack is properly installed.', 'red');
+            $this->note('The menu_items file does not exist. Make sure Backpack is properly installed.', 'red');
 
             return;
         }
@@ -72,7 +68,7 @@ class AddSidebarContent extends Command
 
         if (! $disk->put($path, $contents.PHP_EOL.$code)) {
             $this->errorProgressBlock();
-            $this->note('Could not write to sidebar_content file.', 'red');
+            $this->note('Could not write to menu_items file.', 'red');
 
             return;
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -236,9 +236,9 @@ if (! function_exists('backpack_view')) {
     function backpack_view($view)
     {
         $viewPaths = [
-            config('backpack.ui.view_namespace') . $view,
-            backpack_theme_config('view_namespace_fallback') . $view,
-            'backpack.ui::' . $view,
+            config('backpack.ui.view_namespace').$view,
+            backpack_theme_config('view_namespace_fallback').$view,
+            'backpack.ui::'.$view,
         ];
 
         foreach ($viewPaths as $view) {
@@ -278,13 +278,13 @@ if (! function_exists('backpack_theme_config')) {
         }
 
         // if not, fall back to the config in ui
-        $namespacedKey = 'backpack.ui.' . $key;
+        $namespacedKey = 'backpack.ui.'.$key;
 
         if (config()->has($namespacedKey)) {
             return config($namespacedKey);
         }
 
-        Log::error('Could not find config key: ' . $key . '. Neither in the Backpack theme, nor in the fallback theme, nor in ui.');
+        Log::error('Could not find config key: '.$key.'. Neither in the Backpack theme, nor in the fallback theme, nor in ui.');
 
         return null;
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were using a `php artisan backpack:add-sidebar-content "Something"` command, which no longer made sense. In v6 we're no longer using `sidebar_content.blade.php` to store the menu items but `menu_items.blade.php`

### AFTER - What is happening after this PR?

We add a new command `php artisan backpack:add-menu-content "Something"` that does the same thing and we remove the old one.
