### PR TITLE
Update various docblocks to use \Illuminate\Contracts\View\View

### DIFF
--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -19,7 +19,7 @@ class AdminController extends Controller
     /**
      * Show the admin dashboard.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function dashboard()
     {

--- a/src/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -28,7 +28,7 @@ class ForgotPasswordController extends Controller
     /**
      * Display the form to request a password reset link.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showLinkRequestForm()
     {

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -81,7 +81,7 @@ class RegisterController extends Controller
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showRegistrationForm()
     {

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -65,7 +65,7 @@ class ResetPasswordController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string|null  $token
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showResetForm(Request $request, $token = null)
     {

--- a/src/app/Http/Controllers/MyAccountController.php
+++ b/src/app/Http/Controllers/MyAccountController.php
@@ -19,6 +19,8 @@ class MyAccountController extends Controller
 
     /**
      * Show the user a form to change their personal information & password.
+     *
+     * @return \Illuminate\Contracts\View\View
      */
     public function getAccountInfoForm()
     {

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -49,7 +49,7 @@ trait ListOperation
     /**
      * Display all rows in the database for this entity.
      *
-     * @return \Illuminate\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function index()
     {
@@ -114,7 +114,7 @@ trait ListOperation
      * Used with AJAX in the list view (datatables) to show extra information about that row that didn't fit in the table.
      * It defaults to showing some dummy text.
      *
-     * @return \Illuminate\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function showDetailsRow($id)
     {

--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -50,7 +50,7 @@ trait ReorderOperation
      *
      *  Database columns needed: id, parent_id, lft, rgt, depth, name/title
      *
-     *  @return Response
+     *  @return \Illuminate\Contracts\View\View
      */
     public function reorder()
     {

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -66,7 +66,7 @@ trait ShowOperation
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function show($id)
     {

--- a/src/app/Library/Auth/AuthenticatesUsers.php
+++ b/src/app/Library/Auth/AuthenticatesUsers.php
@@ -14,7 +14,7 @@ trait AuthenticatesUsers
     /**
      * Show the application's login form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showLoginForm()
     {

--- a/src/app/Library/Auth/ConfirmsPasswords.php
+++ b/src/app/Library/Auth/ConfirmsPasswords.php
@@ -12,7 +12,7 @@ trait ConfirmsPasswords
     /**
      * Display the password confirmation view.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showConfirmForm()
     {

--- a/src/app/Library/Auth/RegistersUsers.php
+++ b/src/app/Library/Auth/RegistersUsers.php
@@ -14,7 +14,7 @@ trait RegistersUsers
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\View
      */
     public function showRegistrationForm()
     {

--- a/src/app/Library/Auth/ResetsPasswords.php
+++ b/src/app/Library/Auth/ResetsPasswords.php
@@ -22,7 +22,7 @@ trait ResetsPasswords
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string|null  $token
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function showResetForm(Request $request, $token = null)
     {

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -267,7 +267,7 @@ class CrudButton implements Arrayable
      * The HTML itself of the button.
      *
      * @param  object|null  $entry  The eloquent Model for the current entry or null if no current entry.
-     * @return HTML
+     * @return \Illuminate\Contracts\View\View
      */
     public function getHtml($entry = null)
     {


### PR DESCRIPTION
Add \Illuminate\Contracts\View\View return type on various applicable places

## WHY

### BEFORE - What was wrong? What was happening before this PR?

On various places, there were inaccurate docblocks, e.g. ones listing `\Illuminate\Http\Response` or even a non-qualified `Response`, which sometimes results in PHPStan errors upstream.

### AFTER - What is happening after this PR?

On various methods where views are returned, the correct `\Illuminate\Contracts\View\View` is listed as return type.


## HOW

### How did you achieve that, in technical terms?

Look for all occurences of `return view(...)` in the code and update docblocks accordingly.



### Is it a breaking change?

No, just docblock corrections.


### How can we test the before & after?

-
