### PR TITLE
[FEATURE ] `denyAllAccess()` — Deny access to all the loaded operations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -118,4 +118,12 @@ trait Access
     {
         return $this->get($operation.'.access') !== null;
     }
+
+    /**
+     * Remove the access to all available operations.
+     */
+    public function denyAllAccess(): void
+    {
+        $this->denyAccess($this->getAvailableOperationsList());
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -151,4 +151,19 @@ trait Settings
             }
         }
     }
+
+    /**
+     * Get the current CRUD operations loaded.
+     *
+     * @return array operaiton names
+     */
+    public function getAvailableOperationsList(): array
+    {
+        return collect($this->settings)
+            ->keys()
+            ->filter(fn(string $key): bool => str_contains($key, '.access'))
+            ->map(fn(string $key): string => str_replace('.access', '', $key))
+            ->values()
+            ->toArray();
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -161,8 +161,8 @@ trait Settings
     {
         return collect($this->settings)
             ->keys()
-            ->filter(fn(string $key): bool => str_contains($key, '.access'))
-            ->map(fn(string $key): string => str_replace('.access', '', $key))
+            ->filter(fn (string $key): bool => str_contains($key, '.access'))
+            ->map(fn (string $key): string => str_replace('.access', '', $key))
             ->values()
             ->toArray();
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was no easy way to deny access to all operations.

### AFTER - What is happening after this PR?

We can deny access to everything, and then allow to one only for instance.

### Is it a breaking change?

No 👌

### How can we test the before & after?

This should deny the access to everything except the list operation;
```
  public function setup()
  {
      ...
      CRUD::denyAllAccess();
      CRUD::allowAccess('list');
  }
```
