### PR TITLE
Fix: Table modal display the details row icon in the first column.

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -299,6 +299,7 @@ form .select2.select2-container {
 }
 
 .dt-buttons,
+.dtr-modal .details-control,
 .modal .details-control {
     display: none;
 }
@@ -308,10 +309,6 @@ form .select2.select2-container {
 }
 
 .dtr-bs-modal .crud_bulk_actions_checkbox {
-    display: none;
-}
-
-.dtr-modal .details-control{
     display: none;
 }
 

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -311,6 +311,10 @@ form .select2.select2-container {
     display: none;
 }
 
+.dtr-modal .details-control{
+    display: none;
+}
+
 .content-wrapper {
     min-height: calc(100% - 98px);
 }


### PR DESCRIPTION

Solves #5284 

Open the modal (responsive table) in a list of entries with details row.

### What I expected to happen

To open the model, and have my column value there.

### What happened

the modal opened, but I had the details row icon in the modal text.

![image](https://github.com/Laravel-Backpack/CRUD/assets/7188159/601e4b83-7a98-420f-87ae-e0082501bb68)
