### PR TITLE
Add array support to CrudColumn object.

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -38,15 +38,15 @@ class CrudColumn
 
     protected $attributes;
 
-    public function upload($upload = true)
+    public function __construct($nameOrDefinitionArray)
     {
-        $this->attributes['upload'] = $upload;
+        if (is_array($nameOrDefinitionArray)) {
+            $column = $this->crud()->addAndReturnColumn($nameOrDefinitionArray);
+            $name = $column->getAttributes()['name'];
+        } else {
+            $name = $nameOrDefinitionArray;
+        }
 
-        return $this->save();
-    }
-
-    public function __construct($name)
-    {
         $column = $this->crud()->firstColumnWhere('name', $name);
 
         // if column exists
@@ -157,6 +157,13 @@ class CrudColumn
         $this->crud()->addColumn($this->attributes)->beforeColumn($destinationColumn);
 
         return $this;
+    }
+
+    public function upload($upload = true)
+    {
+        $this->attributes['upload'] = $upload;
+
+        return $this->save();
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -66,26 +66,17 @@ trait Columns
      */
     public function addColumn($column)
     {
-        $column = $this->makeSureColumnHasNeededAttributes($column);
-        $this->addColumnToOperationSettings($column);
-
-        (new CrudColumn($column['name']))->callRegisteredAttributeMacros();
+        $this->prepareAttributesAndAddColumn($column);
 
         return $this;
     }
 
     /**
-     * Add a column at the end of to the CRUD object's "columns" array and return it.
-     *
-     * @param  array|string  $column
-     * @return self
+     * Add a column at the end of the CRUD object's "columns" array and return it
      */
-    public function addAndReturnColumn($column)
+    public function addAndReturnColumn(array|string $column): CrudColumn
     {
-        $column = $this->makeSureColumnHasNeededAttributes($column);
-        $this->addColumnToOperationSettings($column);
-
-        $column = (new CrudColumn($column['name']))->callRegisteredAttributeMacros();
+        $column = $this->prepareAttributesAndAddColumn($column);
 
         return $column;
     }

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -75,7 +75,7 @@ trait Columns
     }
 
     /**
-     * Add a column at the end of to the CRUD object's "columns" array and return it
+     * Add a column at the end of to the CRUD object's "columns" array and return it.
      *
      * @param  array|string  $column
      * @return self

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -75,6 +75,22 @@ trait Columns
     }
 
     /**
+     * Add a column at the end of to the CRUD object's "columns" array and return it
+     *
+     * @param  array|string  $column
+     * @return self
+     */
+    public function addAndReturnColumn($column)
+    {
+        $column = $this->makeSureColumnHasNeededAttributes($column);
+        $this->addColumnToOperationSettings($column);
+
+        $column = (new CrudColumn($column['name']))->callRegisteredAttributeMacros();
+
+        return $column;
+    }
+
+    /**
      * Add multiple columns at the end of the CRUD object's "columns" array.
      *
      * @param  array  $columns
@@ -405,15 +421,16 @@ trait Columns
      * in addition to the existing options:
      * - CRUD::addColumn(['name' => 'price', 'type' => 'number']);
      * - CRUD::column('price')->type('number');
+     * - CRUD::column(['name' => 'price', 'type' => 'number']);
      *
      * And if the developer uses the CrudColumn object as Column in their CrudController:
      * - Column::name('price')->type('number');
      *
-     * @param  string  $name  The name of the column in the db, or model attribute.
+     * @param  string|array  $name  The name of the column in the db, or model attribute.
      * @return CrudColumn
      */
-    public function column($name)
+    public function column($nameOrDefinition)
     {
-        return new CrudColumn($name);
+        return new CrudColumn($nameOrDefinition);
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -72,7 +72,7 @@ trait Columns
     }
 
     /**
-     * Add a column at the end of the CRUD object's "columns" array and return it
+     * Add a column at the end of the CRUD object's "columns" array and return it.
      */
     public function addAndReturnColumn(array|string $column): CrudColumn
     {

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -328,7 +328,7 @@ trait ColumnsProtectedMethods
     }
 
     /**
-     * Prepare the column attributes and add it to operation settings
+     * Prepare the column attributes and add it to operation settings.
      */
     private function prepareAttributesAndAddColumn(array|string $column): CrudColumn
     {

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Backpack\CRUD\app\Library\CrudPanel\CrudColumn;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -324,5 +325,18 @@ trait ColumnsProtectedMethods
         }
 
         return in_array($name, $columns);
