### PR TITLE
dont error in linkTo when route not found

### DIFF
--- a/src/macros.php
+++ b/src/macros.php
@@ -108,7 +108,11 @@ if (! CrudColumn::hasMacro('linkTo')) {
             // if the parameter is callable, we'll call it
             $parameters = collect($parameters)->map(fn ($item) => is_callable($item) ? $item($entry, $related_key, $column, $crud) : $item)->toArray();
 
-            return route($route, $parameters);
+            try {
+                return route($route, $parameters);
+            } catch (\Exception $e) {
+                return false;
+            }
         };
 
         $this->wrapper($wrapper);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

If you had a related column, but without relationship assigned, the `linkTo` would throw an hugly error as reported in https://github.com/Laravel-Backpack/CRUD/pull/5391#issuecomment-1872219557

@promatik fixed this in the mentioned PR, I just ported the fix here because that PR's has BC's that need to be addressed before it becomes mergeable. 
