### PR TITLE
Set/Force the extension to JS/CSS on scripts and styles

### DIFF
--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -8,7 +8,7 @@
         @if(is_array($path))
             @basset(...$path)
         @else
-            @basset($path)
+            @basset(asset: $path, extension: 'js')
         @endif
     @endforeach
 @endif

--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -8,7 +8,7 @@
         @if(is_array($path))
             @basset(...$path)
         @else
-            @basset(asset: $path, extension: 'js')
+            @basset($path, true, [], 'js')
         @endif
     @endforeach
 @endif

--- a/src/resources/views/ui/inc/styles.blade.php
+++ b/src/resources/views/ui/inc/styles.blade.php
@@ -19,7 +19,7 @@
         @if(is_array($path))
             @basset(...$path)
         @else
-            @basset($path)
+            @basset(asset: $path, extension: 'css')
         @endif
     @endforeach
 @endif

--- a/src/resources/views/ui/inc/styles.blade.php
+++ b/src/resources/views/ui/inc/styles.blade.php
@@ -19,7 +19,7 @@
         @if(is_array($path))
             @basset(...$path)
         @else
-            @basset(asset: $path, extension: 'css')
+            @basset($path, true, [], 'css')
         @endif
     @endforeach
 @endif


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Fixes https://github.com/Laravel-Backpack/basset/issues/116 along with https://github.com/Laravel-Backpack/basset/pull/117.

This will force the loaded scripts to be `js` type, and styles to be `css` type.

This way scripts like tailwind: `https://cdn.tailwindcss.com/3.4.3` which has no extension, can be rendered as a script.

Test:

![image](https://github.com/Laravel-Backpack/CRUD/assets/1838187/3d3c9cb7-4713-4a99-897b-833a45449f14)

### Is it a breaking change?

No, it will work with older code/version of Basset.


### How can we test the before & after?

Load the `https://cdn.tailwindcss.com/3.4.3` script on `scripts.blade.php`.