### PR TITLE
add crudbutton position method

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -185,7 +185,7 @@ class CrudButton implements Arrayable
                 break;
         }
 
-        return $this->save();
+        return $this;
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -163,6 +163,32 @@ class CrudButton implements Arrayable
     }
 
     /**
+     * Set the button position. Defines where the button will be shown
+     * in regard to other buttons in the same stack.
+     *
+     * @param  string  $stack  'beginning' or 'end'
+     * @return CrudButton
+     */
+    public function position($position)
+    {
+        switch ($position) {
+            case 'beginning':
+                $this->makeFirst();
+                break;
+
+            case 'end':
+                $this->makeLast();
+                break;
+
+            default:
+                abort(500, "Unknown button position - please use 'beginning' or 'end'.");
+                break;
+        }
+
+        return $this->save();
+    }
+
+    /**
      * Sets the meta that will be available in the view.
      *
      * @param  array  $value  Array of metadata that will be available in the view.

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -285,4 +285,25 @@ class CrudPanelButtonsTest extends BaseCrudPanel
     {
         CrudButton::name(array_values($this->{$buttonName}));
     }
+
+    public function testMovingTheButtonUsingPosition()
+    {
+        $button1 = CrudButton::name('lineTest')->to('line')->view('crud::buttons.test')->type('view');
+        $button2 = CrudButton::name('lineTest2')->to('line')->view('crud::buttons.test')->type('view')->position('beginning');
+        $this->assertEquals($button2->toArray(), $this->crudPanel->buttons()->first()->toArray());
+        $button2->position('end');
+        $this->assertEquals($button1->toArray(), $this->crudPanel->buttons()->first()->toArray());
+    }
+
+    public function testThrowsErrorInUnknownPosition()
+    {
+        try {
+            $button1 = CrudButton::name('lineTest')->to('line')->view('crud::buttons.test')->type('view')->position('unknown');
+        } catch (\Throwable $e) {
+        }
+        $this->assertEquals(
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Unknown button position - please use \'beginning\' or \'end\'.'),
+            $e
+        );
+    }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I tried to do this:
```php
        CRUD::button('something')
            ->stack('line')
            ->position('beginning') // <------- SEE HERE
            ->view('crud::buttons.quick')
            ->meta([
                'access' => true,
                'label' => 'Something',
                'icon' => 'la la-question',
            ]);
```

But I got an error that the `position` method isn't defined. That is very weird, because that's one of the important things you can define on a button. It's even a property on the `CrudButton` object.

### AFTER - What is happening after this PR?

That method exists, and does what you expect. 

## HOW

### How did you achieve that, in technical terms?

I chose NOT to just set the string on the button, because that did nothing. Instead, I called the existing `makeFirst()` and `makeLast()` methods, which would move that button the the beginning/end of the stack.

### Is it a breaking change?

No.


### How can we test the before & after?

Try the code above. It will throw an error. Then checkout this branch, it will not, and it should work as expected.
