### PR TITLE
remove phpunit 9 from test and coverage actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
           tools: composer:v2
       - name: Install dependencies
         run: |
-            composer require "laravel/framework:^10.0" "phpunit/phpunit:^9.0" "doctrine/dbal:^3.0" --no-interaction --no-update --no-suggest
+            composer require "laravel/framework:^10.0" "phpunit/phpunit:^10.0" "doctrine/dbal:^3.0" --no-interaction --no-update --no-suggest
             composer update --prefer-dist --no-interaction
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover coverage.xml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,7 @@ jobs:
                 php: [8.1, 8.2]
                 dbal: [^3.0]
                 laravel: [10.*]
-                phpunit: [9.*, 10.*]
+                phpunit: [10.*]
                 dependency-version: [stable] # to add: lowest
         
 


### PR DESCRIPTION
We only have phpunit ^10 in our `composer.json` but were still run the github actions with phpunit ^9. 

No more. ‼️ 