### PR TITLE
Remove bcrypt() calls use Hash

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -35,7 +35,7 @@
   </source>
   <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BCRYPT_ROUNDS" value="12"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -7,6 +7,7 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
 class RegisterController extends Controller
@@ -76,7 +77,7 @@ class RegisterController extends Controller
         return $user->create([
             'name' => $data['name'],
             backpack_authentication_column() => $data[backpack_authentication_column()],
-            'password' => bcrypt($data['password']),
+            'password' => Hash::make($data['password']),
         ]);
     }
 

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -13,6 +13,7 @@ use Backpack\CRUD\Tests\config\Models\User;
 use Faker\Factory;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Hash;
 
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Create
@@ -132,7 +133,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
         ];
 
         $entry = $this->crudPanel->create($inputData);
@@ -152,7 +153,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'accountDetails' => [
                 'nickname' => $account_details_nickname,
                 'profile_picture' => 'test.jpg',
@@ -184,7 +185,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'accountDetails' => [
                 ['nickname' => $account_details_nickname, 'profile_picture' => 'test.jpg'],
             ],
@@ -251,7 +252,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
         ];
@@ -336,7 +337,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
             'accountDetails' => [
@@ -398,7 +399,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'bills' => [1],
         ];
@@ -434,7 +435,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'recommends' => [
                 [
@@ -492,7 +493,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'superArticles' => [
                 [
@@ -560,7 +561,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
             'accountDetails' => [
@@ -630,7 +631,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'bang_relation_field' => 1,
         ];
@@ -689,7 +690,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
             'accountDetails' => [
@@ -734,7 +735,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
             'accountDetails' => [
@@ -778,7 +779,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'comment' => [
                 'text' => 'some test comment text',
@@ -814,7 +815,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'stars' => [
                 [
@@ -867,7 +868,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'universes' => [
                 [
@@ -952,7 +953,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'planets' => [1, 2],
         ];
@@ -987,7 +988,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'planets' => [1, 2],
         ];
@@ -1052,7 +1053,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'incomes' => [
                 [
@@ -1141,7 +1142,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'planets' => [1, 2],
         ];
@@ -1175,7 +1176,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'planets' => [1, 2],
         ];
@@ -1208,7 +1209,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'comets' => [1, 2],
         ];
@@ -1242,7 +1243,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'planetsNonNullable' => [1, 2],
         ];
@@ -1282,7 +1283,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'universes' => [
                 [
@@ -1335,7 +1336,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'roles' => [1, 2],
             'accountDetails' => [
@@ -1383,7 +1384,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $inputData = [
             'name' => $faker->name,
             'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
             'superArticles' => [
                 [

--- a/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
@@ -33,27 +33,27 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
 
     private $expectedUpdatedFields = [
         'id' => [
-            'name'   => 'id',
-            'type'   => 'hidden',
-            'label'  => 'Id',
+            'name' => 'id',
+            'type' => 'hidden',
+            'label' => 'Id',
             'entity' => false,
         ],
         'name' => [
-            'name'   => 'name',
-            'label'  => 'Name',
-            'type'   => 'text',
+            'name' => 'name',
+            'label' => 'Name',
+            'type' => 'text',
             'entity' => false,
         ],
         'email' => [
-            'name'   => 'email',
-            'type'   => 'email',
-            'label'  => 'Email',
+            'name' => 'email',
+            'type' => 'email',
+            'label' => 'Email',
             'entity' => false,
         ],
         'password' => [
-            'name'   => 'password',
-            'type'   => 'password',
-            'label'  => 'Password',
+            'name' => 'password',
+            'type' => 'password',
+            'label' => 'Password',
             'entity' => false,
         ],
     ];
@@ -64,8 +64,8 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name'     => $faker->name,
-            'email'    => $faker->safeEmail,
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
             'password' => Hash::make($faker->password()),
         ];
 
@@ -83,8 +83,8 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name'     => $faker->name,
-            'email'    => $faker->safeEmail,
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
             'password' => Hash::make($faker->password()),
         ];
 
@@ -98,8 +98,8 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name'     => $faker->name,
-            'email'    => $faker->safeEmail,
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
             'password' => Hash::make($faker->password()),
         ];
         $entry = $this->crudPanel->create($inputData);
@@ -132,10 +132,10 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ], [
             'name' => 'tags',
         ], [
-            'label'     => 'Author',
-            'type'      => 'select',
-            'name'      => 'user_id',
-            'entity'    => 'user',
+            'label' => 'Author',
+            'type' => 'select',
+            'name' => 'user_id',
+            'entity' => 'user',
             'attribute' => 'name',
         ], [
             'name' => 'status',
@@ -149,16 +149,16 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ]);
         $faker = Factory::create();
         $inputData = [
-            'content'     => $faker->text(),
-            'tags'        => $faker->words(3, true),
-            'user_id'     => 1,
-            'metas'       => null,
-            'extras'      => null,
-            'status'      => 'publish',
-            'state'       => 'COLD',
-            'style'       => 'DRAFT',
-            'cast_metas'  => null,
-            'cast_tags'   => null,
+            'content' => $faker->text(),
+            'tags' => $faker->words(3, true),
+            'user_id' => 1,
+            'metas' => null,
+            'extras' => null,
+            'status' => 'publish',
+            'state' => 'COLD',
+            'style' => 'DRAFT',
+            'cast_metas' => null,
+            'cast_tags' => null,
             'cast_extras' => null,
         ];
         $article = $this->crudPanel->create($inputData);

--- a/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelUpdateTest.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\Tests\config\Models\User;
 use Faker\Factory;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Update
@@ -32,27 +33,27 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
 
     private $expectedUpdatedFields = [
         'id' => [
-            'name' => 'id',
-            'type' => 'hidden',
-            'label' => 'Id',
+            'name'   => 'id',
+            'type'   => 'hidden',
+            'label'  => 'Id',
             'entity' => false,
         ],
         'name' => [
-            'name' => 'name',
-            'label' => 'Name',
-            'type' => 'text',
+            'name'   => 'name',
+            'label'  => 'Name',
+            'type'   => 'text',
             'entity' => false,
         ],
         'email' => [
-            'name' => 'email',
-            'type' => 'email',
-            'label' => 'Email',
+            'name'   => 'email',
+            'type'   => 'email',
+            'label'  => 'Email',
             'entity' => false,
         ],
         'password' => [
-            'name' => 'password',
-            'type' => 'password',
-            'label' => 'Password',
+            'name'   => 'password',
+            'type'   => 'password',
+            'label'  => 'Password',
             'entity' => false,
         ],
     ];
@@ -63,9 +64,9 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name' => $faker->name,
-            'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'name'     => $faker->name,
+            'email'    => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
         ];
 
         $entry = $this->crudPanel->update(1, $inputData);
@@ -82,9 +83,9 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name' => $faker->name,
-            'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'name'     => $faker->name,
+            'email'    => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
         ];
 
         $unknownId = DB::getPdo()->lastInsertId() + 2;
@@ -97,9 +98,9 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->addFields($this->userInputFields);
         $faker = Factory::create();
         $inputData = [
-            'name' => $faker->name,
-            'email' => $faker->safeEmail,
-            'password' => bcrypt($faker->password()),
+            'name'     => $faker->name,
+            'email'    => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
         ];
         $entry = $this->crudPanel->create($inputData);
         $this->addValuesToExpectedFields($entry->id, $inputData);
@@ -131,10 +132,10 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ], [
             'name' => 'tags',
         ], [
-            'label' => 'Author',
-            'type' => 'select',
-            'name' => 'user_id',
-            'entity' => 'user',
+            'label'     => 'Author',
+            'type'      => 'select',
+            'name'      => 'user_id',
+            'entity'    => 'user',
             'attribute' => 'name',
         ], [
             'name' => 'status',
@@ -148,16 +149,16 @@ class CrudPanelUpdateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ]);
         $faker = Factory::create();
         $inputData = [
-            'content' => $faker->text(),
-            'tags' => $faker->words(3, true),
-            'user_id' => 1,
-            'metas' => null,
-            'extras' => null,
-            'status' => 'publish',
-            'state' => 'COLD',
-            'style' => 'DRAFT',
-            'cast_metas' => null,
-            'cast_tags' => null,
+            'content'     => $faker->text(),
+            'tags'        => $faker->words(3, true),
+            'user_id'     => 1,
+            'metas'       => null,
+            'extras'      => null,
+            'status'      => 'publish',
+            'state'       => 'COLD',
+            'style'       => 'DRAFT',
+            'cast_metas'  => null,
+            'cast_tags'   => null,
             'cast_extras' => null,
         ];
         $article = $this->crudPanel->create($inputData);

--- a/tests/config/database/seeds/UsersTableSeeder.php
+++ b/tests/config/database/seeds/UsersTableSeeder.php
@@ -20,23 +20,23 @@ class UsersTableSeeder extends Seeder
         $now = \Carbon\Carbon::now();
 
         DB::table('users')->insert([[
-            'id'             => 1,
-            'name'           => $faker->name,
-            'email'          => $faker->unique()->safeEmail,
-            'password'       => Hash::make('secret'),
+            'id' => 1,
+            'name' => $faker->name,
+            'email' => $faker->unique()->safeEmail,
+            'password' => Hash::make('secret'),
             'remember_token' => Str::random(10),
-            'created_at'     => $now,
-            'updated_at'     => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
         ]]);
 
         DB::table('users')->insert([[
-            'id'             => 2,
-            'name'           => $faker->name,
-            'email'          => $faker->unique()->safeEmail,
-            'password'       => Hash::make('secret'),
+            'id' => 2,
+            'name' => $faker->name,
+            'email' => $faker->unique()->safeEmail,
+            'password' => Hash::make('secret'),
             'remember_token' => Str::random(10),
-            'created_at'     => $now,
-            'updated_at'     => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
         ]]);
 
         DB::table('user_role')->insert([
@@ -54,16 +54,16 @@ class UsersTableSeeder extends Seeder
         ]);
 
         DB::table('account_details')->insert([
-            'user_id'         => 1,
-            'nickname'        => $faker->firstName(),
+            'user_id' => 1,
+            'nickname' => $faker->firstName(),
             'profile_picture' => $faker->imageUrl(),
         ]);
 
         DB::table('addresses')->insert([
             'account_details_id' => 1,
-            'city'               => $faker->city,
-            'street'             => $faker->streetName,
-            'number'             => $faker->randomDigitNotNull,
+            'city' => $faker->city,
+            'street' => $faker->streetName,
+            'number' => $faker->randomDigitNotNull,
         ]);
     }
 }

--- a/tests/config/database/seeds/UsersTableSeeder.php
+++ b/tests/config/database/seeds/UsersTableSeeder.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\Tests\Config\Database\Seeds;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 class UsersTableSeeder extends Seeder
@@ -19,23 +20,23 @@ class UsersTableSeeder extends Seeder
         $now = \Carbon\Carbon::now();
 
         DB::table('users')->insert([[
-            'id' => 1,
-            'name' => $faker->name,
-            'email' => $faker->unique()->safeEmail,
-            'password' => bcrypt('secret'),
+            'id'             => 1,
+            'name'           => $faker->name,
+            'email'          => $faker->unique()->safeEmail,
+            'password'       => Hash::make('secret'),
             'remember_token' => Str::random(10),
-            'created_at' => $now,
-            'updated_at' => $now,
+            'created_at'     => $now,
+            'updated_at'     => $now,
         ]]);
 
         DB::table('users')->insert([[
-            'id' => 2,
-            'name' => $faker->name,
-            'email' => $faker->unique()->safeEmail,
-            'password' => bcrypt('secret'),
+            'id'             => 2,
+            'name'           => $faker->name,
+            'email'          => $faker->unique()->safeEmail,
+            'password'       => Hash::make('secret'),
             'remember_token' => Str::random(10),
-            'created_at' => $now,
-            'updated_at' => $now,
+            'created_at'     => $now,
+            'updated_at'     => $now,
         ]]);
 
         DB::table('user_role')->insert([
@@ -53,16 +54,16 @@ class UsersTableSeeder extends Seeder
         ]);
 
         DB::table('account_details')->insert([
-            'user_id' => 1,
-            'nickname' => $faker->firstName(),
+            'user_id'         => 1,
+            'nickname'        => $faker->firstName(),
             'profile_picture' => $faker->imageUrl(),
         ]);
 
         DB::table('addresses')->insert([
             'account_details_id' => 1,
-            'city' => $faker->city,
-            'street' => $faker->streetName,
-            'number' => $faker->randomDigitNotNull,
+            'city'               => $faker->city,
+            'street'             => $faker->streetName,
+            'number'             => $faker->randomDigitNotNull,
         ]);
     }
 }


### PR DESCRIPTION
We were forcing the `bcrypt()` hashing algorithm by using `bcrypt()` helper instead of the `Hash` Facade to encrypt password. 

That made impossible to change the app encryption as reported in https://github.com/Laravel-Backpack/community-forum/issues/895