### PR TITLE
DB schema was loading ALL tables when not necessary

### DIFF
--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\Database;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 
@@ -12,11 +13,11 @@ final class DatabaseSchema
     /**
      * Return the schema for the table.
      */
-    public static function getForTable(string $connection, string $table)
+    public static function getForTable(string $table, string $connection)
     {
         $connection = $connection ?: config('database.default');
 
-        self::generateDatabaseSchema($connection);
+        self::generateDatabaseSchema($connection, $table);
 
         return self::$schema[$connection][$table] ?? null;
     }
@@ -24,16 +25,27 @@ final class DatabaseSchema
     public static function getTables(string $connection = null): array
     {
         $connection = $connection ?: config('database.default');
-        self::generateDatabaseSchema($connection);
 
-        return self::$schema[$connection] ?? [];
+        self::$schema[$connection] = LazyCollection::make(self::getCreateSchema($connection)->getTables())->mapWithKeys(function ($table, $key) use ($connection) {
+            $tableName = is_array($table) ? $table['name'] : $table->getName();
+
+            if ($existingTable = self::$schema[$connection][$tableName] ?? false) {
+                return [$tableName => $existingTable];
+            }
+           
+            $table = self::mapTable($connection, $tableName);
+
+            return [$tableName => $table];
+        })->toArray();
+
+        return self::$schema[$connection];
     }
 
     public function listTableColumnsNames(string $connection, string $table)
     {
-        $table = self::getForTable($connection, $table);
+        $table = self::getForTable($table, $connection);
 
-        return array_keys($table->getColumns());
+        return $table ? array_keys($table->getColumns()) : [];
     }
 
     public function listTableIndexes(string $connection, string $table)
@@ -51,59 +63,53 @@ final class DatabaseSchema
     /**
      * Generates and store the database schema.
      */
