### PR TITLE
dont use layout if theme does not provide it

### DIFF
--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -1,4 +1,4 @@
-@extends(backpack_user() ? backpack_view('layouts.'.backpack_theme_config('layout')) : backpack_view('errors.blank'))
+@extends(backpack_user() ? (backpack_theme_config('layout') ? backpack_view('layouts.'.backpack_theme_config('layout')) : backpack_view('errors.blank')) : backpack_view('errors.blank'))
 {{-- show error using sidebar layout if looged in AND on an admin page; otherwise use a blank page --}}
 
 @php


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in https://github.com/Laravel-Backpack/CRUD/issues/5172 the error pages would attempt to use a layout even if themes didn't provide one and would raise view errors

### AFTER - What is happening after this PR?

No more errors. We don't use theme layout if the theme don't provide it.


## HOW

### How did you achieve that, in technical terms?

conditionals my friends, conditionals.



### Is it a breaking change?

No


### How can we test the before & after?

raise a 500 error for example in a controller using coreui-v2. 