### PR TITLE
Update base.php

### DIFF
--- a/src/resources/lang/it/base.php
+++ b/src/resources/lang/it/base.php
@@ -21,6 +21,8 @@ return [
     'register'               => 'Registrati',
     'name'                   => 'Nome',
     'email_address'          => 'Indirizzo E-mail',
+    'email'                  => 'E-mail,
+    'username'               => 'Nome utente', 
     'password'               => 'Password',
     'old_password'           => 'Vecchia Password',
     'new_password'           => 'Nuova Password',


### PR DESCRIPTION
Added missing italian translations

## WHY

### BEFORE - What was wrong? What was happening before this PR?

2 new strings added in v6.2.1 were not translated in italian locale

### AFTER - What is happening after this PR?

Simply, added 2 new translations following conventions

## HOW

### How did you achieve that, in technical terms?

Simply added 2 entry in the associate array of italian base localization


### Is it a breaking change?

no


### How can we test the before & after?

set laravel app into italian and see if in the login page there are the right strings
