### PR TITLE
Fix argument to strtoupper in layout error template

### DIFF
--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-12 text-center">
     <div class="error_number">
-      <small>{{ strtoupper(trans('backpack::base.error')) }}</small><br>
+      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => ''])) }}</small><br>
       {{ $error_number }}
       <hr>
     </div>

--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-12 text-center">
     <div class="error_number">
-      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => ''])) }}</small><br>
+      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => $error_number])) }}</small><br>
       {{ $error_number }}
       <hr>
     </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

`trans('backpack::base.error')` returns an array and `strtoupper` expects a string.

### AFTER - What is happening after this PR?

It uses using title key in the error array in the translations.

### Is it a breaking change?

Yes, error templates using layout as the base template do not work

### How can we test the before & after?

Test something that throws an error and loads an error template extending the layout template.