### PR TITLE
[WIP] add missing attribute on checkbox fields

### DIFF
--- a/src/resources/views/crud/fields/checkbox.blade.php
+++ b/src/resources/views/crud/fields/checkbox.blade.php
@@ -1,8 +1,6 @@
 {{-- checkbox field --}}
-
 @php
   $field['value'] = old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '';
-  $field['attributes']['class'] = $field['attributes']['class'] ?? 'form-check-input';
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
@@ -15,12 +13,8 @@
           @if ((bool)$field['value'])
             checked="checked"
           @endif
-
-          @if (isset($field['attributes']))
-            @foreach ($field['attributes'] as $attribute => $value)
-    			  {{ $attribute }}="{{ $value }}"
-        	  @endforeach
-          @endif
+          
+          @include('crud::fields.inc.attributes', ['default_class' => 'form-check-input'])
           >
     	  <label class="font-weight-normal fw-normal mb-0 ml-2 ms-2">{!! $field['label'] !!}</label>
 

--- a/src/resources/views/crud/fields/checklist.blade.php
+++ b/src/resources/views/crud/fields/checklist.blade.php
@@ -36,7 +36,11 @@
             <div class="col-sm-{{ intval(12/$field['number_of_columns']) }}">
                 <div class="checkbox">
                   <label class="font-weight-normal">
-                    <input type="checkbox" value="{{ $key }}"> {{ $option }}
+                    <input 
+                      type="checkbox" 
+                      value="{{ $key }}"
+                      @include('crud::fields.inc.attributes', ['default_class' => 'form-check-input'])
+                      > {{ $option }}
                   </label>
                 </div>
             </div>


### PR DESCRIPTION
Checkbox and Checkbox fields don't use the BS class `form-check-input`. 
Adding the class for Tabler was a non-issue because adding the form-check-input does not break anything and we are able to target the checkboxes without targeting "specific fields" (like the checkbox in a checklist or whatever). 

But it breaks for CoreUI's, because the themes provide the attribute styled, but we never used it, and now we would need to release a new CRUD and lock the themes (coreui v2 and v4) to v6.6.x. that I think at this time (very close to a new major), we better do it there I think. 