### PR TITLE
adds a card wrapping the error message

### DIFF
--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -9,21 +9,23 @@
 @section('content')
 <div class="row">
   <div class="col-md-12 text-center">
-    <div class="error_number">
-      <small>ERROR</small><br>
-      {{ $error_number }}
-      <hr>
-    </div>
-    <div class="error_title text-muted">
-      @yield('title')
-    </div>
-    @if(backpack_user())
-    <div class="error_description text-muted">
-      <small>
-        @yield('description')
-     </small>
-    </div>
-    @endif
+      <div class="card pb-4">
+          <div class="error_number">
+              <small>ERROR</small><br>
+              {{ $error_number }}
+              <hr>
+          </div>
+          <div class="error_title text-muted">
+              @yield('title')
+          </div>
+          @if(backpack_user())
+              <div class="error_description text-muted">
+                <small>
+                  @yield('description')
+                </small>
+              </div>
+          @endif
+      </div>
   </div>
 </div>
 @endsection


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As someone very attentive reported in https://github.com/Laravel-Backpack/theme-tabler/issues/122 the overlap layout was causing issues displaying the errors. 

And easy way out that is already style is using the same card we using in forms to wrap the errors. 

### AFTER - What is happening after this PR?

![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/cc626c6c-ff32-4cd4-9e46-8bf5fff56972)
![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/45abbf59-e072-421c-a9f5-15ef31ff1875)
![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/81919674-fccd-463f-b813-151ac40f04a2)
![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/652be05f-df9c-484f-8ff0-a2002c8a3764)



## HOW

### How did you achieve that, in technical terms?

Wrapped the error container in a `div class=card`. 


### Is it a breaking change?

No
