### PR TITLE
[Bug Fix] Wrapper will not print false attributes

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -108,7 +108,11 @@ if (! CrudColumn::hasMacro('linkTo')) {
             // if the parameter is callable, we'll call it
             $parameters = collect($parameters)->map(fn ($item) => is_callable($item) ? $item($entry, $related_key, $column, $crud) : $item)->toArray();
 
-            return route($route, $parameters);
+            try {
+                return route($route, $parameters);
+            } catch (\Exception $e) {
+                return false;
+            }
         };
 
         $this->wrapper($wrapper);

--- a/src/resources/views/crud/columns/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/columns/inc/wrapper_start.blade.php
@@ -11,6 +11,8 @@
 
 <{{ $column['wrapper']['element'] ?? 'a' }}
 @foreach(Arr::except($column['wrapper'], 'element') as $element => $value)
+    @if($value !== false)
     {{$element}}="{{$value}}"
+    @endif
 @endforeach
 >

--- a/src/resources/views/crud/fields/inc/wrapper_start.blade.php
+++ b/src/resources/views/crud/fields/inc/wrapper_start.blade.php
@@ -36,6 +36,8 @@
 
 <{{ $field['wrapper']['element'] }}
 	@foreach($field['wrapper'] as $attribute => $value)
-	    {{ $attribute }}="{{ $value }}"
+		@if($value !== false)
+		{{ $attribute }}="{{ $value }}"
+		@endif
 	@endforeach
 >

--- a/src/resources/views/ui/widgets/inc/wrapper_start.blade.php
+++ b/src/resources/views/ui/widgets/inc/wrapper_start.blade.php
@@ -11,6 +11,8 @@
 
 <{{ $widget['wrapper']['element'] ?? 'div' }}
 @foreach(Arr::where($widget['wrapper'],function($value, $key) { return $key != 'element'; }) as $element => $value)
+    @if($value !== false)
     {{$element}}="{{$value}}"
+    @endif
 @endforeach
 >


### PR DESCRIPTION
This is a fix for both;
- https://github.com/Laravel-Backpack/CRUD/issues/3954 (2yo bug 🎉)
- https://github.com/Laravel-Backpack/CRUD/pull/5391#issuecomment-1872219557

---

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some links where empty:

![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/25f759f3-913d-4fbd-9ea0-b0545f7ef5ed)


### AFTER - What is happening after this PR?

No more empty links.

![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/3df5af2a-6570-4c36-8b03-f3958f63399d)


## HOW

### How did you achieve that, in technical terms?

All `wrapper_start` files (for columns, fields and widgets) will check if the value of attribute is NOT `false`.

Basically if someone has a closure for an HREF, or any other attribute, that attribute will be always printed in the HTML Dom element, even if the value is `false`, or `null`.

With this PR, developers can control that by returning `false` on the closure, it's a strict validation so any _falsy_ value will be printed anyway, `0`, `null` (even though null is not really printed on the html).

<table>
<tr>
 <td>null
 <td><code>href=""
<tr>
 <td>0
 <td><code>href="0"
<tr>
 <td>""
 <td><code>href=""
<tr>
 <td>false
 <td>
</table>

### Is it a breaking change?

I don't believe so.
This is only a breaking change for users who were returning false on some closure, and were expecting the attribute to be rendered empty.

### How can we test the before & after?

By following @karandatwani92 suggestion here https://github.com/Laravel-Backpack/CRUD/pull/5391#issuecomment-1872219557