### PR TITLE
add model table prefix in query count

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -258,7 +258,7 @@ trait Query
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
         // select minimum possible columns for the count
-        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? '*' : $modelTable.'.'.$this->model->getKeyName();
+        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? $modelTable.'.*' : $modelTable.'.'.$this->model->getKeyName();
         $subQuery->select($minimumColumns);
 
         // in case there are raw expressions we need to add them too.


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/Laravel-Backpack/community-forum/issues/657

Using join clauses instead of whereHas would cause ambiguous column names in search. 

### AFTER - What is happening after this PR?

I applied the suggested fix and ran some tests. Can confirm the is fixed.


### Is it a breaking change?

No I don't think so.


### How can we test the before & after?

Add the following clause to your crud list operation: 
```php
$this->crud->addClause(function($query) {
                    return $query->join('postalboxers', 'monsters.id', '=', 'postalboxers.monster_id')
                    ->where('postalboxers.postal_name', 'LIKE', '%test%')
                    ->groupBy('monsters.id');
                        
                });
```
