### PR TITLE
Removed theme custom change for table footer

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -61,15 +61,6 @@ form .select2.select2-container {
 }
 
 /*Table - List View*/
-#crudTable_wrapper tfoot tr {
-    font-size: .625rem;
-    font-weight: var(--tblr-font-weight-bold);
-    text-transform: uppercase;
-    letter-spacing: .04em;
-    line-height: 1rem;
-    color: var(--tblr-muted);
-}
-
 #crudTable_wrapper div.row .col-sm-12 {
     position: relative;
 }


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/theme-coreuiv2/issues/18.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

CRUD was forcing a theme change, it shouldn't.

### AFTER - What is happening after this PR?

No more wrong customization of the table footer by CRUD.

### Is it a breaking change?

No, Tabler theme doesn't not depend on it, and it's a bug for CoreUI v2 and v4.