+    }
+
+    /**
+     * Prepare the column attributes and add it to operation settings
+     */
+    private function prepareAttributesAndAddColumn(array|string $column): CrudColumn
+    {
+        $column = $this->makeSureColumnHasNeededAttributes($column);
+        $this->addColumnToOperationSettings($column);
+
+        $column = (new CrudColumn($column['name']))->callRegisteredAttributeMacros();
+
+        return $column;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -562,15 +562,16 @@ trait Fields
      * in addition to the existing options:
      * - CRUD::addField(['name' => 'price', 'type' => 'number']);
      * - CRUD::field('price')->type('number');
+     * - CRUD::field(['name' => 'price', 'type' => 'number']);
      *
      * And if the developer uses the CrudField object as Field in their CrudController:
      * - Field::name('price')->type('number');
      *
-     * @param  string  $name  The name of the column in the db, or model attribute.
+     * @param  string|array  $nameOrDefinition  The name of the column in the db, or model attribute.
      * @return CrudField
      */
-    public function field($name)
+    public function field($nameOrDefinition)
     {
-        return new CrudField($name);
+        return new CrudField($nameOrDefinition);
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
+++ b/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
@@ -29,10 +29,8 @@ trait MacroableWithAttributes
 
     /**
      * Call the macros registered for the given macroable attributes.
-     *
-     * @return void
      */
-    public function callRegisteredAttributeMacros()
+    public function callRegisteredAttributeMacros(): self
     {
         $macros = $this->getMacros();
         $attributes = $this->getAttributes();
@@ -58,5 +56,6 @@ trait MacroableWithAttributes
                 );
             }
         }
+        return $this;
     }
 }

--- a/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
+++ b/src/app/Library/CrudPanel/Traits/Support/MacroableWithAttributes.php
@@ -56,6 +56,7 @@ trait MacroableWithAttributes
                 );
             }
         }
+
         return $this;
     }
 }

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -621,10 +621,14 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         CrudColumn::name('test');
         $this->assertCount(1, $this->crudPanel->columns());
     }
-
     public function testItCanAddAFluentColumnUsingArray()
     {
         $this->crudPanel->column($this->oneColumnArray);
+        $this->assertCount(1, $this->crudPanel->columns());
+    }
+    public function testItCanAddAFluentColumnUsingArrayWithoutName()
+    {
+        $this->crudPanel->column(['type' => 'text']);
         $this->assertCount(1, $this->crudPanel->columns());
     }
 }

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -621,11 +621,13 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         CrudColumn::name('test');
         $this->assertCount(1, $this->crudPanel->columns());
     }
+
     public function testItCanAddAFluentColumnUsingArray()
     {
         $this->crudPanel->column($this->oneColumnArray);
         $this->assertCount(1, $this->crudPanel->columns());
     }
+
     public function testItCanAddAFluentColumnUsingArrayWithoutName()
     {
         $this->crudPanel->column(['type' => 'text']);

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -621,4 +621,10 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         CrudColumn::name('test');
         $this->assertCount(1, $this->crudPanel->columns());
     }
+
+    public function testItCanAddAFluentColumnUsingArray()
+    {
+        $this->crudPanel->column($this->oneColumnArray);
+        $this->assertCount(1, $this->crudPanel->columns());
+    }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in: https://github.com/Laravel-Backpack/CRUD/issues/5269
Confirmed by @tabacitu https://github.com/Laravel-Backpack/CRUD/issues/5269#issuecomment-1670861748

`CRUD::column()` won't accept an array like `CRUD::field()`. 

### AFTER - What is happening after this PR?

CrudColumn now works similar to CrudField. 


## HOW

### How did you achieve that, in technical terms?

Modified the constructor, and added some helper functions. 


### Is it a breaking change?

I hope not. Going to confirm with @tabacitu 


### How can we test the before & after?

Easy as `CRUD::column(['name' => 'test'])` will fail before, and work now.