### PR TITLE
[WIP] add span to backpack button text

### DIFF
--- a/src/resources/views/crud/buttons/create.blade.php
+++ b/src/resources/views/crud/buttons/create.blade.php
@@ -1,5 +1,5 @@
 @if ($crud->hasAccess('create'))
     <a href="{{ url($crud->route.'/create') }}" class="btn btn-primary" data-style="zoom-in">
-        <span><i class="la la-plus"></i> {{ trans('backpack::crud.add') }} {{ $crud->entity_name }}</span>
+        <span><i class="la la-plus"></i> <span class="create-button-text-span">{{ trans('backpack::crud.add') }} {{ $crud->entity_name }}</span></span>
     </a>
 @endif

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -1,6 +1,6 @@
 @if ($crud->hasAccess('delete'))
     <a href="javascript:void(0)" onclick="deleteEntry(this)" data-route="{{ url($crud->route.'/'.$entry->getKey()) }}" class="btn btn-sm btn-link" data-button-type="delete">
-        <span><i class="la la-trash"></i> {{ trans('backpack::crud.delete') }}</span>
+        <span><i class="la la-trash"></i> <span class="delete-button-text-span">{{ trans('backpack::crud.delete') }}</span></span>
     </a>
 @endif
 

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -29,6 +29,6 @@
         @endforeach
         >
         @if ($icon) <i class="{{ $icon }}"></i> @endif
-        {{ $label }}
+        <span class="{{$button->name}}-button-text-span">{{ $label }}</span>
     </{{ $wrapper['element'] }}>
 @endif

--- a/src/resources/views/crud/buttons/reorder.blade.php
+++ b/src/resources/views/crud/buttons/reorder.blade.php
@@ -1,5 +1,5 @@
 @if ($crud->get('reorder.enabled') && $crud->hasAccess('reorder'))
     <a href="{{ url($crud->route.'/reorder') }}" class="btn btn-outline-primary" data-style="zoom-in">
-        <span><i class="la la-arrows"></i> {{ trans('backpack::crud.reorder') }} {{ $crud->entity_name_plural }}</span>
+        <span><i class="la la-arrows"></i> <span class="reorder-button-text-span">{{ trans('backpack::crud.reorder') }} {{ $crud->entity_name_plural }}</span></span>
     </a>
 @endif

--- a/src/resources/views/crud/buttons/show.blade.php
+++ b/src/resources/views/crud/buttons/show.blade.php
@@ -3,7 +3,7 @@
 
 	{{-- Single edit button --}}
 	<a href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}" class="btn btn-sm btn-link">
-		<span><i class="la la-eye"></i> {{ trans('backpack::crud.preview') }}</span>
+		<span><i class="la la-eye"></i> <span class="show-button-text-span">{{ trans('backpack::crud.preview') }}</span></span>
 	</a>
 
 	@else

--- a/src/resources/views/crud/buttons/update.blade.php
+++ b/src/resources/views/crud/buttons/update.blade.php
@@ -3,7 +3,7 @@
 
 	{{-- Single edit button --}}
 	<a href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}" class="btn btn-sm btn-link">
-		<span><i class="la la-edit"></i> {{ trans('backpack::crud.edit') }}</span>
+		<span><i class="la la-edit"></i> <span class="update-button-text-span">{{ trans('backpack::crud.edit') }}</span></span>
 	</a>
 
 	@else


### PR DESCRIPTION
reported in #5010 

we could make developers life easier when they want to hide the button text and display only an icon by wrapping the button text in a span as suggested by @tabacitu 

I've decided to create a class for each button type, eg: `create-button-text-span`, `update-button-text-span`. That way developers have the ability to hide only specific button texts, or hide all of them with `*-button-text-span` selector. 
