### PR TITLE
Fix theme config publishing

### DIFF
--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -51,7 +51,6 @@ trait InstallsTheme
             $this->newLine();
             $this->line(sprintf('  %s was already installed', self::$addon['name']), 'fg=red');
             $this->newLine();
-
             return;
         }
 
@@ -82,6 +81,13 @@ trait InstallsTheme
 
         // Publish the theme config file
         $this->progressBlock('Publish theme config file');
+
+        // manually include the provider in the run-time
+        if(! class_exists(self::$addon['provider'])) {
+            include(self::$addon['provider_path'] ?? self::$addon['path'].'/src/AddonServiceProvider.php');
+            app()->register(self::$addon['provider']);
+        }
+        
         $this->executeArtisanProcess('vendor:publish', [
             '--tag' => self::$addon['publish_tag'],
         ]);

--- a/src/app/Console/Commands/Themes/InstallsTheme.php
+++ b/src/app/Console/Commands/Themes/InstallsTheme.php
@@ -51,6 +51,7 @@ trait InstallsTheme
             $this->newLine();
             $this->line(sprintf('  %s was already installed', self::$addon['name']), 'fg=red');
             $this->newLine();
+
             return;
         }
 
@@ -83,11 +84,11 @@ trait InstallsTheme
         $this->progressBlock('Publish theme config file');
 
         // manually include the provider in the run-time
-        if(! class_exists(self::$addon['provider'])) {
-            include(self::$addon['provider_path'] ?? self::$addon['path'].'/src/AddonServiceProvider.php');
+        if (! class_exists(self::$addon['provider'])) {
+            include self::$addon['provider_path'] ?? self::$addon['path'].'/src/AddonServiceProvider.php';
             app()->register(self::$addon['provider']);
         }
-        
+
         $this->executeArtisanProcess('vendor:publish', [
             '--tag' => self::$addon['publish_tag'],
         ]);

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -39,6 +39,7 @@ class RequireThemeCoreuiv2 extends Command
         'command' => 'backpack:require:theme-coreuiv2',
         'view_namespace' => 'backpack.theme-coreuiv2::',
         'publish_tag' => 'theme-coreuiv2-config',
+        'provider' => '\Backpack\ThemeCoreuiv2\AddonServiceProvider'
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -39,7 +39,7 @@ class RequireThemeCoreuiv2 extends Command
         'command' => 'backpack:require:theme-coreuiv2',
         'view_namespace' => 'backpack.theme-coreuiv2::',
         'publish_tag' => 'theme-coreuiv2-config',
-        'provider' => '\Backpack\ThemeCoreuiv2\AddonServiceProvider'
+        'provider' => '\Backpack\ThemeCoreuiv2\AddonServiceProvider',
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -39,7 +39,7 @@ class RequireThemeCoreuiv4 extends Command
         'command' => 'backpack:require:theme-coreuiv4',
         'view_namespace' => 'backpack.theme-coreuiv4::',
         'publish_tag' => 'theme-coreuiv4-config',
-        'provider' => '\Backpack\ThemeCoreuiv4\AddonServiceProvider'
+        'provider' => '\Backpack\ThemeCoreuiv4\AddonServiceProvider',
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -39,6 +39,7 @@ class RequireThemeCoreuiv4 extends Command
         'command' => 'backpack:require:theme-coreuiv4',
         'view_namespace' => 'backpack.theme-coreuiv4::',
         'publish_tag' => 'theme-coreuiv4-config',
+        'provider' => '\Backpack\ThemeCoreuiv4\AddonServiceProvider'
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -39,6 +39,7 @@ class RequireThemeTabler extends Command
         'command' => 'backpack:require:theme-tabler',
         'view_namespace' => 'backpack.theme-tabler::',
         'publish_tag' => 'theme-tabler-config',
+        'provider' => '\Backpack\ThemeTabler\AddonServiceProvider'
     ];
 
     /**

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -39,7 +39,7 @@ class RequireThemeTabler extends Command
         'command' => 'backpack:require:theme-tabler',
         'view_namespace' => 'backpack.theme-tabler::',
         'publish_tag' => 'theme-tabler-config',
-        'provider' => '\Backpack\ThemeTabler\AddonServiceProvider'
+        'provider' => '\Backpack\ThemeTabler\AddonServiceProvider',
     ];
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When installing a theme with `php artisan backpack:require:theme-tabler` for example, the config publish command wouldn't work because the provider was not loaded.

### AFTER - What is happening after this PR?

This ensures the provider is loaded before calling the publish config command.


## HOW

### How did you achieve that, in technical terms?

Load the provider file and register it in the container.

### Is it a breaking change?

No


### How can we test the before & after?

Install any theme with `php artisan backpack:require:theme-*`