### PR TITLE
Fix list view css - wrong first column height

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -154,7 +154,6 @@ form .select2.select2-container {
 #crudTable tr td:first-child,
 #crudTable table.dataTable tr th:first-child,
 #crudTable table.dataTable tr td:first-child {
-
     align-items: center;
     padding-top: 1rem;
     padding-bottom: 1rem;

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -147,7 +147,6 @@ form .select2.select2-container {
 
 #crudTable_wrapper #crudTable .crud_bulk_actions_checkbox,
 #crudTable_wrapper table.dataTable .crud_bulk_actions_checkbox {
-    display: flex;
     margin: 0 0.6rem 0 0.45rem;
 }
 
@@ -155,7 +154,7 @@ form .select2.select2-container {
 #crudTable tr td:first-child,
 #crudTable table.dataTable tr th:first-child,
 #crudTable table.dataTable tr td:first-child {
-    display: flex;
+
     align-items: center;
     padding-top: 1rem;
     padding-bottom: 1rem;


### PR DESCRIPTION
Solves #5267 

## I tested this on v5 & v6(all themes)
I got the same output on all v6 themes, so **it's not related to the themes**.
In v5 same thing was doing fine.
Then I had a doubt, is it related to bulk action checkboxes? No, it's not.

## What difference is observed on v5 vs v6 output.
### V5:
**When we put content which occupies height in any column. All columns are centred✅**

![Screenshot 2023-08-10 at 8 30 42 PM](https://github.com/Laravel-Backpack/CRUD/assets/8214221/15a5b3cb-d2d3-491b-b947-f263c05a6320)
#### V6:
- **When we put content which occupies height in any column, All columns are centred except the first column❌**
- **When we put content which occupies height in the first column. The column's height doesn't stretch as expected. ❌**

![Screenshot 2023-08-10 at 8 31 03 PM](https://github.com/Laravel-Backpack/CRUD/assets/8214221/37a7429e-b677-4891-9fe6-6a73ba0ee700)