### PR TITLE
Added a new macro called `disableAutofill`

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -54,6 +54,17 @@ if (! CrudField::hasMacro('withFiles')) {
     });
 }
 
+if (! CrudField::hasMacro('disableAutofill')) {
+    CrudField::macro('disableAutofill', function () {
+        /** @var CrudField $this */
+
+        return $this->attributes([
+            'readonly' => true,
+            'onfocus' => "this.removeAttribute('readonly');"
+        ]);
+    });
+}
+
 if (! CrudColumn::hasMacro('linkTo')) {
     CrudColumn::macro('linkTo', function (string|array|Closure $routeOrConfiguration, ?array $parameters = []): static {
         $wrapper = $this->attributes['wrapper'] ?? [];


### PR DESCRIPTION
Prevent password managers to autofill user/email and password fields.

## WHY

### BEFORE - What was wrong? What was happening before this PR?
When creating or editing a user in backpack, password managers like lastpass often auto-fill email and password fields with the saved credentials for that website.

### AFTER - What is happening after this PR?
Prevent password managers to auto-fill these fields.


## HOW

### How did you achieve that, in technical terms?
On page load set the fields to be readonly and then remove the readonly attribute on input focus.


### Is it a breaking change?
No


### How can we test the before & after?
Create a new crud controller with these fields and make sure you have a password manager with some credentials saved.
The password manager should not auto-fill the read-only fields.
```
CRUD::field('id');
CRUD::field('email')->type('email');
CRUD::field('password')->type('password');
```
->
```
CRUD::field('id');
CRUD::field('email')->type('email')->disableAutofill();
CRUD::field('password')->type('password')->disableAutofill();
```
