### PR TITLE
add widgets back to CRUD

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -48,6 +48,7 @@ class BackpackServiceProvider extends ServiceProvider
     {
         $this->loadViewsWithFallbacks('crud');
         $this->loadViewsWithFallbacks('ui', 'backpack.ui');
+        $this->loadViewNamespace('widgets', 'backpack.ui::widgets');
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
         $this->loadConfigs();
         $this->registerMiddlewareGroup($this->app->router);
@@ -193,6 +194,11 @@ class BackpackServiceProvider extends ServiceProvider
         if (file_exists(base_path().$this->customRoutesFilePath)) {
             $this->loadRoutesFrom(base_path().$this->customRoutesFilePath);
         }
+    }
+
+    public function loadViewNamespace($domain, $namespace)
+    {
+        ViewNamespaces::addFor($domain, $namespace);
     }
 
     public function loadViewsWithFallbacks($dir, $namespace = null)

--- a/src/resources/views/ui/widgets/alert.blade.php
+++ b/src/resources/views/ui/widgets/alert.blade.php
@@ -1,0 +1,23 @@
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+
+@php
+	$dismissible = isset($widget['close_button']) && $widget['close_button'];
+@endphp
+
+<div class="{{ $widget['class'] ?? 'alert alert-primary mb-3' }} {{ $dismissible ? 'alert-dismissible' : '' }}" role="alert">
+
+	@if ($dismissible)	
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+	@endif
+
+	@if (isset($widget['heading']))
+	<h4 class="alert-heading">{!! $widget['heading'] !!}</h4>
+	@endif
+
+	@if (isset($widget['content']))
+	<p>{!! $widget['content'] !!}</p>
+	@endif
+
+</div>
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/card.blade.php
+++ b/src/resources/views/ui/widgets/card.blade.php
@@ -1,0 +1,15 @@
+@php
+	// preserve backwards compatibility with Widgets in Backpack 4.0
+	$widget['wrapper']['class'] = $widget['wrapper']['class'] ?? $widget['wrapperClass'] ?? 'col-sm-6 col-md-4';
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+	<div class="{{ $widget['class'] ?? 'card' }}">
+		@if (isset($widget['content']))
+			@if (isset($widget['content']['header']))
+				<div class="card-header">{!! $widget['content']['header'] !!}</div>
+			@endif
+			<div class="card-body">{!! $widget['content']['body'] !!}</div>
+	  	@endif
+	</div>
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/div.blade.php
+++ b/src/resources/views/ui/widgets/div.blade.php
@@ -1,0 +1,19 @@
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+
+<div
+	@if (count($widget) > 2)
+	    @foreach ($widget as $attribute => $value)
+	        @if (is_string($attribute) && $attribute!='content' && $attribute!='type')
+	            {{ $attribute }}="{{ $value }}"
+	        @endif
+	    @endforeach
+	@endif
+	>
+
+	@if (isset($widget['content']))
+		@include(backpack_view('inc.widgets'), [ 'widgets' => $widget['content'] ])
+	@endif
+
+</div>
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/inc/wrapper_end.blade.php
+++ b/src/resources/views/ui/widgets/inc/wrapper_end.blade.php
@@ -1,0 +1,1 @@
+</{{ $widget['wrapper']['element'] ?? 'div' }}>

--- a/src/resources/views/ui/widgets/inc/wrapper_start.blade.php
+++ b/src/resources/views/ui/widgets/inc/wrapper_start.blade.php
@@ -1,0 +1,16 @@
+@php
+	$widget['wrapper']['element'] = $widget['wrapper']['element'] ?? 'div';
+	$widget['wrapper']['class'] = $widget['wrapper']['class'] ?? "col-sm-6 col-md-4";
+
+    // each wrapper attribute can be a callback or a string
+    // for those that are callbacks, run the callbacks to get the final string to use
+    foreach($widget['wrapper'] as $attribute => $value) {
+        $widget['wrapper'][$attribute] = (!is_string($value) && is_callable($value) ? $value() : $value) ?? '';
+    }
+@endphp
+
+<{{ $widget['wrapper']['element'] ?? 'div' }}
+@foreach(Arr::where($widget['wrapper'],function($value, $key) { return $key != 'element'; }) as $element => $value)
+    {{$element}}="{{$value}}"
+@endforeach
+>

