### PR TITLE
Fix comma separated field names breaking when a space was added

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -47,7 +47,7 @@ trait ColumnsProtectedMethods
     protected function makeSureColumnHasName($column)
     {
         if (is_string($column)) {
-            $column = ['name' => Str::replace(' ', '', $column)];
+            return ['name' => Str::replace(' ', '', $column)];
         }
 
         if (is_array($column) && ! isset($column['name'])) {

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -47,12 +47,14 @@ trait ColumnsProtectedMethods
     protected function makeSureColumnHasName($column)
     {
         if (is_string($column)) {
-            $column = ['name' => $column];
+            $column = ['name' => Str::replace(' ', '', $column)];
         }
 
         if (is_array($column) && ! isset($column['name'])) {
             $column['name'] = 'anonymous_column_'.Str::random(5);
         }
+
+        $column['name'] = Str::replace(' ', '', $column['name']);
 
         return $column;
     }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -112,13 +112,15 @@ trait FieldsProtectedMethods
         }
 
         if (is_string($field)) {
-            return ['name' => $field];
+            return ['name' => $this->trimWhitespacesFromName($field)];
         }
 
         if (is_array($field) && ! isset($field['name'])) {
             abort(500, 'All fields must have their name defined');
         }
 
+        $field['name'] = $this->trimWhitespacesFromName($field['name']);
+        
         return $field;
     }
 
@@ -371,5 +373,13 @@ trait FieldsProtectedMethods
     protected function getFieldKey(array $field): string
     {
         return $field['name'];
+    }
+
+    /**
+     * Makes sure that all name parts don't have white spaces.
+     */
+    private function trimWhitespacesFromName(string $name) : string
+    {
+        return implode(',', array_map(fn($item) => trim($item), explode(',', $name)));
     }
 }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -120,7 +120,7 @@ trait FieldsProtectedMethods
         }
 
         $field['name'] = $this->trimWhitespacesFromName($field['name']);
-        
+
         return $field;
     }
 
@@ -378,8 +378,8 @@ trait FieldsProtectedMethods
     /**
      * Makes sure that all name parts don't have white spaces.
      */
-    private function trimWhitespacesFromName(string $name) : string
+    private function trimWhitespacesFromName(string $name): string
     {
-        return implode(',', array_map(fn($item) => trim($item), explode(',', $name)));
+        return implode(',', array_map(fn ($item) => trim($item), explode(',', $name)));
     }
 }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -112,14 +112,14 @@ trait FieldsProtectedMethods
         }
 
         if (is_string($field)) {
-            return ['name' => $this->trimWhitespacesFromName($field)];
+            return ['name' => Str::replace(' ', '', $field)];
         }
 
         if (is_array($field) && ! isset($field['name'])) {
             abort(500, 'All fields must have their name defined');
         }
 
-        $field['name'] = $this->trimWhitespacesFromName($field['name']);
+        $field['name'] = Str::replace(' ', '', $field['name']);
 
         return $field;
     }
@@ -373,13 +373,5 @@ trait FieldsProtectedMethods
     protected function getFieldKey(array $field): string
     {
         return $field['name'];
-    }
-
-    /**
-     * Makes sure that all name parts don't have white spaces.
-     */
-    private function trimWhitespacesFromName(string $name): string
-    {
-        return implode(',', array_map(fn ($item) => trim($item), explode(',', $name)));
     }
 }

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -270,6 +270,8 @@ trait FieldsProtectedMethods
                 $subfield = ['name' => $subfield];
             }
 
+            $subfield['name'] = Str::replace(' ', '', $subfield['name']);
+
             $subfield['parentFieldName'] = $field['name'];
 
             if (! isset($field['model'])) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This was a tricky one to find and debug. 

Basically the fields wouldn't properly work if developer defined them with a "space" after the comma, eg: `name1, name2` instead of `name1,name2` 

### AFTER - What is happening after this PR?

We now ensure the field name has no spaces in any part of the name.
