### PR TITLE
Remove extra dot from breadcrumbs after entity name

### DIFF
--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -15,7 +15,7 @@
 	<section class="container-fluid">
 	  <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}</small>
 
         @if ($crud->hasAccess('list'))
           <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -15,7 +15,7 @@
 	<section class="container-fluid">
 	  <h2>
         <span class="text-capitalize">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</span>
-        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</small>
+        <small>{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}</small>
 
         @if ($crud->hasAccess('list'))
           <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>


### PR DESCRIPTION
## WHY
Need to remove this extra dot from breadcrumbs in create and edit view. 
### BEFORE - What was wrong? What was happening before this PR?

There is an extra dot(.) after entity name on breadcrumbs in create and edit view.
![dot-issue](https://github.com/Laravel-Backpack/CRUD/assets/69368775/3898229b-b55f-4dfb-b437-ee4431309bd0)

### AFTER - What is happening after this PR?

Removed the dot from breadcrumbs.


## HOW
Just remove the dot(.) from create.blade.php and edit.blade.php

### How did you achieve that, in technical terms?

??

### Is it a breaking change?

No

### How can we test the before & after?

Just check the breadcrumbs in create and edit page.

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