-    private static function generateDatabaseSchema(string $connection)
+    private static function generateDatabaseSchema(string $connection, string $table)
     {
-        if (! isset(self::$schema[$connection])) {
-            self::$schema[$connection] = self::mapTables($connection);
+        if (! isset(self::$schema[$connection][$table])) {
+            self::$schema[$connection][$table] = self::mapTable($connection, $table);
         }
     }
 
-    /**
-     * Map the tables from raw db values into an usable array.
-     *
-     * @param  string  $connection
-     * @return array
-     */
-    private static function mapTables(string $connection)
+    private static function mapTable(string $connection, string $tableName)
     {
-        return LazyCollection::make(self::getCreateSchema($connection)->getTables())->mapWithKeys(function ($table, $key) use ($connection) {
-            $tableName = is_array($table) ? $table['name'] : $table->getName();
+        try {
+            $table = method_exists(self::getCreateSchema($connection), 'getTable') ? 
+                        self::getCreateSchema($connection)->getTable($tableName) : 
+                        self::getCreateSchema($connection)->getColumns($tableName);
+        } catch (\Exception $e) {
+            return new Table($tableName, []);
+        }
+ 
+        if(!is_array($table) || empty($table)) {
+            return $table;
+        }
 
-            if (self::$schema[$connection][$tableName] ?? false) {
-                return [$tableName => self::$schema[$connection][$tableName]];
-            }
+        $schemaManager = self::getSchemaManager($connection);
+        $indexes = $schemaManager->getIndexes($tableName);
 
-            if (is_array($table)) {
-                $table = new Table($tableName, self::mapTableColumns($connection, $tableName));
-            }
+        $indexes = array_map(function ($index) {
+            return $index['columns'];
+        }, $indexes);
 
-            return [$tableName => $table];
-        })->toArray();
+        $table = new Table($tableName, $table);
+        
+        $indexes = Arr::flatten($indexes);
+        $table->setIndexes(array_unique($indexes));
+
+        return $table;
     }
 
     private static function getIndexColumnNames(string $connection, string $table)
     {
-        $schemaManager = self::getSchemaManager($connection);
-        $indexes = method_exists($schemaManager, 'listTableIndexes') ? $schemaManager->listTableIndexes($table) : $schemaManager->getIndexes($table);
+        self::generateDatabaseSchema($connection, $table);
 
-        $indexes = array_map(function ($index) {
-            return is_array($index) ? $index['columns'] : $index->getColumns();
-        }, $indexes);
-
-        $indexes = \Illuminate\Support\Arr::flatten($indexes);
+        $indexes = self::$schema[$connection][$table]->getIndexes();
+        
+        $indexes = \Illuminate\Support\Arr::flatten(array_map(function ($index) {
+            return is_string($index) ? $index : $index->getColumns();
+        }, $indexes));
 
         return array_unique($indexes);
-    }
-
-    private static function mapTableColumns(string $connection, string $table)
-    {
-        $indexedColumns = self::getIndexColumnNames($connection, $table);
-
-        return LazyCollection::make(self::getSchemaManager($connection)->getColumns($table))->mapWithKeys(function ($column, $key) use ($indexedColumns) {
-            $column['index'] = array_key_exists($column['name'], $indexedColumns) ? true : false;
-
-            return [$column['name'] => $column];
-        })->toArray();
     }
 
     private static function getCreateSchema(string $connection)

--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -32,7 +32,7 @@ final class DatabaseSchema
             if ($existingTable = self::$schema[$connection][$tableName] ?? false) {
                 return [$tableName => $existingTable];
             }
-           
+
             $table = self::mapTable($connection, $tableName);
 
             return [$tableName => $table];
@@ -73,14 +73,14 @@ final class DatabaseSchema
     private static function mapTable(string $connection, string $tableName)
     {
         try {
-            $table = method_exists(self::getCreateSchema($connection), 'getTable') ? 
-                        self::getCreateSchema($connection)->getTable($tableName) : 
+            $table = method_exists(self::getCreateSchema($connection), 'getTable') ?
+                        self::getCreateSchema($connection)->getTable($tableName) :
                         self::getCreateSchema($connection)->getColumns($tableName);
         } catch (\Exception $e) {
             return new Table($tableName, []);
         }
- 
-        if(!is_array($table) || empty($table)) {
+
+        if (! is_array($table) || empty($table)) {
             return $table;
         }
 
@@ -92,7 +92,7 @@ final class DatabaseSchema
         }, $indexes);
 
         $table = new Table($tableName, $table);
-        
+
         $indexes = Arr::flatten($indexes);
         $table->setIndexes(array_unique($indexes));
 
@@ -104,7 +104,7 @@ final class DatabaseSchema
         self::generateDatabaseSchema($connection, $table);
 
         $indexes = self::$schema[$connection][$table]->getIndexes();
-        
+
         $indexes = \Illuminate\Support\Arr::flatten(array_map(function ($index) {
             return is_string($index) ? $index : $index->getColumns();
         }, $indexes));

--- a/src/app/Library/Database/Table.php
+++ b/src/app/Library/Database/Table.php
@@ -6,6 +6,7 @@ final class Table
 {
     private string $name;
     private array $columns = [];
+    private array $indexes = [];
 
     public function __construct(string $name, array $columns = [])
     {
@@ -73,5 +74,15 @@ final class Table
     public function getColumn(string $columnName)
     {
         return $this->columns[$columnName];
+    }
+
+    public function getIndexes()
+    {
+        return $this->indexes;
+    }
+
+    public function setIndexes(array $indexes)
+    {
+        $this->indexes = $indexes;
     }
 }

--- a/src/app/Library/Database/TableSchema.php
+++ b/src/app/Library/Database/TableSchema.php
@@ -9,7 +9,7 @@ class TableSchema
 
     public function __construct(string $connection, string $table)
     {
-        $this->schema = app('DatabaseSchema')->getForTable($connection, $table);
+        $this->schema = app('DatabaseSchema')->getForTable($table, $connection);
     }
 
     /**
@@ -66,7 +66,7 @@ class TableSchema
      */
     public function columnIsNullable($columnName)
     {
-        if (! $this->columnExists($columnName)) {
+        if (! $this->hasColumn($columnName)) {
             return true;
         }
 
@@ -83,7 +83,7 @@ class TableSchema
      */
     public function columnHasDefault($columnName)
     {
-        if (! $this->columnExists($columnName)) {
+        if (! $this->hasColumn($columnName)) {
             return false;
         }
 
@@ -100,7 +100,7 @@ class TableSchema
      */
     public function getColumnDefault($columnName)
     {
-        if (! $this->columnExists($columnName)) {
+        if (! $this->hasColumn($columnName)) {
             return false;
         }
 
@@ -121,21 +121,6 @@ class TableSchema
         }
 
         return $this->schema->getColumns();
-    }
-
-    /**
-     * Make sure column exists or throw an exception.
-     *
-     * @param  string  $columnName
-     * @return bool
-     */
-    private function columnExists($columnName)
-    {
-        if (! $this->schemaExists()) {
-            return false;
-        }
-
-        return $this->schema->hasColumn($columnName);
     }
 
     /**


### PR DESCRIPTION
Some of my latest changes in the upgrade to Laravel 11, made the DB schema class a little to eager to get the table information, that was requesting information from tables that we are not specifically using in certain cruds.

In big applications it could lead to some performance issues. 

@promatik can you confirm this brings back the previous behavior ? 

I've tested this in L10 with dbal and L11 using the Laravel native classes. 

