### PR TITLE
Improve subfields errors on handling

### DIFF
--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -258,8 +258,8 @@ trait FieldsProtectedMethods
             return $field;
         }
 
-        if (! is_multidimensional_array($field['subfields'])) {
-            $field['subfields'] = [$field['subfields']];
+        if(! is_multidimensional_array($field['subfields'], true)) {
+            abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields');
         }
 
         foreach ($field['subfields'] as $key => $subfield) {

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -254,8 +254,12 @@ trait FieldsProtectedMethods
      */
     protected function makeSureSubfieldsHaveNecessaryAttributes($field)
     {
-        if (! isset($field['subfields'])) {
+        if (! isset($field['subfields']) || ! is_array($field['subfields'])) {
             return $field;
+        }
+
+        if(! is_multidimensional_array($field['subfields'])) {
+            $field['subfields'] = [$field['subfields']];
         }
 
         foreach ($field['subfields'] as $key => $subfield) {

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -258,7 +258,7 @@ trait FieldsProtectedMethods
             return $field;
         }
 
-        if(! is_multidimensional_array($field['subfields'])) {
+        if (! is_multidimensional_array($field['subfields'])) {
             $field['subfields'] = [$field['subfields']];
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -258,7 +258,7 @@ trait FieldsProtectedMethods
             return $field;
         }
 
-        if(! is_multidimensional_array($field['subfields'], true)) {
+        if (! is_multidimensional_array($field['subfields'], true)) {
             abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields.');
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -259,12 +259,12 @@ trait FieldsProtectedMethods
         }
 
         if(! is_multidimensional_array($field['subfields'], true)) {
-            abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields');
+            abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields.');
         }
 
         foreach ($field['subfields'] as $key => $subfield) {
             if (empty($subfield) || ! isset($subfield['name'])) {
-                abort(500, 'Subfield name can\'t be empty');
+                abort(500, 'A subfield of «'.$field['name'].'» is malformed. Subfield attribute name can\'t be empty.');
             }
 
             // make sure the field definition is an array

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -370,15 +370,20 @@ if (! function_exists('is_multidimensional_array')) {
      * @param  array  $array
      * @return bool
      */
-    function is_multidimensional_array(array $array)
+    function is_multidimensional_array(array $array, bool $strict = false)
     {
         foreach ($array as $item) {
-            if (is_array($item)) {
-                return true;
+            if($strict) {
+                if (! is_array($item)) {
+                    return false;
+                }
+            }else{
+                if (is_array($item)) {
+                    return true;
+                }
             }
         }
-
-        return false;
+        return $strict;
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -379,6 +379,7 @@ if (! function_exists('is_multidimensional_array')) {
                 return true;
             }
         }
+
         return $strict;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -365,12 +365,11 @@ if (! function_exists('old_empty_or_null')) {
 
 if (! function_exists('is_multidimensional_array')) {
     /**
-     * If any of the items inside a given array is an array, the array is considered multidimensional.
-     *
-     * @param  array  $array
-     * @return bool
+     * Check if the array is multidimensional.
+     * 
+     * If $strict is enabled, the array is considered multidimensional only if all elements of the array are arrays. 
      */
-    function is_multidimensional_array(array $array, bool $strict = false)
+    function is_multidimensional_array(array $array, bool $strict = false): bool
     {
         foreach ($array as $item) {
             if($strict) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -372,17 +372,13 @@ if (! function_exists('is_multidimensional_array')) {
     function is_multidimensional_array(array $array, bool $strict = false): bool
     {
         foreach ($array as $item) {
-            if ($strict) {
-                if (! is_array($item)) {
-                    return false;
-                }
-            } else {
-                if (is_array($item)) {
-                    return true;
-                }
+            if ($strict && ! is_array($item)) {
+                return false;
+            }
+            if (! $strict && is_array($item)) {
+                return true;
             }
         }
-
         return $strict;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -366,22 +366,23 @@ if (! function_exists('old_empty_or_null')) {
 if (! function_exists('is_multidimensional_array')) {
     /**
      * Check if the array is multidimensional.
-     * 
-     * If $strict is enabled, the array is considered multidimensional only if all elements of the array are arrays. 
+     *
+     * If $strict is enabled, the array is considered multidimensional only if all elements of the array are arrays.
      */
     function is_multidimensional_array(array $array, bool $strict = false): bool
     {
         foreach ($array as $item) {
-            if($strict) {
+            if ($strict) {
                 if (! is_array($item)) {
                     return false;
                 }
-            }else{
+            } else {
                 if (is_array($item)) {
                     return true;
                 }
             }
         }
+
         return $strict;
     }
 }


### PR DESCRIPTION
We would let some errors skip through the subfields handling, for example `subfields => false` would error.

I've changed the handling and the errors thrown to be more descriptive:
- return if subfields are not an array (previously we only return if subfields are not set, so it would run with `subfields => false`)
- check if the array of subfields is well-formed in structure (array of arrays)
- improved the error messages to include the parent name
