### PR TITLE
[HOT-FIX] basset not properly working with cdn links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "laravel/framework": "^10.0|^11.0",
         "prologue/alerts": "^1.0",
-        "backpack/basset": "^1.1.1|^1.3",
+        "backpack/basset": "^1.1.1|^1.3.1",
         "creativeorange/gravatar": "~1.0",
         "doctrine/dbal": "^3.0|^4.0",
         "guzzlehttp/guzzle": "^7.0"


### PR DESCRIPTION
Recently some cdns stopped working with request that included the cache bust string. 
https://github.com/Laravel-Backpack/community-forum/issues/928


We fixed it upstream in basset. 