### PR TITLE
allow dynamic href in quick button

### DIFF
--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -14,6 +14,9 @@
     $wrapper = $button->meta['wrapper'] ?? [];
     $wrapper['element'] = $wrapper['element'] ?? 'a';
     $wrapper['href'] = $wrapper['href'] ?? $defaultHref;
+    if (is_a($wrapper['href'], \Closure::class, true)) {
+        $wrapper['href'] = ($wrapper['href'])($entry, $crud);
+    }
     $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
 @endphp
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I was trying to create a quick button where the href required the current line entry id. I had no access to the current line entry, so I couldn't build the button url.

### AFTER - What is happening after this PR?

We check if the href is a closure, if it is, feed it the current entry and the crud instance to generate the url.

### Is it a breaking change?

I don't think so, no. 


### How can we test the before & after?

Try to create a dynamic url in a quick line button that requires the current line entry id. 
