### PR TITLE
Check if uploader column is translatable in translation enabled models

### DIFF
--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -288,17 +288,23 @@ abstract class Uploader implements UploaderInterface
 
     private function getOriginalValue(Model $entry, $field = null)
     {
+        $field = $field ?? $this->getAttributeName();
+        
         if ($this->updatedPreviousFiles !== null) {
             return $this->updatedPreviousFiles;
         }
 
-        $previousValue = $entry->getOriginal($field ?? $this->getAttributeName());
+        $previousValue = $entry->getOriginal($field);
 
         if (! $previousValue) {
             return $previousValue;
         }
 
-        if (method_exists($entry, 'translationEnabled') && $entry->translationEnabled()) {
+        if (
+            method_exists($entry, 'translationEnabled') && 
+            $entry->translationEnabled() &&
+            $entry->isTranslatableAttribute($field)
+        ) {
             return $previousValue[$entry->getLocale()] ?? null;
         }
 

--- a/src/app/Library/Uploaders/Uploader.php
+++ b/src/app/Library/Uploaders/Uploader.php
@@ -288,7 +288,7 @@ abstract class Uploader implements UploaderInterface
 
     private function getOriginalValue(Model $entry, $field = null)
     {
-        $field = $field ?? $this->getAttributeName();
+        $field ??= $this->getAttributeName();
         
         if ($this->updatedPreviousFiles !== null) {
             return $this->updatedPreviousFiles;


### PR DESCRIPTION
## WHY

Because there was a bug, reported in #5466 

### BEFORE - What was wrong? What was happening before this PR?

On create it works as expected but on update I get a "Integrity constraint violation column cannot be null" on the uploader not translated column even when the validation and content are ok.

### AFTER - What is happening after this PR?

The reported bug is fixed.


## HOW

### How did you achieve that, in technical terms?

Adding a check in the `Uploader::getOriginalValue` method. It checks, on top of the validation that the model is translatable and the translation is enabled that the uploader field is a translatable attribute.


### Is it a breaking change?

No.


### How can we test the before & after?

Enabling/disabling the if check that I added in the `Uploader::getOriginalValue` and updating a translatable model with a non translated uploader attribute.