### PR TITLE
Allow themes to register components

### DIFF
--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -3,9 +3,9 @@
 namespace Backpack\CRUD;
 
 use Backpack\Basset\Facades\Basset;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
-use Illuminate\Support\Facades\Blade;
 
 class ThemeServiceProvider extends ServiceProvider
 {
@@ -264,7 +264,7 @@ class ThemeServiceProvider extends ServiceProvider
 
     public function registerPackageBladeComponents()
     {
-        if($this->componentsNamespace) {
+        if ($this->componentsNamespace) {
             $this->app->afterResolving(BladeCompiler::class, function () {
                 Blade::componentNamespace($this->componentsNamespace, $this->packageName);
             });

--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -4,6 +4,8 @@ namespace Backpack\CRUD;
 
 use Backpack\Basset\Facades\Basset;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\Support\Facades\Blade;
 
 class ThemeServiceProvider extends ServiceProvider
 {
@@ -12,6 +14,7 @@ class ThemeServiceProvider extends ServiceProvider
     protected string $packageName = 'theme-name';
     protected array $commands = [];
     protected bool $theme = true;
+    protected null|string $componentsNamespace = null;
 
     /**
      * -------------------------
@@ -56,6 +59,8 @@ class ThemeServiceProvider extends ServiceProvider
         if ($this->packageDirectoryExistsAndIsNotEmpty('routes')) {
             $this->loadRoutesFrom($this->packageRoutesFile());
         }
+
+        $this->registerPackageBladeComponents();
 
         // Publishing is only necessary when using the CLI.
         if (app()->runningInConsole()) {
@@ -255,5 +260,14 @@ class ThemeServiceProvider extends ServiceProvider
 
         return config('backpack.ui.view_namespace') === $viewNamespace ||
             config('backpack.ui.view_namespace_fallback') === $viewNamespace;
+    }
+
+    public function registerPackageBladeComponents()
+    {
+        if($this->componentsNamespace) {
+            $this->app->afterResolving(BladeCompiler::class, function () {
+                Blade::componentNamespace($this->componentsNamespace, $this->packageName);
+            });
+        }
     }
 }

--- a/src/app/View/Components/MenuDropdown.php
+++ b/src/app/View/Components/MenuDropdown.php
@@ -18,6 +18,7 @@ class MenuDropdown extends Component
         public bool $open = false,
         public array $items = [],
         public bool $nested = false,
+        public bool $withColumns = false,
     ) {
     }
 


### PR DESCRIPTION
Themes had now way to register components. 

Now they do. 

I am not using this yet in tabler because I didn't wanted to force a new crud version so close to a new major version, so I will do that change when we bump versions in next major.