### PR TITLE
fix PHPDoc CrudController

### DIFF
--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -9,11 +9,10 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
 
 /**
- * Class CrudController
+ * Class CrudController.
  *
  * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
  * @property array $data
- * @package Backpack\CRUD\app\Http\Controllers
  */
 class CrudController extends Controller
 {

--- a/src/app/Http/Controllers/CrudController.php
+++ b/src/app/Http/Controllers/CrudController.php
@@ -8,13 +8,17 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Str;
 
+/**
+ * Class CrudController
+ *
+ * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
+ * @property array $data
+ * @package Backpack\CRUD\app\Http\Controllers
+ */
 class CrudController extends Controller
 {
     use DispatchesJobs, ValidatesRequests;
 
-    /**
-     * @var \Backpack\CRUD\app\Library\CrudPanel\CrudPanel
-     */
     public $crud;
     public $data = [];
 


### PR DESCRIPTION
## WHY

Simplifying PHPDoc.

### BEFORE - What was wrong? What was happening before this PR?

Now we need to add a PHPDoc block to each CrudController class:

~~~php
/**
 * Class DummyClassCrudController
 * @package App\Http\Controllers\Admin
 * @property-read \Backpack\CRUD\app\Library\CrudPanel\CrudPanel $crud
 */
class DummyClassCrudController extends CrudController
{
    public function setup()
    {
        $this->crud->[ _autocomplete_works_ ];
    }
}
~~~

### AFTER - What is happening after this PR?

After the patch, it will no longer be necessary to add a PHPDoc block to each CrudController class:
~~~php
class DummyClassCrudController extends CrudController
{
    public function setup()
    {
        $this->crud->[ _autocomplete_works_ ];
    }
}
~~~

### Is it a breaking change?

No


### How can we test the before & after?

Check autocomplete in PhpStorm or another IDE.

