### PR TITLE
Fix tabs navigation using #hash in urls

### DIFF
--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -4,8 +4,6 @@
 @basset('https://unpkg.com/pace-js@1.2.4/pace.min.js')
 @basset('https://unpkg.com/sweetalert@2.1.2/dist/sweetalert.min.js')
 
-@basset(base_path('vendor/backpack/crud/src/resources/assets/js/common.js'))
-
 @if (backpack_theme_config('scripts') && count(backpack_theme_config('scripts')))
     @foreach (backpack_theme_config('scripts') as $path)
         @if(is_array($path))
@@ -31,3 +29,5 @@
 @if(config('app.debug'))
     @include('crud::inc.ajax_error_frame')
 @endif
+
+@basset(base_path('vendor/backpack/crud/src/resources/assets/js/common.js'))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported here: https://github.com/Laravel-Backpack/CRUD/issues/5079
Navigation in tabs using `#tabHash` in the url was broken because the `common.js` script was loaded before the `theme scripts` that contains the `bootstrap` needed in `common.js`. 

### AFTER - What is happening after this PR?

We load the `common.js` as the last script to make sure backpack + theme scripts are loaded before.


## HOW

### How did you achieve that, in technical terms?

Moved it to the end of the file.



### Is it a breaking change?

Didn't find anything broken, I don't think so, no.


### How can we test the before & after?

Try navigating to https://demo-v6.backpackforlaravel.com/admin/monster/create#selects  - you expect to land on the `selects` tab, but that does not happen.

After this PR it will work.