### PR TITLE
Make swal buttons all look similar

### DIFF
--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -23,7 +23,21 @@
 		  title: "{!! trans('backpack::base.warning') !!}",
 		  text: "{!! trans('backpack::crud.delete_confirm') !!}",
 		  icon: "warning",
-		  buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+		  buttons: {
+		  cancel: {
+				  text: "{!! trans('backpack::crud.cancel') !!}",
+				  value: null,
+				  visible: true,
+				  className: "bg-secondary",
+				  closeModal: true,
+				},
+			  	delete: {
+				  text: "{!! trans('backpack::crud.delete') !!}",
+				  value: true,
+				  visible: true,
+				  className: "bg-danger",
+				},
+			},
 		  dangerMode: true,
 		}).then((value) => {
 			if (value) {

--- a/src/resources/views/crud/buttons/delete.blade.php
+++ b/src/resources/views/crud/buttons/delete.blade.php
@@ -24,18 +24,18 @@
 		  text: "{!! trans('backpack::crud.delete_confirm') !!}",
 		  icon: "warning",
 		  buttons: {
-		  cancel: {
-				  text: "{!! trans('backpack::crud.cancel') !!}",
-				  value: null,
-				  visible: true,
-				  className: "bg-secondary",
-				  closeModal: true,
-				},
-			  	delete: {
-				  text: "{!! trans('backpack::crud.delete') !!}",
-				  value: true,
-				  visible: true,
-				  className: "bg-danger",
+		  	cancel: {
+				text: "{!! trans('backpack::crud.cancel') !!}",
+				value: null,
+				visible: true,
+				className: "bg-secondary",
+				closeModal: true,
+			},
+			delete: {
+				text: "{!! trans('backpack::crud.delete') !!}",
+				value: true,
+				visible: true,
+				className: "bg-danger",
 				},
 			},
 		  dangerMode: true,

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -120,7 +120,21 @@
             title: "{!! trans('backpack::base.warning') !!}",
             text: "{!! trans('backpack::crud.delete_confirm') !!}",
             icon: "warning",
-            buttons: ["{!! trans('backpack::crud.cancel') !!}", "{!! trans('backpack::crud.delete') !!}"],
+            buttons: {
+		  	cancel: {
+				text: "{!! trans('backpack::crud.cancel') !!}",
+				value: null,
+				visible: true,
+				className: "bg-secondary",
+				closeModal: true,
+			},
+			delete: {
+				text: "{!! trans('backpack::crud.delete') !!}",
+				value: true,
+				visible: true,
+				className: "bg-danger",
+				},
+			},
             dangerMode: true,
         }).then((value) => {
             if (value) {


### PR DESCRIPTION
Some swals had the `bg-secondary` on the cancel button, others don't. 

That was creating weird looks across the app, even more noticeable using dark theme. 

I think we should wrap the swals in our application in a BackpackSwal Component, allowing us to use less code/repetition to trigger similar modals. 

This is the "cheap way" for now to fix it. 