### PR TITLE
fix comma delimited fake fields

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FakeFields.php
+++ b/src/app/Library/CrudPanel/Traits/FakeFields.php
@@ -32,16 +32,18 @@ trait FakeFields
 
         foreach ($fields as $field) {
             // compact fake fields
-            // cast the field name to array first, to account for array field names
-            // in fields that send multiple inputs and want them all saved to the database
-            foreach ((array) $field['name'] as $fieldName) {
+            // explode the comma delimited names, eg: start,end in a date_range:
+            $field['name'] = explode(',', $field['name']);
+            foreach ($field['name'] as $fieldName) {
                 $fakeFieldKey = isset($field['store_in']) ? $field['store_in'] : 'extras';
                 $isFakeField = $field['fake'] ?? false;
 
                 // field is represented by the subfields
                 if (isset($field['subfields']) && isset($field['model']) && $field['model'] === get_class($model)) {
                     foreach ($field['subfields'] as $subfield) {
-                        foreach ((array) $subfield['name'] as $subfieldName) {
+                        // explode the comma delimited names, eg: start,end in a date_range:
+                        $subfield['name'] = explode(',', $subfield['name']);
+                        foreach ($subfield['name'] as $subfieldName) {
                             $subfieldName = Str::afterLast($subfieldName, '.');
                             $isSubfieldFake = $subfield['fake'] ?? false;
                             $subFakeFieldKey = isset($subfield['store_in']) ? $subfield['store_in'] : 'extras';


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5221

A leftover from removing array field names, the fake fields were not updated in the database.

### AFTER - What is happening after this PR?

Everything works as expected 👍 

### Is it a breaking change?

No


### How can we test the before & after?

Add a `date_range` field as a fake field. 
