### PR TITLE
New column clipboard

### DIFF
--- a/src/resources/lang/ca/crud.php
+++ b/src/resources/lang/ca/crud.php
@@ -164,6 +164,10 @@ return [
     'select_entry' => 'Selecciona un element',
     'select_entries' => 'Selecciona elements',
     'upload_multiple_files_selected' => 'Files selected. After save, they will show up above.',
+    'clipboard' => [
+        'confirmation_message' => 'Element copiat correctament',
+        'error_message' => 'No s\'ha pogut copiar l\'element',
+    ],
 
     // Table field
     'table_cant_add' => 'No es pot afegir una nova :entity',

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -169,6 +169,10 @@ return [
     'select_entry' => 'Select an entry',
     'select_entries' => 'Select entries',
     'upload_multiple_files_selected' => 'Files selected. After save, they will show up above.',
+    'clipboard' => [
+        'confirmation_message' => 'Item copied successfully',
+        'error_message' => 'Failed to copy item',
+    ],
 
     //Table field
     'table_cant_add' => 'Cannot add new :entity',

--- a/src/resources/lang/es/crud.php
+++ b/src/resources/lang/es/crud.php
@@ -163,6 +163,10 @@ return [
     'new_item' => 'Nuevo elemento',
     'select_entry' => 'Selecciona un elemento',
     'select_entries' => 'Selecciona elementos',
+    'clipboard' => [
+        'confirmation_message' => 'Elemento copiado correctamente',
+        'error_message' => 'No se pudo copiar el elemento',
+    ],
 
     // Table field
     'table_cant_add' => 'No se puede agregar una nueva :entity',

--- a/src/resources/views/crud/columns/clipboard.blade.php
+++ b/src/resources/views/crud/columns/clipboard.blade.php
@@ -1,0 +1,59 @@
+{{-- regular object attribute --}}
+@php
+    $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
+    $column['escaped'] = $column['escaped'] ?? true;
+    $column['limit'] = $column['limit'] ?? 32;
+    $column['prefix'] = $column['prefix'] ?? '';
+    $column['suffix'] = $column['suffix'] ?? '';
+    $column['text'] = $column['default'] ?? '-';
+
+    if ($column['value'] instanceof \Closure) {
+        $column['value'] = $column['value']($entry);
+    }
+
+    if (is_array($column['value'])) {
+        $column['value'] = json_encode($column['value']);
+    }
+
+    if (!empty($column['value'])) {
+        $column['text'] = $column['prefix'] . Str::limit($column['value'], $column['limit'], '…') . $column['suffix'];
+    }
+@endphp
+
+<span onclick="copyToClipboard('{{ $column['text'] }}')" role="button">
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
+    @if ($column['escaped'])
+        {{ $column['text'] }}
+    @else
+        {!! $column['text'] !!}
+    @endif
+    <i class="las la-copy"></i>
+
+    @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_end')
+</span>
+
+@bassetBlock('backpack/crud/columns/clipboard.js')
+    <script>
+        const copyToClipboard = async (text) => {
+            try {
+                await navigator.clipboard.writeText(text);
+                new Noty({
+                    type: "success",
+                    text: `{!! '<strong>' .
+                        trans('backpack::base.success') .
+                        '</strong><br>' .
+                        trans('backpack::crud.clipboard.confirmation_message') !!}`
+                }).show();
+            } catch (error) {
+                console.error("Failed to copy to clipboard:", error);
+                new Noty({
+                    type: "error",
+                    text: `{!! '<strong>' .
+                        trans('backpack::base.error') .
+                        '</strong><br>' .
+                        trans('backpack::crud.clipboard.error_message') !!}`
+                }).show();
+            }
+        };
+    </script>
+@endBassetBlock


### PR DESCRIPTION
## WHY

I need a be able to copy the content of the column to the clipboard. Basically is a text column with an icon and on click the span copy the content to the clipboard.
Maybe this can be and optional parameter on the basic column text buy for now i created a separated column. 
Using a column this can be used in lists and in show view.
On click show a Noty to the user to report whether it was able to be copied or not
![image](https://github.com/Laravel-Backpack/CRUD/assets/20278289/36d1fea4-4319-4df6-9671-44d2c2b21200)


## HOW

### How did you achieve that, in technical terms?

Use javascript to copy text to clipboard using `await navigator.clipboard.writeText(text);`


### Is it a breaking change?

No


### How can we test the before & after?
Note: on localhost only show the error message. To work need https otherwise the browser will block the action.
```php
  [
        'name'  => 'name',
        'label' => trans('backpack.name'),
        'type' => 'clipboard',
  ],
```
