### PR TITLE
Make uploaders aware of fake fields

### DIFF
--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -19,7 +19,7 @@ class MultipleFiles extends Uploader
     {
         $filesToDelete = CRUD::getRequest()->get('clear_'.$this->getName());
         $value = $value ?? CRUD::getRequest()->file($this->getName());
-        $previousFiles = $entry->getOriginal($this->getName()) ?? [];
+        $previousFiles = $this->getPreviousFiles() ?? [];
 
         if (! is_array($previousFiles) && is_string($previousFiles)) {
             $previousFiles = json_decode($previousFiles, true);

--- a/src/app/Library/Uploaders/SingleBase64Image.php
+++ b/src/app/Library/Uploaders/SingleBase64Image.php
@@ -12,7 +12,7 @@ class SingleBase64Image extends Uploader
     public function uploadFiles(Model $entry, $value = null)
     {
         $value = $value ?? CRUD::getRequest()->get($this->getName());
-        $previousImage = $entry->getOriginal($this->getName());
+        $previousImage = $this->getPreviousFiles($entry);
 
         if (! $value && $previousImage) {
             Storage::disk($this->getDisk())->delete($previousImage);

--- a/src/app/Library/Uploaders/SingleFile.php
+++ b/src/app/Library/Uploaders/SingleFile.php
@@ -11,7 +11,7 @@ class SingleFile extends Uploader
     public function uploadFiles(Model $entry, $value = null)
     {
         $value = $value ?? CrudPanelFacade::getRequest()->file($this->getName());
-        $previousFile = $entry->getOriginal($this->getName());
+        $previousFile = $this->getPreviousFiles($entry);
 
         if ($value && is_file($value) && $value->isValid()) {
             if ($previousFile) {

--- a/src/app/Library/Uploaders/Support/Interfaces/UploaderInterface.php
+++ b/src/app/Library/Uploaders/Support/Interfaces/UploaderInterface.php
@@ -52,4 +52,6 @@ interface UploaderInterface
     public function shouldDeleteFiles(): bool;
 
     public function canHandleMultipleFiles(): bool;
+
+    public function getPreviousFiles(Model $entry): mixed;
 }

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -25,6 +25,8 @@ abstract class Uploader implements UploaderInterface
 
     private bool $deleteWhenEntryIsDeleted = true;
 
+    private bool|string $attachedToFakeField = false;
+
     /**
      * Cloud disks have the ability to generate temporary URLs to files, should we do it?
      */
@@ -45,6 +47,7 @@ abstract class Uploader implements UploaderInterface
         $this->name = $crudObject['name'];
         $this->disk = $configuration['disk'] ?? $crudObject['disk'] ?? $this->disk;
         $this->path = $this->getPathFromConfiguration($crudObject, $configuration);
+        $this->attachedToFakeField = $crudObject['fake'] ? ($crudObject['store_in'] ?? 'extras') : ($crudObject['store_in'] ?? false);
         $this->useTemporaryUrl = $configuration['temporaryUrl'] ?? $this->useTemporaryUrl;
         $this->temporaryUrlExpirationTimeInMinutes = $configuration['temporaryUrlExpirationTime'] ?? $this->temporaryUrlExpirationTimeInMinutes;
         $this->deleteWhenEntryIsDeleted = $configuration['deleteWhenEntryIsDeleted'] ?? $this->deleteWhenEntryIsDeleted;
@@ -68,7 +71,15 @@ abstract class Uploader implements UploaderInterface
             return $this->handleRepeatableFiles($entry);
         }
 
-        $entry->{$this->name} = $this->uploadFiles($entry);
+        if($this->attachedToFakeField) {
+            $fakeFieldValue = $entry->{$this->attachedToFakeField};
+            $fakeFieldValue = is_string($fakeFieldValue) ? json_decode($fakeFieldValue, true) : (array)$fakeFieldValue;
+            $fakeFieldValue[$this->getName()] = $this->uploadFiles($entry);
+            $entry->{$this->attachedToFakeField} = json_encode($fakeFieldValue);
+            return $entry;
+        }
+        
+        $entry->{$this->getName()} = $this->uploadFiles($entry);
 
         return $entry;
     }

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -156,6 +156,18 @@ abstract class Uploader implements UploaderInterface
         return $this->handleMultipleFiles;
     }
 
+    public function getPreviousFiles(Model $entry): mixed {
+
+        if(! $this->attachedToFakeField) {
+            return $entry->getOriginal($this->getName()); 
+        }
+
+        $value = $entry->getOriginal($this->attachedToFakeField);
+        $value = is_string($value) ? json_decode($value, true) : (array)$value;
+
+        return $value[$this->getName()] ?? null;      
+    }
+
     /*******************************
      * Setters - fluently configure the uploader
      *******************************/

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -71,14 +71,15 @@ abstract class Uploader implements UploaderInterface
             return $this->handleRepeatableFiles($entry);
         }
 
-        if($this->attachedToFakeField) {
+        if ($this->attachedToFakeField) {
             $fakeFieldValue = $entry->{$this->attachedToFakeField};
-            $fakeFieldValue = is_string($fakeFieldValue) ? json_decode($fakeFieldValue, true) : (array)$fakeFieldValue;
+            $fakeFieldValue = is_string($fakeFieldValue) ? json_decode($fakeFieldValue, true) : (array) $fakeFieldValue;
             $fakeFieldValue[$this->getName()] = $this->uploadFiles($entry);
             $entry->{$this->attachedToFakeField} = json_encode($fakeFieldValue);
+
             return $entry;
         }
-        
+
         $entry->{$this->getName()} = $this->uploadFiles($entry);
 
         return $entry;

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -204,6 +204,14 @@ abstract class Uploader implements UploaderInterface
             return $entry;
         }
 
+        if($this->attachedToFakeField) {
+            $values = $entry->{$this->attachedToFakeField};
+            $values = is_string($values) ? json_decode($values, true) : (array)$values;
+            $values[$this->name] = Str::after($values[$this->name], $this->path);
+            $entry->{$this->attachedToFakeField} = json_encode($values);
+            return $entry;
+        }
+
         $entry->{$this->name} = Str::after($value, $this->path);
 
         return $entry;

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -204,11 +204,12 @@ abstract class Uploader implements UploaderInterface
             return $entry;
         }
 
-        if($this->attachedToFakeField) {
+        if ($this->attachedToFakeField) {
             $values = $entry->{$this->attachedToFakeField};
-            $values = is_string($values) ? json_decode($values, true) : (array)$values;
+            $values = is_string($values) ? json_decode($values, true) : (array) $values;
             $values[$this->name] = Str::after($values[$this->name], $this->path);
             $entry->{$this->attachedToFakeField} = json_encode($values);
+
             return $entry;
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/PageManager/issues/135

The uploaders were not aware of the possibility of fake fields and tried to save the fake field as part of the main entry, raising sql errors.

### AFTER - What is happening after this PR?

Uploaders are now aware if they are attached to a fake field, in case they are the upload value is written to the fake field key and not the main entry.


## HOW

### How did you achieve that, in technical terms?

Added an `attachedToFakeField` property that can be `false` or `string` (the name of the fake attribute in database).

### Is it a breaking change?

No


### How can we test the before & after?

Try adding `->withFiles()` to a fake field.