### PR TITLE
initialize the variable as an empty array

### DIFF
--- a/src/app/Library/Database/Table.php
+++ b/src/app/Library/Database/Table.php
@@ -5,7 +5,7 @@ namespace Backpack\CRUD\app\Library\Database;
 final class Table
 {
     private string $name;
-    private array $columns;
+    private array $columns = [];
 
     public function __construct(string $name, array $columns = [])
     {


### PR DESCRIPTION
Reported in #5480 

I spent quite sometime trying to reproduce this issue. 

It's was only possible to get this error if you were able to create a table without columns at all, thing that is not allowed at least in mysql and sqlite. 

Apparently pgsql allow you to create an empty table, not sure if that's the case in the reported issue, it doesn't matter 🤷 

We just init the columns to an empty array to fix this.

