### PR TITLE
Fix doc blocks in Traits\Settings

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -15,7 +15,7 @@ trait Settings
      * Getter for the settings key-value store.
      *
      * @param  string  $key  Usually operation.name (ex: list.exportButtons)
-     * @return mixed [description]
+     * @return mixed Setting value or null
      */
     public function get(string $key)
     {
@@ -96,7 +96,7 @@ trait Settings
      * Defaults to the current operation.
      *
      * @param  string  $key  Has no operation prepended. (ex: exportButtons)
-     * @return mixed [description]
+     * @return mixed Setting value or null
      */
     public function getOperationSetting(string $key, $operation = null)
     {
@@ -110,7 +110,7 @@ trait Settings
      * Defaults to the current operation.
      *
      * @param  string  $key  Has no operation prepended. (ex: exportButtons)
-     * @return mixed [description]
+     * @return bool 
      */
     public function hasOperationSetting(string $key, $operation = null)
     {
@@ -124,7 +124,7 @@ trait Settings
      * Defaults to the current operation.
      *
      * @param  string  $key  Has no operation prepended. (ex: max_level)
-     * @param  bool  $value  True/false depending on success.
+     * @param  mixed  $value  The value you want to store.
      */
     public function setOperationSetting(string $key, $value, $operation = null)
     {

--- a/src/app/Library/CrudPanel/Traits/Settings.php
+++ b/src/app/Library/CrudPanel/Traits/Settings.php
@@ -110,7 +110,7 @@ trait Settings
      * Defaults to the current operation.
      *
      * @param  string  $key  Has no operation prepended. (ex: exportButtons)
-     * @return bool 
+     * @return bool
      */
     public function hasOperationSetting(string $key, $operation = null)
     {


### PR DESCRIPTION
I didn't added typed parameters because they are public methods and that would be a BC. 

I think next version is the version everything becomes typed, I hope! There is no sense in using @docBlocks in 2024 to ensure basic type enforcing like arrays or strings. 
