### PR TITLE
Update styles.blade.php

### DIFF
--- a/src/resources/views/ui/inc/styles.blade.php
+++ b/src/resources/views/ui/inc/styles.blade.php
@@ -5,6 +5,12 @@
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-regular-400.woff2')
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-solid-900.woff2')
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-brands-400.woff2')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-regular-400.woff')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-solid-900.woff')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-brands-400.woff')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-regular-400.ttf')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-solid-900.ttf')
+@basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-brands-400.ttf')
 
 @basset(base_path('vendor/backpack/crud/src/resources/assets/css/common.css'))
 


### PR DESCRIPTION
Added woff and ttf to force import from bassets

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some browser are requiring ttf or woff version of line awesome files
So  users cannot see icons in the coreui-v4

### AFTER - What is happening after this PR?

With this PR, we can do a `basset:internalize` and predownload all required files.
Also, we fix the behaviour with icons don't loaded

## HOW

Added @basset instructions  for woff and ttf file of used files

### How did you achieve that, in technical terms?

Added @basset instructions  for woff and ttf file of used files

### Is it a breaking change?

No

### How can we test the before & after?

IDK, sorry

