### PR TITLE
[Feature] Custom access closures

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -22,7 +22,7 @@ trait Access
     /**
      * Disable the access to a certain operation, or the current one.
      */
-    public function denyAccess(array|string $operation) : bool
+    public function denyAccess(array|string $operation): bool
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', false);
@@ -50,7 +50,7 @@ trait Access
     /**
      * Check if any operations are allowed for a Crud Panel. Return false if not.
      */
-    public function hasAccessToAny(array|string $operation_array, ?Model $entry = null) : bool
+    public function hasAccessToAny(array|string $operation_array, ?Model $entry = null): bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if ($this->hasAccess($operation, $entry) == true) {
@@ -64,7 +64,7 @@ trait Access
     /**
      * Check if all operations are allowed for a Crud Panel. Return false if not.
      */
-    public function hasAccessToAll(array|string $operation_array, ?Model $entry = null) : bool
+    public function hasAccessToAll(array|string $operation_array, ?Model $entry = null): bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if (! $this->hasAccess($operation, $entry)) {
@@ -80,7 +80,7 @@ trait Access
      *
      * @throws \Backpack\CRUD\Exception\AccessDeniedException in case the operation is not enabled
      */
-    public function hasAccessOrFail(string $operation, ?Model $entry = null) : bool
+    public function hasAccessOrFail(string $operation, ?Model $entry = null): bool
     {
         if (! $this->hasAccess($operation, $entry)) {
             throw new AccessDeniedException(trans('backpack::crud.unauthorized_access', ['access' => $operation]));

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -12,7 +12,7 @@ trait Access
      * @param  string|array  $operation
      * @return bool
      */
-    public function allowAccess(array|string $operation) : bool
+    public function allowAccess(array|string $operation): bool
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', true);
@@ -43,12 +43,13 @@ trait Access
      * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccess(string $operation, $entry = null) : bool
+    public function hasAccess(string $operation, $entry = null): bool
     {
         $condition = $this->get($operation.'.access');
 
         if (is_callable($condition)) {
             $entry = $entry ?? $this->getCurrentEntry();
+
             return $condition($entry);
         }
 
@@ -62,7 +63,7 @@ trait Access
      * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccessToAny(array|string $operation_array, $entry = null) : bool
+    public function hasAccessToAny(array|string $operation_array, $entry = null): bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if ($this->hasAccess($operation, $entry) == true) {
@@ -80,7 +81,7 @@ trait Access
      * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccessToAll(array|string $operation_array, $entry = null) : bool
+    public function hasAccessToAll(array|string $operation_array, $entry = null): bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if (! $this->hasAccess($operation, $entry)) {
@@ -100,7 +101,7 @@ trait Access
      *
      * @throws \Backpack\CRUD\Exception\AccessDeniedException in case the operation is not enabled
      */
-    public function hasAccessOrFail(string $operation, $entry = null) : bool
+    public function hasAccessOrFail(string $operation, $entry = null): bool
     {
         if (! $this->hasAccess($operation, $entry)) {
             throw new AccessDeniedException(trans('backpack::crud.unauthorized_access', ['access' => $operation]));
@@ -116,7 +117,7 @@ trait Access
      * @param  string  $operation
      * @return bool|callable|null
      */
-    public function getAccessCondition(string $operation) : bool|callable|null
+    public function getAccessCondition(string $operation): bool|callable|null
     {
         return $this->get($operation.'.access');
     }
@@ -128,7 +129,7 @@ trait Access
      * @param  bool|callable|null  $condition
      * @return void
      */
-    public function setAccessCondition(array|string $operation, bool|callable|null $condition) : void
+    public function setAccessCondition(array|string $operation, bool|callable|null $condition): void
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', $condition);
@@ -142,9 +143,8 @@ trait Access
      * @param  string  $operation
      * @return bool
      */
-    public function hasAccessCondition(string $operation) : bool
+    public function hasAccessCondition(string $operation): bool
     {
         return $this->get($operation.'.access') !== null;
     }
-
 }

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -39,7 +39,10 @@ trait Access
         $condition = $this->get($operation.'.access');
 
         if (is_callable($condition)) {
-            $entry = $entry ?? $this->getCurrentEntry() ? $this->getCurrentEntry() : null;
+            // supply the current entry, if $entry is missing
+            if (! $entry && $this->getCurrentEntry()) {
+                $entry = $this->getCurrentEntry();
+            } // this also makes sure the entry is null when missing
 
             return $condition($entry);
         }

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -40,9 +40,8 @@ trait Access
 
         if (is_callable($condition)) {
             // supply the current entry, if $entry is missing
-            if (! $entry && $this->getCurrentEntry()) {
-                $entry = $this->getCurrentEntry();
-            } // this also makes sure the entry is null when missing
+            // this also makes sure the entry is null when missing
+            $entry ??= $this->getCurrentEntry() ?: null;
 
             return $condition($entry);
         }

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -12,7 +12,7 @@ trait Access
      * @param  string|array  $operation
      * @return bool
      */
-    public function allowAccess($operation)
+    public function allowAccess(array|string $operation) : bool
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', true);
@@ -27,7 +27,7 @@ trait Access
      * @param  string|array  $operation  [description]
      * @return [type] [description]
      */
-    public function denyAccess($operation)
+    public function denyAccess(array|string $operation)
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', false);
@@ -40,23 +40,32 @@ trait Access
      * Check if a operation is allowed for a Crud Panel. Return false if not.
      *
      * @param  string  $operation
+     * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccess($operation)
+    public function hasAccess(string $operation, $entry = null) : bool
     {
-        return $this->get($operation.'.access') ?? false;
+        $condition = $this->get($operation.'.access');
+
+        if (is_callable($condition)) {
+            $entry = $entry ?? $this->getCurrentEntry();
+            return $condition($entry);
+        }
+
+        return $condition ?? false;
     }
 
     /**
      * Check if any operations are allowed for a Crud Panel. Return false if not.
      *
      * @param  string|array  $operation_array
+     * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccessToAny($operation_array)
+    public function hasAccessToAny(array|string $operation_array, $entry = null) : bool
     {
         foreach ((array) $operation_array as $key => $operation) {
-            if ($this->get($operation.'.access') == true) {
+            if ($this->hasAccess($operation, $entry) == true) {
                 return true;
             }
         }
@@ -68,12 +77,13 @@ trait Access
      * Check if all operations are allowed for a Crud Panel. Return false if not.
      *
      * @param  array  $operation_array  Permissions.
+     * @param  \Model  $entry
      * @return bool
      */
-    public function hasAccessToAll($operation_array)
+    public function hasAccessToAll(array|string $operation_array, $entry = null) : bool
     {
         foreach ((array) $operation_array as $key => $operation) {
-            if (! $this->get($operation.'.access')) {
+            if (! $this->hasAccess($operation, $entry)) {
                 return false;
             }
         }
@@ -85,16 +95,56 @@ trait Access
      * Check if a operation is allowed for a Crud Panel. Fail if not.
      *
      * @param  string  $operation
+     * @param  \Model  $entry
      * @return bool
      *
      * @throws \Backpack\CRUD\Exception\AccessDeniedException in case the operation is not enabled
      */
-    public function hasAccessOrFail($operation)
+    public function hasAccessOrFail(string $operation, $entry = null) : bool
     {
-        if (! $this->get($operation.'.access')) {
+        if (! $this->hasAccess($operation, $entry)) {
             throw new AccessDeniedException(trans('backpack::crud.unauthorized_access', ['access' => $operation]));
         }
 
         return true;
     }
+
+    /**
+     * Get an operation's access condition, if set. A condition
+     * can be anything, but usually a boolean or a callable.
+     *
+     * @param  string  $operation
+     * @return bool|callable|null
+     */
+    public function getAccessCondition(string $operation) : bool|callable|null
+    {
+        return $this->get($operation.'.access');
+    }
+
+    /**
+     * Set the condition under which an operation is allowed for a Crud Panel.
+     *
+     * @param  string|array  $operation
+     * @param  bool|callable|null  $condition
+     * @return void
+     */
+    public function setAccessCondition(array|string $operation, bool|callable|null $condition) : void
+    {
+        foreach ((array) $operation as $op) {
+            $this->set($op.'.access', $condition);
+        }
+    }
+
+    /**
+     * Check if an operation has an access condition already set.
+     * A condition can be anything, but usually a boolean or a callable.
+     *
+     * @param  string  $operation
+     * @return bool
+     */
+    public function hasAccessCondition(string $operation) : bool
+    {
+        return $this->get($operation.'.access') !== null;
+    }
+
 }

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -3,14 +3,12 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\app\Exceptions\AccessDeniedException;
+use Illuminate\Database\Eloquent\Model;
 
 trait Access
 {
     /**
      * Set an operation as having access using the Settings API.
-     *
-     * @param  string|array  $operation
-     * @return bool
      */
     public function allowAccess(array|string $operation): bool
     {
@@ -23,11 +21,8 @@ trait Access
 
     /**
      * Disable the access to a certain operation, or the current one.
-     *
-     * @param  string|array  $operation  [description]
-     * @return [type] [description]
      */
-    public function denyAccess(array|string $operation)
+    public function denyAccess(array|string $operation) : bool
     {
         foreach ((array) $operation as $op) {
             $this->set($op.'.access', false);
@@ -38,10 +33,6 @@ trait Access
 
     /**
      * Check if a operation is allowed for a Crud Panel. Return false if not.
-     *
-     * @param  string  $operation
-     * @param  \Model  $entry
-     * @return bool
      */
     public function hasAccess(string $operation, $entry = null): bool
     {
@@ -58,12 +49,8 @@ trait Access
 
     /**
      * Check if any operations are allowed for a Crud Panel. Return false if not.
-     *
-     * @param  string|array  $operation_array
-     * @param  \Model  $entry
-     * @return bool
      */
-    public function hasAccessToAny(array|string $operation_array, $entry = null): bool
+    public function hasAccessToAny(array|string $operation_array, ?Model $entry = null) : bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if ($this->hasAccess($operation, $entry) == true) {
@@ -76,12 +63,8 @@ trait Access
 
     /**
      * Check if all operations are allowed for a Crud Panel. Return false if not.
-     *
-     * @param  array  $operation_array  Permissions.
-     * @param  \Model  $entry
-     * @return bool
      */
-    public function hasAccessToAll(array|string $operation_array, $entry = null): bool
+    public function hasAccessToAll(array|string $operation_array, ?Model $entry = null) : bool
     {
         foreach ((array) $operation_array as $key => $operation) {
             if (! $this->hasAccess($operation, $entry)) {
@@ -95,13 +78,9 @@ trait Access
     /**
      * Check if a operation is allowed for a Crud Panel. Fail if not.
      *
-     * @param  string  $operation
-     * @param  \Model  $entry
-     * @return bool
-     *
      * @throws \Backpack\CRUD\Exception\AccessDeniedException in case the operation is not enabled
      */
-    public function hasAccessOrFail(string $operation, $entry = null): bool
+    public function hasAccessOrFail(string $operation, ?Model $entry = null) : bool
     {
         if (! $this->hasAccess($operation, $entry)) {
             throw new AccessDeniedException(trans('backpack::crud.unauthorized_access', ['access' => $operation]));
@@ -113,9 +92,6 @@ trait Access
     /**
      * Get an operation's access condition, if set. A condition
      * can be anything, but usually a boolean or a callable.
-     *
-     * @param  string  $operation
-     * @return bool|callable|null
      */
     public function getAccessCondition(string $operation): bool|callable|null
     {
@@ -124,10 +100,6 @@ trait Access
 
     /**
      * Set the condition under which an operation is allowed for a Crud Panel.
-     *
-     * @param  string|array  $operation
-     * @param  bool|callable|null  $condition
-     * @return void
      */
     public function setAccessCondition(array|string $operation, bool|callable|null $condition): void
     {
@@ -139,9 +111,6 @@ trait Access
     /**
      * Check if an operation has an access condition already set.
      * A condition can be anything, but usually a boolean or a callable.
-     *
-     * @param  string  $operation
-     * @return bool
      */
     public function hasAccessCondition(string $operation): bool
     {

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -39,7 +39,7 @@ trait Access
         $condition = $this->get($operation.'.access');
 
         if (is_callable($condition)) {
-            $entry = $entry ?? $this->getCurrentEntry();
+            $entry = $entry ?? $this->getCurrentEntry() ? $this->getCurrentEntry() : null;
 
             return $condition($entry);
         }

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('delete'))
+@if ($crud->hasAccess('delete', $entry))
     <a href="javascript:void(0)" onclick="deleteEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-sm btn-link" data-button-type="delete">
         <span><i class="la la-trash"></i> {{ trans('backpack::crud.delete') }}</span>
     </a>

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -20,7 +20,7 @@
     $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
 @endphp
 
-@if ($access === true || $crud->hasAccess($access))
+@if ($access === true || $crud->hasAccess($access, isset($entry) ? $entry : null))
     <{{ $wrapper['element'] }}
         @foreach ($wrapper as $attribute => $value)
             @if (is_string($attribute))

--- a/src/resources/views/crud/buttons/show.blade.php
+++ b/src/resources/views/crud/buttons/show.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('show'))
+@if ($crud->hasAccess('show', $entry))
 	@if (!$crud->model->translationEnabled())
 
 	{{-- Single edit button --}}

--- a/src/resources/views/crud/buttons/update.blade.php
+++ b/src/resources/views/crud/buttons/update.blade.php
@@ -1,4 +1,4 @@
-@if ($crud->hasAccess('update'))
+@if ($crud->hasAccess('update', $entry))
 	@if (!$crud->model->translationEnabled())
 
 	{{-- Single edit button --}}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We could not prevent access to an entire operation. ✅
But could NOT prevent access to an operation for a certain entry. ❌

For example, in a Product CRUD, say a user 
- had access to `list` and `show` all items;
- BUT only had access to `update` and `delete` THEIR items;
 
Before this PR, that was very difficult to do in Backpack. You had to override the Update operation and the Update button. 🤢Horrible. 

### AFTER - What is happening after this PR?

An access condition can still be `true` and `false` like before. But in addition to that, it can also be a `callable`. 

The developer can define their own closure that defines if an operation has access or not. And inside that closure, they have access to `$entry`, so they can define access depending on `$entry`, `backpack_user()` etc.

That means you can do THIS in your `ProductCrudController`:

```php
public function setup()
    {
        // ...

        CRUD::setAccessCondition(['update', 'delete'], function ($entry) {
            if (backpack_user()->isSuperAdmin()) {
                return true;
            }

            if ($entry->user->id == backpack_user()->id) {
                return true;
            }

            return false;
        });
    }
```

Note that this is one of those VERY FEW things that is best done in the `setup()` method, so that it applies for all operations. For example, you want to set this access closure for the `update` and `delete` operations even during the `list` operation, so that the `update` and `delete` buttons get hidden... like magic 🪄

## HOW

### How did you achieve that, in technical terms?

- added a few methods:
    - `hasAccessCondition(string $operation) : bool`
    - `getAccessCondition(string $operation) : bool|callable|null`
    - `setAccessCondition(array|string $operation, bool|callable|null $condition) : void`
- added a second OPTIONAL parameter to the check functions: 
    - `hasAccess($operation, $entry)`
    - `hasAccessOrFail($operation, $entry)`
    - `hasAccessToAll($operation, $entry)`
    - `hasAccessToAny($operation, $entry)`
    - this second parameter is optional - if missing, Backpack will pass the current entry to the closure (if available);



### Is it a breaking change?

NO. All extra parameters are optional. All return types and parameters types I've added are exactly as the ones in the comment blocks before. No change in scope for old functionality.

### How can we test the before & after?

Use the example above in a CrudController. You should notice:
- the `update` and `delete` buttons disappear for the entries you exclude
- the `show` button still shows
- if you manually go to the `update` page, it will throw a 403 error
