### PR TITLE
Cache gravatar before showing it

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Backpack\Basset\Facades\Basset;
+use Creativeorange\Gravatar\Facades\Gravatar;
 use Illuminate\Support\Facades\Log;
 
 if (! function_exists('backpack_url')) {
@@ -144,7 +146,14 @@ if (! function_exists('backpack_avatar_url')) {
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
                 if (backpack_users_have_email() && ! empty($user->email)) {
-                    return Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email);
+                    $avatarLink = Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email, ['size' => 80]);
+
+                    // if we can save it locally, for safer loading, let's do it
+                    if (in_array(Basset::basset($avatarLink, false)->name, ['INTERNALIZED', 'IN_CACHE', 'LOADED'])) {
+                        return Basset::getUrl($avatarLink);
+                    }
+
+                    return $avatarLink;
                 }
                 break;
             default:


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As highlighted in https://github.com/Laravel-Backpack/CRUD/issues/5145 the current Gravatar implementation makes a call to a third-party endpoint, on every pageload. So _even though_ we have removed all CDNs using Basset... we still have one feature that pings 3rd parties. On. Every. Pageload. 😱

### AFTER - What is happening after this PR?

That ping will no longer reveal anything about the user. In fact, the Gravatar server won't have any idea who the user is. That's because the ping is no longer coming from the user browser, it's coming from the app server. 

Rehrased: 
- Basset accesses the gravatar URL from the server
- Basset caches it 
- the cached URL will be shown to the user (not the one from Gravatar)

So from Gravatar's perspective, they're only getting calls from the server... NOT the end-user browser. Tada... GDPR-friendly enchilada.

![here-it-is-season-6-gif-by-friends](https://github.com/Laravel-Backpack/CRUD/assets/1032474/e920a68e-4635-454c-995a-f6aea55fccc4)


## HOW

### How did you achieve that, in technical terms?

Code should be self-explanatory.



### Is it a breaking change?

Non-breaking.


### How can we test the before & after?

> First of all, if you're testing theme-tabler, you might want to get the latest commit, I've pushed some bug fixes there that are somewhat related. But this should work just as well without it, after all the only thing it affects is the URL of the avatar. Surgical! 🩺🩻🔪

**Before**:
- when logged in as an admin with a real email address, you get your image shown, but the URL reads `https://secure.gravatar.com/avatar/832dca008bde06aaecf218b4ab8ed9c8.jpg?s=80&d=blank&r=g`

**After**:
- you get EXACTLY the same thing if Basset is turned off; URL from Gravatar;
- but if you turn on Basset by doing `BASSET_DEV_MODE=false` in your `.ENV` file, when logged in as an admin with a real email address, you get your image shown, the URL should read `http://your-app-name.test/storage/basset/secure.gravatar.com/avatar/832dca008bde06aaecf218b4ab8ed9c8.jpg`

From an UI perspective, they should both show exactly the same thing:
- the image when the user is real
- a placeholder when the user is fake


https://github.com/Laravel-Backpack/CRUD/assets/1032474/d30d866b-69a4-4f44-b365-0b26bda14a09

