### PR TITLE
Crud update cancel button was removed

### DIFF
--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -29,7 +29,7 @@
         @endif
 
         @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))
-            <button onclick="confirmAndDeleteEntry()" type="button" class="btn btn-danger float-right"><i class="la la-trash-alt"></i> {{ trans('backpack::crud.delete') }}</button>
+            <button onclick="confirmAndDeleteEntry()" type="button" class="btn btn-danger float-right float-end"><i class="la la-trash-alt"></i> {{ trans('backpack::crud.delete') }}</button>
         @endif
     </div>
 @endif

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -28,6 +28,9 @@
             <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
         @endif
 
+        @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))
+            <button onclick="confirmAndDeleteEntry()" type="button" class="btn btn-danger float-right"><i class="la la-trash-alt"></i> {{ trans('backpack::crud.delete') }}</button>
+        @endif
     </div>
 @endif
 
@@ -108,4 +111,76 @@
         });
     });
 </script>
+
+@if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))
+<script>
+    function confirmAndDeleteEntry() {
+        // Ask for confirmation before deleting an item
+        swal({
+            title: "{!! trans('backpack::base.warning') !!}",
+            text: "{!! trans('backpack::crud.delete_confirm') !!}",
+            icon: "warning",
+            buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+            dangerMode: true,
+        }).then((value) => {
+            if (value) {
+                $.ajax({
+                    url: '{{ url($crud->route.'/'.$entry->getKey()) }}',
+                    type: 'DELETE',
+                    success: function(result) {
+                        if (result !== '1') {
+                            // if the result is an array, it means
+                            // we have notification bubbles to show
+                            if (result instanceof Object) {
+                                // trigger one or more bubble notifications
+                                Object.entries(result).forEach(function(entry) {
+                                    var type = entry[0];
+                                    entry[1].forEach(function(message, i) {
+                                        new Noty({
+                                            type: type,
+                                            text: message
+                                        }).show();
+                                    });
+                                });
+                            } else { // Show an error alert
+                                swal({
+                                    title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+                                    text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+                                    icon: "error",
+                                    timer: 4000,
+                                    buttons: false,
+                                });
+                            }
+                        }
+                        // All is good, show a success message!
+                        swal({
+                            title: "{!! trans('backpack::crud.delete_confirmation_title') !!}",
+                            text: "{!! trans('backpack::crud.delete_confirmation_message') !!}",
+                            icon: "success",
+                            buttons: false,
+                            closeOnClickOutside: false,
+                            closeOnEsc: false,
+                        });
+
+                        // Redirect in 1 sec so that admins get to see the success message
+                        setTimeout(function () {
+                            window.location.href = '{{ is_bool($crud->get('update.showDeleteButton')) ? url($crud->route) : (string) $crud->get('update.showDeleteButton') }}';
+                        }, 1000);
+                    },
+                    error: function() {
+                        // Show an alert with the result
+                        swal({
+                            title: "{!! trans('backpack::crud.delete_confirmation_not_title') !!}",
+                            text: "{!! trans('backpack::crud.delete_confirmation_not_message') !!}",
+                            icon: "error",
+                            timer: 4000,
+                            buttons: false,
+                        });
+                    }
+                });
+            }
+        });
+    }
+</script>
+@endif
 @endpush


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fixes https://github.com/Laravel-Backpack/CRUD/issues/5285

The Cancel button script for edit page was removed.

### AFTER - What is happening after this PR?

I've re-added it, and fixed the classes for BS 5


## HOW

### How did you achieve that, in technical terms?

copy pasta!



### Is it a breaking change?


No


