### PR TITLE
Don't call controller constructors on route setup

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Http\Controllers;
 
+use Backpack\CRUD\app\Library\Attributes\DeprecatedIgnoreOnRuntime;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
@@ -59,6 +60,7 @@ class CrudController extends Controller
      * @param  string  $routeName  Route name prefix (ends with .).
      * @param  string  $controller  Name of the current controller.
      */
+    #[DeprecatedIgnoreOnRuntime('we dont call this method anymore unless you had it overwritten in your CrudController')]
     public function setupRoutes($segment, $routeName, $controller)
     {
         preg_match_all('/(?<=^|;)setup([^;]+?)Routes(;|$)/', implode(';', get_class_methods($this)), $matches);

--- a/src/app/Library/Attributes/DeprecatedIgnoreOnRuntime.php
+++ b/src/app/Library/Attributes/DeprecatedIgnoreOnRuntime.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\Attributes;
+use Attribute;
+
+/**
+ * There is a new behavior defined for this method. We use this attribute to provide backwards compatibility
+ * We plan to remove this function in a future version.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class DeprecatedIgnoreOnRuntime
+{
+}

--- a/src/app/Library/Attributes/DeprecatedIgnoreOnRuntime.php
+++ b/src/app/Library/Attributes/DeprecatedIgnoreOnRuntime.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Backpack\CRUD\app\Library\Attributes;
+
 use Attribute;
 
 /**

--- a/src/app/Library/CrudPanel/CrudRouter.php
+++ b/src/app/Library/CrudPanel/CrudRouter.php
@@ -2,7 +2,6 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel;
 
-use Backpack\CRUD\app\Library\Contracts\CrudControllerContract;
 use Illuminate\Support\Facades\App;
 use ReflectionClass;
 
@@ -11,7 +10,7 @@ final class CrudRouter
     public static function setupControllerRoutes(string $name, string $routeName, string $controller, string $groupNamespace = ''): void
     {
         $namespacedController = $groupNamespace.$controller;
-            
+
         $controllerReflection = new ReflectionClass($namespacedController);
         $setupRoutesMethod = $controllerReflection->getMethod('setupRoutes');
 
@@ -20,6 +19,7 @@ final class CrudRouter
             // when the attribute is not found the developer has overwritten the method
             // we will keep the old behavior for backwards compatibility
             $setupRoutesMethod->invoke(App::make($namespacedController), $name, $routeName, $controller);
+
             return;
         }
 

--- a/src/app/Library/CrudPanel/CrudRouter.php
+++ b/src/app/Library/CrudPanel/CrudRouter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\CrudPanel;
+
+use Backpack\CRUD\app\Library\Contracts\CrudControllerContract;
+use Illuminate\Support\Facades\App;
+use ReflectionClass;
+
+final class CrudRouter
+{
+    public static function setupControllerRoutes(string $name, string $routeName, string $controller, string $groupNamespace = ''): void
+    {
+        $namespacedController = $groupNamespace.$controller;
+            
+        $controllerReflection = new ReflectionClass($namespacedController);
+        $setupRoutesMethod = $controllerReflection->getMethod('setupRoutes');
+
+        // check if method has #[DeprecatedIgnoreOnRuntime] attribute
+        if (empty($setupRoutesMethod->getAttributes(\Backpack\CRUD\app\Library\Attributes\DeprecatedIgnoreOnRuntime::class))) {
+            // when the attribute is not found the developer has overwritten the method
+            // we will keep the old behavior for backwards compatibility
+            $setupRoutesMethod->invoke(App::make($namespacedController), $name, $routeName, $controller);
+            return;
+        }
+
+        $controllerInstance = $controllerReflection->newInstanceWithoutConstructor();
+        foreach ($controllerReflection->getMethods() as $method) {
+            if (($method->isPublic() ||
+                $method->isProtected()) &&
+                $method->getName() !== 'setupRoutes' &&
+                str_starts_with($method->getName(), 'setup') &&
+                str_ends_with($method->getName(), 'Routes')
+            ) {
+                $method->setAccessible(true);
+                $method->invoke($controllerInstance, $name, $routeName, $controller);
+            }
+        }
+    }
+}

--- a/src/macros.php
+++ b/src/macros.php
@@ -1,12 +1,12 @@
 <?php
 
+use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Library\CrudPanel\CrudColumn;
 use Backpack\CRUD\app\Library\CrudPanel\CrudField;
 use Backpack\CRUD\app\Library\Uploaders\Support\RegisterUploadEvents;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use Backpack\CRUD\app\Http\Controllers\CrudController;
-use Illuminate\Support\Facades\App;
 
 /**
  * This macro adds the ability to convert a dot.notation string into a [braket][notation] with some special
@@ -160,21 +160,21 @@ if (! Route::hasMacro('crud')) {
         // check if method has deprecated attribute, in case it does it means developer didn't overwrite the method
         // and we can safely use reflection instead of instantiating the controller class
         $deprecated = $setupRoutesMethod->getAttributes(\Backpack\CRUD\app\Library\Attributes\DeprecatedIgnoreOnRuntime::class);
-        
-        if(empty($deprecated)){
+
+        if (empty($deprecated)) {
             // when the attribute DeprecatedIgnoreOnRuntime is not found is because the developer has overwritten the method
             // we will keep the old behavior for backwards compatibility
             $setupRoutesMethod->invoke(App::make($namespacedController), $name, $routeName, $controller);
-        }else{
+        } else {
             foreach ($reflection->getMethods() as $method) {
                 if (($method->isPublic() ||
                     $method->isProtected()) &&
                     $method->getName() !== 'setupRoutes' &&
                     str_starts_with($method->getName(), 'setup') &&
                     str_ends_with($method->getName(), 'Routes')
-                    ) {
-                        $method->setAccessible(true);
-                        $method->invoke($reflection->newInstanceWithoutConstructor(), $name, $routeName, $controller);
+                ) {
+                    $method->setAccessible(true);
+                    $method->invoke($reflection->newInstanceWithoutConstructor(), $name, $routeName, $controller);
                 }
             }
         }

--- a/src/macros.php
+++ b/src/macros.php
@@ -152,28 +152,6 @@ if (! Route::hasMacro('crud')) {
             $groupNamespace = '';
         }
 
-        $namespacedController = $groupNamespace.$controller;
-        $controllerReflection = new ReflectionClass($namespacedController);
-        $setupRoutesMethod = $controllerReflection->getMethod('setupRoutes');
-
-        // check if method has #[DeprecatedIgnoreOnRuntime] attribute
-        if (empty($setupRoutesMethod->getAttributes(\Backpack\CRUD\app\Library\Attributes\DeprecatedIgnoreOnRuntime::class))) {
-            // when the attribute is not found the developer has overwritten the method
-            // or the CrudPanel, we will keep the old behavior for backwards compatibility
-            $setupRoutesMethod->invoke(App::make($namespacedController), $name, $routeName, $controller);
-        } else {
-            $controllerInstance = $controllerReflection->newInstanceWithoutConstructor();
-            foreach ($controllerReflection->getMethods() as $method) {
-                if (($method->isPublic() ||
-                    $method->isProtected()) &&
-                    $method->getName() !== 'setupRoutes' &&
-                    str_starts_with($method->getName(), 'setup') &&
-                    str_ends_with($method->getName(), 'Routes')
-                ) {
-                    $method->setAccessible(true);
-                    $method->invoke($controllerInstance, $name, $routeName, $controller);
-                }
-            }
-        }
+        \Backpack\CRUD\app\Library\CrudPanel\CrudRouter::setupControllerRoutes($name, $routeName, $controller, $groupNamespace); 
     });
 }

--- a/src/macros.php
+++ b/src/macros.php
@@ -4,7 +4,6 @@ use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Backpack\CRUD\app\Library\CrudPanel\CrudColumn;
 use Backpack\CRUD\app\Library\CrudPanel\CrudField;
 use Backpack\CRUD\app\Library\Uploaders\Support\RegisterUploadEvents;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
@@ -152,6 +151,6 @@ if (! Route::hasMacro('crud')) {
             $groupNamespace = '';
         }
 
-        \Backpack\CRUD\app\Library\CrudPanel\CrudRouter::setupControllerRoutes($name, $routeName, $controller, $groupNamespace); 
+        \Backpack\CRUD\app\Library\CrudPanel\CrudRouter::setupControllerRoutes($name, $routeName, $controller, $groupNamespace);
     });
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

To setup the routes, we initialize a new controller instance and that's causing issues.

Technically speaking what we are doing is initializing controllers at a provider level, and by that time, we can't be sure that all the providers have their services setup, and that prevents developers from reliably injecting services on their controllers as reported in #5379 

### AFTER - What is happening after this PR?

We initialize the controller instance but without constructor, we don't need the full instance to setup the routes, as all parameters are provided to those functions. Those functions shouldn't be part of the CrudController anyway, the controller should only be constructed in full when certain route is requested. If part of the CrudController, they should def. be static. 

We can decide next version if we completely remove it, make them static or whatever. 

I used reflection to get the class methods, I think it's a pretty straightforward way to also allow to call protected methods outside of the class scope, like the `setupXXXRoutes()`.

The controller will be constructed later by Laravel when you access the controller routes, as expected, not at the Provider level.

## HOW

### How did you achieve that, in technical terms?

The `setupXXXRoutes` are protected methods that can be overwritten so a direct change to the method would be a BC. 

The way I found to work around the BC is by using php attributes. We introduce now a `#[DeprecatedIgnoreOnRuntime]` that tell backpack, and developers, that function is deprecated. 

We still call the function the backwards compatible way if we don't find that attribute in the function, meaning developer is using an overwritten `CrudPanel` or has overwritten the `setupRoutes` method in that some crud controller. 

In case we find that attribute, we just use the instance without constructor, avoiding constructing controller at the wrong application lifetime.

### Is it a breaking change?

I hope I made it non-breaking

### How can we test the before & after?

in any crud controller, put on the `__construct()` `Log::info('constructed')`. See your logs after you access one of those controller routes.