### PR TITLE
Add mariadb to the list, as Laravel support thats driver now

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -177,7 +177,7 @@ class CrudPanel
      */
     public function getSqlDriverList()
     {
-        return ['mysql', 'sqlsrv', 'sqlite', 'pgsql'];
+        return ['mysql', 'sqlsrv', 'sqlite', 'pgsql', 'mariadb'];
     }
 
     /**


### PR DESCRIPTION
On this issue https://github.com/Laravel-Backpack/community-forum/issues/920 is a problem when use mariadb driver, Laravel 11 support thats driver now, but we havent add it to our SQL list.

Cheers.