### PR TITLE
[WIP-discussion] Allow show operation to use the panel query

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -85,8 +85,12 @@ trait ShowOperation
             return view($this->crud->getShowView(), $this->data);
         }
 
+        // when enabled we will call the findOrFail() directly in the crud panel query, instead of the model query.
+        // this allow developers to setup constrains on the query that can be applied in multiple operations.
         if ($this->crud->get('show.usePanelQuery')) {
             $this->data['entry'] = $this->crud->query->withTrashed()->findOrFail($id);
+            // we will miss the "magic __call() to findOrFail" in the model when it's translatable, 
+            // so we need to manually set the locale when needed.
             $this->data['entry'] = $this->crud->setLocaleOnModel($this->data['entry']);
 
             return view($this->crud->getShowView(), $this->data);

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -81,17 +81,19 @@ trait ShowOperation
         // get the info for that entry (include softDeleted items if the trait is used)
         if (! $this->crud->get('show.softDeletes') || ! in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
             $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+
             return view($this->crud->getShowView(), $this->data);
         }
-        
-        if($this->crud->get('show.usePanelQuery')) {
+
+        if ($this->crud->get('show.usePanelQuery')) {
             $this->data['entry'] = $this->crud->query->withTrashed()->findOrFail($id);
             $this->data['entry'] = $this->crud->setLocaleOnModel($this->data['entry']);
+
             return view($this->crud->getShowView(), $this->data);
         }
-           
+
         $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
-       
+
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getShowView(), $this->data);
     }

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -75,16 +75,23 @@ trait ShowOperation
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
 
-        // get the info for that entry (include softDeleted items if the trait is used)
-        if ($this->crud->get('show.softDeletes') && in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
-            $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
-        } else {
-            $this->data['entry'] = $this->crud->getEntryWithLocale($id);
-        }
-
         $this->data['crud'] = $this->crud;
         $this->data['title'] = $this->crud->getTitle() ?? trans('backpack::crud.preview').' '.$this->crud->entity_name;
 
+        // get the info for that entry (include softDeleted items if the trait is used)
+        if (! $this->crud->get('show.softDeletes') || ! in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this->crud->model))) {
+            $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+            return view($this->crud->getShowView(), $this->data);
+        }
+        
+        if($this->crud->get('show.usePanelQuery')) {
+            $this->data['entry'] = $this->crud->query->withTrashed()->findOrFail($id);
+            $this->data['entry'] = $this->crud->setLocaleOnModel($this->data['entry']);
+            return view($this->crud->getShowView(), $this->data);
+        }
+           
+        $this->data['entry'] = $this->crud->getModel()->withTrashed()->findOrFail($id);
+       
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getShowView(), $this->data);
     }

--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -89,7 +89,7 @@ trait ShowOperation
         // this allow developers to setup constrains on the query that can be applied in multiple operations.
         if ($this->crud->get('show.usePanelQuery')) {
             $this->data['entry'] = $this->crud->query->withTrashed()->findOrFail($id);
-            // we will miss the "magic __call() to findOrFail" in the model when it's translatable, 
+            // we will miss the "magic __call() to findOrFail" in the model when it's translatable,
             // so we need to manually set the locale when needed.
             $this->data['entry'] = $this->crud->setLocaleOnModel($this->data['entry']);
 

--- a/src/config/backpack/operations/show.php
+++ b/src/config/backpack/operations/show.php
@@ -26,4 +26,6 @@ return [
 
     // When using tabbed forms (create & update), what kind of tabs would you like?
     'tabsType' => 'horizontal', //options: horizontal, vertical
+
+    'usePanelQuery' => false,
 ];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Heads up: This is working, but it's just a POC to be discussed. We may need to add documentation about it if we decide to do it.

Reported in https://github.com/Laravel-Backpack/CRUD/issues/5204 and we also had some discussions about it. 

In my understanding, and the user reporting the issue, all the operations should be performing their queries over the Panel Query. This would be a huge change in behavior and we may miss use cases that we will break doing such a global change on a non-breaking version. 


### AFTER - What is happening after this PR?

I've thought about this for a while and decided to "experiment" with the feature in the show operation behind a configuration.

I think this is the way to go now, without risking breaking all people apps. We may eventually turn it `true` by default in a future version. 


## HOW

### How did you achieve that, in technical terms?

I introduced the `usePanelQuery` config in show operation, that will tell the operation if it should perform the `findOrFail` in the model, or in panel query. 

### Is it a breaking change?

I don't think so no, it need to be enabled.


### How can we test the before & after?

Steps described in the linked issue. But to sum up, create a constrain on the crud query and watch it being applied in the List but not in the show operation.
