### PR TITLE
Change v6 install command - add theme chooser and make `coreuiv2` the default theme

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -30,6 +30,9 @@ class BackpackServiceProvider extends ServiceProvider
         \Backpack\CRUD\app\Console\Commands\Addons\RequireDevTools::class,
         \Backpack\CRUD\app\Console\Commands\Addons\RequireEditableColumns::class,
         \Backpack\CRUD\app\Console\Commands\Addons\RequirePro::class,
+        \Backpack\CRUD\app\Console\Commands\Themes\RequireThemeTabler::class,
+        \Backpack\CRUD\app\Console\Commands\Themes\RequireThemeCoreuiv2::class,
+        \Backpack\CRUD\app\Console\Commands\Themes\RequireThemeCoreuiv4::class,
         \Backpack\CRUD\app\Console\Commands\Fix::class,
     ];
 

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -83,7 +83,7 @@ class Install extends Command
 
         // Install Backpack Generators
         $this->progressBlock('Installing Generators');
-        if (!file_exists('vendor/backpack/generators/composer.json')) {
+        if (! file_exists('vendor/backpack/generators/composer.json')) {
             // only do this if Generators aren't already required
             $process = new Process(['composer', 'require', '--dev', 'backpack/generators']);
             $process->setTimeout(300);
@@ -320,7 +320,7 @@ class Install extends Command
             }, 0);
 
         $total = 0;
