### PR TITLE
[BugFix] CRUD table action cell should encapsulate buttons only once

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -403,21 +403,23 @@
     function formatActionColumnAsDropdown() {
         // Get action column
         const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
-        if (actionColumnIndex !== -1) {
-            $('#crudTable tr').each(function (i, tr) {
-                const actionCell = $(tr).find('td').eq(actionColumnIndex);
-                const actionButtons = $(actionCell).find('a.btn.btn-link');
-                // Wrap the cell with the component needed for the dropdown
-                actionCell.wrapInner('<div class="nav-item dropdown"></div>');
-                actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
-                // Prepare buttons as dropdown items
-                actionButtons.map((index, action) => {
-                    $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
-                    $(action).find('i').addClass('me-2 text-primary');
-                });
-                actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+        if (actionColumnIndex === -1) return;
+
+        $('#crudTable tbody tr').each(function (i, tr) {
+            const actionCell = $(tr).find('td').eq(actionColumnIndex);
+            if(actionCell.find('.actions-buttons-column').length) return;
+
+            // Wrap the cell with the component needed for the dropdown
+            actionCell.wrapInner('<div class="nav-item dropdown"></div>');
+            actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+            
+            // Prepare buttons as dropdown items
+            actionCell.find('a.btn.btn-link').each((index, action) => {
+                $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
+                $(action).find('i').addClass('me-2 text-primary');
             });
-        }
+            actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+        });
     }
   </script>
 


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/community-forum/issues/740

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Action Cell method was encapsulating buttons multiple times, when called multiple times.
This happens inside Editable Columns.

### AFTER - What is happening after this PR?

The method will check if the buttons are already encapsulated, and will early return if so.

### Is it a breaking change?

No, just bug fix 👌

### How can we test the before & after?

Enable `'lineButtonsAsDropdown' => true,` on `config\backpack\operations\list.php`.
