### PR TITLE
clear code, allow force export overriding

### DIFF
--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -128,7 +128,7 @@
             extend: 'colvis',
             text: '<i class="la la-eye-slash"></i> {{ trans('backpack::crud.export.column_visibility') }}',
             columns: function ( idx, data, node ) {
-                return $(node).attr('data-visible-in-table') == 'false' && $(node).attr('data-can-be-visible-in-table') == 'true';
+                return $(node).attr('data-can-be-visible-in-table') == 'true';
             },
             dropup: true
         }

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -87,10 +87,10 @@
                     data-force-export => force export even if columns are hidden
                     --}}
 
-                    data-visible="{{ $exportOnlyColumn ? 'false' : var_export($visibleInTable, true) }}"
-                    data-visible-in-table="{{ var_export($visibleInTable, true) }}"
+                    data-visible="{{ $exportOnlyColumn ? 'false' : var_export($visibleInTable) }}"
+                    data-visible-in-table="{{ var_export($visibleInTable) }}"
                     data-can-be-visible-in-table="{{ $exportOnlyColumn ? 'false' : 'true' }}"
-                    data-visible-in-modal="{{ var_export($visibleInModal, true) }}"
+                    data-visible-in-modal="{{ var_export($visibleInModal) }}"
                     data-visible-in-export="{{ $exportOnlyColumn ? 'true' : ($visibleInExport ? 'true' : 'false') }}"
                     data-force-export="{{ var_export($forceExport) }}"
                   >

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -67,6 +67,13 @@
               <tr>
                 {{-- Table columns --}}
                 @foreach ($crud->columns() as $column)
+                  @php
+                  $exportOnlyColumn = $column['exportOnlyColumn'] ?? false;
+                  $visibleInTable = $column['visibleInTable'] ?? true;
+                  $visibleInModal = $column['visibleInModal'] ?? true;
+                  $visibleInExport = $column['visibleInExport'] ?? true;
+                  $forceExport = $column['forceExport'] ?? (isset($column['exportOnlyColumn']) ? true : false);
+                  @endphp
                   <th
                     data-orderable="{{ var_export($column['orderable'], true) }}"
                     data-priority="{{ $column['priority'] }}"
@@ -81,19 +88,11 @@
                     --}}
 
                     {{-- If it is an export field only, we are done. --}}
-                    @php
-                    $exportOnlyField = $column['exportOnlyField'] ?? false;
-                    $visibleInTable = $column['visibleInTable'] ?? true;
-                    $visibleInModal = $column['visibleInModal'] ?? true;
-                    $visibleInExport = $column['visibleInExport'] ?? true;
-                    $forceExport = $column['forceExport'] ?? ($column['exportOnlyField'] ? true : false);
-                    @endphp
-
-                    data-visible="{{ $exportOnlyField ? 'false' : var_export($visibleInTable, true) }}"
+                    data-visible="{{ $exportOnlyColumn ? 'false' : var_export($visibleInTable, true) }}"
                     data-visible-in-table="{{ var_export($visibleInTable, true) }}"
-                    data-can-be-visible-in-table="{{ $exportOnlyField ? 'false' : 'true' }}"
+                    data-can-be-visible-in-table="{{ $exportOnlyColumn ? 'false' : 'true' }}"
                     data-visible-in-modal="{{ var_export($visibleInModal, true) }}"
-                    data-visible-in-export="{{ $exportOnlyField ? 'true' : ($visibleInExport ? 'true' : 'false') }}"
+                    data-visible-in-export="{{ $exportOnlyColumn ? 'true' : ($visibleInExport ? 'true' : 'false') }}"
                     data-force-export="{{ var_export($forceExport, true) }}"
                   >
                     {{-- Bulk checkbox --}}

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -69,8 +69,8 @@
                 @foreach ($crud->columns() as $column)
                   @php
                   $exportOnlyColumn = $column['exportOnlyColumn'] ?? false;
-                  $visibleInTable = $column['visibleInTable'] ?? true;
-                  $visibleInModal = $column['visibleInModal'] ?? true;
+                  $visibleInTable = $column['visibleInTable'] ?? ($exportOnlyColumn ? false : true);
+                  $visibleInModal = $column['visibleInModal'] ?? ($exportOnlyColumn ? false : true);
                   $visibleInExport = $column['visibleInExport'] ?? true;
                   $forceExport = $column['forceExport'] ?? (isset($column['exportOnlyColumn']) ? true : false);
                   @endphp
