### PR TITLE
remove prism css

### DIFF
--- a/src/resources/views/ui/inc/styles.blade.php
+++ b/src/resources/views/ui/inc/styles.blade.php
@@ -1,6 +1,5 @@
 @basset('https://unpkg.com/animate.css@4.1.1/animate.compat.css')
 @basset('https://unpkg.com/noty@3.2.0-beta-deprecated/lib/noty.css')
-@basset('https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism.css')
 
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css')
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-regular-400.woff2')


### PR DESCRIPTION
This may be some leftover from creating the themes.

Only loading prism css has no effect without loading the JS. 

Linked to: https://github.com/Laravel-Backpack/theme-coreuiv4/pull/18