### PR TITLE
[Show] Render only one `td` with column `value` if label is `empty`

### DIFF
--- a/src/resources/views/crud/inc/show_table.blade.php
+++ b/src/resources/views/crud/inc/show_table.blade.php
@@ -3,10 +3,12 @@
         <tbody>
         @foreach($columns as $column)
             <tr>
-                <td @if($loop->index === 0) class="border-top-0" @endif>
-                    <strong>{!! $column['label'] !!}:</strong>
-                </td>
-                <td @if($loop->index === 0) class="border-top-0" @endif>
+                @if(!empty($column['label']))
+                    <td @if($loop->index === 0) class="border-top-0" @endif>
+                        <strong>{!! $column['label'] !!}:</strong>
+                    </td>
+                @endif
+                <td colspan="{{ !empty($column['label']) ? 1 : 2 }}" @if($loop->index === 0) class="border-top-0" @endif>
                     @php
                         // create a list of paths to column blade views
                         // including the configured view_namespaces


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?
Showing `:` in `show` operation if the column label is empty
![Screenshot from 2023-10-19 14-48-18](https://github.com/Laravel-Backpack/CRUD/assets/17728443/df2e36c5-c492-4859-af5b-7a1b0ab4ad16)

### AFTER - What is happening after this PR?
Only render one `td` with `colspan="2"` and display only the column value
![Screenshot from 2023-10-19 14-48-48](https://github.com/Laravel-Backpack/CRUD/assets/17728443/12eb072b-4c95-4869-979e-c76d8bb61bcb)

## HOW

### How did you achieve that, in technical terms?
Check if `$column['label']` is empty and display only column value `td` with `colspan="2"`

### Is it a breaking change?
I guess?


### How can we test the before & after?
Set a column `label` to an empty string and go to a show page with the current code and the code from the pull request.
