### PR TITLE
fix tabs in show operation

### DIFF
--- a/src/resources/views/crud/inc/show_tabbed_table.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_table.blade.php
@@ -19,11 +19,13 @@
             @foreach ($columnsWithTabs as $k => $tabLabel)
                 <li role="presentation" class="nav-item">
                     <a href="#tab_{{ Str::slug($tabLabel) }}"
-                       aria-controls="tab_{{ Str::slug($tabLabel) }}"
-                       role="tab"
-                       tab_name="{{ Str::slug($tabLabel) }}"
-                       data-toggle="tab"
-                       class="nav-link {{ $k === 0 ? 'active' : '' }}"
+                        aria-controls="tab_{{ Str::slug($tabLabel) }}"
+                        role="tab"
+                        data-toggle="tab" {{-- tab indicator for Bootstrap v4 --}}
+                        tab_name="{{ Str::slug($tabLabel) }}" {{-- tab name for Bootstrap v4 --}}
+                        data-name="{{ Str::slug($tabLabel) }}" {{-- tab name for Bootstrap v5 --}}
+                        data-bs-toggle="tab" {{-- tab name for Bootstrap v5 --}}
+                        class="nav-link {{ $k === 0 ? 'active' : '' }}"
                     >{{ $tabLabel }}</a>
                 </li>
             @endforeach


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5176

Show operation tabs didn't had the necessary BS5 attributes to work.

### AFTER - What is happening after this PR?

They have. 💪 

## HOW

### How did you achieve that, in technical terms?

Copy from the field tabs attributes 🙄 



### Is it a breaking change?

No


### How can we test the before & after?

Enable tabs in show operation. 
