### PR TITLE
Added bootstrap5 class form-select

### DIFF
--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -66,7 +66,7 @@
     @include('crud::fields.inc.translatable_icon')
     <select
         name="{{ $field['name'] }}"
-        @include('crud::fields.inc.attributes')
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
         >
 
         @if ($entity_model::isColumnNullable($field['name']))

--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -66,7 +66,7 @@
     @include('crud::fields.inc.translatable_icon')
     <select
         name="{{ $field['name'] }}"
-        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-control form-select'])
         >
 
         @if ($entity_model::isColumnNullable($field['name']))

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -25,7 +25,7 @@
         @if(isset($field['prefix'])) <span class="input-group-text">{!! $field['prefix'] !!}</span> @endif
         <select
             name="{{ $field['name'] }}"
-            @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
+            @include('crud::fields.inc.attributes', ['default_class' => 'form-control form-select'])
             >
 
             @if ($field['allows_null'])

--- a/src/resources/views/crud/fields/select.blade.php
+++ b/src/resources/views/crud/fields/select.blade.php
@@ -25,7 +25,7 @@
         @if(isset($field['prefix'])) <span class="input-group-text">{!! $field['prefix'] !!}</span> @endif
         <select
             name="{{ $field['name'] }}"
-            @include('crud::fields.inc.attributes')
+            @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
             >
 
             @if ($field['allows_null'])

--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -10,7 +10,7 @@
     @if($field['multiple'])<input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />@endif
     <select
         name="{{ $field['name'] }}@if ($field['multiple'])[]@endif"
-        @include('crud::fields.inc.attributes')
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
         @if ($field['multiple'])multiple bp-field-main-input @endif
         >
 

--- a/src/resources/views/crud/fields/select_from_array.blade.php
+++ b/src/resources/views/crud/fields/select_from_array.blade.php
@@ -10,7 +10,7 @@
     @if($field['multiple'])<input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />@endif
     <select
         name="{{ $field['name'] }}@if ($field['multiple'])[]@endif"
-        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-control form-select'])
         @if ($field['multiple'])multiple bp-field-main-input @endif
         >
 

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -21,7 +21,7 @@
         @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
         <select
             name="{{ $field['name'] }}"
-            @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
+            @include('crud::fields.inc.attributes', ['default_class' => 'form-control form-select'])
             >
 
                 @if ($field['allows_null'])

--- a/src/resources/views/crud/fields/select_grouped.blade.php
+++ b/src/resources/views/crud/fields/select_grouped.blade.php
@@ -21,7 +21,7 @@
         @if(isset($field['prefix'])) <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div> @endif
         <select
             name="{{ $field['name'] }}"
-            @include('crud::fields.inc.attributes', ['default_class' =>  'form-control'])
+            @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
             >
 
                 @if ($field['allows_null'])

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -22,9 +22,8 @@
     {{-- To make sure a value gets submitted even if the "select multiple" is empty, we need a hidden input --}}
     <input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />
     <select
-    	class="form-control"
         name="{{ $field['name'] }}[]"
-        @include('crud::fields.inc.attributes')
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
         bp-field-main-input
     	multiple>
 

--- a/src/resources/views/crud/fields/select_multiple.blade.php
+++ b/src/resources/views/crud/fields/select_multiple.blade.php
@@ -23,7 +23,7 @@
     <input type="hidden" name="{{ $field['name'] }}" value="" @if(in_array('disabled', $field['attributes'] ?? [])) disabled @endif />
     <select
         name="{{ $field['name'] }}[]"
-        @include('crud::fields.inc.attributes', ['default_class' => 'form-select'])
+        @include('crud::fields.inc.attributes', ['default_class' => 'form-control form-select'])
         bp-field-main-input
     	multiple>
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

After switching to bootstrap5, the design of the `<select>` field was broken.

In the `<select>` field need to add the `form-select` class by default.  https://getbootstrap.com/docs/5.0/forms/select/

### AFTER - What is happening after this PR?

The `<select>` field design will be restored.
