### PR TITLE
Replaced translation keys for error page

### DIFF
--- a/src/resources/lang/en/base.php
+++ b/src/resources/lang/en/base.php
@@ -53,7 +53,7 @@ return [
     'welcome'                => 'Welcome!',
     'use_sidebar'            => 'Use the sidebar to the left to create, edit or delete content.',
 
-    'error' => [
+    'error_page' => [
         'title'              => 'Error :error',
         'button'             => 'Take me home',
         'message_4xx'        => 'Please <a :href_back>go back</a> or return to <a :href_homepage>our homepage</a>.',

--- a/src/resources/lang/pt/base.php
+++ b/src/resources/lang/pt/base.php
@@ -53,7 +53,7 @@ return [
     'welcome'                => 'Bem-vindo!',
     'use_sidebar'            => 'Use a barra lateral à esquerda para criar, editar ou apagar conteúdo.',
 
-    'error' => [
+    'error_page' => [
         'title'              => 'Erro :error',
         'button'             => 'Voltar ao início',
     ],

--- a/src/resources/views/ui/errors/4xx.blade.php
+++ b/src/resources/views/ui/errors/4xx.blade.php
@@ -5,11 +5,11 @@
 @endphp
 
 @section('title')
-  {{ trans('backpack::base.error.'.$error_number) }}
+  {{ trans('backpack::base.error_page.'.$error_number) }}
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error.message_4xx', [
+  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_4xx', [
     'href_back' => 'href="javascript:history.back()"',
     'href_homepage' => 'href="'.url('').'"',
   ]) !!}

--- a/src/resources/views/ui/errors/500.blade.php
+++ b/src/resources/views/ui/errors/500.blade.php
@@ -5,9 +5,9 @@
 @endphp
 
 @section('title')
-  {{ trans('backpack::base.error.500') }}
+  {{ trans('backpack::base.error_page.500') }}
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error.message_500') !!}
+  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_500') !!}
 @endsection

--- a/src/resources/views/ui/errors/503.blade.php
+++ b/src/resources/views/ui/errors/503.blade.php
@@ -5,9 +5,9 @@
 @endphp
 
 @section('title')
-  {{ trans('backpack::base.error.503') }}
+  {{ trans('backpack::base.error_page.503') }}
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error.message_503') !!}
+  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_503') !!}
 @endsection

--- a/src/resources/views/ui/errors/blank.blade.php
+++ b/src/resources/views/ui/errors/blank.blade.php
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{{ trans('backpack::base.error.title', ['error' => $error_number]) }}</title>
+        <title>{{ trans('backpack::base.error_page.title', ['error' => $error_number]) }}</title>
         <style>
           .error_number {
               font-size: 156px;

--- a/src/resources/views/ui/errors/layout.blade.php
+++ b/src/resources/views/ui/errors/layout.blade.php
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="col-md-12 text-center">
     <div class="error_number">
-      <small>{{ strtoupper(trans('backpack::base.error.title', ['error' => ''])) }}</small><br>
+      <small>{{ strtoupper(trans('backpack::base.error_page.title', ['error' => ''])) }}</small><br>
       {{ $error_number }}
       <hr>
     </div>


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/CRUD/issues/5314.

After this one gets merged, we should merge;
- https://github.com/Laravel-Backpack/theme-tabler/pull/146
- https://github.com/Laravel-Backpack/theme-coreuiv2/pull/31 (includes error page layout)
- https://github.com/Laravel-Backpack/theme-coreuiv4/pull/47 (includes error page layout)