### PR TITLE
make tabler the default theme

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -49,9 +49,9 @@ class Install extends Command
      * @var array
      */
     protected $themes = [
-        Themes\RequireThemeCoreuiv2::class,
-        Themes\RequireThemeCoreuiv4::class,
         Themes\RequireThemeTabler::class,
+        Themes\RequireThemeCoreuiv4::class,
+        Themes\RequireThemeCoreuiv2::class,
     ];
 
     /**
@@ -109,7 +109,7 @@ class Install extends Command
         } elseif (! $this->isAnyThemeInstalled()) {
             // Install default theme
             $this->progressBlock('Installing default theme');
-            $this->executeArtisanProcess('backpack:require:theme-coreuiv2');
+            $this->executeArtisanProcess('backpack:require:theme-tabler');
             $this->closeProgressBlock();
         }
 

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv2.php
@@ -29,9 +29,9 @@ class RequireThemeCoreuiv2 extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'CoreUIv2 <fg=green>(default)</>',
+        'name'        => 'CoreUIv2',
         'description' => [
-            'UI provided by CoreUIv2, a Boostrap 4 template.',
+            'UI provided by CoreUIv2, a Boostrap 4 template. Considered legacy, but useful for IE support.',
             '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv2/</>',
         ],
         'repo'    => 'backpack/theme-coreuiv2',

--- a/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
+++ b/src/app/Console/Commands/Themes/RequireThemeCoreuiv4.php
@@ -29,7 +29,7 @@ class RequireThemeCoreuiv4 extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'CoreUIv4 <fg=yellow>(public beta)</>',
+        'name'        => 'CoreUIv4',
         'description' => [
             'UI provided by CoreUIv4, a Boostrap 5 template.',
             '<fg=blue>https://github.com/laravel-backpack/theme-coreuiv4/</>',

--- a/src/app/Console/Commands/Themes/RequireThemeTabler.php
+++ b/src/app/Console/Commands/Themes/RequireThemeTabler.php
@@ -29,9 +29,9 @@ class RequireThemeTabler extends Command
      * @var array
      */
     public static $addon = [
-        'name'        => 'Tabler',
+        'name'        => 'Tabler <fg=green>(default)</>',
         'description' => [
-            'UI provided by Tabler, a Boostrap 5 template.',
+            'UI provided by Tabler, a Boostrap 5 template. Lots of new features, including a dark mode.',
             '<fg=blue>https://github.com/laravel-backpack/theme-tabler/</>',
         ],
         'repo'    => 'backpack/theme-tabler',


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

See https://github.com/Laravel-Backpack/CRUD/issues/5164

CoreUIv2 was the default theme. Because Tabler and CoreUIv4 weren't stable enough.

### AFTER - What is happening after this PR?

The king is dead. Long live the king!