### PR TITLE
throw http errors in custom exceptions to render the error views

### DIFF
--- a/src/app/Exceptions/AccessDeniedException.php
+++ b/src/app/Exceptions/AccessDeniedException.php
@@ -14,6 +14,6 @@ class AccessDeniedException extends Exception
      */
     public function render($request)
     {
-        return response(view('errors.403', ['exception' => $this]), 403);
+        return abort(403, $this->getMessage());
     }
 }

--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -20,6 +20,6 @@ class BackpackProRequiredException extends \Exception
                 break;
         }
 
-        return response(view('errors.500', ['exception' => $this]), 500);
+        return abort(500, $this->getMessage());
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Accidentally reported in https://github.com/Laravel-Backpack/docs/pull/480

Our custom exceptions were not updated when we removed the error views. 

Since the error views are only registered when Exception is handled our custom exception are now more a proxy. 

We could throw the 403 directly instead instead of the custom exception, but since now people may be trying to catch that specific exception, removing it would be a breaking change. 

### AFTER - What is happening after this PR?

You can do `CRUD::denyAccess('list')` and it will properly throw the access denied exception and render the error.


## HOW

### How did you achieve that, in technical terms?

Turned our custom exception into proxys, so technically they throw a subsequent http error to be rendered when they are thrown. 

### Is it a breaking change?

I don't think so, no. 


### How can we test the before & after?

Try adding `CRUD::denyAccess('list')`