### PR TITLE
Add missing fallback themes config for list operation

### DIFF
--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -131,4 +131,17 @@ return [
         // 'resources/js/app.js',
     ],
 
+    'classes' => [
+        /**
+         * Use this as fallback config for themes to pass classes to the table displayed in List Operation
+         * It defaults to: "table table-striped table-hover nowrap rounded card-table table-vcenter card-table shadow-xs border-xs"
+         */
+        'table' => null,
+
+        /**
+         * Use this as fallback config for themes to pass classes to the table wrapper component displayed in List Operation
+         */
+        'tableWrapper' => null,
+    ],
+
 ];


### PR DESCRIPTION
## Solves 
- https://github.com/Laravel-Backpack/theme-coreuiv4/issues/38
- https://github.com/Laravel-Backpack/CRUD/issues/5184

## How
by adding a fallback theme config to `ui.php` for list operation.