### PR TITLE
Wrong Bootstrap class override

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -488,35 +488,27 @@ form .select2.select2-container {
     font-size: 156px;
     font-weight: 600;
     line-height: 100px;
-  }
-  .error_number small {
+}
+.error_number small {
     font-size: 56px;
     font-weight: 700;
-  }
+}
 
-  .error_number hr {
+.error_number hr {
     margin-top: 60px;
     margin-bottom: 0;
     width: 50px;
-  }
+}
 
-  .error_title {
+.error_title {
     margin-top: 40px;
     font-size: 36px;
     font-weight: 400;
-  }
+}
 
-  .error_description {
+.error_description {
     font-size: 24px;
     font-weight: 400;
-  }
-
-  .align-content-center{
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
 }
 
 /* Summernote */


### PR DESCRIPTION
## WHY
Solves https://github.com/Laravel-Backpack/CRUD/issues/5305


### BEFORE - What was wrong? What was happening before this PR?

An extra CSS class found `align-content-center`

### AFTER - What is happening after this PR?
Removed: `align-content-center`

## HOW

### How did you achieve that, in technical terms?

1) Checked Usage: Not being used any of Backpack packages
2) Removed: `align-content-center`


### Is it a breaking change?

No
