### PR TITLE
Add dropdown header component

### DIFF
--- a/src/app/View/Components/MenuDropdownHeader.php
+++ b/src/app/View/Components/MenuDropdownHeader.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backpack\CRUD\app\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class MenuDropdownHeader extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public ?string $title = null,
+        public ?string $icon = null,
+        public ?string $link = null,
+    ) {
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return backpack_view('components.menu-dropdown-header');
+    }
+}

--- a/src/resources/views/ui/components/menu-dropdown-header.blade.php
+++ b/src/resources/views/ui/components/menu-dropdown-header.blade.php
@@ -1,0 +1,4 @@
+<h6 {{ $attributes->merge(['class' => 'dropdown-header']) }}>
+    @if ($icon != null)<i class="nav-icon {{ $icon }}"></i>@endif
+    @if ($title!=null) <span>{{ $title }}</span>@endif
+</h6>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We had no way to split dropdowns into multiple areas.

### AFTER - What is happening after this PR?

We do, for all themes:
![CleanShot 2023-06-30 at 15 53 47](https://github.com/Laravel-Backpack/CRUD/assets/1032474/c38375e8-8876-40e6-9205-401f313bf9f1)
![CleanShot 2023-06-30 at 15 54 10](https://github.com/Laravel-Backpack/CRUD/assets/1032474/ecdbb612-a191-4d50-8fbd-7e8ef1d4a697)
![CleanShot 2023-06-30 at 15 54 45](https://github.com/Laravel-Backpack/CRUD/assets/1032474/0b99a135-dc62-4017-8d28-ca4de36562ef)
![CleanShot 2023-06-30 at 15 56 25](https://github.com/Laravel-Backpack/CRUD/assets/1032474/8b09e857-65bf-4de8-8ec6-a1d9b19b5e26)


## HOW

### How did you achieve that, in technical terms?

New component.

### Is it a breaking change?

No.