### PR TITLE
QuickButton class and blade file

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -280,7 +280,7 @@ class CrudButton implements Arrayable
      *
      * @return array
      */
-    private function getViewPathsWithFallbacks()
+    protected function getViewPathsWithFallbacks()
     {
         $type = $this->name;
         $paths = array_map(function ($item) use ($type) {
@@ -290,7 +290,7 @@ class CrudButton implements Arrayable
         return array_merge([$this->content], $paths);
     }
 
-    private function getFinalViewPath()
+    protected function getFinalViewPath()
     {
         foreach ($this->getViewPathsWithFallbacks() as $path) {
             if (view()->exists($path)) {
@@ -441,7 +441,7 @@ class CrudButton implements Arrayable
      *
      * @return CrudButton
      */
-    private function save()
+    protected function save()
     {
         if ($this->collection()->isEmpty()) {
             $this->crud()->addCrudButton($this);

--- a/src/app/Library/CrudPanel/QuickButton.php
+++ b/src/app/Library/CrudPanel/QuickButton.php
@@ -18,7 +18,7 @@ class QuickButton extends CrudButton
     /**
      * Only show the button if there's access to this operation.
      *
-     * @param string|bool $access
+     * @param  string|bool  $access
      * @return QuickButton
      */
     public function access(string|bool $access)
@@ -31,7 +31,7 @@ class QuickButton extends CrudButton
     /**
      * Set the url of the button (eg. url('home')).
      *
-     * @param string $url
+     * @param  string  $url
      * @return QuickButton
      */
     public function url(string $url)
@@ -44,7 +44,7 @@ class QuickButton extends CrudButton
     /**
      * Set the CSS classes of the button (eg. btn btn-outline-primary).
      *
-     * @param string $classes
+     * @param  string  $classes
      * @return QuickButton
      */
     public function classes(string $classes)
@@ -57,7 +57,7 @@ class QuickButton extends CrudButton
     /**
      * Set the icon class of the button (eg. la la-home).
      *
-     * @param string $icon
+     * @param  string  $icon
      * @return QuickButton
      */
     public function icon(string $icon)
@@ -70,7 +70,7 @@ class QuickButton extends CrudButton
     /**
      * Set the text of the button (eg. Moderate).
      *
-     * @param string $text
+     * @param  string  $text
      * @return QuickButton
      */
     public function text(string $text)
@@ -106,8 +106,8 @@ class QuickButton extends CrudButton
     protected function getDefaultUrl($entry)
     {
         $id = ($entry != null) ? $entry->getKey() : false;
-        $idUrlSegment = ($id ? '/'.$id .'/' : '/');
+        $idUrlSegment = ($id ? '/'.$id.'/' : '/');
 
-        return url($this->crud()->route . $idUrlSegment . Str::of($this->name)->kebab());
+        return url($this->crud()->route.$idUrlSegment.Str::of($this->name)->kebab());
     }
 }

--- a/src/app/Library/CrudPanel/QuickButton.php
+++ b/src/app/Library/CrudPanel/QuickButton.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel;
+
+use Illuminate\Support\Str;
+
+class QuickButton extends CrudButton
+{
+    public $type = 'view';
+    public $content = 'crud::buttons.quick';
+
+    public $access;
+    public $url = null;
+    public $classes = null;
+    public $icon = null;
+    public $text = null;
+
+    /**
+     * Only show the button if there's access to this operation.
+     *
+     * @param string|bool $access
+     * @return QuickButton
+     */
+    public function access(string|bool $access)
+    {
+        $this->access = $access;
+
+        return $this->save();
+    }
+
+    /**
+     * Set the url of the button (eg. url('home')).
+     *
+     * @param string $url
+     * @return QuickButton
+     */
+    public function url(string $url)
+    {
+        $this->url = $url;
+
+        return $this->save();
+    }
+
+    /**
+     * Set the CSS classes of the button (eg. btn btn-outline-primary).
+     *
+     * @param string $classes
+     * @return QuickButton
+     */
+    public function classes(string $classes)
+    {
+        $this->classes = $classes;
+
+        return $this->save();
+    }
+
+    /**
+     * Set the icon class of the button (eg. la la-home).
+     *
+     * @param string $icon
+     * @return QuickButton
+     */
+    public function icon(string $icon)
+    {
+        $this->icon = $icon;
+
+        return $this->save();
+    }
+
+    /**
+     * Set the text of the button (eg. Moderate).
+     *
+     * @param string $text
+     * @return QuickButton
+     */
+    public function text(string $text)
+    {
+        $this->text = $text;
+
+        return $this->save();
+    }
+
+    /**
+     * Get the end result that should be displayed to the user.
+     * The HTML itself of the button.
+     *
+     * @param  object|null  $entry  The eloquent Model for the current entry or null if no current entry.
+     * @return HTML
+     */
+    public function getHtml($entry = null)
+    {
+        $button = $this;
+        $crud = $this->crud();
+
+        $button->url = $button->url ?? $button->getDefaultUrl($entry);
+        $button->access = $button->access ?? Str::of($button->name)->studly()->toString();
+        $button->classes = $button->classes ?? ($button->stack == 'top' ? 'btn btn-outline-primary' : 'btn btn-sm btn-link');
+        $button->icon = $button->icon ?? null;
+        $button->text = $button->text ?? Str::of($button->name)->headline()->toString();
+
+        if ($this->type == 'view') {
+            return view($button->getFinalViewPath(), compact('button', 'crud', 'entry'));
+        }
+    }
+
+    protected function getDefaultUrl($entry)
+    {
+        $id = ($entry != null) ? $entry->getKey() : false;
+        $idUrlSegment = ($id ? '/'.$id .'/' : '/');
+
+        return url($this->crud()->route . $idUrlSegment . Str::of($this->name)->kebab());
+    }
+}

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -1,0 +1,5 @@
+@if ($button->access == true || $crud->hasAccess($button->access))
+    <a href="{{ $button->url }}" class="{{ $button->classes }}">
+        <i class="{{ $button->icon }}"></i> {{ $button->text }}
+    </a>
+@endif


### PR DESCRIPTION
## WHY

This is an alternative to https://github.com/Laravel-Backpack/CRUD/pull/5118

### BEFORE - What was wrong? What was happening before this PR?

We couldn't pass parameters to button blade files. So from your `$crud->addButton()` syntax, there was nothing you could do to send a value to the end blade file.

I've submitted https://github.com/Laravel-Backpack/CRUD/pull/5118 to fix that but Pedro thought we could do better, with a `QuickButton` / `OperationButton` / `QuickViewButton` class. Here, I tried to do better 😀

### AFTER - What is happening after this PR?

We kind of have a solution, but not a good one. I don't like it, I don't think it's better than https://github.com/Laravel-Backpack/CRUD/pull/5118

PROs:
- 🔵 we have a QuickButton class, so you can do `QuickButton::name('do-something')->stack('line')->access(true)->text('Different Text');` and have auto-completion on custom methods like `access` and `text`;

CONs:
- 🔴 **there's still no way to pass parameters to button blade files, for any other button than this one we've just created** 🤦‍♂️ so if a developer wants to create a custom button with parameters... they'd have to create both a blade file, and a class like this one; which is a lot of work for something this simple; we can move over the parameters to an array... but that would mean we'd just be re-creating PR #5118 and just create a class for a better API;
- 🔴 we are introducing a new paradigm, different to how Fields, Columns, Filters work right now; where if you want to create a new X, you create both a blade file (like now) but also a Class (new); but it's sort of messy; to achieve that you have to override an important method, to set any reasonable defaults; I don't like that we're doing this ourselves, and I definitely wouldn't like to instruct people to do this; it took me 2 hours to do, it would take other less experienced devs more than this... to just create a freaking button! no way Jose;
- 🟡 it has a bug - the URL stays the same across the ListOperation table (after it's first set, it gets registered in CrudPanel); this is even after I've moved the setting of defaults from the constructor to the `getHtml()` method; this is probably fixable (and easy) but I've spent >30min on it already and I don't think it's worth fixing right now;


## HOW

### How did you achieve that, in technical terms?

I've added a new class `QuickButton extends CrudButton`, which as a few additional properties and methods to define those properties. Those properties are then passed to the end view (HTML).

### Is it a breaking change?

No. But it does turn some `private` method in CrudButton to `protected`.


### How can we test the before & after?

You can do `QuickButton::name('do-something')->stack('line')->access(true)->text('Different Text');` in your `setupListOperation()`. But it really isn't worth trying, because I'm not going to merge this. 

----

# Conclusion

The CONs here outweigh the PROs. 

The minimal benefit that comes from this class (syntax auto-completion) comes at the expense of 
- a more difficult and costly process for devs to do the same;
- the solution only applying to this particular button;

So I don't think it's smart to do this. This was a distraction from the original idea in https://github.com/Laravel-Backpack/CRUD/pull/5118 which provided a good simple fix. Now let's get back to that one and get things done.