### PR TITLE
Make setup of details row routes optional

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -27,11 +27,13 @@ trait ListOperation
             'operation' => 'list',
         ]);
 
-        Route::get($segment.'/{id}/details', [
-            'as'        => $routeName.'.showDetailsRow',
-            'uses'      => $controller.'@showDetailsRow',
-            'operation' => 'list',
-        ]);
+        if(!isset($this->listOperationDetailsRow) || (isset($this->listOperationDetailsRow) && is_bool($this->listOperationDetailsRow) && $this->listOperationDetailsRow)) {
+            Route::get($segment.'/{id}/details', [
+                'as'        => $routeName.'.showDetailsRow',
+                'uses'      => $controller.'@showDetailsRow',
+                'operation' => 'list',
+            ]);
+        }
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -27,7 +27,7 @@ trait ListOperation
             'operation' => 'list',
         ]);
 
-        if (! isset($this->setupDetailsRowRoutes) || $this->setupDetailsRowRoutes === true) {
+        if (! isset($this->setupDetailsRowRoute) || $this->setupDetailsRowRoute === true) {
             Route::get($segment.'/{id}/details', [
                 'as'        => $routeName.'.showDetailsRow',
                 'uses'      => $controller.'@showDetailsRow',

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -27,7 +27,7 @@ trait ListOperation
             'operation' => 'list',
         ]);
 
-        if (! isset($this->listOperationDetailsRow) || $this->listOperationDetailsRow) {
+        if (! isset($this->setupDetailsRowRoutes) || $this->setupDetailsRowRoutes === true) {
             Route::get($segment.'/{id}/details', [
                 'as'        => $routeName.'.showDetailsRow',
                 'uses'      => $controller.'@showDetailsRow',

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -27,7 +27,7 @@ trait ListOperation
             'operation' => 'list',
         ]);
 
-        if(!isset($this->listOperationDetailsRow) || (isset($this->listOperationDetailsRow) && is_bool($this->listOperationDetailsRow) && $this->listOperationDetailsRow)) {
+        if (! isset($this->listOperationDetailsRow) || (isset($this->listOperationDetailsRow) && is_bool($this->listOperationDetailsRow) && $this->listOperationDetailsRow)) {
             Route::get($segment.'/{id}/details', [
                 'as'        => $routeName.'.showDetailsRow',
                 'uses'      => $controller.'@showDetailsRow',

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -27,7 +27,7 @@ trait ListOperation
             'operation' => 'list',
         ]);
 
-        if (! isset($this->listOperationDetailsRow) || (isset($this->listOperationDetailsRow) && is_bool($this->listOperationDetailsRow) && $this->listOperationDetailsRow)) {
+        if (! isset($this->listOperationDetailsRow) || $this->listOperationDetailsRow) {
             Route::get($segment.'/{id}/details', [
                 'as'        => $routeName.'.showDetailsRow',
                 'uses'      => $controller.'@showDetailsRow',


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This was reported in https://github.com/Laravel-Backpack/community-forum/discussions/774 and @karandatwani92 brought this to my attention in https://github.com/Laravel-Backpack/CRUD/issues/5395

TLDR: If you use ListOperation in your CrudController, the details row routes are always setup, even if you don't `enableDetailsRow()`. So technically you can access `admin/monster/1/details` **even when details row is not enabled**. 

### AFTER - What is happening after this PR?

This PR adds a way for developers to disable the details row setup if they don't plan to use it in their List Operation.

## HOW

### How did you achieve that, in technical terms?

The correct way to go about this would be to separate the details row into a new operation, that you can add when you need. That way routes would only be setup when you add the operation to the controller. 

That would be a BC at the moment. So I thought about the other ways we could go about this. 

**a)** We could create a new ListOperation without the details row. Like `SimpleList` or something similar. 
- I don't think this is a good solution, because traits cannot be extended so we would have a lot of duplicated code.

**b)** We could create a php attribute `#[WithoutDetailsInList]` or something similar for example an interface to implement in the controller `implements WithoutDetailsRow`
- I don't dislike neither ways to be used as a configuration mechanism, but to make this non-breaking we would be using them on the "negative". I wouldn't have nothing against if we were talking about `WithDetailsRow`, but it being negative makes it a not so good option. 

**c)** use a property as config so that developer can prevent the route setup.
- Indeed, this looks the easiest and cleanest way out. Setting `protect $setupDetailsRowRoutes = false` in your controller would work similar as if you didn't include that operation in that controller. 

### Is it a breaking change?

No I don't think so. 


### How can we test the before & after?

You can go to any controller where you don't have the `enableDetailsRow()`, and access `entity/{id}/details`.
docs: https://github.com/Laravel-Backpack/docs/pull/528
