### PR TITLE
Updated phpDoc for `filter` function

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -323,11 +323,11 @@ trait Filters
      * - CRUD::addFilter(['name' => 'price', 'type' => 'range'], false, function($value) {});
      * - CRUD::filter('price')->type('range')->whenActive(function($value) {});
      *
-     * And if the developer uses the CrudField object as Field in their CrudController:
+     * And if the developer uses the CrudFilter object as Field in their CrudController:
      * - Filter::name('price')->type('range')->whenActive(function($value) {});
      *
      * @param  string  $name  The name of the column in the db, or model attribute.
-     * @return CrudField
+     * @return CrudFilter
      */
     public function filter($name)
     {

--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -323,7 +323,7 @@ trait Filters
      * - CRUD::addFilter(['name' => 'price', 'type' => 'range'], false, function($value) {});
      * - CRUD::filter('price')->type('range')->whenActive(function($value) {});
      *
-     * And if the developer uses the CrudFilter object as Field in their CrudController:
+     * And if the developer uses the CrudFilter object as Filter in their CrudController:
      * - Filter::name('price')->type('range')->whenActive(function($value) {});
      *
      * @param  string  $name  The name of the column in the db, or model attribute.


### PR DESCRIPTION
## WHY
Wrong return type for `filter` function

### BEFORE - What was wrong? What was happening before this PR?
IDE showing CrudField as a type for the created filter

### AFTER - What is happening after this PR?
IDE showing CrudFilter as a type for the created filter

### Is it a breaking change?
No
