### PR TITLE
Fix upload return path in repeatable uploaders

### DIFF
--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -94,15 +94,16 @@ trait HandleRepeatableUploads
         $values = $entry->{$this->getRepeatableContainerName()};
         $values = is_string($values) ? json_decode($values, true) : $values;
         $repeatableUploaders = app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName());
-        $values = array_map(function($item) use ($repeatableUploaders) {
+        $values = array_map(function ($item) use ($repeatableUploaders) {
             foreach ($repeatableUploaders as $upload) {
                 $item[$upload->getName()] = isset($item[$upload->getName()]) ? Str::after($item[$upload->getName()], $upload->getPath()) : null;
             }
+
             return $item;
-            
         }, $values);
-        
+
         $entry->{$this->getRepeatableContainerName()} = $values;
+
         return $entry;
     }
 

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -188,13 +188,15 @@ trait HandleRepeatableUploads
         return $previousValues ?? [];
     }
 
-    private function getValuesWithPathStripped(array|string|null $item, UploaderInterface $upload) {
+    private function getValuesWithPathStripped(array|string|null $item, UploaderInterface $upload)
+    {
         $uploadedValues = $item[$upload->getName()] ?? null;
-        if(is_array($uploadedValues)) {
-            return array_map(function($value) use ($upload) {
+        if (is_array($uploadedValues)) {
+            return array_map(function ($value) use ($upload) {
                 return Str::after($value, $upload->getPath());
-            },$uploadedValues);
-        }    
+            }, $uploadedValues);
+        }
+
         return isset($uploadedValues) ? Str::after($uploadedValues, $upload->getPath()) : null;
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5232

We return only the file name and "re-generate" the url in the fields. In case of repeatable fields we were skipping this step and returning the file prefixed. 

### AFTER - What is happening after this PR?

Similar to how we do for "regular" fields, we do it for "repeatable" fields. 

### Is it a breaking change?

No


### How can we test the before & after?

Add an upload field inside a repeatable container, and add a `path` configuration for the upload. 