### PR TITLE
Removed forced padding on CRUD

### DIFF
--- a/src/resources/views/crud/inc/grouped_errors.blade.php
+++ b/src/resources/views/crud/inc/grouped_errors.blade.php
@@ -1,6 +1,6 @@
 {{-- Show the errors, if any --}}
 @if ($crud->groupedErrorsEnabled() && session()->get('errors'))
-    <div class="alert alert-danger pb-0">
+    <div class="alert alert-danger">
         <ul class="list-unstyled">
             @foreach(session()->get('errors')->getBags() as $bag => $errorMessages)
                 @foreach($errorMessages->getMessages() as $errorMessageForInput)


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

CRUD was forcing a padding and it shouldn't, CRUD should be the most agnostic as possible to any styles.

### AFTER - What is happening after this PR?

No more forced paddings.

### Is it a breaking change?

Yes, but No 🤷‍♂️
This is for v6.

This was an issue in Core UI, so the fixes for coreui are here;
https://github.com/Laravel-Backpack/theme-coreuiv2/pull/19
https://github.com/Laravel-Backpack/theme-coreuiv4/pull/31

---

Core UI v2
![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/20c2cdbb-60d2-4e08-9195-dd31e4a5da35)

Core UI v4
![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/615020fc-eb80-4d19-b317-cab3bc1609e6)

Tabler
![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/abad14cd-338a-4c93-a4c1-e0907cdfcadb)

