### PR TITLE
CRUD buttons can now pass parameters to views

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -32,7 +32,9 @@ class CrudButton implements Arrayable
 
     public $position;
 
-    public function __construct($nameOrAttributes, $stack = null, $type = null, $content = null, $position = null)
+    public $parameters = [];
+
+    public function __construct($nameOrAttributes, $stack = null, $type = null, $content = null, $position = null, $parameters = [])
     {
         // in case an array was passed as name
         // assume it's an array that includes [$name, $stack, $type, $content]
@@ -44,6 +46,7 @@ class CrudButton implements Arrayable
         $this->stack = $stack ?? 'top';
         $this->type = $type ?? 'view';
         $this->content = $content;
+        $this->parameters = $parameters;
 
         // if no position was passed, the defaults are:
         // - 'beginning' for the 'line' stack
@@ -160,6 +163,19 @@ class CrudButton implements Arrayable
     }
 
     /**
+     * Sets the parameters that will be sent to the view.
+     *
+     * @param  array  $value  Path to view file.
+     * @return CrudButton
+     */
+    public function parameters($value)
+    {
+        $this->parameters = $value;
+
+        return $this->save();
+    }
+
+    /**
      * Sets the name of the method on the model that contains the HTML for this button.
      * Sets the button type as 'model_function'.
      *
@@ -257,6 +273,7 @@ class CrudButton implements Arrayable
     {
         $button = $this;
         $crud = $this->crud();
+        $parameters = $this->parameters;
 
         if ($this->type == 'model_function') {
             if (is_null($entry)) {
@@ -267,7 +284,7 @@ class CrudButton implements Arrayable
         }
 
         if ($this->type == 'view') {
-            return view($button->getFinalViewPath(), compact('button', 'crud', 'entry'));
+            return view($button->getFinalViewPath(), compact('button', 'crud', 'entry', 'parameters'));
         }
 
         abort(500, 'Unknown button type');

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -32,9 +32,9 @@ class CrudButton implements Arrayable
 
     public $position;
 
-    public $parameters = [];
+    public $meta = [];
 
-    public function __construct($nameOrAttributes, $stack = null, $type = null, $content = null, $position = null, $parameters = [])
+    public function __construct($nameOrAttributes, $stack = null, $type = null, $content = null, $position = null, $meta = [])
     {
         // in case an array was passed as name
         // assume it's an array that includes [$name, $stack, $type, $content]
@@ -46,7 +46,7 @@ class CrudButton implements Arrayable
         $this->stack = $stack ?? 'top';
         $this->type = $type ?? 'view';
         $this->content = $content;
-        $this->parameters = $parameters;
+        $this->meta = $meta;
 
         // if no position was passed, the defaults are:
         // - 'beginning' for the 'line' stack
@@ -163,14 +163,14 @@ class CrudButton implements Arrayable
     }
 
     /**
-     * Sets the parameters that will be sent to the view.
+     * Sets the meta that will be available in the view.
      *
-     * @param  array  $value  Path to view file.
+     * @param  array  $value  Array of metadata that will be available in the view.
      * @return CrudButton
      */
-    public function parameters($value)
+    public function meta($value)
     {
-        $this->parameters = $value;
+        $this->meta = $value;
 
         return $this->save();
     }
