### PR TITLE
Trigger events on the input instead of the jQuery wrapper

### DIFF
--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -101,7 +101,8 @@
             if(this.isSubfield) {
                 window.crud.subfieldsCallbacks[this.parent.name]?.forEach(callback => callback.triggerChange = true);
             } else {
-                this.$input.trigger('change');
+                let event = new Event('change');
+                this.input.dispatchEvent(event);
             }
 
             return this;
@@ -109,7 +110,8 @@
 
         show(value = true) {
             this.wrapper.toggleClass('d-none', !value);
-            this.$input.trigger(`CrudField:${value ? 'show' : 'hide'}`);
+            let event = new Event(`CrudField:${value ? 'show' : 'hide'}`);
+            this.input.dispatchEvent(event);
             return this;
         }
 
@@ -119,7 +121,8 @@
 
         enable(value = true) {
             this.$input.attr('disabled', !value && 'disabled');
-            this.$input.trigger(`CrudField:${value ? 'enable' : 'disable'}`);
+            let event = new Event(`CrudField:${value ? 'enable' : 'disable'}`);
+            this.input.dispatchEvent(event);
             return this;
         }
 
@@ -129,7 +132,8 @@
 
         require(value = true) {
             this.wrapper.toggleClass('required', value);
-            this.$input.trigger(`CrudField:${value ? 'require' : 'unrequire'}`);
+            let event = new Event(`CrudField:${value ? 'require' : 'unrequire'}`);
+            this.input.dispatchEvent(event);
             return this;
         }
 

--- a/src/resources/views/crud/inc/form_fields_script.blade.php
+++ b/src/resources/views/crud/inc/form_fields_script.blade.php
@@ -102,7 +102,7 @@
                 window.crud.subfieldsCallbacks[this.parent.name]?.forEach(callback => callback.triggerChange = true);
             } else {
                 let event = new Event('change');
-                this.input.dispatchEvent(event);
+                this.input?.dispatchEvent(event);
             }
 
             return this;
@@ -111,7 +111,7 @@
         show(value = true) {
             this.wrapper.toggleClass('d-none', !value);
             let event = new Event(`CrudField:${value ? 'show' : 'hide'}`);
-            this.input.dispatchEvent(event);
+            this.input?.dispatchEvent(event);
             return this;
         }
 
@@ -122,7 +122,7 @@
         enable(value = true) {
             this.$input.attr('disabled', !value && 'disabled');
             let event = new Event(`CrudField:${value ? 'enable' : 'disable'}`);
-            this.input.dispatchEvent(event);
+            this.input?.dispatchEvent(event);
             return this;
         }
 
@@ -133,7 +133,7 @@
         require(value = true) {
             this.wrapper.toggleClass('required', value);
             let event = new Event(`CrudField:${value ? 'require' : 'unrequire'}`);
-            this.input.dispatchEvent(event);
+            this.input?.dispatchEvent(event);
             return this;
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Events like `enable, disable, show` etc were triggered by Crud JS API on the jQuery wrapped element. 

Triggering events on jQuery wrapped elements can only be listened using jQuery functions, not natively with `addEventListener`. 

The other way around works fine, triggering the event on the native input and jQuery is able to listen to it.

### AFTER - What is happening after this PR?

The `CrudField:events` are triggered in the native input instead of the jQuery wrapped one.

### Is it a breaking change?

No I don't think so. From my tests everything that was previously working, still works the same now. 


### How can we test the before & after?

Best way would be to use the demo `Field Monsters`. I've updated it in https://github.com/Laravel-Backpack/demo/pull/514


