### PR TITLE
use strict comparison in quick button

### DIFF
--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -20,7 +20,7 @@
     $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
 @endphp
 
-@if ($access == true || $crud->hasAccess($access))
+@if ($access === true || $crud->hasAccess($access))
     <{{ $wrapper['element'] }}
         @foreach ($wrapper as $attribute => $value)
             @if (is_string($attribute))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in #5295 

We were using loose comparison and it would always be true. 

### AFTER - What is happening after this PR?

We use strict comparison. 
