### PR TITLE
Fix uploads in relationship repeatables

### DIFF
--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -25,10 +25,10 @@ class MultipleFiles extends Uploader
         $value = $value ?? collect(CRUD::getRequest()->file($this->getNameForRequest()))->flatten()->toArray();
         $previousFiles = $this->getPreviousFiles($entry) ?? [];
 
-        if(is_array($previousFiles) && empty($previousFiles[0] ?? [])){
+        if (is_array($previousFiles) && empty($previousFiles[0] ?? [])) {
             $previousFiles = [];
         }
-        
+
         if (! is_array($previousFiles) && is_string($previousFiles)) {
             $previousFiles = json_decode($previousFiles, true);
         }

--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -25,6 +25,10 @@ class MultipleFiles extends Uploader
         $value = $value ?? collect(CRUD::getRequest()->file($this->getNameForRequest()))->flatten()->toArray();
         $previousFiles = $this->getPreviousFiles($entry) ?? [];
 
+        if(is_array($previousFiles) && empty($previousFiles[0] ?? [])){
+            $previousFiles = [];
+        }
+        
         if (! is_array($previousFiles) && is_string($previousFiles)) {
             $previousFiles = json_decode($previousFiles, true);
         }

--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -21,7 +21,7 @@ class MultipleFiles extends Uploader
             $value = false;
         }
 
-        $filesToDelete = collect(CRUD::getRequest()->get('clear_'.$this->getNameForRequest()))->flatten()->toArray();
+        $filesToDelete = $this->getFilesToDeleteFromRequest();
         $value = $value ?? collect(CRUD::getRequest()->file($this->getNameForRequest()))->flatten()->toArray();
         $previousFiles = $this->getPreviousFiles($entry) ?? [];
 
@@ -81,4 +81,23 @@ class MultipleFiles extends Uploader
 
         return $fileOrder;
     }
+
+    protected function hasDeletedFiles($value): bool
+    {
+        return empty($this->getFilesToDeleteFromRequest()) ? false : true;
+    }
+
+    protected function getEntryAttributeValue(Model $entry)
+    {
+        $value = $entry->{$this->getAttributeName()};
+
+        return isset($entry->getCasts()[$this->getName()]) ? $value : json_encode($value);
+    }
+
+    private function getFilesToDeleteFromRequest(): array
+    {
+        return collect(CRUD::getRequest()->get('clear_'.$this->getNameForRequest()))->flatten()->toArray();
+    }
+
+
 }

--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -98,6 +98,4 @@ class MultipleFiles extends Uploader
     {
         return collect(CRUD::getRequest()->get('clear_'.$this->getNameForRequest()))->flatten()->toArray();
     }
-
-
 }

--- a/src/app/Library/Uploaders/SingleBase64Image.php
+++ b/src/app/Library/Uploaders/SingleBase64Image.php
@@ -59,4 +59,14 @@ class SingleBase64Image extends Uploader
 
         return $values;
     }
+
+    protected function shouldUploadFiles($value): bool
+    {
+        return $value && is_string($value) && Str::startsWith($value, 'data:image');
+    }
+
+    protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool
+    {
+        return $entry->exists && is_string($entryValue) && !Str::startsWith($entryValue, 'data:image');
+    }
 }

--- a/src/app/Library/Uploaders/SingleBase64Image.php
+++ b/src/app/Library/Uploaders/SingleBase64Image.php
@@ -67,6 +67,6 @@ class SingleBase64Image extends Uploader
 
     protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool
     {
-        return $entry->exists && is_string($entryValue) && !Str::startsWith($entryValue, 'data:image');
+        return $entry->exists && is_string($entryValue) && ! Str::startsWith($entryValue, 'data:image');
     }
 }

--- a/src/app/Library/Uploaders/SingleFile.php
+++ b/src/app/Library/Uploaders/SingleFile.php
@@ -13,6 +13,11 @@ class SingleFile extends Uploader
         $value = $value ?? CrudPanelFacade::getRequest()->file($this->getName());
         $previousFile = $this->getPreviousFiles($entry);
 
+        if($value === false && $previousFile) {
+            Storage::disk($this->getDisk())->delete($previousFile);
+            return null;
+        }
+
         if ($value && is_file($value) && $value->isValid()) {
             if ($previousFile) {
                 Storage::disk($this->getDisk())->delete($previousFile);
@@ -28,7 +33,6 @@ class SingleFile extends Uploader
 
             return null;
         }
-
         return $previousFile;
     }
 
@@ -54,5 +58,23 @@ class SingleFile extends Uploader
         }
 
         return $orderedFiles;
