### PR TITLE
[v7] Enable database transactions by default

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -172,7 +172,7 @@ return [
     // Should we use DB transactions when executing multiple queries? For example when creating an entry and it's relationships.
     // By wrapping in a database transaction you ensure that either all queries went ok, or if some failed the whole process
     // is rolled back and considered failed. This is a good setting for data integrity.
-    'useDatabaseTransactions' => false,
+    'useDatabaseTransactions' => true,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
DB Transactions were introduced in v6, here; https://github.com/Laravel-Backpack/CRUD/pull/5403
It remained as disabled as default to avoid the breaking change.
It should now go to enabled by default on v7 👌 