### PR TITLE
error layout fix

### DIFF
--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-12 text-center">
     <div class="error_number">
-      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => $error_number])) }}</small><br>
+      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => ''])) }}</small><br>
       {{ $error_number }}
       <hr>
     </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We show the error number twice in the template.

### AFTER - What is happening after this PR?

We show it only once.


## HOW

### How did you achieve that, in technical terms?

I reverted the change I did in https://github.com/Laravel-Backpack/CRUD/pull/5293 as it made the error pop up twice. 

### Is it a breaking change?

No it's not.