### PR TITLE
[v7] Reorder HasForm trait parameters

### DIFF
--- a/src/app/Http/Controllers/Operations/Concerns/HasForm.php
+++ b/src/app/Http/Controllers/Operations/Concerns/HasForm.php
@@ -18,13 +18,13 @@ trait HasForm
         $postFormMethod = 'post'.$operationName.'Form';
 
         Route::get($segment.$secondSegment.$thirdSegment, [
-            'as' => $routeName.'.'.$getFormMethod,
-            'uses' => $controller.'@'.$getFormMethod,
+            'as'        => $routeName.'.'.$getFormMethod,
+            'uses'      => $controller.'@'.$getFormMethod,
             'operation' => $operationName,
         ]);
         Route::post($segment.$secondSegment.$thirdSegment, [
-            'as' => $routeName.'.'.$postFormMethod,
-            'uses' => $controller.'@'.$postFormMethod,
+            'as'        => $routeName.'.'.$postFormMethod,
+            'uses'      => $controller.'@'.$postFormMethod,
             'operation' => $operationName,
         ]);
     }
@@ -50,7 +50,7 @@ trait HasForm
 
             // add a reasonable "save and back" save action
             $this->crud->addSaveAction([
-                'name' => 'save_and_back',
+                'name'    => 'save_and_back',
                 'visible' => function ($crud) use ($operationName) {
                     return $crud->hasAccess($operationName);
                 },
@@ -101,7 +101,7 @@ trait HasForm
      *
      * @return array|\Illuminate\Http\RedirectResponse
      */
-    public function formAction(?int $id = null, callable $formLogic)
+    public function formAction(callable $formLogic, ?int $id = null)
     {
         if ($id) {
             // Get entry ID from Request (makes sure its the last ID for nested resources)

--- a/src/app/Http/Controllers/Operations/Concerns/HasForm.php
+++ b/src/app/Http/Controllers/Operations/Concerns/HasForm.php
@@ -18,13 +18,13 @@ trait HasForm
         $postFormMethod = 'post'.$operationName.'Form';
 
         Route::get($segment.$secondSegment.$thirdSegment, [
-            'as'        => $routeName.'.'.$getFormMethod,
-            'uses'      => $controller.'@'.$getFormMethod,
+            'as' => $routeName.'.'.$getFormMethod,
+            'uses' => $controller.'@'.$getFormMethod,
             'operation' => $operationName,
         ]);
         Route::post($segment.$secondSegment.$thirdSegment, [
-            'as'        => $routeName.'.'.$postFormMethod,
-            'uses'      => $controller.'@'.$postFormMethod,
+            'as' => $routeName.'.'.$postFormMethod,
+            'uses' => $controller.'@'.$postFormMethod,
             'operation' => $operationName,
         ]);
     }
@@ -50,7 +50,7 @@ trait HasForm
 
             // add a reasonable "save and back" save action
             $this->crud->addSaveAction([
-                'name'    => 'save_and_back',
+                'name' => 'save_and_back',
                 'visible' => function ($crud) use ($operationName) {
                     return $crud->hasAccess($operationName);
                 },


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Optional parameters before required are deprecated. They are "technically" required as pointed in #5458 . 

### AFTER - What is happening after this PR?

We change the order of the parameters. It's a breaking change. 
In preparation for that, I've created https://github.com/Laravel-Backpack/Generators/pull/204 that from now on will generate the stub with named parameters. 

That way, this will not be a breaking change for developers that create their new forms with the command as the named parameters will ensure no breaking change for them. 