@@ -273,7 +273,6 @@ class CrudButton implements Arrayable
     {
         $button = $this;
         $crud = $this->crud();
-        $parameters = $this->parameters;
 
         if ($this->type == 'model_function') {
             if (is_null($entry)) {
@@ -284,7 +283,7 @@ class CrudButton implements Arrayable
         }
 
         if ($this->type == 'view') {
-            return view($button->getFinalViewPath(), compact('button', 'crud', 'entry', 'parameters'));
+            return view($button->getFinalViewPath(), compact('button', 'crud', 'entry'));
         }
 
         abort(500, 'Unknown button type');

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -1,0 +1,22 @@
+@php
+    $access = $parameters['access'] ?? Str::of($button->name)->studly();
+    $icon = $parameters['icon'] ?? '';
+    $label = $parameters['label'] ?? Str::of($button->name)->headline();
+
+    $wrapper = $parameters['wrapper'] ?? [];
+    $wrapper['element'] = $wrapper['element'] ?? 'a';
+    $wrapper['href'] = $wrapper['href'] ?? url($crud->route. ($entry?->getKey() ? '/'.$entry?->getKey().'/' : '/') . Str::of($button->name)->kebab());
+    $wrapper['class'] = $wrapper['class'] ?? ($button->stack == 'top' ? 'btn btn-outline-primary' : 'btn btn-sm btn-link');
+@endphp
+
+@if ($parameters['access'] == true || $crud->hasAccess($access))
+    <{{ $wrapper['element'] }}
+        @foreach ($wrapper as $attribute => $value)
+            @if (is_string($attribute))
+            {{ $attribute }}="{{ $value }}"
+            @endif
+        @endforeach
+        >
+        <i class="{{ $icon }}"></i> {{ $label }}
+    </{{ $wrapper['element'] }}>
+@endif

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -1,12 +1,20 @@
 @php
-    $access = $parameters['access'] ?? Str::of($button->name)->studly();
-    $icon = $parameters['icon'] ?? '';
-    $label = $parameters['label'] ?? Str::of($button->name)->headline();
+    $access = $button->meta['access'] ?? Str::of($button->name)->studly();
+    $icon = $button->meta['icon'] ?? '';
+    $label = $button->meta['label'] ?? Str::of($button->name)->headline();
 
-    $wrapper = $parameters['wrapper'] ?? [];
+    $defaultHref = url($crud->route. ($entry?->getKey() ? '/'.$entry?->getKey().'/' : '/') . Str::of($button->name)->kebab());
+    $defaultClass = match ($button->stack) {
+        'line' => 'btn btn-sm btn-link',
+        'top' => 'btn btn-outline-primary',
+        'bottom' => 'btn btn-sm btn-secondary',
+        default => 'btn btn-outline-primary',
+    };
+
+    $wrapper = $button->meta['wrapper'] ?? [];
     $wrapper['element'] = $wrapper['element'] ?? 'a';
-    $wrapper['href'] = $wrapper['href'] ?? url($crud->route. ($entry?->getKey() ? '/'.$entry?->getKey().'/' : '/') . Str::of($button->name)->kebab());
-    $wrapper['class'] = $wrapper['class'] ?? ($button->stack == 'top' ? 'btn btn-outline-primary' : 'btn btn-sm btn-link');
+    $wrapper['href'] = $wrapper['href'] ?? $defaultHref;
+    $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
 @endphp
 
 @if ($access == true || $crud->hasAccess($access))
@@ -17,6 +25,7 @@
             @endif
         @endforeach
         >
-        <i class="{{ $icon }}"></i> {{ $label }}
+        @if ($icon) <i class="{{ $icon }}"></i> @endif
+        {{ $label }}
     </{{ $wrapper['element'] }}>
 @endif

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -9,7 +9,7 @@
     $wrapper['class'] = $wrapper['class'] ?? ($button->stack == 'top' ? 'btn btn-outline-primary' : 'btn btn-sm btn-link');
 @endphp
 
-@if ($parameters['access'] == true || $crud->hasAccess($access))
+@if ($access == true || $crud->hasAccess($access))
     <{{ $wrapper['element'] }}
         @foreach ($wrapper as $attribute => $value)
             @if (is_string($attribute))

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -32,6 +32,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'stack'   => 'top',
             'type'    => 'view',
             'content' => 'crud::buttons.show',
+            'parameters' => [],
         ];
         $this->lineViewButton = [
             'name'     => 'lineViewButton',
@@ -39,6 +40,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'view',
             'content'  => 'crud::buttons.show',
             'position' => null,
+            'parameters' => [],
         ];
         $this->bottomViewButton = [
             'name'     => 'bottomViewButton',
@@ -46,6 +48,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'view',
             'content'  => 'crud::buttons.show',
             'position' => null,
+            'parameters' => [],
         ];
         $this->topModelFunctionButton = [
             'name'     => 'topModelFunctionButton',
@@ -53,6 +56,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'model_function',
             'content'  => 'crud::buttons.show',
             'position' => null,
+            'parameters' => [],
         ];
     }
 

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -32,7 +32,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'stack'   => 'top',
             'type'    => 'view',
             'content' => 'crud::buttons.show',
