### PR TITLE
Prevent crud installation without theme

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -311,14 +311,14 @@ class Install extends Command
             }, 0);
 
         $total = 0;
-        $input = (int) $this->listChoice('Which Backpack theme would you like to install? <fg=gray>(enter option number: 1, 2 or 3)</>', $this->themes()->toArray());
-
+        $input = (int) $this->listChoice('Which Backpack theme would you like to install? <fg=gray>(enter option number: 1, 2 or 3)</>', $this->themes()->toArray(), 1);
+        
         if ($input < 1 || $input > $this->themes()->count()) {
             $this->deleteLines(3);
-            $this->note('Skipping installing a theme.');
+            $this->note('Unknown theme. Using default theme value.');
             $this->newLine();
 
-            return;
+            $input = 1;
         }
 
         // Clear list

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -312,7 +312,7 @@ class Install extends Command
 
         $total = 0;
         $input = (int) $this->listChoice('Which Backpack theme would you like to install? <fg=gray>(enter option number: 1, 2 or 3)</>', $this->themes()->toArray(), 1);
-        
+
         if ($input < 1 || $input > $this->themes()->count()) {
             $this->deleteLines(3);
             $this->note('Unknown theme. Using default theme value.');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fixes #5274 

Installing Backpack without a theme would break it. 

### AFTER - What is happening after this PR?

On the installation phase we always ensure the "default" theme tabler is installed if no other option is selected by developer.
