### PR TITLE
[Feature] Accept classes on routes

### DIFF
--- a/src/app/Library/CrudPanel/CrudRouter.php
+++ b/src/app/Library/CrudPanel/CrudRouter.php
@@ -9,7 +9,7 @@ final class CrudRouter
 {
     public static function setupControllerRoutes(string $name, string $routeName, string $controller, string $groupNamespace = ''): void
     {
-        $namespacedController = $groupNamespace.$controller;
+        $namespacedController = class_exists($controller) ? $controller : $groupNamespace.$controller;
 
         $controllerReflection = new ReflectionClass($namespacedController);
         $setupRoutesMethod = $controllerReflection->getMethod('setupRoutes');


### PR DESCRIPTION
## WHY

This goes in line with what we do in Laravel.

### BEFORE - What was wrong? What was happening before this PR?

```php
Route::crud('calendar', 'CalendarCrudController');
```

### AFTER - What is happening after this PR?

```php
Route::crud('calendar', CalendarCrudController::class);
```


## HOW

### How did you achieve that, in technical terms?

Simple validation on `CrudRouter` class.



### Is it a breaking change?

No, old strings are still available.


---

Maybe we should even deprecate the string method on v7.
