### PR TITLE
Add attribute to validation array

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -315,7 +315,7 @@ trait Validation
                 return array_key_exists('validationAttribute', $value) || array_key_exists('subfields', $value);
             })->each(function ($item, $key) use (&$attributes) {
                 if (isset($item['validationAttribute'])) {
-                    $attributes[$key] = $item['validationAttribute']; 
+                    $attributes[$key] = $item['validationAttribute'];
                 }
                 // add attributes from subfields
                 if (array_key_exists('subfields', $item)) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We only got `rules` and `messages`. 
Laravel provides also the `attributes`, something like your field is called `whatever` and you want to change the display name from whatever to `new whatever`, so you provide in your request:
```php
public function attributes()
{
return [
    'whatever' => 'new whatever'
];
}
```

### AFTER - What is happening after this PR?

We  now also pick the attributes, also from the field definition with `validationAttribute`


## HOW

### How did you achieve that, in technical terms?

Implemented the same stuff there is currently implemented for rules and messages. 
That `Validation` class could see some love and refactor alot of similar/identical code, but at the moment I am in a hurry to finish other tasks can't spend time on this.



### Is it a breaking change?

Nop I don't think, the added parameters to functions are optionals and have defaults.

### How can we test the before & after?

You can define the `attributes()` in your request and in the field definition with `validationAttribute`

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
