### PR TITLE
[HOT-FIX] add --no-interaction into the install basset command.

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -93,7 +93,7 @@ class Install extends Command
 
         // Install Backpack Basset
         $this->progressBlock('Installing Basset');
-        $this->executeArtisanProcess('basset:install --no-check');
+        $this->executeArtisanProcess('basset:install --no-check --no-interaction');
         $this->closeProgressBlock();
 
         // Optional commands


### PR DESCRIPTION
The no iteraction is required to avoid stopping the execution when something is printed to console by child command. 

This fixes #5264  