### PR TITLE
Better debug error message for backpack_view() function

### DIFF
--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -50,7 +50,7 @@ trait ReorderOperation
      *
      *  Database columns needed: id, parent_id, lft, rgt, depth, name/title
      *
-     *  @return \Illuminate\Contracts\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function reorder()
     {

--- a/src/app/Http/Requests/CrudRequest.php
+++ b/src/app/Http/Requests/CrudRequest.php
@@ -35,19 +35,19 @@ class CrudRequest extends FormRequest
     // OPTIONAL OVERRIDE
     // public function forbiddenResponse()
     // {
-        // Optionally, send a custom response on authorize failure
-        // (default is to just redirect to initial page with errors)
+    // Optionally, send a custom response on authorize failure
+    // (default is to just redirect to initial page with errors)
         //
-        // Can return a response, a view, a redirect, or whatever else
-        // return Response::make('Permission denied foo!', 403);
+    // Can return a response, a view, a redirect, or whatever else
+    // return Response::make('Permission denied foo!', 403);
     // }
 
     // OPTIONAL OVERRIDE
     // public function response()
     // {
-        // If you want to customize what happens on a failed validation,
-        // override this method.
-        // See what it does natively here:
-        // https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Http/FormRequest.php
+    // If you want to customize what happens on a failed validation,
+    // override this method.
+    // See what it does natively here:
+    // https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Http/FormRequest.php
     // }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -259,7 +259,7 @@ if (! function_exists('backpack_view')) {
         // we only run the back trace in case we couldn't find the view
         // and help developer understand where is the error
         $backtrace = env('APP_ENV') !== 'production' && env('APP_DEBUG') ? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1) : [];
-    
+
         $functionCaller = $backtrace[0] ?? [];
         $functionLine = $functionCaller['line'] ?? 'N/A';
         $functionFile = $functionCaller['file'] ?? 'N/A';

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -264,7 +264,7 @@ if (! function_exists('backpack_view')) {
         $functionLine = $functionCaller['line'] ?? 'N/A';
         $functionFile = $functionCaller['file'] ?? 'N/A';
 
-        abort(500, 'The view: ['.$view.'] was not found in any of the following view paths: '.implode(' || ', $viewPaths).' - called on: '.$functionFile.' on line: '.$functionLine);
+        abort(500, 'The view: ['.$view.'] was not found in any of the following view paths: ['.implode(' ], [ ', $viewPaths).'] - called on: '.$functionFile.' on line: '.$functionLine);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -256,7 +256,15 @@ if (! function_exists('backpack_view')) {
             }
         }
 
-        dd('Could not find Backpack view ['.$view.'] in theme namespace, fallback namespace nor UI namespace.');
+        // we only run the back trace in case we couldn't find the view
+        // and help developer understand where is the error
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+    
+        $functionCaller = $backtrace[0] ?? [];
+        $functionLine = $functionCaller['line'] ?? '';
+        $functionFile = $functionCaller['file'] ?? '';
+
+        abort(500, 'The view: ['.$view.'] was not found in any of the following view paths: ' . implode(' || ', $viewPaths) . ' - called on: ' . $functionFile . ' on line: ' . $functionLine);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,6 +3,7 @@
 use Backpack\Basset\Facades\Basset;
 use Creativeorange\Gravatar\Facades\Gravatar;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 if (! function_exists('backpack_url')) {
     /**
@@ -256,15 +257,23 @@ if (! function_exists('backpack_view')) {
             }
         }
 
-        // we only run the back trace in case we couldn't find the view
-        // and help developer understand where is the error
-        $backtrace = env('APP_ENV') !== 'production' && env('APP_DEBUG') ? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1) : [];
+        $errorMessage = 'The view: ['.$view.'] was not found in any of the following view paths: ['.implode(' ], [ ', $viewPaths).']';
 
-        $functionCaller = $backtrace[0] ?? [];
-        $functionLine = $functionCaller['line'] ?? 'N/A';
-        $functionFile = $functionCaller['file'] ?? 'N/A';
+        $errorDetails = (function() {
+            if (env('APP_ENV') === 'production' || !env('APP_DEBUG')) {
+                return '';
+            }
 
-        abort(500, 'The view: ['.$view.'] was not found in any of the following view paths: ['.implode(' ], [ ', $viewPaths).'] - called on: '.$functionFile.' on line: '.$functionLine);
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2) ?? [];
+            $functionCaller = $backtrace[1] ?? [];
+            $functionLine = $functionCaller['line'] ?? 'N/A';
+            $functionFile = $functionCaller['file'] ?? 'N/A';
+
+            return '- Called in: '.Str::after($functionFile, base_path()).' on line: '.$functionLine;
+        })();
+        
+        
+        abort(500, $errorMessage.$errorDetails);
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -259,8 +259,8 @@ if (! function_exists('backpack_view')) {
 
         $errorMessage = 'The view: ['.$view.'] was not found in any of the following view paths: ['.implode(' ], [ ', $viewPaths).']';
 
-        $errorDetails = (function() {
-            if (env('APP_ENV') === 'production' || !env('APP_DEBUG')) {
+        $errorDetails = (function () {
+            if (env('APP_ENV') === 'production' || ! env('APP_DEBUG')) {
                 return '';
             }
 
@@ -271,8 +271,7 @@ if (! function_exists('backpack_view')) {
 
             return '- Called in: '.Str::after($functionFile, base_path()).' on line: '.$functionLine;
         })();
-        
-        
+
         abort(500, $errorMessage.$errorDetails);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -258,11 +258,11 @@ if (! function_exists('backpack_view')) {
 
         // we only run the back trace in case we couldn't find the view
         // and help developer understand where is the error
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $backtrace = env('APP_ENV') !== 'production' && env('APP_DEBUG') ? debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1) : [];
     
         $functionCaller = $backtrace[0] ?? [];
-        $functionLine = $functionCaller['line'] ?? '';
-        $functionFile = $functionCaller['file'] ?? '';
+        $functionLine = $functionCaller['line'] ?? 'N/A';
+        $functionFile = $functionCaller['file'] ?? 'N/A';
 
         abort(500, 'The view: ['.$view.'] was not found in any of the following view paths: ' . implode(' || ', $viewPaths) . ' - called on: ' . $functionFile . ' on line: ' . $functionLine);
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5167

The error message was not very helpful. 

### AFTER - What is happening after this PR?

![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/50f65a40-9f7e-4e82-a550-cb62b933e7f7)

I also added a check for app in production and debug=true to avoid exposing sensitive information if developer pushed to prod with missing views. 

view name and view path I think it's fine, server path is not ok, but it helps in development. 