### PR TITLE
Add option to escape reorder operation label

### DIFF
--- a/src/config/backpack/operations/reorder.php
+++ b/src/config/backpack/operations/reorder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configurations for Backpack's ReorderOperation.
+ * Configurations for Backpack ReorderOperation.
  *
  * @see https://backpackforlaravel.com/docs/crud-operation-reorder
  */
@@ -10,4 +10,7 @@ return [
     // Define the size/looks of the content div for all CRUDs
     // To override per Controller use $this->crud->setReorderContentClass('class-string')
     'contentClass' => 'col-md-12 col-md-offset-2',
+
+    // should the content of the reorder label be escaped? 
+    'escaped' => false,
 ];

--- a/src/config/backpack/operations/reorder.php
+++ b/src/config/backpack/operations/reorder.php
@@ -11,6 +11,6 @@ return [
     // To override per Controller use $this->crud->setReorderContentClass('class-string')
     'contentClass' => 'col-md-12 col-md-offset-2',
 
-    // should the content of the reorder label be escaped? 
+    // should the content of the reorder label be escaped?
     'escaped' => false,
 ];

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -31,10 +31,10 @@
             // mark the element as shown
             $all_entries[$key]->tree_element_shown = true;
             $entry->tree_element_shown = true;
-
+            $entryLabel = $crud->get('reorder.escaped') ? e(object_get($entry, $crud->get('reorder.label'))) : object_get($entry, $crud->get('reorder.label'));
             // show the tree element
             echo '<li id="list_'.$entry->getKey().'">';
-            echo '<div><span class="disclose"><span></span></span>'.object_get($entry, $crud->get('reorder.label')).'</div>';
+            echo '<div><span class="disclose"><span></span></span>'.$entryLabel.'</div>';
 
             // see if this element has any children
             $children = [];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We had no built-in way to escape the reorder label without overwriting the field. 

As we discussed, it would be a good practice to escape by default and make non-escaped an option for those who know what they are looking for. 

We are not escaping by default right now as it would be a BC, but we plan to do it for v7. 

Docs here: