### PR TITLE
add hide functionality to menu components

### DIFF
--- a/src/app/View/Components/Concerns/CanBeHidden.php
+++ b/src/app/View/Components/Concerns/CanBeHidden.php
@@ -2,12 +2,12 @@
 
 namespace Backpack\CRUD\app\View\Components\Concerns;
 
-trait CanBeHidden {
-
+trait CanBeHidden
+{
     /**
      * Should this component output its HTML?
      *
-     * @return boolean
+     * @return bool
      */
     public function isHidden(): bool
     {
@@ -21,10 +21,10 @@ trait CanBeHidden {
     /**
      * Should this component ouput its HTML?
      *
-     * @return boolean
+     * @return bool
      */
     public function isVisible(): bool
     {
-        return !$this->isHidden();
+        return ! $this->isHidden();
     }
 }

--- a/src/app/View/Components/Concerns/CanBeHidden.php
+++ b/src/app/View/Components/Concerns/CanBeHidden.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Backpack\CRUD\app\View\Components\Concerns;
+
+trait CanBeHidden {
+
+    /**
+     * Should this component output its HTML?
+     *
+     * @return boolean
+     */
+    public function isHidden(): bool
+    {
+        if ($this->hidden instanceof Closure) {
+            return $this->hidden();
+        }
+
+        return $this->hidden;
+    }
+
+    /**
+     * Should this component ouput its HTML?
+     *
+     * @return boolean
+     */
+    public function isVisible(): bool
+    {
+        return !$this->isHidden();
+    }
+}

--- a/src/app/View/Components/MenuDropdown.php
+++ b/src/app/View/Components/MenuDropdown.php
@@ -8,6 +8,8 @@ use Illuminate\View\Component;
 
 class MenuDropdown extends Component
 {
+    use Concerns\CanBeHidden;
+
     /**
      * Create a new component instance.
      */
@@ -16,6 +18,7 @@ class MenuDropdown extends Component
         public ?string $icon = null,
         public ?string $link = null,
         public array $items = [],
+        public $hidden = false,
     ) {
     }
 
@@ -24,6 +27,10 @@ class MenuDropdown extends Component
      */
     public function render(): View|Closure|string
     {
+        if ($this->isHidden()) {
+            return '';
+        }
+
         return backpack_view('components.menu-dropdown');
     }
 }

--- a/src/app/View/Components/MenuDropdownItem.php
+++ b/src/app/View/Components/MenuDropdownItem.php
@@ -8,6 +8,8 @@ use Illuminate\View\Component;
 
 class MenuDropdownItem extends Component
 {
+    use Concerns\CanBeHidden;
+
     /**
      * Create a new component instance.
      */
@@ -15,6 +17,7 @@ class MenuDropdownItem extends Component
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $link = null,
+        public $hidden = false,
     ) {
     }
 
@@ -23,6 +26,10 @@ class MenuDropdownItem extends Component
      */
     public function render(): View|Closure|string
     {
+        if ($this->isHidden()) {
+            return '';
+        }
+
         return backpack_view('components.menu-dropdown-item');
     }
 }

--- a/src/app/View/Components/MenuItem.php
+++ b/src/app/View/Components/MenuItem.php
@@ -8,6 +8,8 @@ use Illuminate\View\Component;
 
 class MenuItem extends Component
 {
+    use Concerns\CanBeHidden;
+
     /**
      * Create a new component instance.
      */
@@ -15,6 +17,7 @@ class MenuItem extends Component
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $link = null,
+        public $hidden = false,
     ) {
     }
 
@@ -23,6 +26,10 @@ class MenuItem extends Component
      */
     public function render(): View|Closure|string
     {
+        if ($this->isHidden()) {
+            return '';
+        }
+
         return backpack_view('components.menu-item');
     }
 }

--- a/src/app/View/Components/MenuSeparator.php
+++ b/src/app/View/Components/MenuSeparator.php
@@ -8,11 +8,14 @@ use Illuminate\View\Component;
 
 class MenuSeparator extends Component
 {
+    use Concerns\CanBeHidden;
+
     /**
      * Create a new component instance.
      */
     public function __construct(
-        public ?string $title = null
+        public ?string $title = null,
+        public $hidden = false,
     ) {
     }
 
@@ -21,6 +24,10 @@ class MenuSeparator extends Component
      */
     public function render(): View|Closure|string
     {
+        if ($this->isHidden()) {
+            return '';
+        }
+
         return backpack_view('components.menu-separator');
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We've implemented menu components in https://github.com/Laravel-Backpack/CRUD/pull/5135/ . One nice feature Pedro mentioned was the ability to hide a component, upon a condition. For example, when a user is not an admin, hide a menu item.

### AFTER - What is happening after this PR?

You can do exactly that, by using the `:hidden` attribute on all components we have:

```php
<!-- Users, Roles Permissions -->
@php
$is_admin = true;
@endphp

<x-backpack::menu-dropdown title="Authentication" icon="la la-group" :hidden="$is_admin">
    <x-backpack::menu-dropdown-item title="Users" icon="la la-user" :link="backpack_url('user')" />
    <x-backpack::menu-dropdown-item title="Roles" icon="la la-group" :link="backpack_url('role')" />
    <x-backpack::menu-dropdown-item title="Permissions" icon="la la-key" :link="backpack_url('permission')" />
</x-backpack::menu-dropdown>
```

## HOW

### How did you achieve that, in technical terms?

The `hidden` attribute can be:
- a `boolean`
- a `Closure`

That gets evaluated, and if it's `false` the PHP Component itself won't even load the blade file. No HTML gets written on page.

### Is it a breaking change?

No - it's non-breaking. No PRs to themes is necessary.