### PR TITLE
dont output the spinner svg when loaded with @basset()

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -13,7 +13,7 @@
   @basset('https://cdn.datatables.net/fixedheader/3.3.1/js/dataTables.fixedHeader.min.js')
   @basset('https://cdn.datatables.net/fixedheader/3.3.1/css/fixedHeader.dataTables.min.css')
 
-  @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'))
+  @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
 
   <script>
     // here we will check if the cached dataTables paginator length is conformable with current paginator settings.


### PR DESCRIPTION
Reported in https://github.com/Laravel-Backpack/theme-coreuiv2/issues/37

Since we added support to output SVGs in basset, this spinner started to display in the page. 

We probably do something in Tabler to prevent it from showing, but in CoreUI-v2/v4 the spinner displayed under the table. 

The solution is to tell Basset to don't output the svg at this time. We will get this asset later with `Basset::getUrl()` on the datatable script initialization.

