### PR TITLE
Run CI tests on PHP 8.3

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
             # run all combinations of the following, to make sure they're working together
             matrix:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
-                php: [8.1, 8.2]
+                php: [8.1, 8.2, 8.3]
                 dbal: [^3.0]
                 laravel: [10.*]
                 phpunit: [10.*]


### PR DESCRIPTION
With a few RC's released and the final release coming up in november, it might be a good thing to start running tests on the new PHP.