### PR TITLE
Create method locale override

### DIFF
--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -80,7 +80,13 @@ trait HasTranslations
         // do the actual saving
         foreach ($attributes as $attribute => $value) {
             if ($model->isTranslatableAttribute($attribute)) { // the attribute is translatable
-                $model->setTranslation($attribute, $locale, $value);
+                if (config('backpack.crud.override_available_locales_on_create')) {
+                    foreach ($model->getAvailableLocales() as $key => $lang) {
+                        $model->setTranslation($attribute, $key, $value);
+                    }
+                } else {
+                    $model->setTranslation($attribute, $locale, $value);
+                }
             } else { // the attribute is NOT translatable
                 $non_translatable[$attribute] = $value;
             }

--- a/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
+++ b/src/app/Models/Traits/SpatieTranslatable/HasTranslations.php
@@ -80,7 +80,7 @@ trait HasTranslations
         // do the actual saving
         foreach ($attributes as $attribute => $value) {
             if ($model->isTranslatableAttribute($attribute)) { // the attribute is translatable
-                if (config('backpack.crud.override_available_locales_on_create')) {
+                if (config('backpack.crud.fill_missing_locales')) {
                     foreach ($model->getAvailableLocales() as $key => $lang) {
                         $model->setTranslation($attribute, $key, $value);
                     }

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -13,6 +13,7 @@ return [
     */
 
     'show_translatable_field_icon' => true,
+    'override_available_locales_on_create' => true,
     'translatable_field_icon_position' => 'right', // left or right
 
     'locales' => [

--- a/src/config/backpack/crud.php
+++ b/src/config/backpack/crud.php
@@ -13,7 +13,7 @@ return [
     */
 
     'show_translatable_field_icon' => true,
-    'override_available_locales_on_create' => true,
+    'fill_missing_locales' => false,
     'translatable_field_icon_position' => 'right', // left or right
 
     'locales' => [


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

On crud creation it wouldn't set the translations to all the available languages, leaving blank spaces

### AFTER - What is happening after this PR?

This PR gives the option assign the current field not only into the current user lang but all the available


## HOW

### How did you achieve that, in technical terms?

A config field to disable/enable this option.
If true it fetches all the available languages and it loops by them


### Is it a breaking change?

No, in case the config key doesn't exists the code will keep the current/old method running


### How can we test the before & after?

Create a new entry where there's a translatable field
Change the config key between true/false 