### PR TITLE
[v6 - BC] Remove support for arrays in field names 

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -53,7 +53,7 @@ class CrudField
             $this->crud()->addField($nameOrDefinition);
             $nameOrDefinition = $nameOrDefinition['name'];
         }
-
+        
         $field = $this->crud()->firstFieldWhere('name', $nameOrDefinition);
 
         // if field exists

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -53,7 +53,7 @@ class CrudField
             $this->crud()->addField($nameOrDefinition);
             $nameOrDefinition = $nameOrDefinition['name'];
         }
-        
+
         $field = $this->crud()->firstFieldWhere('name', $nameOrDefinition);
 
         // if field exists

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -43,13 +43,18 @@ class CrudField
 
     protected $attributes;
 
-    public function __construct($name)
+    public function __construct($nameOrDefinition)
     {
-        if (empty($name)) {
+        if (empty($nameOrDefinition)) {
             abort(500, 'Field name can\'t be empty.');
         }
 
-        $field = $this->crud()->firstFieldWhere('name', $name);
+        if (is_array($nameOrDefinition)) {
+            $this->crud()->addField($nameOrDefinition);
+            $nameOrDefinition = $nameOrDefinition['name'];
+        }
+
+        $field = $this->crud()->firstFieldWhere('name', $nameOrDefinition);
 
         // if field exists
         if ((bool) $field) {
@@ -58,7 +63,7 @@ class CrudField
         } else {
             // it means we're creating the field now,
             // so at the very least set the name attribute
-            $this->setAttributeValue('name', $name);
+            $this->setAttributeValue('name', $nameOrDefinition);
         }
 
         $this->save();

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -43,18 +43,20 @@ class CrudField
 
     protected $attributes;
 
-    public function __construct($nameOrDefinition)
+    public function __construct($nameOrDefinitionArray)
     {
-        if (empty($nameOrDefinition)) {
+        if (empty($nameOrDefinitionArray)) {
             abort(500, 'Field name can\'t be empty.');
         }
 
-        if (is_array($nameOrDefinition)) {
-            $this->crud()->addField($nameOrDefinition);
-            $nameOrDefinition = $nameOrDefinition['name'];
+        if (is_array($nameOrDefinitionArray)) {
+            $this->crud()->addField($nameOrDefinitionArray);
+            $name = $nameOrDefinitionArray['name'];
+        } else {
+            $name = $nameOrDefinitionArray;
         }
 
-        $field = $this->crud()->firstFieldWhere('name', $nameOrDefinition);
+        $field = $this->crud()->firstFieldWhere('name', $name);
 
         // if field exists
         if ((bool) $field) {
@@ -63,7 +65,7 @@ class CrudField
         } else {
             // it means we're creating the field now,
             // so at the very least set the name attribute
-            $this->setAttributeValue('name', $nameOrDefinition);
+            $this->setAttributeValue('name', $name);
         }
 
         $this->save();

--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -109,7 +109,7 @@ trait AutoSet
             return 'email';
         }
 
-        if (is_array($fieldName)) {
+        if ($this->holdMultipleInputs($fieldName)) {
             return 'text'; // not because it's right, but because we don't know what it is
         }
 

--- a/src/app/Library/CrudPanel/Traits/AutoSet.php
+++ b/src/app/Library/CrudPanel/Traits/AutoSet.php
@@ -109,7 +109,7 @@ trait AutoSet
             return 'email';
         }
 
-        if ($this->holdMultipleInputs($fieldName)) {
+        if ($this->holdsMultipleInputs($fieldName)) {
             return 'text'; // not because it's right, but because we don't know what it is
         }
 

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -60,7 +60,7 @@ trait Create
             // then take those fields into account (check if they have relationships);
             // this is done in particular for the checklist_dependency field,
             // but other fields could use it too, in the future;
-            if ($this->holdMultipleInputs($field['name']) &&
+            if ($this->holdsMultipleInputs($field['name']) &&
                 isset($field['subfields']) &&
                 is_array($field['subfields'])) {
                 foreach ($field['subfields'] as $subfield) {

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -60,10 +60,9 @@ trait Create
             // then take those fields into account (check if they have relationships);
             // this is done in particular for the checklist_dependency field,
             // but other fields could use it too, in the future;
-            if (is_array($field['name']) &&
+            if ($this->holdMultipleInputs($field['name']) &&
                 isset($field['subfields']) &&
-                is_array($field['subfields']) &&
-                count($field['subfields'])) {
+                is_array($field['subfields'])) {
                 foreach ($field['subfields'] as $subfield) {
                     if (isset($subfield['model']) && $subfield['model'] !== false) {
                         array_push($relationFields, $subfield);

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -474,7 +474,21 @@ trait Fields
      */
     public function getAllFieldNames()
     {
-        return Arr::flatten(Arr::pluck($this->getCleanStateFields(), 'name'));
+        $fieldNamesArray = array_column($this->getCleanStateFields(), 'name');
+
+        return array_reduce($fieldNamesArray, function ($names, $item) {
+            if (strpos($item, ',') === false) {
+                $names[] = $item;
+
+                return $names;
+            }
+
+            foreach (explode(',', $item) as $fieldName) {
+                $names[] = $fieldName;
+            }
+
+            return $names;
+        });
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\app\Library\CrudPanel\CrudField;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait Fields
 {
@@ -233,10 +234,9 @@ trait Fields
     {
         $fieldsArray = $this->getCleanStateFields();
         $field = $this->firstFieldWhere('name', $fieldName);
-        $fieldKey = $this->getFieldKey($field);
 
         foreach ($modifications as $attributeName => $attributeValue) {
-            $fieldsArray[$fieldKey][$attributeName] = $attributeValue;
+            $fieldsArray[$field['name']][$attributeName] = $attributeValue;
         }
 
         $this->enableTabsIfFieldUsesThem($modifications);
@@ -532,6 +532,15 @@ trait Fields
         return Arr::first($this->getCleanStateFields(), function ($field, $fieldKey) use ($attribute, $value) {
             return isset($field[$attribute]) && $field[$attribute] == $value;
         });
+    }
+
+    /**
+     * The field hold multiple inputs (one field represent multiple model attributes / relations)
+     * eg: date range or checklist dependency.
+     */
+    public function holdMultipleInputs(string $fieldName): bool
+    {
+        return Str::contains($fieldName, ',');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -538,7 +538,7 @@ trait Fields
      * The field hold multiple inputs (one field represent multiple model attributes / relations)
      * eg: date range or checklist dependency.
      */
-    public function holdMultipleInputs(string $fieldName): bool
+    public function holdsMultipleInputs(string $fieldName): bool
     {
         return Str::contains($fieldName, ',');
     }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -69,7 +69,7 @@ trait FieldsProtectedMethods
      */
     public function overwriteFieldNameFromDotNotationToArray($field)
     {
-        if (! is_array($field['name']) && strpos($field['name'], '.') !== false) {
+        if (strpos($field['name'], '.') !== false) {
             $entity_array = explode('.', $field['name']);
             $name_string = '';
 
@@ -141,11 +141,6 @@ trait FieldsProtectedMethods
         // by default, entity is false if we cannot link it with guessing functions to a relation
         $field['entity'] = false;
 
-        // if the name is an array it's definitely not a relationship
-        if (is_array($field['name'])) {
-            return $field;
-        }
-
         //if the name is dot notation we are sure it's a relationship
         if (strpos($field['name'], '.') !== false) {
             $possibleMethodName = Str::of($field['name'])->before('.');
@@ -209,7 +204,7 @@ trait FieldsProtectedMethods
     protected function makeSureFieldHasLabel($field)
     {
         if (! isset($field['label'])) {
-            $name = is_array($field['name']) ? $field['name'][0] : $field['name'];
+            $name = str_replace(',', ' ', $field['name']);
             $name = str_replace('_id', '', $name);
             $field['label'] = mb_ucfirst(str_replace('_', ' ', $name));
         }
@@ -264,8 +259,8 @@ trait FieldsProtectedMethods
         }
 
         foreach ($field['subfields'] as $key => $subfield) {
-            if (empty($field)) {
-                abort(500, 'Field name can\'t be empty');
+            if (empty($subfield) || ! isset($subfield['name'])) {
+                abort(500, 'Subfield name can\'t be empty');
             }
 
             // make sure the field definition is an array
@@ -273,7 +268,7 @@ trait FieldsProtectedMethods
                 $subfield = ['name' => $subfield];
             }
 
-            $subfield['parentFieldName'] = is_array($field['name']) ? false : $field['name'];
+            $subfield['parentFieldName'] = $field['name'];
 
             if (! isset($field['model'])) {
                 // we're inside a simple 'repeatable' with no model/relationship, so
@@ -342,10 +337,8 @@ trait FieldsProtectedMethods
      */
     protected function addFieldToOperationSettings($field)
     {
-        $fieldKey = $this->getFieldKey($field);
-
         $allFields = $this->getOperationSetting('fields');
-        $allFields = array_merge($this->getCleanStateFields(), [$fieldKey => $field]);
+        $allFields = array_merge($this->getCleanStateFields(), [$field['name'] => $field]);
 
         $this->setOperationSetting('fields', $allFields);
     }
@@ -353,20 +346,11 @@ trait FieldsProtectedMethods
     /**
      * Get the string that should be used as an array key, for the attributive array
      * where the fields are stored for the current operation.
-     *
-     * The array key for the field should be:
-     * - name (if the name is a string)
-     * - name1_name2_name3 (if the name is an array)
-     *
-     * @param  array  $field  Field definition array.
-     * @return string The string that should be used as array key.
+     * 
+     * @deprecated v6
      */
-    protected function getFieldKey($field)
+    protected function getFieldKey(array $field): string
     {
-        if (is_array($field['name'])) {
-            return implode('_', $field['name']);
-        }
-
         return $field['name'];
     }
 }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -346,7 +346,7 @@ trait FieldsProtectedMethods
     /**
      * Get the string that should be used as an array key, for the attributive array
      * where the fields are stored for the current operation.
-     * 
+     *
      * @deprecated v6
      */
     protected function getFieldKey(array $field): string

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -76,7 +76,7 @@ trait Update
             return $this->getModelAttributeValueFromRelationship($model, $field);
         }
 
-        if ($this->holdMultipleInputs($field['name'])) {
+        if ($this->holdsMultipleInputs($field['name'])) {
             $result = array_map(function ($item) use ($model) {
                 return $model->{$item};
             }, explode(',', $field['name']));

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -76,18 +76,15 @@ trait Update
             return $this->getModelAttributeValueFromRelationship($model, $field);
         }
 
-        if (is_string($field['name'])) {
-            return $model->{$field['name']};
-        }
-
-        if (is_array($field['name'])) {
-            $result = [];
-            foreach ($field['name'] as $name) {
-                $result[] = $model->{$name};
-            }
+        if ($this->holdMultipleInputs($field['name'])) {
+            $result = array_map(function ($item) use ($model) {
+                return $model->{$item};
+            }, explode(',', $field['name']));
 
             return $result;
         }
+
+        return $model->{$field['name']};
     }
 
     /**
@@ -123,6 +120,7 @@ trait Update
                     // we just return the plain models as we only need the ids
                     if (! isset($field['subfields'])) {
                         $result->push($model);
+
                         continue;
                     }
                     // when subfields are set we need to parse their values so they can be displayed

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -10,7 +10,7 @@
 	// we add an astherisc for it. Case it's a subfield, that check is done upstream in repeatable_row. 
 	// the reason for that is that here the field name is already the repeatable name: parent[row][fieldName]
 	if(!isset($field['parentFieldName']) || !$field['parentFieldName']) {
-		$fieldName = $crud->holdMultipleInputs($field['name']) ? explode(',', $field['name']) : [$field['name']];
+		$fieldName = $crud->holdsMultipleInputs($field['name']) ? explode(',', $field['name']) : [$field['name']];
 		foreach($fieldName as $inputName) {
 			$required = (isset($action) && $crud->isRequired($inputName)) ? ' required' : '';
 			// if any of the hold inputs is required, the whole field is required

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -10,8 +10,14 @@
 	// we add an astherisc for it. Case it's a subfield, that check is done upstream in repeatable_row. 
 	// the reason for that is that here the field name is already the repeatable name: parent[row][fieldName]
 	if(!isset($field['parentFieldName']) || !$field['parentFieldName']) {
-		$fieldName = is_array($field['name']) ? current($field['name']) : $field['name'];
-		$required = (isset($action) && $crud->isRequired($fieldName)) ? ' required' : '';
+		$fieldName = $crud->holdMultipleInputs($field['name']) ? explode(',', $field['name']) : [$field['name']];
+		foreach($fieldName as $inputName) {
+			$required = (isset($action) && $crud->isRequired($inputName)) ? ' required' : '';
+			// if any of the hold inputs is required, the whole field is required
+			if(!empty($required)) {
+				break;
+			}
+		}
 	}
 	
 	// if the developer has intentionally set the required attribute on the field

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -1261,7 +1261,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->assertCount(0, $planets);
     }
 
-    public function testCreateHasManyRelationWithArrayedNameSubfields()
+    public function testCreateHasManyRelationWithDelimitedNameSubfields()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
@@ -1272,7 +1272,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
                     'name' => 'title',
                 ],
                 [
-                    'name' => ['start_date', 'end_date'],
+                    'name' => 'start_date,end_date',
                     'type' => 'date_range',
                 ],
             ],
@@ -1309,7 +1309,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->assertEquals($inputData['universes'][1]['start_date'], $entry->universes()->find(2)->start_date);
     }
 
-    public function testCreateHasOneRelationWithArrayedNameSubfields()
+    public function testCreateHasOneRelationWithDelimitedNameSubfields()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->setOperation('create');
@@ -1322,7 +1322,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
                         'name' => 'nickname',
                     ],
                     [
-                        'name' => ['start_date', 'end_date'],
+                        'name' => 'start_date,end_date',
                     ],
                     [
                         'name' => 'profile_picture',
@@ -1355,7 +1355,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->assertEquals($account_details->end_date, '2091-01-26');
     }
 
-    public function testBelongsToManyWithArrayedNameSubfields()
+    public function testBelongsToManyWithDelimitedNameSubfields()
     {
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
@@ -1366,7 +1366,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
                     'name' => 'notes',
                 ],
                 [
-                    'name' => ['start_date', 'end_date'],
+                    'name' => 'start_date,end_date',
                 ],
             ],
         ]);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We supported arrays in field names and that was blocking us from adding some functionality.
It was not possible to construct the `CrudField` with an array because some fields like `date_range` and `checklist_dependency` used arrays as their names. 

### AFTER - What is happening after this PR?

We can construct the `CrudField` with an array like with `CRUD::addField([...])` and can use the CrudField class fluently to target any field since now all field names are strings.

```php
CRUD::field('start_date,end_date')->type('date_range');

// you can still add some attributes later
CRUD::field('start_date,end_date')->label('My custom label');
```

Regarding accepting now arrays in `CrudField` constructor the main difference is that `addField([...])` return the `CrudPanel` object, while `field([...])` will return the `CrudField` object, so that you can continue to fluently configure the field. 

This is sibling to https://github.com/Laravel-Backpack/PRO/pull/157