### PR TITLE
Allow menu dropdown component to be open by default

### DIFF
--- a/src/app/View/Components/MenuDropdown.php
+++ b/src/app/View/Components/MenuDropdown.php
@@ -15,6 +15,7 @@ class MenuDropdown extends Component
         public ?string $title = null,
         public ?string $icon = null,
         public ?string $link = null,
+        public bool $open = false,
         public array $items = [],
     ) {
     }

--- a/src/resources/views/ui/components/menu-dropdown.blade.php
+++ b/src/resources/views/ui/components/menu-dropdown.blade.php
@@ -2,14 +2,14 @@
     <a {{ $attributes->merge([
                                 'class' => 'nav-link dropdown-toggle',
                                 'href' => $link ?? '#',
-                                'data-bs-toggle'=> 'dropdown',
+                                'data-bs-toggle' => 'dropdown',
                                 'role' => 'button',
                                 'aria-expanded' => 'true'
                             ]) }}>
         @if($icon)<i class="nav-icon {{ $icon }} d-block d-lg-none d-xl-block"></i>@endif
-        @if($title) <span>{{ $title }}</span>@endif
+        @if($title)<span>{{ $title }}</span>@endif
     </a>
-    <div class="dropdown-menu" data-bs-popper="static">
+    <div class="dropdown-menu {{ $open ? 'show' : '' }}" data-bs-popper="static">
     {!! $slot !!}
     </div>
 </li>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Menu dropdowns were always closed initially (unless a link within them is currently active), with no way to force them to be open by default. This is useful for some cases, where you want to group menu items in a dropdown but still show them by default.

### AFTER - What is happening after this PR?

The option `:open="true"` can be passed to the component to have it open by default.


## HOW

### How did you achieve that, in technical terms?

Add a new attribute to the Blade component and template.

Note: this requires similar changes in the upstream themes which copy/override the component template.



### Is it a breaking change?

No.


### How can we test the before & after?

Add `:open="true"` to a `x-backpack::menu-item` component.
