### PR TITLE
add content_class and heading_class to jumbotron

### DIFF
--- a/src/resources/views/ui/dashboard.blade.php
+++ b/src/resources/views/ui/dashboard.blade.php
@@ -10,7 +10,9 @@
         $widgets['before_content'][] = [
             'type'        => 'jumbotron',
             'heading'     => trans('backpack::base.welcome'),
+            'heading_class' => 'display-3 '.(backpack_theme_config('layout') === 'horizontal_overlap' ? ' text-white' : ''),
             'content'     => trans('backpack::base.use_sidebar'),
+            'content_class' => backpack_theme_config('layout') === 'horizontal_overlap' ? 'text-white' : '',
             'button_link' => backpack_url('logout'),
             'button_text' => trans('backpack::base.logout'),
         ];

--- a/src/resources/views/ui/widgets/jumbotron.blade.php
+++ b/src/resources/views/ui/widgets/jumbotron.blade.php
@@ -6,14 +6,14 @@
 @endphp
 
 @includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
-	<div class="jumbotron mb-2">
+	<div class="jumbotron mb-2 ">
 
 	  @if (isset($widget['heading']))
-	  <h1 class="display-3">{!! $widget['heading'] !!}</h1>
+	  <h1 class="{{ $widget['heading_class'] ?? 'display-3'}}">{!! $widget['heading'] !!}</h1>
 	  @endif
 
 	  @if (isset($widget['content']))
-	  <p>{!! $widget['content'] !!}</p>
+	  <p class="{{ $widget['content_class'] ?? ''}}">{!! $widget['content'] !!}</p>
 	  @endif
 
 	  @if (isset($widget['button_link']))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was not possible to add extra classes to the default ones. 

### AFTER - What is happening after this PR?

This PR introduces `content_class` and `heading_class` so that you can further customize your jumbotron without overwriting files. 

This helps us specifically on the "default dashboard", that we can style different when a specific layout is defined.


### Is it a breaking change?

No