--- a/src/resources/views/ui/widgets/jumbotron.blade.php
+++ b/src/resources/views/ui/widgets/jumbotron.blade.php
@@ -1,0 +1,25 @@
+@php
+	// preserve backwards compatibility with Widgets in Backpack 4.0
+	if (isset($widget['wrapperClass'])) {
+		$widget['wrapper']['class'] = $widget['wrapperClass'];
+	}
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+	<div class="jumbotron mb-2">
+
+	  @if (isset($widget['heading']))
+	  <h1 class="display-3">{!! $widget['heading'] !!}</h1>
+	  @endif
+
+	  @if (isset($widget['content']))
+	  <p>{!! $widget['content'] !!}</p>
+	  @endif
+
+	  @if (isset($widget['button_link']))
+	  <p class="lead">
+	    <a class="btn btn-primary" href="{{ $widget['button_link'] }}" role="button">{{ $widget['button_text'] }}</a>
+	  </p>
+	  @endif
+	</div>
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/progress.blade.php
+++ b/src/resources/views/ui/widgets/progress.blade.php
@@ -1,0 +1,34 @@
+@php
+  // defaults; backwards compatibility with Backpack 4.0 widgets
+  $widget['wrapper']['class'] = $widget['wrapper']['class'] ?? $widget['wrapperClass'] ?? 'col-sm-6 col-lg-3';
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+  <div class="{{ $widget['class'] ?? 'card text-white bg-primary' }}">
+    <div class="card-body">
+      @if (isset($widget['value']))
+      <div class="text-value">{!! $widget['value'] !!}</div>
+      @endif
+
+      @if (isset($widget['description']))
+      <div>{!! $widget['description'] !!}</div>
+      @endif
+      
+      @if (isset($widget['progress']))
+      <div class="progress progress-white progress-xs my-2">
+        <div class="progress-bar" role="progressbar" style="width: {{ $widget['progress']  }}%" aria-valuenow="{{ $widget['progress']  }}" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+      @endif
+      
+      @if (isset($widget['hint']))
+      <small class="text-muted">{!! $widget['hint'] !!}</small>
+      @endif
+    </div>
+    
+    @if (isset($widget['footer_link']))
+    <div class="card-footer px-3 py-2">
+      <a class="btn-block text-muted d-flex justify-content-between align-items-center" href="{{ $widget['footer_link'] ?? '#' }}"><span class="small font-weight-bold">{{ $widget['footer_text'] ?? 'View more' }}</span><i class="la la-angle-right"></i></a>
+    </div>
+    @endif
+  </div>
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/progress_white.blade.php
+++ b/src/resources/views/ui/widgets/progress_white.blade.php
@@ -1,0 +1,34 @@
+@php
+  // defaults; backwards compatibility with Backpack 4.0 widgets
+  $widget['wrapper']['class'] = $widget['wrapper']['class'] ?? $widget['wrapperClass'] ?? 'col-sm-6 col-lg-3';
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+  <div class="{{ $widget['class'] ?? 'card' }}">
+    <div class="card-body">
+      @if (isset($widget['value']))
+      <div class="text-value">{!! $widget['value'] !!}</div>
+      @endif
+
+      @if (isset($widget['description']))
+      <div>{!! $widget['description'] !!}</div>
+      @endif
+      
+      @if (isset($widget['progress']))
+      <div class="progress progress-xs my-2">
+        <div class="{{ $widget['progressClass'] ?? 'progress-bar bg-info' }}" role="progressbar" style="width: {{ $widget['progress']  }}%" aria-valuenow="{{ $widget['progress']  }}" aria-valuemin="0" aria-valuemax="100"></div>
+      </div>
+      @endif
+      
+      @if (isset($widget['hint']))
+      <small class="text-muted">{!! $widget['hint'] !!}</small>
+      @endif
+    </div>
+
+    @if (isset($widget['footer_link']))
+    <div class="card-footer px-3 py-2">
+      <a class="btn-block text-muted d-flex justify-content-between align-items-center" href="{{ $widget['footer_link'] ?? '#' }}"><span class="small font-weight-bold">{{ $widget['footer_text'] ?? 'View more' }}</span><i class="la la-angle-right"></i></a>
+    </div>
+    @endif
+  </div>
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))

--- a/src/resources/views/ui/widgets/script.blade.php
+++ b/src/resources/views/ui/widgets/script.blade.php
@@ -1,0 +1,8 @@
+@php
+    $src = $widget['src'] ?? $widget['content'] ?? $widget['path'];
+    $attributes = collect($widget)->except(['name', 'section', 'type', 'stack', 'src', 'content', 'path'])->toArray();
+@endphp
+
+@push($widget['stack'] ?? 'after_scripts')
+    @basset($src, true, $attributes)
+@endpush

--- a/src/resources/views/ui/widgets/style.blade.php
+++ b/src/resources/views/ui/widgets/style.blade.php
@@ -1,0 +1,10 @@
+@php
+    $widget['rel'] = $widget['rel'] ?? 'stylesheet';
+
+    $href = asset($widget['href'] ?? $widget['content'] ?? $widget['path']);
+    $attributes = collect($widget)->except(['name', 'section', 'type', 'stack', 'href', 'content', 'path'])->toArray();
+@endphp
+
+@push($widget['stack'] ?? 'after_styles')
+    @basset($href, true, $attributes, 'style')
+@endpush

--- a/src/resources/views/ui/widgets/view.blade.php
+++ b/src/resources/views/ui/widgets/view.blade.php
@@ -1,0 +1,6 @@
+{{-- view field --}}
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+	
+	@include($widget['view'], ['widget' => $widget])
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In v6-beta, widgets were provided by each theme individually. That meant every theme needed to provide every widget. And there was no guarantee that all themes have some widgets (eg. script, style, card etc).

### AFTER - What is happening after this PR?

Widgets are provided by Backpack/CRUD, from the `ui.widgets` directory. If themes want to override them, good. If they don't, good.


## HOW

### How did you achieve that, in technical terms?

- loaded the `backpack.ui::widgets` namespace in BackpackServiceProvider;
- added all the views for widgets, back to `resources/views/ui/widgets`; I've used the views from `theme-coreuiv2` because they are the simplest and most compatible with the other themes; then the newer themes (CoreUIv4 and Tabler) override a few of those views to add a bit of styling or extra features (`progress`, `progress-white`, `card`);

### Is it a breaking change?

Kind of, yes. If a developer installs Backpack v6 beta and runs `composer update` on a theme, but NOT on CRUD, they will not have the default views. But since that's unlikely if we merge the CRUD PR first, themes second... I'm going to call this non-breaking.
