### PR TITLE
Fix Custom Validation Rules to validate repeatable fields

### DIFF
--- a/src/app/Library/Validation/Rules/ValidFileArray.php
+++ b/src/app/Library/Validation/Rules/ValidFileArray.php
@@ -52,7 +52,7 @@ abstract class ValidFileArray extends BackpackCustomRule
             $validator = Validator::make([$cleanAttribute => $file], [
                 $cleanAttribute => $this->getFileRules(),
             ], $this->validator->customMessages, $this->validator->customAttributes);
-           
+
             if ($validator->fails()) {
                 foreach ($validator->errors()->messages() ?? [] as $attr => $message) {
                     foreach ($message as $messageText) {
@@ -92,11 +92,10 @@ abstract class ValidFileArray extends BackpackCustomRule
         return $value;
     }
 
-    private function getValidationAttributeString($attribute) 
-    {  
+    private function getValidationAttributeString($attribute)
+    {
         return Str::substrCount($attribute, '.') > 1 ?
                 Str::before($attribute, '.').'.*.'.Str::afterLast($attribute, '.') :
                 $attribute;
-    
     }
 }

--- a/src/app/Library/Validation/Rules/ValidFileArray.php
+++ b/src/app/Library/Validation/Rules/ValidFileArray.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 abstract class ValidFileArray extends BackpackCustomRule
 {
@@ -46,11 +47,12 @@ abstract class ValidFileArray extends BackpackCustomRule
 
     protected function validateItems(string $attribute, array $items, Closure $fail): void
     {
+        $cleanAttribute = Str::afterLast($attribute, '.');
         foreach ($items as $file) {
-            $validator = Validator::make([$attribute => $file], [
-                $attribute => $this->getFileRules(),
+            $validator = Validator::make([$cleanAttribute => $file], [
+                $cleanAttribute => $this->getFileRules(),
             ], $this->validator->customMessages, $this->validator->customAttributes);
-
+           
             if ($validator->fails()) {
                 foreach ($validator->errors()->messages() ?? [] as $attr => $message) {
                     foreach ($message as $messageText) {
@@ -65,9 +67,9 @@ abstract class ValidFileArray extends BackpackCustomRule
     {
         $data = $data ?? $this->data;
         $rules = $rules ?? $this->getFieldRules();
-
+        $validationRuleAttribute = $this->getValidationAttributeString($attribute);
         $validator = Validator::make($data, [
-            $attribute => $rules,
+            $validationRuleAttribute => $rules,
         ], $this->validator->customMessages, $this->validator->customAttributes);
 
         if ($validator->fails()) {
@@ -88,5 +90,13 @@ abstract class ValidFileArray extends BackpackCustomRule
         }
 
         return $value;
+    }
+
+    private function getValidationAttributeString($attribute) 
+    {  
+        return Str::substrCount($attribute, '.') > 1 ?
+                Str::before($attribute, '.').'.*.'.Str::afterLast($attribute, '.') :
+                $attribute;
+    
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As we were aware, the validation rules were not finished. 

There were some issues regarding using the Custom Validation rules in repeatable fields.

### AFTER - What is happening after this PR?

We can properly validate fields inside repeatable.

## HOW

### How did you achieve that, in technical terms?

The missing key here was using the proper attribute name so that our custom validation rule can properly pick it and return the appropriate validation message. 

### Is it a breaking change?

No, I don't think so.


### How can we test the before & after?

Trying to validate for example a dropzone inside a repeatable would fail, now it should properly work (almost, after merging the PRO PR https://github.com/Laravel-Backpack/PRO/pull/164 ). 


