### PR TITLE
Bump basset version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "laravel/framework": "^10.0|^11.0",
         "prologue/alerts": "^1.0",
-        "backpack/basset": "^1.1.1|^1.3.1",
+        "backpack/basset": "^1.1.1|^1.3.2",
         "creativeorange/gravatar": "~1.0",
         "doctrine/dbal": "^3.0|^4.0",
         "guzzlehttp/guzzle": "^7.0"


### PR DESCRIPTION
We introduced a BC in basset 1.3.1. 

I've already fixed it in 1.3.2 that we are now requiring as minimum version. 