-        while (!$this->isEveryThemeInstalled()) {
+        while (! $this->isEveryThemeInstalled()) {
             $input = (int) $this->listChoice('Which Backpack theme would you like to install? <fg=gray>(enter option number: 1, 2 or 3)</>', $this->themes->toArray());
 
             if ($input < 1 || $input > $this->themes->count()) {

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -53,7 +53,7 @@ class Install extends Command
         $this->infoBlock('Installing Backpack CRUD:', 'Step 1');
 
         // Publish files
-        $this->progressBlock('Publishing configs, views, js and css files');
+        $this->progressBlock('Publishing configs, views, routes and assets');
         $this->executeArtisanProcess('vendor:publish', [
             '--provider' => BackpackServiceProvider::class,
             '--tag' => 'minimum',
@@ -71,10 +71,13 @@ class Install extends Command
         $this->closeProgressBlock();
 
         // Install Backpack Generators
-        $this->progressBlock('Installing Backpack Generators');
-        $process = new Process(['composer', 'require', '--dev', 'backpack/generators']);
-        $process->setTimeout(300);
-        $process->run();
+        $this->progressBlock('Installing Generators');
+        if (!file_exists('vendor/backpack/generators/composer.json')) {
+            // only do this if Generators aren't already required
+            $process = new Process(['composer', 'require', '--dev', 'backpack/generators']);
+            $process->setTimeout(300);
+            $process->run();
+        }
         $this->closeProgressBlock();
 
         // Install Backpack Basset
@@ -224,7 +227,7 @@ class Install extends Command
 
         $total = 0;
         while (! $this->isEveryAddonInstalled()) {
-            $input = (int) $this->listChoice('Would you like to install a premium Backpack add-on? <fg=gray>(enter option number)</>', $this->addons->toArray());
+            $input = (int) $this->listChoice('Would you like to install a premium Backpack add-on? <fg=gray>(enter option number: 1, 2 or 3)</>', $this->addons->toArray());
 
             if ($input < 1 || $input > $this->addons->count()) {
                 $this->deleteLines(3);

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -106,7 +106,7 @@ class Install extends Command
 
             // Addons
             $this->installAddons();
-        } elseif (!$this->isAnyThemeInstalled()) {
+        } elseif (! $this->isAnyThemeInstalled()) {
             // Install default theme
             $this->progressBlock('Installing default theme');
             $this->executeArtisanProcess('backpack:require:theme-coreuiv2');
@@ -315,6 +315,7 @@ class Install extends Command
             $this->deleteLines(3);
             $this->note('Skipping installing a theme.');
             $this->newLine();
+
             return;
         }
 
@@ -334,7 +335,6 @@ class Install extends Command
         } catch (\Throwable $e) {
             $this->errorBlock($e->getMessage());
         }
-
     }
 
     public function themes()

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -143,6 +143,13 @@ class Install extends Command
         $currentUsers = $userModel->count();
         $this->note(sprintf('Currently there %s in the <fg=blue>%s</> table.', trans_choice("{0} are <fg=blue>no users</>|{1} is <fg=blue>1 user</>|[2,*] are <fg=blue>$currentUsers users</>", $currentUsers), $userModel->getTable()));
 
+        if ($currentUsers) {
+            $this->note('Skipping creating an admin user.');
+            $this->newLine();
+
+            return;
+        }
+
         $total = 0;
         while ($this->confirm(' Add '.($total ? 'another' : 'an').' admin user?')) {
             $name = $this->ask(' Name');

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -35,6 +35,7 @@ trait InstallsTheme
     // 'repo'    => 'backpack/theme-coreuiv2',
     // 'path'    => 'vendor/backpack/theme-coreuiv2',
     // 'command' => 'backpack:require:theme-coreuiv2',
+    // 'view_namespace' => 'backpack.theme-coreuiv2::',
     // 'publish_tag' => 'theme-coreuiv2-config',
     // ];
 

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -27,15 +27,15 @@ trait InstallsTheme
      * @var array
      */
     // public static $addon = [
-        // 'name'        => 'CoreUIv2',
-        // 'description' => [
+    // 'name'        => 'CoreUIv2',
+    // 'description' => [
         //     'UI provided by CoreUIv2, a Boostrap 4 template.',
         //     '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv2/</>',
-        // ],
-        // 'repo'    => 'backpack/theme-coreuiv2',
-        // 'path'    => 'vendor/backpack/theme-coreuiv2',
-        // 'command' => 'backpack:require:theme-coreuiv2',
-        // 'publish-tag' => 'theme-coreuiv2-config',
+    // ],
+    // 'repo'    => 'backpack/theme-coreuiv2',
+    // 'path'    => 'vendor/backpack/theme-coreuiv2',
+    // 'command' => 'backpack:require:theme-coreuiv2',
+    // 'publish-tag' => 'theme-coreuiv2-config',
     // ];
 
     /**

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands\Themes;
+
+trait InstallsTheme
+{
+    use \Backpack\CRUD\app\Console\Commands\Traits\PrettyCommandOutput;
+    use \Backpack\CRUD\app\Console\Commands\Traits\AddonsHelper;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    // protected $signature = 'backpack:require:theme-name {--debug} : Show process output or not. Useful for debugging.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    // protected $description = 'Install Backpack\'s XXX Theme';
+
+    /**
+     * Backpack addons install attribute.
+     *
+     * @var array
+     */
+    // public static $addon = [
+        // 'name'        => 'CoreUIv2',
+        // 'description' => [
+        //     'UI provided by CoreUIv2, a Boostrap 4 template.',
+        //     '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv2/</>',
+        // ],
+        // 'repo'    => 'backpack/theme-coreuiv2',
+        // 'path'    => 'vendor/backpack/theme-coreuiv2',
+        // 'command' => 'backpack:require:theme-coreuiv2',
+        // 'publish-tag' => 'theme-coreuiv2-config',
+    // ];
+
+    /**
+     * Run the theme installation process.
+     *
+     * @return void
+     */
+    public function installTheme()
+    {
+        // Check if it is installed
+        if ($this->isInstalled()) {
+            $this->newLine();
+            $this->line(sprintf('  %s was already installed', self::$addon['name']), 'fg=red');
+            $this->newLine();
+
+            return;
+        }
+
+        $this->newLine();
+        $this->progressBlock($this->description);
+
+        // Require package
+        try {
+            $this->composerRequire(self::$addon['repo']);
+            $this->closeProgressBlock();
+        } catch (\Throwable $e) {
+            $this->errorProgressBlock();
+            $this->line('  '.$e->getMessage(), 'fg=red');
+            $this->newLine();
+
+            return;
+        }
+
+        // Display general error in case it failed
+        if (! $this->isInstalled()) {
+            $this->errorProgressBlock();
+            $this->note('For further information please check the log file.');
+            $this->note('You can also follow the manual installation process documented on Github.');
+            $this->newLine();
+
+            return;
+        }
+
+        // Publish the theme config file
+        $this->newLine();
+        $this->progressBlock('Publish theme config file');
+        $this->executeArtisanProcess('vendor:publish', [
+            '--tag' => self::$addon['publish-tag'],
+        ]);
+
+        // Finish
+        $this->closeProgressBlock();
+        $this->newLine();
+    }
+
+    public function isInstalled()
+    {
+        return file_exists(self::$addon['path'].'/composer.json');
+    }
+}

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -35,7 +35,7 @@ trait InstallsTheme
     // 'repo'    => 'backpack/theme-coreuiv2',
     // 'path'    => 'vendor/backpack/theme-coreuiv2',
     // 'command' => 'backpack:require:theme-coreuiv2',
-    // 'publish-tag' => 'theme-coreuiv2-config',
+    // 'publish_tag' => 'theme-coreuiv2-config',
     // ];
 
     /**
@@ -82,10 +82,13 @@ trait InstallsTheme
         // Publish the theme config file
         $this->progressBlock('Publish theme config file');
         $this->executeArtisanProcess('vendor:publish', [
-            '--tag' => self::$addon['publish-tag'],
+            '--tag' => self::$addon['publish_tag'],
         ]);
+        $this->closeProgressBlock();
 
-        // Finish
+        // add this theme's view namespace to the ui config file
+        $this->progressBlock('Use theme as view namespace in <fg=blue>config/backpack/ui.php</>');
+        $this->useViewNamespaceInConfigFile();
         $this->closeProgressBlock();
         $this->newLine();
     }
@@ -93,5 +96,15 @@ trait InstallsTheme
     public function isInstalled()
     {
         return file_exists(self::$addon['path'].'/composer.json');
+    }
+
+    public function useViewNamespaceInConfigFile()
+    {
+        $config_file = config_path('backpack/ui.php');
+        $config_contents = file_get_contents($config_file);
+        $config_contents = preg_replace("/'view_namespace' => '.*'/", "'view_namespace' => '".self::$addon['view_namespace']."'", $config_contents);
+        $config_contents = preg_replace("/'view_namespace_fallback' => '.*'/", "'view_namespace_fallback' => '".self::$addon['view_namespace']."'", $config_contents);
+
+        file_put_contents($config_file, $config_contents);
     }
 }

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -80,7 +80,6 @@ trait InstallsTheme
         }
 
         // Publish the theme config file
-        $this->newLine();
         $this->progressBlock('Publish theme config file');
         $this->executeArtisanProcess('vendor:publish', [
             '--tag' => self::$addon['publish-tag'],

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands\Themes;
+
+use Illuminate\Console\Command;
+use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
+
+class RequireThemeCoreuiv2 extends Command
+{
+    use InstallsTheme;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:require:theme-coreuiv2
+                                {--debug} : Show process output or not. Useful for debugging.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install Backpack\'s CoreUIv2 Theme';
+
+    /**
+     * Backpack addons install attribute.
+     *
+     * @var array
+     */
+    public static $addon = [
+        'name'        => 'CoreUIv2',
+        'description' => [
+            'UI provided by CoreUIv2, a Boostrap 4 template.',
+            '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv2/</>',
+        ],
+        'repo'    => 'backpack/theme-coreuiv2',
+        'path'    => 'vendor/backpack/theme-coreuiv2',
+        'command' => 'backpack:require:theme-coreuiv2',
+        'publish-tag' => 'theme-coreuiv2-config',
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed Command-line output
+     */
+    public function handle()
+    {
+        $this->installTheme();
+    }
+}

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -21,7 +21,7 @@ class RequireThemeCoreuiv2 extends Command
      *
      * @var string
      */
-    protected $description = 'Install Backpack\'s CoreUIv2 Theme';
+    protected $description = 'Install the CoreUIv2 theme';
 
     /**
      * Backpack addons install attribute.
@@ -29,7 +29,7 @@ class RequireThemeCoreuiv2 extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'CoreUIv2',
+        'name'        => 'CoreUIv2 <fg=green>(default)</>',
         'description' => [
             'UI provided by CoreUIv2, a Boostrap 4 template.',
             '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv2/</>',

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -37,7 +37,8 @@ class RequireThemeCoreuiv2 extends Command
         'repo'    => 'backpack/theme-coreuiv2',
         'path'    => 'vendor/backpack/theme-coreuiv2',
         'command' => 'backpack:require:theme-coreuiv2',
-        'publish-tag' => 'theme-coreuiv2-config',
+        'view_namespace' => 'backpack.theme-coreuiv2::',
+        'publish_tag' => 'theme-coreuiv2-config',
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands\Themes;
 
 use Illuminate\Console\Command;
-use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
 
 class RequireThemeCoreuiv2 extends Command
 {

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -21,7 +21,7 @@ class RequireThemeCoreuiv4 extends Command
      *
      * @var string
      */
-    protected $description = 'Install Backpack\'s CoreUIv4 Theme';
+    protected $description = 'Install the CoreUIv4 theme';
 
     /**
      * Backpack addons install attribute.
@@ -29,7 +29,7 @@ class RequireThemeCoreuiv4 extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'CoreUIv4',
+        'name'        => 'CoreUIv4 <fg=yellow>(public beta)</>',
         'description' => [
             'UI provided by CoreUIv4, a Boostrap 5 template.',
             '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv4/</>',

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands\Themes;
 
 use Illuminate\Console\Command;
-use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
 
 class RequireThemeCoreuiv4 extends Command
 {

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -37,7 +37,8 @@ class RequireThemeCoreuiv4 extends Command
         'repo'    => 'backpack/theme-coreuiv4',
         'path'    => 'vendor/backpack/theme-coreuiv4',
         'command' => 'backpack:require:theme-coreuiv4',
-        'publish-tag' => 'theme-coreuiv4-config',
+        'view_namespace' => 'backpack.theme-coreuiv4::',
+        'publish_tag' => 'theme-coreuiv4-config',
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands\Themes;
+
+use Illuminate\Console\Command;
+use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
+
+class RequireThemeCoreuiv4 extends Command
+{
+    use InstallsTheme;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:require:theme-coreuiv4
+                                {--debug} : Show process output or not. Useful for debugging.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install Backpack\'s CoreUIv4 Theme';
+
+    /**
+     * Backpack addons install attribute.
+     *
+     * @var array
+     */
+    public static $addon = [
+        'name'        => 'CoreUIv4',
+        'description' => [
+            'UI provided by CoreUIv4, a Boostrap 5 template.',
+            '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv4/</>',
+        ],
+        'repo'    => 'backpack/theme-coreuiv4',
+        'path'    => 'vendor/backpack/theme-coreuiv4',
+        'command' => 'backpack:require:theme-coreuiv4',
+        'publish-tag' => 'theme-coreuiv4-config',
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed Command-line output
+     */
+    public function handle()
+    {
+        $this->installTheme();
+    }
+}

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Backpack\CRUD\app\Console\Commands\Themes;
+
+use Illuminate\Console\Command;
+use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
+
+class RequireThemeTabler extends Command
+{
+    use InstallsTheme;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:require:theme-tabler
+                                {--debug} : Show process output or not. Useful for debugging.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install Backpack\'s Tabler Theme';
+
+    /**
+     * Backpack addons install attribute.
+     *
+     * @var array
+     */
+    public static $addon = [
+        'name'        => 'Tabler',
+        'description' => [
+            'UI provided by Tabler, a Boostrap 5 template.',
+            '<fg=blue>https://github.com/laravel-backpack/theme-tabler/</>',
+        ],
+        'repo'    => 'backpack/theme-tabler',
+        'path'    => 'vendor/backpack/theme-tabler',
+        'command' => 'backpack:require:theme-tabler',
+        'publish-tag' => 'theme-tabler-config',
+    ];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed Command-line output
+     */
+    public function handle()
+    {
+        $this->installTheme();
+    }
+}

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\app\Console\Commands\Themes;
 
 use Illuminate\Console\Command;
-use Backpack\CRUD\app\Console\Commands\Themes\InstallsTheme;
 
 class RequireThemeTabler extends Command
 {

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -21,7 +21,7 @@ class RequireThemeTabler extends Command
      *
      * @var string
      */
-    protected $description = 'Install Backpack\'s Tabler Theme';
+    protected $description = 'Install the Tabler theme';
 
     /**
      * Backpack addons install attribute.
@@ -29,7 +29,7 @@ class RequireThemeTabler extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'Tabler',
+        'name'        => 'Tabler <fg=yellow>(public beta)</>',
         'description' => [
             'UI provided by Tabler, a Boostrap 5 template.',
             '<fg=blue>https://github.com/laravel-backpack/theme-tabler/</>',

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -37,7 +37,8 @@ class RequireThemeTabler extends Command
         'repo'    => 'backpack/theme-tabler',
         'path'    => 'vendor/backpack/theme-tabler',
         'command' => 'backpack:require:theme-tabler',
-        'publish-tag' => 'theme-tabler-config',
+        'view_namespace' => 'backpack.theme-tabler::',
+        'publish_tag' => 'theme-tabler-config',
     ];
 
     /**

--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -18,8 +18,8 @@ return [
     // and choosing that view_namespace instead of the default one. Backpack will load a file from there
     // if it exists, otherwise it will load it from the fallback namespace.
 
-    'view_namespace' => 'backpack.theme-tabler::',
-    'view_namespace_fallback' => 'backpack.theme-tabler::',
+    'view_namespace' => 'backpack.theme-coreuiv2::',
+    'view_namespace_fallback' => 'backpack.theme-coreuiv2::',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

- we were using `theme-tabler` as the default, even though it's a little buggy right now;
- we were running the generators installation process even if they were already installed;
- we were asking whether the user wants to add users, even if users already existed;
- we didn't have a way to install themes from the command line;

### AFTER - What is happening after this PR?

- we're using `theme-coreuiv2` as the default; that has no known bugs so... that's the only one that we can _reasonably_ use as the default _right now_; after we fix more Tabler bugs... we can move over to that one as the default;
- we have a way to install themes - `php artisan backpack:require:theme-tabler` but please note this does NOT add the view_namespace to the config file;
- fixed the above;

## HOW

### How did you achieve that, in technical terms?

Had a coffee. Thought about it. Wrote the code. Technically. Then rewrote it 'cause it was crap. Then wanted to rewrite it again but said "fuck it". It's technically good enough.

### Is it a breaking change?

Yes. It changes the default theme from `theme-tabler` to `theme-coreuiv2`.

### How can we test the before & after?

Install a new Laravel project, do `composer require backpack/crud:"v6.x-dev"` then run `php artisan backpack:install`. It should use `coreuiv2` as the default theme (without even asking) and everything should work fine.
