### PR TITLE
Add string completion to field and column type parameter

### DIFF
--- a/ide.json
+++ b/ide.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "https://laravel-ide.com/schema/laravel-ide-v2.json",
+    "completions": [
+        {
+            "complete": "staticStrings",
+            "options": {
+                "strings": [
+                    "boolean",
+                    "check",
+                    "checkbox",
+                    "checklist",
+                    "checklist_dependency",
+                    "closure",
+                    "color",
+                    "custom_html",
+                    "date",
+                    "datetime",
+                    "email",
+                    "enum",
+                    "hidden",
+                    "image",
+                    "json",
+                    "model_function",
+                    "model_function_attribute",
+                    "month",
+                    "multidimensional_array",
+                    "number",
+                    "password",
+                    "phone",
+                    "radio",
+                    "range",
+                    "relationship_count",
+                    "row_number",
+                    "select",
+                    "select_from_array",
+                    "select_grouped",
+                    "select_multiple",
+                    "summernote",
+                    "switch",
+                    "text",
+                    "textarea",
+                    "time",
+                    "upload",
+                    "upload_multiple",
+                    "url",
+                    "view",
+                    "week"
+                ]
+            },
+            "condition": [
+                {
+                    "methodNames": [
+                        "type"
+                    ],
+                    "classFqn": [
+                        "\\Backpack\\CRUD\\app\\Library\\CrudPanel\\CrudColumn"
+                    ],
+                    "parameters": [
+                        1
+                    ]
+                },
+                {
+                    "place": "arrayValueWithKey",
+                    "keys": [
+                        "type"
+                    ],
+                    "methodNames": [
+                        "addColumn"
+                    ],
+                    "classFqn": [
+                        "\\Backpack\\CRUD\\app\\Library\\CrudPanel\\CrudPanelFacade"
+                    ]
+                }
+            ]
+        },
+        {
+            "complete": "staticStrings",
+            "options": {
+                "strings": [
+                    "checkbox",
+                    "checklist",
+                    "checklist_dependency",
+                    "color",
+                    "custom_html",
+                    "date",
+                    "datetime",
+                    "email",
+                    "enum",
+                    "hidden",
+                    "month",
+                    "number",
+                    "password",
+                    "radio",
+                    "range",
+                    "select",
+                    "select_grouped",
+                    "select_multiple",
+                    "select_from_array",
+                    "summernote",
+                    "switch",
+                    "text",
+                    "textarea",
+                    "time",
+                    "upload",
+                    "upload_multiple",
+                    "url",
+                    "view",
+                    "week"
+                ]
+            },
+            "condition": [
+                {
+                    "methodNames": [
+                        "type"
+                    ],
+                    "classFqn": [
+                        "\\Backpack\\CRUD\\app\\Library\\CrudPanel\\CrudField"
+                    ],
+                    "parameters": [
+                        1
+                    ]
+                },
+                {
+                    "place": "arrayValueWithKey",
+                    "keys": [
+                        "type"
+                    ],
+                    "methodNames": [
+                        "addField"
+                    ],
+                    "classFqn": [
+                        "\\Backpack\\CRUD\\app\\Library\\CrudPanel\\CrudPanelFacade"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## WHY
Make life easier for developers who use Laravel idea plugin for phpstorm.
![image](https://github.com/Laravel-Backpack/CRUD/assets/17728443/42f70e5b-7abe-4b72-8cd0-2efdd53b23d2)


### BEFORE - What was wrong? What was happening before this PR?
No autocompletion for type parameter for columns and fields.

### AFTER - What is happening after this PR?
A list of possible values for type parameter for fields and columns

## HOW

### How did you achieve that, in technical terms?
Adding the `ide.json` file in the root package for Laravel idea to pick it up

### Is it a breaking change?
No

### How can we test the before & after?
Have Laravel idea installed into Phpstorm.
Type `date` into the `type` function for a column or a field with and without the `ide.json` file.
`CRUD::column('column')->type('date')`
`CRUD::field('column')->type('date')`

If this pull will get merged, i will come back with the rest of things that can be completed.
More info: https://laravel-idea.com/docs/ide_json/completion