@@ -79,21 +79,20 @@
                     data-priority="{{ $column['priority'] }}"
                     data-column-name="{{ $column['name'] }}"
                     {{--
-                    data-visible-in-table => if developer forced field in table with 'visibleInTable => true'
-                    data-visible => regular visibility of the field
-                    data-can-be-visible-in-table => prevents the column to be loaded into the table (export-only)
+                    data-visible-in-table => if developer forced column to be in the table with 'visibleInTable => true'
+                    data-visible => regular visibility of the column
+                    data-can-be-visible-in-table => prevents the column to be visible into the table (export-only)
                     data-visible-in-modal => if column appears on responsive modal
-                    data-visible-in-export => if this field is exportable
-                    data-force-export => force export even if field are hidden
+                    data-visible-in-export => if this column is exportable
+                    data-force-export => force export even if columns are hidden
                     --}}
 
-                    {{-- If it is an export field only, we are done. --}}
                     data-visible="{{ $exportOnlyColumn ? 'false' : var_export($visibleInTable, true) }}"
                     data-visible-in-table="{{ var_export($visibleInTable, true) }}"
                     data-can-be-visible-in-table="{{ $exportOnlyColumn ? 'false' : 'true' }}"
                     data-visible-in-modal="{{ var_export($visibleInModal, true) }}"
                     data-visible-in-export="{{ $exportOnlyColumn ? 'true' : ($visibleInExport ? 'true' : 'false') }}"
-                    data-force-export="{{ var_export($forceExport, true) }}"
+                    data-force-export="{{ var_export($forceExport) }}"
                   >
                     {{-- Bulk checkbox --}}
                     @if($loop->first && $crud->getOperationSetting('bulkActions'))

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -81,31 +81,20 @@
                     --}}
 
                     {{-- If it is an export field only, we are done. --}}
-                    @if(isset($column['exportOnlyField']) && $column['exportOnlyField'] === true)
-                      data-visible="false"
-                      data-visible-in-table="false"
-                      data-can-be-visible-in-table="false"
-                      data-visible-in-modal="false"
-                      data-visible-in-export="true"
-                      data-force-export="true"
-                    @else
-                      data-visible-in-table="{{var_export($column['visibleInTable'] ?? false)}}"
-                      data-visible="{{var_export($column['visibleInTable'] ?? true)}}"
-                      data-can-be-visible-in-table="true"
-                      data-visible-in-modal="{{var_export($column['visibleInModal'] ?? true)}}"
-                      @if(isset($column['visibleInExport']))
-                         @if($column['visibleInExport'] === false)
-                           data-visible-in-export="false"
-                           data-force-export="false"
-                         @else
-                           data-visible-in-export="true"
-                           data-force-export="true"
-                         @endif
-                       @else
-                         data-visible-in-export="true"
-                         data-force-export="false"
-                       @endif
-                    @endif
+                    @php
+                    $exportOnlyField = $column['exportOnlyField'] ?? false;
+                    $visibleInTable = $column['visibleInTable'] ?? true;
+                    $visibleInModal = $column['visibleInModal'] ?? true;
+                    $visibleInExport = $column['visibleInExport'] ?? true;
+                    $forceExport = $column['forceExport'] ?? ($column['exportOnlyField'] ? true : false);
+                    @endphp
+
+                    data-visible="{{ $exportOnlyField ? 'false' : var_export($visibleInTable, true) }}"
+                    data-visible-in-table="{{ var_export($visibleInTable, true) }}"
+                    data-can-be-visible-in-table="{{ $exportOnlyField ? 'false' : 'true' }}"
+                    data-visible-in-modal="{{ var_export($visibleInModal, true) }}"
+                    data-visible-in-export="{{ $exportOnlyField ? 'true' : ($visibleInExport ? 'true' : 'false') }}"
+                    data-force-export="{{ var_export($forceExport, true) }}"
                   >
                     {{-- Bulk checkbox --}}
                     @if($loop->first && $crud->getOperationSetting('bulkActions'))


### PR DESCRIPTION
This piece of code was a bit of spaghetti that can be organized. And I did.

I took the opportunity to fix an issue where `force-export` couldn't be overwritten by developers and `visibleInTable` was yielding wrong results. 
