### PR TITLE
[WIP] dont load locally when in dev mode

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -150,7 +150,7 @@ if (! function_exists('backpack_avatar_url')) {
                     $avatarLink = Gravatar::fallback(config('backpack.base.gravatar_fallback'))->get($user->email, ['size' => 80]);
 
                     // if we can save it locally, for safer loading, let's do it
-                    if (in_array(Basset::basset($avatarLink, false)->name, ['INTERNALIZED', 'IN_CACHE', 'LOADED'])) {
+                    if (in_array(Basset::basset($avatarLink, false)->name, ['INTERNALIZED', 'IN_CACHE', 'LOADED']) && ! Basset::isDevMode()) {
                         return Basset::getUrl($avatarLink);
                     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When basset is in Dev mode, calling `Basset::basset($asset)` marks it as loaded even if not internalized. 

We have two options here:
- as I did, don't attempt to load local file (that doesn't exist) while in dev mode. 
- remove LOADED from the array of valid asset status.

This PR works as expected and is the easiest (from the side effects perspective), but removing `LOADED` from the status array is the cleanest, so I opened this PR in the hopes that we can remove the LOADED, but I am not sure about all the implications, nor why LOADED was added there. 
Maybe for the use case when you have multiple `backpack_avatar_url()` calls ? 

Clarify my doubts here @promatik 🙏 


