### PR TITLE
use upsert instead of 2 queries per row

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -38,6 +38,7 @@ trait Reorder
 
             // unset mapped items properties.
             unset($item['item_id'], $item['left'], $item['right']);
+
             return $item;
         })->toArray();
 
@@ -46,7 +47,7 @@ trait Reorder
             $primaryKey,
             ['parent_id', 'depth', 'lft', 'rgt']
         );
-       
+
         return count($reorderItems);
     }
 

--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -19,11 +19,11 @@ trait Reorder
 
         // we use the upsert method that should update the values of the matching ids.
         // it has the drawback of creating new entries when the id is not found
-        // for that reason we get a list of all the ids and filter the ones 
+        // for that reason we get a list of all the ids and filter the ones
         // sent in the request that are not in the database
         $itemKeys = $this->model->all()->pluck('id');
 
-        $reorderItems = collect($request)->filter(function($item) use ($itemKeys) {
+        $reorderItems = collect($request)->filter(function ($item) use ($itemKeys) {
             return $item['item_id'] != '' && $item['item_id'] != null && $itemKeys->contains($item['item_id']);
         })->map(function ($item) use ($primaryKey) {
             $item[$primaryKey] = $item['item_id'];
@@ -32,9 +32,10 @@ trait Reorder
             $item['lft'] = empty($item['left']) ? null : $item['left'];
             $item['rgt'] = empty($item['right']) ? null : $item['right'];
             unset($item['item_id']);
+
             return $item;
         })->toArray();
-       
+
         $this->model->upsert(
             $reorderItems,
             [$primaryKey],


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were using `DB::` transactions to wrap the reordering updates on database.
We did this because we were looping over all the tree elements and doing two database queries for each of the elements. 

Wrapping the queries in a DB transaction does not make less queries, it just means that if any of the queries fail we are able to revert the whole process. So for ordering 10 items, we would still make 20 queries. 

I switched to use a combination of `upsert` and validating the ids to do the WHOLE process in only two queries.
- One query gets the db id's
- One query updates all the values

If we do it all in one query, if the query fails it fails as a whole, and we don't need to wrap this in a transaction.

This would allow us to also fix some compatibility issue with MongoDB reported in https://github.com/Laravel-Backpack/CRUD/issues/4909