### PR TITLE
fix uploads not returning the correct request name

### DIFF
--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -21,8 +21,8 @@ class MultipleFiles extends Uploader
             $value = false;
         }
 
-        $filesToDelete = collect(CRUD::getRequest()->get('clear_'.$this->getRepeatableContainerName() ?? $this->getName()))->flatten()->toArray();
-        $value = $value ?? collect(CRUD::getRequest()->file($this->getRepeatableContainerName() ?? $this->getName()))->flatten()->toArray();
+        $filesToDelete = collect(CRUD::getRequest()->get('clear_'.$this->getNameForRequest()))->flatten()->toArray();
+        $value = $value ?? collect(CRUD::getRequest()->file($this->getNameForRequest()))->flatten()->toArray();
         $previousFiles = $this->getPreviousFiles($entry) ?? [];
 
         if (! is_array($previousFiles) && is_string($previousFiles)) {

--- a/src/app/Library/Uploaders/SingleFile.php
+++ b/src/app/Library/Uploaders/SingleFile.php
@@ -23,7 +23,7 @@ class SingleFile extends Uploader
             return $this->getPath().$fileName;
         }
 
-        if (! $value && CrudPanelFacade::getRequest()->has($this->getRepeatableContainerName() ?? $this->getName()) && $previousFile) {
+        if (! $value && CrudPanelFacade::getRequest()->has($this->getNameForRequest()) && $previousFile) {
             Storage::disk($this->getDisk())->delete($previousFile);
 
             return null;

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -13,7 +13,7 @@ trait HandleRepeatableUploads
 {
     public bool $handleRepeatableFiles = false;
 
-    public ?string $repeatableContainerName = null;
+    public null|string $repeatableContainerName = null;
 
     /*******************************
      * Setters - fluently configure the uploader
@@ -30,7 +30,7 @@ trait HandleRepeatableUploads
     /*******************************
      * Getters
      *******************************/
-    public function getRepeatableContainerName(): ?string
+    public function getRepeatableContainerName(): null|string
     {
         return $this->repeatableContainerName;
     }

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -157,6 +157,11 @@ abstract class Uploader implements UploaderInterface
         return $this->name;
     }
 
+    public function getNameForRequest(): string
+    {
+        return $this->repeatableContainerName ?? $this->name;
+    }
+
     public function canHandleMultipleFiles(): bool
     {
         return $this->handleMultipleFiles;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/Laravel-Backpack/CRUD/issues/5411

The name used by the uploader to get the values from the request was not properly built and that was preventing from deleting files in `upload_multiple` uploaders.

### AFTER - What is happening after this PR?

It properly builds the name, and it works as expected.

## HOW

### How did you achieve that, in technical terms?

created a getter for the request name in the Uploader class.

### Is it a breaking change?

No


### How can we test the before & after?

Follow the steps in https://github.com/Laravel-Backpack/CRUD/issues/5411#issuecomment-1872089352

