### PR TITLE
fix: deprecation on dynamic property (PHP82)

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -8,6 +8,10 @@ use Illuminate\Routing\Controller;
 
 class LoginController extends Controller
 {
+    protected ?string $loginPath = null;
+    protected ?string $redirectTo = null;
+    protected ?string $redirectAfterLogout = null;
+
     protected $data = []; // the information we send to the view
 
     /*
@@ -40,16 +44,13 @@ class LoginController extends Controller
         // ----------------------------------
 
         // If not logged in redirect here.
-        $this->loginPath = property_exists($this, 'loginPath') ? $this->loginPath
-            : backpack_url('login');
+        $this->loginPath = !empty($this->loginPath) ? $this->loginPath : backpack_url('login');
 
         // Redirect here after successful login.
-        $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
-            : backpack_url('dashboard');
+        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
 
         // Redirect here after logout.
-        $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
-            : backpack_url('login');
+        $this->redirectAfterLogout = !empty($this->redirectAfterLogout) ? $this->redirectAfterLogout : backpack_url('login');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -44,13 +44,13 @@ class LoginController extends Controller
         // ----------------------------------
 
         // If not logged in redirect here.
-        $this->loginPath = ! empty($this->loginPath) ? $this->loginPath : backpack_url('login');
+        $this->loginPath ??= backpack_url('login');
 
         // Redirect here after successful login.
-        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
+        $this->redirectTo ??= backpack_url('dashboard');
 
         // Redirect here after logout.
-        $this->redirectAfterLogout = ! empty($this->redirectAfterLogout) ? $this->redirectAfterLogout : backpack_url('login');
+        $this->redirectAfterLogout ??= backpack_url('login');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -44,13 +44,13 @@ class LoginController extends Controller
         // ----------------------------------
 
         // If not logged in redirect here.
-        $this->loginPath = !empty($this->loginPath) ? $this->loginPath : backpack_url('login');
+        $this->loginPath = ! empty($this->loginPath) ? $this->loginPath : backpack_url('login');
 
         // Redirect here after successful login.
-        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
+        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
 
         // Redirect here after logout.
-        $this->redirectAfterLogout = !empty($this->redirectAfterLogout) ? $this->redirectAfterLogout : backpack_url('login');
+        $this->redirectAfterLogout = ! empty($this->redirectAfterLogout) ? $this->redirectAfterLogout : backpack_url('login');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -10,6 +10,8 @@ use Validator;
 
 class RegisterController extends Controller
 {
+    protected ?string $redirectTo = null;
+
     protected $data = []; // the information we send to the view
 
     /*
@@ -36,8 +38,7 @@ class RegisterController extends Controller
         $this->middleware("guest:$guard");
 
         // Where to redirect users after login / registration.
-        $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
-            : config('backpack.base.route_prefix', 'dashboard');
+        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : config('backpack.base.route_prefix', 'dashboard');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -38,7 +38,7 @@ class RegisterController extends Controller
         $this->middleware("guest:$guard");
 
         // Where to redirect users after login / registration.
-        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : config('backpack.base.route_prefix', 'dashboard');
+        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : config('backpack.base.route_prefix', 'dashboard');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -38,7 +38,7 @@ class RegisterController extends Controller
         $this->middleware("guest:$guard");
 
         // Where to redirect users after login / registration.
-        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : config('backpack.base.route_prefix', 'dashboard');
+        $this->redirectTo ??= config('backpack.base.route_prefix', 'dashboard');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -53,7 +53,7 @@ class ResetPasswordController extends Controller
         }
 
         // where to redirect after password was reset
-        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
+        $this->redirectTo ??= backpack_url('dashboard');
     }
 
     // -------------------------------------------------------

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Password;
 
 class ResetPasswordController extends Controller
 {
-    private string $redirectTo;
+    protected ?string $redirectTo = null;
 
     protected $data = []; // the information we send to the view
 

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -53,7 +53,7 @@ class ResetPasswordController extends Controller
         }
 
         // where to redirect after password was reset
-        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
+        $this->redirectTo = ! empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
     }
 
     // -------------------------------------------------------

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Password;
 
 class ResetPasswordController extends Controller
 {
+    private string $redirectTo;
+
     protected $data = []; // the information we send to the view
 
     /*
@@ -51,7 +53,7 @@ class ResetPasswordController extends Controller
         }
 
         // where to redirect after password was reset
-        $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo : backpack_url('dashboard');
+        $this->redirectTo = !empty($this->redirectTo) ? $this->redirectTo : backpack_url('dashboard');
     }
 
     // -------------------------------------------------------


### PR DESCRIPTION
## WHY

I have a lot a warning on Backpack login:
```
[2023-05-24 17:15:46] production.WARNING: ErrorException: Creation of dynamic property Backpack\CRUD\app\Http\Controllers\Auth\LoginController::$redirectAfterLogout is deprecated in /laravel/vendor/backpack/crud/src/app/Http/Controllers/Auth/LoginController.php:51
```

On **PHP 8.2** env.

Deprecated feature: https://php.watch/versions/8.2/dynamic-properties-deprecated


## HOW

I replace dynamic properties with nullable (and default null) properties.

### Is it a breaking change?

No breaking change.


### How can we test the before & after?

1. Try a login / forget / reset password
2. Try to override `$redirectTo` on LoginController ([doc](https://backpackforlaravel.com/docs/5.x/base-how-to#customizing-the-auth-controllers))