### PR TITLE
remove unused code

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -348,16 +348,6 @@
             localStorage.setItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength', len);
         });
 
-        // make sure AJAX requests include XSRF token
-        $.ajaxPrefilter(function(options, originalOptions, xhr) {
-            var token = $('meta[name="csrf_token"]').attr('content');
-
-            if (token) {
-                return xhr.setRequestHeader('X-XSRF-TOKEN', token);
-            }
-        });
-
-
         $('#crudTable').on( 'page.dt', function () {
             localStorage.setItem('page_changed', true);
         });


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

our meta is called `csrf-token` not `csrf_token`. What should go as header is `x-csrf-token` not `x-xcrf-token`. 

Dunno what this code is doing here, at the moment nothing, is probably a leftover 🙏 
