### PR TITLE
[BUG] - Backpack install hangs when asset:check fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "laravel/framework": "^10.0",
         "prologue/alerts": "^1.0",
-        "backpack/basset": "^1.0.0",
+        "backpack/basset": "^1.1.1",
         "creativeorange/gravatar": "~1.0",
         "doctrine/dbal": "^3.0",
         "guzzlehttp/guzzle": "^7.0"

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -9,10 +9,12 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Exception;
 
 class Install extends Command
 {
     use Traits\PrettyCommandOutput;
+    use \Backpack\Basset\Console\Commands\Helpers\BassetNotWorkingMessage;
 
     protected $progressBar;
 
@@ -92,9 +94,8 @@ class Install extends Command
         $this->closeProgressBlock();
 
         // Install Backpack Basset
-        $this->progressBlock('Installing Basset');
-        $this->executeArtisanProcess('basset:install --no-interaction');
-        $this->closeProgressBlock();
+        $this->call('basset:install');
+       
 
         // Optional commands
         if (! $this->option('no-interaction')) {

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
-use Exception;
 
 class Install extends Command
 {
@@ -95,7 +94,6 @@ class Install extends Command
 
         // Install Backpack Basset
         $this->call('basset:install');
-       
 
         // Optional commands
         if (! $this->option('no-interaction')) {

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -13,7 +13,6 @@ use Symfony\Component\Process\Process;
 class Install extends Command
 {
     use Traits\PrettyCommandOutput;
-    use \Backpack\Basset\Console\Commands\Helpers\BassetNotWorkingMessage;
 
     protected $progressBar;
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5257

The `basset:check` command was blocking the Backpack CRUD install script when the check failed.

The main reason was the fact that we were calling `callArtisanProcess` that would call the command in isolation, terminate the main process and never output the results.

I could have caught this before hand if I didn't test the `basset:check` and `basset:install` in isolation.

This requires https://github.com/Laravel-Backpack/basset/pull/78

### Is it a breaking change?

No, but it made the install command a little ugly.

I've already talked with @promatik and he's on it to make it beautiful again. For now we are just fixing the blocking error.


### How can we test the before & after?

Ran `php artisan backpack:install` without basset properly configured. 
