### PR TITLE
Use white text-color on single save action button

### DIFF
--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -3,7 +3,7 @@
         <input type="hidden" name="_save_action" value="{{ $saveAction['active']['value'] }}">
 
         @if(empty($saveAction['options']))
-            <button type="submit" class="btn btn-success">
+            <button type="submit" class="btn btn-success text-white">
                 <span class="la la-save" role="presentation" aria-hidden="true"></span> &nbsp;
                 <span data-value="{{ $saveAction['active']['value'] }}">{{ $saveAction['active']['label'] }}</span>
             </button>


### PR DESCRIPTION
## WHY

When only one save action button is displayed, the text-color remains black in CoreUI4 theme. It should default to white text-color.

### BEFORE - What was wrong? What was happening before this PR?

![CleanShot 2023-11-06 at 11 35 22](https://github.com/Laravel-Backpack/CRUD/assets/171715/a9b3e0e0-6697-4925-a753-79a844fccf1d)

### AFTER - What is happening after this PR?

![CleanShot 2023-11-06 at 11 35 02](https://github.com/Laravel-Backpack/CRUD/assets/171715/6ffc5c12-d998-4955-acf0-4e7ff1019698)

## HOW

### How did you achieve that, in technical terms?

Added the default `text-white` color in the button.

### Is it a breaking change?

No.

### How can we test the before & after?

Activate the CoreUI4 theme and in any crud controller, remove the action buttons like below:

```php
CRUD::removeSaveActions(['save_and_back','save_and_edit', 'save_and_preview']);
```