### PR TITLE
Suggestion for adding an autocomplete text field

### DIFF
--- a/src/resources/views/crud/fields/autocomplete-text.blade.php
+++ b/src/resources/views/crud/fields/autocomplete-text.blade.php
@@ -1,31 +1,4 @@
-{{-- text input --}}
-
-@include('crud::fields.inc.wrapper_start')
-<label>{!! $field['label'] !!}</label>
-@include('crud::fields.inc.translatable_icon')
-
-@if(isset($field['prefix']) || isset($field['suffix']))
-    <div class="input-group"> @endif
-        @if(isset($field['prefix']))
-            <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div>
-        @endif
-        <input
-            type="text"
-            name="{{ $field['name'] }}"
-            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
-            @include('crud::fields.inc.attributes')
-        >
-        @if(isset($field['suffix']))
-            <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div>
-        @endif
-        @if(isset($field['prefix']) || isset($field['suffix'])) </div>
-@endif
-
-{{-- HINT --}}
-@if (isset($field['hint']))
-    <p class="help-block">{!! $field['hint'] !!}</p>
-@endif
-@include('crud::fields.inc.wrapper_end')
+@include('crud::fields.text')
 
 {{-- FIELD CSS - will be loaded in the after_styles section --}}
 @push('crud_fields_styles')

--- a/src/resources/views/crud/fields/autocomplete-text.blade.php
+++ b/src/resources/views/crud/fields/autocomplete-text.blade.php
@@ -1,0 +1,50 @@
+{{-- text input --}}
+
+@include('crud::fields.inc.wrapper_start')
+<label>{!! $field['label'] !!}</label>
+@include('crud::fields.inc.translatable_icon')
+
+@if(isset($field['prefix']) || isset($field['suffix']))
+    <div class="input-group"> @endif
+        @if(isset($field['prefix']))
+            <div class="input-group-prepend"><span class="input-group-text">{!! $field['prefix'] !!}</span></div>
+        @endif
+        <input
+            type="text"
+            name="{{ $field['name'] }}"
+            value="{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}"
+            @include('crud::fields.inc.attributes')
+        >
+        @if(isset($field['suffix']))
+            <div class="input-group-append"><span class="input-group-text">{!! $field['suffix'] !!}</span></div>
+        @endif
+        @if(isset($field['prefix']) || isset($field['suffix'])) </div>
+@endif
+
+{{-- HINT --}}
+@if (isset($field['hint']))
+    <p class="help-block">{!! $field['hint'] !!}</p>
+@endif
+@include('crud::fields.inc.wrapper_end')
+
+{{-- FIELD CSS - will be loaded in the after_styles section --}}
+@push('crud_fields_styles')
+    {{-- include jQuery UI --}}
+    @loadOnce('packages/jquery-ui-dist/jquery-ui.css')
+@endpush
+
+{{-- FIELD JS - will be loaded in the after_scripts section --}}
+@push('crud_fields_scripts')
+    {{-- include jQuery UI --}}
+    @loadOnce('packages/jquery-ui-dist/jquery-ui.min.js')
+
+    <script>
+        $(function () {
+            var availableOptions = {!! json_encode(($field['options'] ?? [])) !!};
+
+            $("input[name='{{ $field['name'] }}']").autocomplete({
+                source: availableOptions
+            });
+        });
+    </script>
+@endpush


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There were no `text` type fields with autocomplete.

![CleanShot 2023-11-13 at 12 21 41](https://github.com/Laravel-Backpack/CRUD/assets/12893613/8d1bdfbe-4fbe-4ffc-80f5-1a10bf1925e1)

### AFTER - What is happening after this PR?

Added an `autocomplete-text` field which allows you to enter text and have autocompletion suggested.

## HOW

### How did you achieve that, in technical terms?

I took the text field and added the jquery ui load already present in the project to allow autocomplete.

I did not modify the `text` field because I do not think that this is a behavior that should be able to be activated on a `text` field. This is a very specific use in my opinion which is only used when needed.


### Is it a breaking change?

No, just a suggestion for an addition.

```
CRUD::field('sound')
             ->type('autocomplete-text')
             ->options(["pushover", "bike", "bugle", "cashregister", "classical", "cosmic", "falling", "gamelan", "incoming", "intermission", "magic", " mechanical", "pianobar", "siren", "spacealarm", "tugboat", "alien", "climb", "persistent", "echo", "updown", "vibrate", "none"]);
```


### How can we test the before & after?

Get the field code and use the `autocomplete-text` type in its crud, remembering to add a table in the `options` option.