### PR TITLE
Fix uploaders lifecycle for repeatable uploaders

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -226,9 +226,12 @@ class CrudField
      */
     public function subfields($subfields)
     {
+        $callAttributeMacro = ! isset($this->attributes['subfields']);
         $this->attributes['subfields'] = $subfields;
         $this->attributes = $this->crud()->makeSureFieldHasNecessaryAttributes($this->attributes);
-        $this->callRegisteredAttributeMacros();
+        if ($callAttributeMacro) {
+            $this->callRegisteredAttributeMacros();
+        }
 
         return $this->save();
     }

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -228,6 +228,11 @@ class CrudPanel
         return $this->route;
     }
 
+    public function setEntry($entry)
+    {
+        $this->entry = $entry;
+    }
+
     /**
      * Set the entity name in singular and plural.
      * Used all over the CRUD interface (header, add button, reorder button, breadcrumbs).

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -228,11 +228,6 @@ class CrudPanel
         return $this->route;
     }
 
-    public function setEntry($entry)
-    {
-        $this->entry = $entry;
-    }
-
     /**
      * Set the entity name in singular and plural.
      * Used all over the CRUD interface (header, add button, reorder button, breadcrumbs).

--- a/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
+++ b/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
@@ -43,12 +43,19 @@ trait MacroableWithAttributes
                 continue;
             }
             if (isset($attributes['subfields'])) {
-                foreach ($attributes['subfields'] as $subfield) {
-                    if (isset($subfield[$macro])) {
-                        $config = ! is_array($subfield[$macro]) ? [] : $subfield[$macro];
-                        $this->{$macro}($config, $subfield);
+                $subfieldsWithMacros = collect($attributes['subfields'])
+                                        ->filter(fn($item) => isset($item[$macro]));
+
+                $subfieldsWithMacros->each(
+                    function($item) use ($subfieldsWithMacros, $macro) {
+                        $config = ! is_array($item[$macro]) ? [] : $item[$macro];
+                        if($subfieldsWithMacros->last() === $item) {
+                            $this->{$macro}($config, $item);
+                        }else{
+                            $this->{$macro}($config, $item, false);
+                        }
                     }
-                }
+                );
             }
         }
     }

--- a/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
+++ b/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
@@ -44,14 +44,14 @@ trait MacroableWithAttributes
             }
             if (isset($attributes['subfields'])) {
                 $subfieldsWithMacros = collect($attributes['subfields'])
-                                        ->filter(fn($item) => isset($item[$macro]));
+                                        ->filter(fn ($item) => isset($item[$macro]));
 
                 $subfieldsWithMacros->each(
-                    function($item) use ($subfieldsWithMacros, $macro) {
+                    function ($item) use ($subfieldsWithMacros, $macro) {
                         $config = ! is_array($item[$macro]) ? [] : $item[$macro];
-                        if($subfieldsWithMacros->last() === $item) {
+                        if ($subfieldsWithMacros->last() === $item) {
                             $this->{$macro}($config, $item);
-                        }else{
+                        } else {
                             $this->{$macro}($config, $item, false);
                         }
                     }

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -99,7 +99,7 @@ final class RegisterUploadEvents
      * Register the saving, retrieved and deleting events on model to handle the various upload stages.
      * In case of CrudColumn we don't register the saving event.
      */
