### PR TITLE
Fix #5227 

### DIFF
--- a/src/resources/views/crud/fields/color.blade.php
+++ b/src/resources/views/crud/fields/color.blade.php
@@ -38,13 +38,13 @@ $value = old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['de
 @push('crud_fields_styles')
     @bassetBlock('backpack/crud/fields/color.css')
     <style>
-        [bp-field-name="color"] input[type="color"] {
+        [bp-field-type="color"] input[type="color"] {
             background-color: unset;
             border: 0;
             width: 1.8rem;
             height: 1.8rem;
         }
-        [bp-field-name="color"] .input-group-text {
+        [bp-field-type="color"] .input-group-text {
             padding: 0 0.4rem;
         }
     </style>


### PR DESCRIPTION
## WHY
Fix #5227 

### BEFORE - What was wrong? What was happening before this PR?

Css selector only apply styles if the input is named "color"

### AFTER - What is happening after this PR?

Change to use `bp-field-type`