### PR TITLE
Use ServiceContainer to instantiate CRUD Model

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -117,7 +117,7 @@ class CrudPanel
             throw new \Exception('Please use CrudTrait on the model.', 500);
         }
 
-        $this->model = new $model_namespace();
+        $this->model = app($model_namespace);
         $this->query = clone $this->totalQuery = $this->model->select('*');
         $this->entry = null;
     }


### PR DESCRIPTION
This allows developers to bind a model in their AppServiceProvider... to override a Model that comes in package.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

I was working with @phpfour on the Backpack website. Over there, we have quite few CRUDs that are separated in addons. That addon (a package) includes the CrudController, CrudRequest and the Model, everything for that entity.

But... we wanted to edit the Model from vendor a bit... to add a trait to it. We did this in AppServiceProvider, expecting it to work:
```php
        $this->app->bind(
            \Backpack\PackageManager\Http\Controllers\Admin\PackageCrudController::class,
            \App\Http\Controllers\Admin\PackageCrudController::class
        );
```

But it didn't. WHY? Because Backpack doesn't actually use the Laravel Service Container to resolve the Model. It did `new $model()`.

### AFTER - What is happening after this PR?

We do `app($model)` which creates a new instance of the object using Laravel's ServiceContainer. So people can plug into that process, and override it (so the code above works). 

## HOW

### How did you achieve that, in technical terms?

See diff. Super-simple.

### Is it a breaking change?

I don't _think so_. But it could be a huge change. So I really want @pxpm to think about this, before we merge it. Could this come bite us in the ass?!

### How can we test the before & after?

A good example is in our demo, using NewsCRUD. We have:
- `Backpack\NewsCRUD\app\Models\Article`;
- `App\Models\Article` that extends the one above;

But ArticleCrudController does NOT use this custom `Article` model. It can't without this PR! To do it, go to `app\Providers\AppServiceProvider.php` and in the `register()` method add:

```php
        $this->app->bind(
            \Backpack\NewsCRUD\app\Models\Article::class,
            \App\Models\Article::class
        );
```

Then go to your `App\Models\Article` model and add this method:

```php
    public static function boot()
    {
        dd('You are now using App\Models\Article. Congrats!');
    }
```

Now test:
- without this PR - you can go to News CRUD and it won't crash; because the model used is the one in the package;
- with this PR - you go to NewsCRUD and it will crash, saying "_You are now using App\Models\Article. Congrats!_"