### PR TITLE
Load directives after resolving

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\View\Compilers\BladeCompiler;
 
 class BackpackServiceProvider extends ServiceProvider
 {
@@ -302,7 +303,10 @@ class BackpackServiceProvider extends ServiceProvider
 
     public function loadViewComponents()
     {
-        Blade::componentNamespace('Backpack\\CRUD\\app\\View\\Components', 'backpack');
+        $this->app->afterResolving(BladeCompiler::class, function () {
+            Blade::componentNamespace('Backpack\\CRUD\\app\\View\\Components', 'backpack');
+        });
+        
     }
 
     /**

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -306,7 +306,6 @@ class BackpackServiceProvider extends ServiceProvider
         $this->app->afterResolving(BladeCompiler::class, function () {
             Blade::componentNamespace('Backpack\\CRUD\\app\\View\\Components', 'backpack');
         });
-        
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/community-forum/issues/597

We should either move the component registering to boot, or load the components after the compiler is resolved like we do for other blade directives.

I opted by loading the same way we load other stuff related with blade.