-    private function setupModelEvents(string $model, UploaderInterface $uploader): void
+    private function setupModelEvents(string $model, UploaderInterface $uploader, $isLastUploaderInGroup = true): void
     {
         if (app('UploadersRepository')->isUploadHandled($uploader->getIdentifier())) {
             return;
@@ -119,7 +119,7 @@ final class RegisterUploadEvents
         // if the entry is already retrieved from database, don't register the event
         // just process the uploader on the crud entry we already got.
         if (app('crud')->entry) {
-            app('crud')->entry = $uploader->retrieveUploadedFiles(app('crud')->entry);
+            app('crud')->setEntry($uploader->retrieveUploadedFiles(app('crud')->entry));
         } else {
             $model::retrieved(function ($entry) use ($uploader) {
                 $entry = $uploader->retrieveUploadedFiles($entry);

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -24,20 +24,20 @@ final class RegisterUploadEvents
         }
     }
 
-    public static function handle(CrudField|CrudColumn $crudObject, array $uploaderConfiguration, string $macro, ?array $subfield = null, ?bool $isLastUploaderInGroup = true): void
+    public static function handle(CrudField|CrudColumn $crudObject, array $uploaderConfiguration, string $macro, ?array $subfield = null, ?bool $registerModelEvents = true): void
     {
         $instance = new self($crudObject, $uploaderConfiguration, $macro);
 
-        $instance->registerEvents($subfield, $isLastUploaderInGroup);
+        $instance->registerEvents($subfield, $registerModelEvents);
     }
 
     /*******************************
      * Private methods - implementation
      *******************************/
-    private function registerEvents(array|null $subfield = [], ?bool $isLastUploaderInGroup = true): void
+    private function registerEvents(array|null $subfield = [], ?bool $registerModelEvents = true): void
     {
         if (! empty($subfield)) {
-            $this->registerSubfieldEvent($subfield, $isLastUploaderInGroup);
+            $this->registerSubfieldEvent($subfield, $registerModelEvents);
 
             return;
         }
@@ -50,7 +50,7 @@ final class RegisterUploadEvents
         $this->setupUploadConfigsInCrudObject($uploader);
     }
 
-    private function registerSubfieldEvent(array $subfield, bool $isLastUploaderInGroup = true): void
+    private function registerSubfieldEvent(array $subfield, bool $registerModelEvents = true): void
     {
         $uploader = $this->getUploader($subfield, $this->uploaderConfiguration);
         $crudObject = $this->crudObject->getAttributes();
@@ -69,9 +69,8 @@ final class RegisterUploadEvents
             $uploader = $uploader->relationship(true);
         }
 
-        // for subfields, we only register one event so that we have access to the repeatable container name.
-        // all the uploaders for a given container are stored in the UploadersRepository.
-        if ($isLastUploaderInGroup) {
+        // only the last subfield uploader will setup the model events for the whole group
+        if ($registerModelEvents) {
             $this->setupModelEvents($model, $uploader);
         }
 
@@ -118,7 +117,7 @@ final class RegisterUploadEvents
         }
         // if the entry is already retrieved from database, don't register the event
         // just process the uploader on the crud entry we already got.
-        if (app('crud')->entry) { 
+        if (app('crud')->entry) {
             app('crud')->entry = $uploader->retrieveUploadedFiles(app('crud')->entry);
         } else {
             $model::retrieved(function ($entry) use ($uploader) {

--- a/src/macros.php
+++ b/src/macros.php
@@ -35,18 +35,18 @@ if (! Str::hasMacro('dotsToSquareBrackets')) {
     });
 }
 if (! CrudColumn::hasMacro('withFiles')) {
-    CrudColumn::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $isLastInGroup = true) {
+    CrudColumn::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $registerUploaderEvents = true) {
         /** @var CrudField|CrudColumn $this */
-        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $isLastInGroup);
+        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $registerUploaderEvents);
 
         return $this;
     });
 }
 
 if (! CrudField::hasMacro('withFiles')) {
-    CrudField::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $isLastInGroup = true) {
+    CrudField::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $registerUploaderEvents = true) {
         /** @var CrudField|CrudColumn $this */
-        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $isLastInGroup);
+        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $registerUploaderEvents);
 
         return $this;
     });

--- a/src/macros.php
+++ b/src/macros.php
@@ -35,18 +35,18 @@ if (! Str::hasMacro('dotsToSquareBrackets')) {
     });
 }
 if (! CrudColumn::hasMacro('withFiles')) {
-    CrudColumn::macro('withFiles', function ($uploadDefinition = [], $subfield = null) {
+    CrudColumn::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $isLastInGroup = true) {
         /** @var CrudField|CrudColumn $this */
-        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield);
+        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $isLastInGroup);
 
         return $this;
     });
 }
 
 if (! CrudField::hasMacro('withFiles')) {
-    CrudField::macro('withFiles', function ($uploadDefinition = [], $subfield = null) {
+    CrudField::macro('withFiles', function ($uploadDefinition = [], $subfield = null, $isLastInGroup = true) {
         /** @var CrudField|CrudColumn $this */
-        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield);
+        RegisterUploadEvents::handle($this, $uploadDefinition, 'withFiles', $subfield, $isLastInGroup);
 
         return $this;
     });


### PR DESCRIPTION
The lifecycle of uploaders was wrong. I partially fixed it for "regular" uploads https://github.com/Laravel-Backpack/CRUD/pull/5066. But for repeatable uploads the problem persists (because of the way subfields works, by manually calling the macros functions). 

I added a `isLastUploaderInGroup` property to the event system, that allow us to only register the repeatable events on the last uploader, ensuring all others for that repeatable are set. 