-            'parameters' => [],
+            'meta' => [],
         ];
         $this->lineViewButton = [
             'name'     => 'lineViewButton',
@@ -40,7 +40,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'view',
             'content'  => 'crud::buttons.show',
             'position' => null,
-            'parameters' => [],
+            'meta' => [],
         ];
         $this->bottomViewButton = [
             'name'     => 'bottomViewButton',
@@ -48,7 +48,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'view',
             'content'  => 'crud::buttons.show',
             'position' => null,
-            'parameters' => [],
+            'meta' => [],
         ];
         $this->topModelFunctionButton = [
             'name'     => 'topModelFunctionButton',
@@ -56,7 +56,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             'type'     => 'model_function',
             'content'  => 'crud::buttons.show',
             'position' => null,
-            'parameters' => [],
+            'meta' => [],
         ];
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When creating CRUD buttons in the CrudController, we could NOT pass any parameters to the button view. Only the CrudButton and its attributes were passed.

### AFTER - What is happening after this PR?

We have a `->parameters()` method on CrudButton, that holds an array that gets passed to the final view (if that button is type view).


## HOW

### How did you achieve that, in technical terms?

- created a new property on CrudButton;
- created a new method on CrudButton;
- added `parameters` as the last parameter in the constructor signature, so it can be used both with Fluent and Array syntaxes;

### Is it a breaking change?

Not really, no. But there are some inconsistencies left. I don't understand why Pedro in a separate PR has changed `$name` to `$nameOrAttributes`, maybe he meant this to go in a different direction. I think he wanted CrudButtons to be able to set parameters in a fluent way (using a magic method), but I wouldn't do that to be honest. For some reason I don't like it, seems like these parameters would only be used for adding quick buttons, and adding a magic method to CrudButton only for that seems overkill. 

One could argue that we NEED the magic method for CrudButton to work like CrudField and CrudColumn... But I see `parameters` in CrudButton more like `wrapperAttributes` in CrudField for some reason. Something that isn't that important, something that's secondary. Something that's view-only.

Dunno. Could change my mind. But that's how I feel right now.

### How can we test the before & after?

If you add a button called `quick.blade.php` with this content:

```php
@php
    $id = (isset($entry) && $entry != null) ? $entry->getKey() : false;
    $access = $parameters['access'] ?? Str::of($button->name)->studly();
    $url = $parameters['url'] ?? url($crud->route. ($id ? '/'.$id.'/' : '/'). Str::of($button->name)->kebab());
    $classes = $parameters['classes'] ?? ($button->stack == 'top' ? 'btn btn-outline-primary' : 'btn btn-sm btn-link');
    $icon = $parameters['icon'] ?? '';
    $text = $parameters['text'] ?? Str::of($button->name)->headline();
@endphp

@if ($crud->hasAccess($access))
    <a href="{{ $url }}" class="{{ $classes }}">
        <i class="{{ $icon }}"></i> {{ $text }}
    </a>
@endif
```

You'll be able to do this in your CrudController:

```php
        // Button
        $this->crud->operation('list', function () {
            $this->crud->button('add-something')->stack('top')->view('crud::buttons.quick')->parameters([
                // 'access' => 'AddSomething',
                // 'url' => url($this->crud->route . '/add-something'),
                // 'classes' => 'btn btn-sm btn-link',
                // 'icon' => 'la la-question',
                // 'text' => 'Add Something',
            ]);
        });
```
