### PR TITLE
add de translations for email verification

### DIFF
--- a/src/resources/lang/de/base.php
+++ b/src/resources/lang/de/base.php
@@ -67,4 +67,11 @@ return [
     'confirm_new_password' => 'Bestätige das neue Passwort',
     'throttled'            => 'Du hast kürzlich bereits ein Zurücksetzen des Passworts beantragt. Bitte prüfe deine E-Mails. Solltest du keine E-Mail erhalten haben, versuche es später bitte erneut.',
     'throttled_request'    => 'Du hast das Limit an Versuchen erreicht. Bitte warte ein paar Minuten und versuche es erneut.',
+
+    'verify_email' => [
+        'email_verification' => 'E-Mail-Verifizierung',
+        'verification_link_sent' => 'Ein Verifizierungslink wurde an deine E-Mail-Adresse gesendet.',
+        'email_verification_required' => 'Bitte verifiziere deine E-Mail-Adresse, indem du auf den Link klickst, den wir dir geschickt haben.',
+        'resend_verification_link' => 'Link erneut senden',
+    ],
 ];


### PR DESCRIPTION
## WHY

Due to Backpack 6 supporting email verification out of the box I discovered that there are translations missing for the German language.

### BEFORE - What was wrong? What was happening before this PR?

If the language is German you'll get the English texts related to email verification.

### AFTER - What is happening after this PR?

If the language is German you'll get the German texts related to email verification.


## HOW

### How did you achieve that, in technical terms?

I translated the corresponding language keys.

### Is it a breaking change?

No


### How can we test the before & after?

Configure "de" as language and enable email verification. Then register a new user and check the texts on the verify view.
