### PR TITLE
remove pace.js

### DIFF
--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -1,7 +1,6 @@
 @basset('https://unpkg.com/jquery@3.6.1/dist/jquery.min.js')
 @basset('https://unpkg.com/@popperjs/core@2.11.6/dist/umd/popper.min.js')
 @basset('https://unpkg.com/noty@3.2.0-beta-deprecated/lib/noty.min.js')
-@basset('https://unpkg.com/pace-js@1.2.4/pace.min.js')
 @basset('https://unpkg.com/sweetalert@2.1.2/dist/sweetalert.min.js')
 
 @if (backpack_theme_config('scripts') && count(backpack_theme_config('scripts')))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The PR https://github.com/Laravel-Backpack/CRUD/pull/5083 removed the pace script to refresh on ajax requests, but we still load the js library.

I created this PR more as a discussion on the topic, because I am not sure we should completely remove the script or fix it.

When removing this script we no longer have the top loading indicator (**that is broken anyway** https://github.com/Laravel-Backpack/CRUD/issues/5116 ) . I am not a fan of it myself.

The issue is in tabler repository but the error is happening on all themes, the loading indicator keeps going forever. You can see it on demo https://demo-v6.backpackforlaravel.com/admin/dashboard

Is this progress bar something we care about and should fix ? Or should we completely remove it ? 

