### PR TITLE
[FEATURE] `allowAccessOnlyTo()` — Allow access only to selected operations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -126,4 +126,14 @@ trait Access
     {
         $this->denyAccess($this->getAvailableOperationsList());
     }
+
+    /**
+     * Allow access only to operations in the array.
+     * By denying access to all other operations.
+     */
+    public function allowAccessOnlyTo(array|string $operation): void
+    {
+        $this->denyAllAccess();
+        $this->allowAccess($operation);
+    }
 }

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -161,8 +161,8 @@ trait Settings
     {
         return collect($this->settings)
             ->keys()
-            ->filter(fn(string $key): bool => str_contains($key, '.access'))
-            ->map(fn(string $key): string => str_replace('.access', '', $key))
+            ->filter(fn (string $key): bool => str_contains($key, '.access'))
+            ->map(fn (string $key): string => str_replace('.access', '', $key))
             ->values()
             ->toArray();
     }


### PR DESCRIPTION
Depends on https://github.com/Laravel-Backpack/CRUD/pull/5383.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was not possible to allow access only to some operations.

### AFTER - What is happening after this PR?

We can now allow access to only some operations.
It will by default deny the access to all other operations.

### Is it a breaking change?

No 👌

### How can we test the before & after?

```php
public function setup()
{
    ...
    CRUD::allowAccessOnlyTo(['list', 'create']);
}
```
