### PR TITLE
Add workaround for quick button inconsistency

### DIFF
--- a/src/app/Http/Controllers/Operations/Concerns/HasForm.php
+++ b/src/app/Http/Controllers/Operations/Concerns/HasForm.php
@@ -105,7 +105,7 @@ trait HasForm
     {
         if ($id) {
             // Get entry ID from Request (makes sure its the last ID for nested resources)
-            $id =  $this->crud->getCurrentEntryId() ?: $id;
+            $id = $this->crud->getCurrentEntryId() ?: $id;
             $entry = $this->crud->getEntryWithLocale($id);
         }
 

--- a/src/app/Http/Controllers/Operations/Concerns/HasForm.php
+++ b/src/app/Http/Controllers/Operations/Concerns/HasForm.php
@@ -74,7 +74,7 @@ trait HasForm
     {
         if ($id) {
             // Get entry ID from Request (makes sure its the last ID for nested resources)
-            $this->data['id'] = $this->crud->getCurrentEntryId() ?? $id;
+            $this->data['id'] = $this->crud->getCurrentEntryId() ?: $id;
             $this->data['entry'] = $this->crud->getEntryWithLocale($this->data['id']);
         }
 
@@ -105,7 +105,7 @@ trait HasForm
     {
         if ($id) {
             // Get entry ID from Request (makes sure its the last ID for nested resources)
-            $id = $this->crud->getCurrentEntryId() ?? $id;
+            $id =  $this->crud->getCurrentEntryId() ?: $id;
             $entry = $this->crud->getEntryWithLocale($id);
         }
 

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -38,14 +38,7 @@ trait Access
     public function hasAccess(string $operation, $entry = null): bool
     {
         $condition = $this->get($operation.'.access');
-
-        // this shouldn't happen, but in v6 we introduced the "quick" button with an inconsistency with other buttons.
-        // the quick button name is converted with `Str::studly()` to get the access string and that makes it impossible
-        // for this function to determine the proper access key. For example, a quick button with the name `comment`
-        // would have the access key `Comment`, while create, update, delete etc have the access keys `create`, `update`, `delete` without transformation.
-        // we should remove the transformation in vendor\backpack\crud\src\resources\views\crud\buttons\quick.blade.php and remove this line from here in v7.
-        $condition = $condition ?? $this->get(Str::camel($operation).'.access');
-
+        
         if (is_callable($condition)) {
             // supply the current entry, if $entry is missing
             // this also makes sure the entry is null when missing

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\app\Exceptions\AccessDeniedException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 trait Access
 {
@@ -37,6 +38,13 @@ trait Access
     public function hasAccess(string $operation, $entry = null): bool
     {
         $condition = $this->get($operation.'.access');
+
+        // this shouldn't happen, but in v6 we introduced the "quick" button with an inconsistency with other buttons. 
+        // the quick button name is converted with `Str::studly()` to get the access string and that makes it impossible 
+        // for this function to determine the proper access key. For example, a quick button with the name `comment`
+        // would have the access key `Comment`, while create, update, delete etc have the access keys `create`, `update`, `delete` without transformation.
+        // we should remove the transformation in vendor\backpack\crud\src\resources\views\crud\buttons\quick.blade.php and remove this line from here in v7.
+        $condition = $condition ?? $this->get(Str::camel($operation).'.access');
 
         if (is_callable($condition)) {
             // supply the current entry, if $entry is missing

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -39,8 +39,8 @@ trait Access
     {
         $condition = $this->get($operation.'.access');
 
-        // this shouldn't happen, but in v6 we introduced the "quick" button with an inconsistency with other buttons. 
-        // the quick button name is converted with `Str::studly()` to get the access string and that makes it impossible 
+        // this shouldn't happen, but in v6 we introduced the "quick" button with an inconsistency with other buttons.
+        // the quick button name is converted with `Str::studly()` to get the access string and that makes it impossible
         // for this function to determine the proper access key. For example, a quick button with the name `comment`
         // would have the access key `Comment`, while create, update, delete etc have the access keys `create`, `update`, `delete` without transformation.
         // we should remove the transformation in vendor\backpack\crud\src\resources\views\crud\buttons\quick.blade.php and remove this line from here in v7.

--- a/src/app/Library/CrudPanel/Traits/Access.php
+++ b/src/app/Library/CrudPanel/Traits/Access.php
@@ -4,7 +4,6 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Backpack\CRUD\app\Exceptions\AccessDeniedException;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 
 trait Access
 {
@@ -38,7 +37,7 @@ trait Access
     public function hasAccess(string $operation, $entry = null): bool
     {
         $condition = $this->get($operation.'.access');
-        
+
         if (is_callable($condition)) {
             // supply the current entry, if $entry is missing
             // this also makes sure the entry is null when missing

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -1,5 +1,10 @@
 @php
-    $access = $button->meta['access'] ?? Str::of($button->name)->studly();
+    $access = (function() use ($crud, $button) {
+        if (isset($button->meta['access']) && $button->meta['access'] !== null && $button->meta['access'] !== false) {
+            return $button->meta['access'];
+        }
+        return !is_null($crud->get(Str::of($button->name)->studly().'.access'))  ? Str::of($button->name)->studly() : $button->name;
+    })();
     $icon = $button->meta['icon'] ?? '';
     $label = $button->meta['label'] ?? Str::of($button->name)->headline();
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #5421 

Following a simple tutorial that should "just work", was not "just working" 🤷‍♂️ 

I've debugged the issue and the culprit is the fact that we `->studly($buttonName)` to get the access string. So a button with the name `comment` would have the access string `Comment`. 

### AFTER - What is happening after this PR?

It checks both operation name strings. First the regular one and as a fallback the `camelCased` version of the operation.

## HOW

### How did you achieve that, in technical terms?

I could have just changed the stub and define the operation button with `access => Str::studly($operationName)` or just removed the `studly()` in the `quick.blade.php` file, but that would be a BC at the moment in any of those cases. But it's what I've planned for v7. 

So I made it fallback to a camelCased version of the name as last resort to try to find access. 
I don't think this would ever be a BC the way I implemented because it wouldn't be possible for you to have a `moderate` and a `Moderate` operations, or a `SuperModerate` and `superModerate` operations at the same time.


### Is it a breaking change?

I don't think so, no.


### How can we test the before & after?

Follow the tutorial in Backpack website https://backpackforlaravel.com/docs/6.x/crud-operations#creating-a-new-operation-with-a-form-1 . It will fail previously, it will work after. 

