### PR TITLE
Take theme-tabler out of public beta

### DIFF
--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -29,7 +29,7 @@ class RequireThemeTabler extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'Tabler <fg=yellow>(public beta)</>',
+        'name'        => 'Tabler',
         'description' => [
             'UI provided by Tabler, a Boostrap 5 template.',
             '<fg=blue>https://github.com/laravel-backpack/theme-tabler/</>',


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We had a "public beta" notice on ThemeTabler.

### AFTER - What is happening after this PR?

We do not.
