### PR TITLE
Fixed the 419 csrf token mismatch/List CRUD operation

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -269,6 +269,9 @@
               "data": {
                 "totalEntryCount": "{{$crud->getOperationSetting('totalEntryCount') ?? false}}"
             },
+            "headers": {
+                'X-CSRF-TOKEN': '<?php echo e(csrf_token()); ?>'
+            },
           },
           dom:
             "<'row hidden'<'col-sm-6'i><'col-sm-6 d-print-none'f>>" +


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Error 419 - Token Mismatch: search@ListOperation

### AFTER - What is happening after this PR?

CRUDs are now being listed


## HOW

### How did you achieve that, in technical terms?

Adding csrf_token headers to an ajax post configuration



### Is it a breaking change?

No.


### How can we test the before & after?

New backpack project
php artisan backpack:crud tag
Go to Tags section in dashboard
Before: Error 419
After: Shows Tags information
