### PR TITLE
Validate length parameter server side

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -79,6 +79,11 @@ trait ListOperation
         $length = (int) request()->input('length');
         $search = request()->input('search');
 
+        // we get the max length from the page length menu possibilities
+        $maxLength = $this->crud->maxPageLength();
+
+        $length = $maxLength === -1 ? $length : ($length > $maxLength ? $maxLength : $length);
+
         // if a search term was present
         if ($search && $search['value'] ?? false) {
             // filter the results accordingly

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -79,10 +79,12 @@ trait ListOperation
         $length = (int) request()->input('length');
         $search = request()->input('search');
 
-        // we get the max length from the page length menu possibilities
-        $maxLength = $this->crud->maxPageLength();
-
-        $length = $maxLength === -1 ? $length : ($length > $maxLength ? $maxLength : $length);
+        // check if length is allowed by developer
+        if ($length && ! in_array($length, $this->crud->getPageLengthMenu()[0])) {
+            return response()->json([
+                'error' => 'Unknown page length.',
+            ], 400);
+        }
 
         // if a search term was present
         if ($search && $search['value'] ?? false) {

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -226,11 +226,11 @@ trait Read
     {
         $pageLengthMenu = $this->getPageLengthMenu();
 
-        if(in_array(-1, $pageLengthMenu[0])) {
+        if (in_array(-1, $pageLengthMenu[0])) {
             return -1;
         }
 
-        return (int)max($pageLengthMenu[0]);
+        return (int) max($pageLengthMenu[0]);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -219,6 +219,21 @@ trait Read
     }
 
     /**
+     * Get the higher limit from the page length menu.
+     * -1 means "All" so if present it means no limit.
+     */
+    public function maxPageLength(): int
+    {
+        $pageLengthMenu = $this->getPageLengthMenu();
+
+        if(in_array(-1, $pageLengthMenu[0])) {
+            return -1;
+        }
+
+        return (int)max($pageLengthMenu[0]);
+    }
+
+    /**
      * If a custom page length was specified as default, make sure it
      * also show up in the page length menu.
      */

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -219,21 +219,6 @@ trait Read
     }
 
     /**
-     * Get the higher limit from the page length menu.
-     * -1 means "All" so if present it means no limit.
-     */
-    public function maxPageLength(): int
-    {
-        $pageLengthMenu = $this->getPageLengthMenu();
-
-        if (in_array(-1, $pageLengthMenu[0])) {
-            return -1;
-        }
-
-        return (int) max($pageLengthMenu[0]);
-    }
-
-    /**
      * If a custom page length was specified as default, make sure it
      * also show up in the page length menu.
      */


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/community-forum/discussions/939#discussioncomment-9129888

There was no server side validation for the `length` parameter, so one could just change the parameter in the URL and fetch more information from the server at once than what the developer would have intended. 

It's not that the user does not have access to that information, as he can just keep going page after page, so I wouldn't consider this a "security" issue.
But it can indeed be a "performance" issue, if some user started requesting millions of rows at the same time when you allowed MAX 30 for example, in your page length menu.  