### PR TITLE
Fix provider for password resets broker registration

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -275,8 +275,8 @@ class BackpackServiceProvider extends ServiceProvider
 
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
-        $laravelFirstPasswordBroker = is_array($laravelAuthPasswordBrokers) && current($laravelAuthPasswordBrokers) ? 
-                                        current($laravelAuthPasswordBrokers)['table'] : 
+        $laravelFirstPasswordBroker = is_array($laravelAuthPasswordBrokers) && current($laravelAuthPasswordBrokers) ?
+                                        current($laravelAuthPasswordBrokers)['table'] :
                                         '';
 
         $backpackPasswordBrokerTable = config('backpack.base.password_resets_table') ??

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -275,10 +275,11 @@ class BackpackServiceProvider extends ServiceProvider
 
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
+        $laravelFirstPasswordBroker = current($laravelAuthPasswordBrokers) ? current($laravelAuthPasswordBrokers)['table'] : '';
 
         $backpackPasswordBrokerTable = config('backpack.base.password_resets_table') ??
                                         config('auth.passwords.users.table') ??
-                                        current($laravelAuthPasswordBrokers)['table'];
+                                        $laravelFirstPasswordBroker;
 
         app()->config['auth.passwords'] = $laravelAuthPasswordBrokers +
         [

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -275,7 +275,9 @@ class BackpackServiceProvider extends ServiceProvider
 
         // add the backpack_users password broker to the configuration
         $laravelAuthPasswordBrokers = app()->config['auth.passwords'];
-        $laravelFirstPasswordBroker = current($laravelAuthPasswordBrokers) ? current($laravelAuthPasswordBrokers)['table'] : '';
+        $laravelFirstPasswordBroker = is_array($laravelAuthPasswordBrokers) && current($laravelAuthPasswordBrokers) ? 
+                                        current($laravelAuthPasswordBrokers)['table'] : 
+                                        '';
 
         $backpackPasswordBrokerTable = config('backpack.base.password_resets_table') ??
                                         config('auth.passwords.users.table') ??


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #5247 . 

Using an empty array in Laravel password brokers would make Backpack throw an ugly error. 

If you have an empty array in the password brokers, and no configured password reset table in Backpack, we will use an empty string as the table to avoid throwing the error.

The reason why I kept setting up the Backpack password broker even without table is because developers may set this config later in the run-time, and not registering it may constitute a breaking change. 

This way is non breaking, and no more errors thrown. 
