### PR TITLE
use Hash to encrypt password as we use to decrypt

### DIFF
--- a/src/app/Console/Commands/CreateUser.php
+++ b/src/app/Console/Commands/CreateUser.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
 
 class CreateUser extends Command
 {
@@ -46,7 +47,7 @@ class CreateUser extends Command
         }
 
         if ($this->option('encrypt')) {
-            $password = bcrypt($password);
+            $password = Hash::make($password);
         }
 
         $auth = config('backpack.base.user_model_fqn', 'App\User');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was an issue creating users using the console command `backpack:user`. We were forcely using `bcrypt()` on the password and then using `Hash::verify()` that wouldn't be able to match the password given different algorithm options. 

### AFTER - What is happening after this PR?

It works as expected.


## HOW

### How did you achieve that, in technical terms?

Replaced the `bcrypt()` call with a `Hash::make()` that would use the same configuration used by ``Hash::verify()`. 


### Is it a breaking change?

I don't think so, no.


### How can we test the before & after?

Create a user with `php artisan backpack:user`. 
