### PR TITLE
Fix upload multiple in relationships

### DIFF
--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -17,10 +17,14 @@ class MultipleFiles extends Uploader
 
     public function uploadFiles(Model $entry, $value = null)
     {
-        $filesToDelete = CRUD::getRequest()->get('clear_'.$this->getName());
-        $value = $value ?? CRUD::getRequest()->file($this->getName());
-        $previousFiles = $this->getPreviousFiles($entry) ?? [];
+        if($value && isset($value[0]) && is_null($value[0])) {
+            $value = false;
+        }
 
+        $filesToDelete = collect(CRUD::getRequest()->get('clear_'.$this->getRepeatableContainerName() ?? $this->getName()))->flatten()->toArray();
+        $value = $value ?? CRUD::getRequest()->file($this->getRepeatableContainerName() ?? $this->getName());
+        $previousFiles = $this->getPreviousFiles($entry) ?? [];
+       
         if (! is_array($previousFiles) && is_string($previousFiles)) {
             $previousFiles = json_decode($previousFiles, true);
         }
@@ -37,7 +41,11 @@ class MultipleFiles extends Uploader
             }
         }
 
-        foreach ($value ?? [] as $file) {
+        if(!is_array($value)) {
+            $value = [];
+        }
+
+        foreach ($value as $file) {
             if ($file && is_file($file)) {
                 $fileName = $this->getFileName($file);
                 $file->storeAs($this->getPath(), $fileName, $this->getDisk());

--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -22,7 +22,7 @@ class MultipleFiles extends Uploader
         }
 
         $filesToDelete = collect(CRUD::getRequest()->get('clear_'.$this->getRepeatableContainerName() ?? $this->getName()))->flatten()->toArray();
-        $value = $value ?? CRUD::getRequest()->file($this->getRepeatableContainerName() ?? $this->getName());
+        $value = $value ?? collect(CRUD::getRequest()->file($this->getRepeatableContainerName() ?? $this->getName()))->flatten()->toArray();
         $previousFiles = $this->getPreviousFiles($entry) ?? [];
        
         if (! is_array($previousFiles) && is_string($previousFiles)) {

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -64,7 +64,7 @@ trait HandleRepeatableUploads
      
         foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
             if (array_key_exists($modelCount, $value) && array_key_exists($uploader->getAttributeName(), $value[$modelCount])) {
-                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $value[$modelCount][$uploader->getAttributeName()] ?? null);
+                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $value[$modelCount][$uploader->getAttributeName()]);
             }
         }
 

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -64,7 +64,9 @@ trait HandleRepeatableUploads
 
         foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
             if (array_key_exists($modelCount, $value) && array_key_exists($uploader->getAttributeName(), $value[$modelCount])) {
-                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $value[$modelCount][$uploader->getAttributeName()]);
+                $entryFiles = request()->file($this->getRepeatableContainerName())[$modelCount] ?? null;
+                $entryFiles = !is_null($entryFiles) ? $entryFiles[$uploader->getAttributeName()] : ($value[$modelCount][$uploader->getAttributeName()] ?? false);
+                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $entryFiles);
             }
         }
 

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -61,12 +61,10 @@ trait HandleRepeatableUploads
     {
         $modelCount = CRUD::get('uploaded_'.$this->getRepeatableContainerName().'_count');
         $value = $value->slice($modelCount, 1)->toArray();
-
+     
         foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
             if (array_key_exists($modelCount, $value) && array_key_exists($uploader->getAttributeName(), $value[$modelCount])) {
-                $entryFiles = request()->file($this->getRepeatableContainerName())[$modelCount] ?? null;
-                $entryFiles = !is_null($entryFiles) ? $entryFiles[$uploader->getAttributeName()] : ($value[$modelCount][$uploader->getAttributeName()] ?? false);
-                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $entryFiles);
+                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $value[$modelCount][$uploader->getAttributeName()] ?? null);
             }
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in https://github.com/Laravel-Backpack/CRUD/issues/5392 the `MultipleFiles` uploader was not working when inside repeatable relationships. 

### AFTER - What is happening after this PR?

It works 🤷 We had fixed it already for `SingleFile` uploader, but I missed this use case. https://github.com/Laravel-Backpack/CRUD/commit/86419ca204b7ecce244ea7ad0ea6c5d4d5dfd64a


## HOW

### How did you achieve that, in technical terms?

The files deleted need to take into account the repeatable container too. 



### Is it a breaking change?

No I don't think so.