+    }
+
+    /**
+     * Single file uploaders send no value when they are not dirty
+     */
+    protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool
+    {
+        return is_string($entryValue);
+    }
+
+    protected function hasDeletedFiles($entryValue): bool
+    {
+        return $entryValue === null;
+    }
+
+    protected function shouldUploadFiles($value): bool
+    {
+        return is_a($value, 'Illuminate\Http\UploadedFile', true);
     }
 }

--- a/src/app/Library/Uploaders/SingleFile.php
+++ b/src/app/Library/Uploaders/SingleFile.php
@@ -13,8 +13,9 @@ class SingleFile extends Uploader
         $value = $value ?? CrudPanelFacade::getRequest()->file($this->getName());
         $previousFile = $this->getPreviousFiles($entry);
 
-        if($value === false && $previousFile) {
+        if ($value === false && $previousFile) {
             Storage::disk($this->getDisk())->delete($previousFile);
+
             return null;
         }
 
@@ -33,6 +34,7 @@ class SingleFile extends Uploader
 
             return null;
         }
+
         return $previousFile;
     }
 
@@ -61,7 +63,7 @@ class SingleFile extends Uploader
     }
 
     /**
-     * Single file uploaders send no value when they are not dirty
+     * Single file uploaders send no value when they are not dirty.
      */
     protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool
     {

--- a/src/app/Library/Uploaders/Support/Interfaces/UploaderInterface.php
+++ b/src/app/Library/Uploaders/Support/Interfaces/UploaderInterface.php
@@ -51,6 +51,8 @@ interface UploaderInterface
 
     public function getIdentifier(): string;
 
+    public function getNameForRequest(): string;
+
     public function shouldDeleteFiles(): bool;
 
     public function canHandleMultipleFiles(): bool;

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -112,13 +112,7 @@ final class RegisterUploadEvents
 
         if ($this->crudObjectType === 'field') {
             $model::saving(function ($entry) use ($uploader) {
-                $updatedCountKey = 'uploaded_'.($uploader->getRepeatableContainerName() ?? $uploader->getName()).'_count';
-
-                CRUD::set($updatedCountKey, CRUD::get($updatedCountKey) ?? 0);
-
                 $entry = $uploader->storeUploadedFiles($entry);
-
-                CRUD::set($updatedCountKey, CRUD::get($updatedCountKey) + 1);
             });
         }
         // if the entry is already retrieved from database, don't register the event
@@ -132,7 +126,7 @@ final class RegisterUploadEvents
 
             $retrieveModel::retrieved(function ($entry) use ($uploader) {
                 if ($entry->translationEnabled()) {
-                    $locale = request('_locale', \App::getLocale());
+                    $locale = request('_locale', app()->getLocale());
                     if (in_array($locale, array_keys($entry->getAvailableLocales()))) {
                         $entry->setLocale($locale);
                     }

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
 use Backpack\CRUD\app\Library\Uploaders\Support\Interfaces\UploaderInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -44,33 +45,87 @@ trait HandleRepeatableUploads
 
     protected function handleRepeatableFiles(Model $entry): Model
     {
+        if ($this->isRelationship) {
+            return $this->processRelationshipRepeatableUploaders($entry);
+        }
+
         $values = collect(CRUD::getRequest()->get($this->getRepeatableContainerName()));
         $files = collect(CRUD::getRequest()->file($this->getRepeatableContainerName()));
         $value = $this->mergeValuesRecursive($values, $files);
-
-        if ($this->isRelationship) {
-            return $this->uploadRelationshipFiles($entry, $value);
-        }
 
         $entry->{$this->getRepeatableContainerName()} = json_encode($this->processRepeatableUploads($entry, $value));
 
         return $entry;
     }
 
-    private function uploadRelationshipFiles(Model $entry, mixed $value): Model
+    private function processRelationshipRepeatableUploaders(Model $entry)
     {
-        $modelCount = CRUD::get('uploaded_'.$this->getRepeatableContainerName().'_count');
-        $value = $value->slice($modelCount, 1)->toArray();
-
-        foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
-            if (array_key_exists($modelCount, $value) && array_key_exists($uploader->getAttributeName(), $value[$modelCount])) {
-                $entry->{$uploader->getAttributeName()} = $uploader->uploadFiles($entry, $value[$modelCount][$uploader->getAttributeName()]);
-            }
+        foreach(app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
+            $entry = $uploader->uploadRelationshipFiles($entry);
         }
 
         return $entry;
     }
 
+    protected function uploadRelationshipFiles(Model $entry): Model
+    {
+        $entryValue = $this->getFilesFromEntry($entry);
+        
+        if($this->handleMultipleFiles && is_string($entryValue)) {
+            try {
+                $entryValue = json_decode($entryValue, true);
+            } catch (\Exception) {
+               return $entry;
+            }
+        }
+
+        if ($this->hasDeletedFiles($entryValue)) {
+            $entry->{$this->getAttributeName()} = $this->uploadFiles($entry, false);
+            $this->updatedPreviousFiles = $this->getEntryAttributeValue($entry);
+        }
+
+        if($this->shouldKeepPreviousValueUnchanged($entry, $entryValue)) {
+            $entry->{$this->getAttributeName()} = $this->updatedPreviousFiles ?? $this->getEntryOriginalValue($entry);
+            return $entry;
+        }
+
+        if($this->shouldUploadFiles($entryValue)) {
+            $entry->{$this->getAttributeName()} = $this->uploadFiles($entry, $entryValue);
+        }
+
+        return $entry;
+    }
+
+    protected function getFilesFromEntry(Model $entry)
+    {
+        return $entry->getAttribute($this->getAttributeName());
+    }
+
+    protected function getEntryAttributeValue(Model $entry)
+    {
+        return $entry->{$this->getAttributeName()};
+    }
+
+    protected function getEntryOriginalValue(Model $entry)
+    {
+        return $entry->getOriginal($this->getAttributeName());
+    }
+
+    protected function shouldUploadFiles($entryValue): bool
+    {
+        return true;
+    }
+
+    protected function shouldKeepPreviousValueUnchanged(Model $entry, $entryValue): bool
+    {
+        return $entry->exists && ($entryValue === null || $entryValue === [null]);
+    }
+
+    protected function hasDeletedFiles($entryValue): bool
+    {
+        return $entryValue === false || $entryValue === null || $entryValue === [null];
+    }
+    
     protected function processRepeatableUploads(Model $entry, Collection $values): Collection
     {
         foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
@@ -240,6 +295,13 @@ trait HandleRepeatableUploads
 
     private function deleteRelationshipFiles(Model $entry): void
     {
+        foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
+            $uploader->deleteRepeatableRelationFiles($entry);
+        }
+    }
+
+    private function deleteRepeatableRelationFiles(Model $entry)
+    {
         if (in_array($this->getRepeatableRelationType(), ['BelongsToMany', 'MorphToMany'])) {
             $pivotAttributes = $entry->getAttributes();
             $connectedPivot = $entry->pivotParent->{$this->getRepeatableContainerName()}->where(function ($item) use ($pivotAttributes) {
@@ -257,6 +319,16 @@ trait HandleRepeatableUploads
             if (! $files) {
                 return;
             }
+
+            if($this->handleMultipleFiles && is_string($files)) {
+                try {
+                    $files = json_decode($files, true);
+                } catch (\Exception) {
+                   Log::error('Could not parse files for deletion pivot entry with key: '. $entry->getKey() . ' and uploader: ' . $this->getName());
+                   return;
+                }
+            }
+           
 
             if (is_array($files)) {
                 foreach ($files as $value) {

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -60,7 +60,7 @@ trait HandleRepeatableUploads
 
     private function processRelationshipRepeatableUploaders(Model $entry)
     {
-        foreach(app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
+        foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
             $entry = $uploader->uploadRelationshipFiles($entry);
         }
 
@@ -70,12 +70,12 @@ trait HandleRepeatableUploads
     protected function uploadRelationshipFiles(Model $entry): Model
     {
         $entryValue = $this->getFilesFromEntry($entry);
-        
-        if($this->handleMultipleFiles && is_string($entryValue)) {
+
+        if ($this->handleMultipleFiles && is_string($entryValue)) {
             try {
                 $entryValue = json_decode($entryValue, true);
             } catch (\Exception) {
-               return $entry;
+                return $entry;
             }
         }
 
@@ -84,12 +84,13 @@ trait HandleRepeatableUploads
             $this->updatedPreviousFiles = $this->getEntryAttributeValue($entry);
         }
 
-        if($this->shouldKeepPreviousValueUnchanged($entry, $entryValue)) {
+        if ($this->shouldKeepPreviousValueUnchanged($entry, $entryValue)) {
             $entry->{$this->getAttributeName()} = $this->updatedPreviousFiles ?? $this->getEntryOriginalValue($entry);
+
             return $entry;
         }
 
-        if($this->shouldUploadFiles($entryValue)) {
+        if ($this->shouldUploadFiles($entryValue)) {
             $entry->{$this->getAttributeName()} = $this->uploadFiles($entry, $entryValue);
         }
 
@@ -125,7 +126,7 @@ trait HandleRepeatableUploads
     {
         return $entryValue === false || $entryValue === null || $entryValue === [null];
     }
-    
+
     protected function processRepeatableUploads(Model $entry, Collection $values): Collection
     {
         foreach (app('UploadersRepository')->getRepeatableUploadersFor($this->getRepeatableContainerName()) as $uploader) {
@@ -320,15 +321,15 @@ trait HandleRepeatableUploads
                 return;
             }
 
-            if($this->handleMultipleFiles && is_string($files)) {
+            if ($this->handleMultipleFiles && is_string($files)) {
                 try {
                     $files = json_decode($files, true);
                 } catch (\Exception) {
-                   Log::error('Could not parse files for deletion pivot entry with key: '. $entry->getKey() . ' and uploader: ' . $this->getName());
-                   return;
+                    Log::error('Could not parse files for deletion pivot entry with key: '.$entry->getKey().' and uploader: '.$this->getName());
+
+                    return;
                 }
             }
-           
 
             if (is_array($files)) {
                 foreach ($files as $value) {

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -243,8 +243,8 @@ abstract class Uploader implements UploaderInterface
     private function deleteFiles(Model $entry)
     {
         $values = $entry->{$this->getAttributeName()};
-        
-        if($values === null) {
+
+        if ($values === null) {
             return;
         }
 
@@ -288,7 +288,7 @@ abstract class Uploader implements UploaderInterface
 
     private function getOriginalValue(Model $entry, $field = null)
     {
-        if($this->updatedPreviousFiles !== null) {
+        if ($this->updatedPreviousFiles !== null) {
             return $this->updatedPreviousFiles;
         }
 

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -42,6 +42,11 @@ abstract class Uploader implements UploaderInterface
      */
     private bool $isRelationship = false;
 
+    /**
+     * When previous files are updated, we need to keep track of them so that we don't add deleted files to the new list.
+     */
+    private $updatedPreviousFiles = null;
+
     public function __construct(array $crudObject, array $configuration)
     {
         $this->name = $crudObject['name'];
@@ -237,22 +242,27 @@ abstract class Uploader implements UploaderInterface
 
     private function deleteFiles(Model $entry)
     {
-        $values = $entry->{$this->name};
+        $values = $entry->{$this->getAttributeName()};
+        
+        if($values === null) {
+            return;
+        }
 
         if ($this->handleMultipleFiles) {
             // ensure we have an array of values when field is not casted in model.
             if (! isset($entry->getCasts()[$this->name]) && is_string($values)) {
                 $values = json_decode($values, true);
             }
-            foreach ($values as $value) {
-                Storage::disk($this->disk)->delete($this->path.$value);
+            foreach ($values ?? [] as $value) {
+                $value = Str::start($value, $this->path);
+                Storage::disk($this->disk)->delete($value);
             }
 
             return;
         }
 
-        $values = Str::after($values, $this->path);
-        Storage::disk($this->disk)->delete($this->path.$values);
+        $values = Str::start($values, $this->path);
+        Storage::disk($this->disk)->delete($values);
     }
 
     private function performFileDeletion(Model $entry)
@@ -278,6 +288,10 @@ abstract class Uploader implements UploaderInterface
 
     private function getOriginalValue(Model $entry, $field = null)
     {
+        if($this->updatedPreviousFiles !== null) {
+            return $this->updatedPreviousFiles;
+        }
+
         $previousValue = $entry->getOriginal($field ?? $this->getAttributeName());
 
         if (! $previousValue) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

A lot of stuff were broken and there were many issues reported regarding uploaders in relationships. I've been pushing small fixes but never got to the end of the issue because the problem was the implementation as a whole and not only small broken bits.

https://github.com/Laravel-Backpack/CRUD/issues/5355
https://github.com/Laravel-Backpack/CRUD/issues/5299
https://stackoverflow.com/questions/77794931/backpack-6-repeatable-with-file-upload-field

### AFTER - What is happening after this PR?

The uploaders should properly work on repeatable relationships 


## HOW

### How did you achieve that, in technical terms?

I needed to re-work the whole saving process for repeatable relationships in the uploaders.
In the end we endup with more customized uploaders, tailored each for their needs without having to guess what belongs to where, that was causing most of the issues. 

Docs were updated too. Most noticeable change in docs is the mention that "uploaders in relationships should **NOT** be casted in the models". https://github.com/Laravel-Backpack/docs/pull/537

This is a limitation by the fact that we hook to the "saving" event and if they are casted we can't get the sent files from the entry (only from request),  and the request is not reliable due to the nature of how repeatable works.

### Is it a breaking change?

No I don't think so.

### How can we test the before & after?

Just trying to add a file uploader to any relationship will be enough to get into a broken scenario. 
