### PR TITLE
fix: getCurrentEntryId() should return null instead of false

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -13,7 +13,7 @@ trait Read
     /**
      * Find and retrieve the id of the current entry.
      *
-     * @return int|bool The id in the db or false.
+     * @return int|null The id in the db or null.
      */
     public function getCurrentEntryId()
     {
@@ -29,7 +29,7 @@ trait Read
                 // otherwise use the next to last parameter
                 array_values($params)[count($params) - 1] ??
                 // otherwise return false
-                false;
+                null;
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

`getCurrentEntryId()` returns false, but ideally it should be returning null if unable to retrieve a value.

There are also several places in the codebase that use this line to get the crud ID:
```
$id = $this->crud->getCurrentEntryId() ?? $id;
```

A few files:
`src/app/Http/Controllers/Operations/DeleteOperation.php`
`src/app/Http/Controllers/Operations/ListOperation.php`
`src/app/Http/Controllers/Operations/ShowOperation.php`
`src/app/Http/Controllers/Operations/UpdateOperation.php`


This will never allow you to fallback to `$id` using null coalescing since it returns false and doesn't return null.

### AFTER - What is happening after this PR?

change the return type from false to null, so that we can make use of fallbacks via null coalescing


## HOW

### How did you achieve that, in technical terms?

update the return type from false -> null

### Is it a breaking change?

potentially if people are strictly checking for `FALSE` but if loosely `null` is falsy so should be fine


### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
