### PR TITLE
Avoid double json encode the fake fields in uploaders

### DIFF
--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -75,7 +75,7 @@ abstract class Uploader implements UploaderInterface
             $fakeFieldValue = $entry->{$this->attachedToFakeField};
             $fakeFieldValue = is_string($fakeFieldValue) ? json_decode($fakeFieldValue, true) : (array) $fakeFieldValue;
             $fakeFieldValue[$this->getName()] = $this->uploadFiles($entry);
-          
+
             $entry->{$this->attachedToFakeField} = isset($entry->getCasts()[$this->attachedToFakeField]) ? $fakeFieldValue : json_encode($fakeFieldValue);
 
             return $entry;

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -75,7 +75,8 @@ abstract class Uploader implements UploaderInterface
             $fakeFieldValue = $entry->{$this->attachedToFakeField};
             $fakeFieldValue = is_string($fakeFieldValue) ? json_decode($fakeFieldValue, true) : (array) $fakeFieldValue;
             $fakeFieldValue[$this->getName()] = $this->uploadFiles($entry);
-            $entry->{$this->attachedToFakeField} = json_encode($fakeFieldValue);
+          
+            $entry->{$this->attachedToFakeField} = isset($entry->getCasts()[$this->attachedToFakeField]) ? $fakeFieldValue : json_encode($fakeFieldValue);
 
             return $entry;
         }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

the uploaders were partially fixed to work with fake fields.

if developers casted their fields we would double json encode the payload and it would make the database value unusable. 

### AFTER - What is happening after this PR?

We check if the field is casted in the model, If it is we don't cast the value and just return it.


### Is it a breaking change?

No

### How can we test the before & after?

Add a upload field in `PageManager` package that stores in `extras`.
