### PR TITLE
[Feature] Add Ajax support to Quick button 😎

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -194,6 +194,6 @@ return [
     // Quick button messages
     'quick_button_ajax_error_title' => 'Request failed!',
     'quick_button_ajax_error_message' => 'There was an error while executing request. Please retry.',
-    'quick_button_ajax_success_title'                   => 'Request successful!',
-    'quick_button_ajax_success_message'                 => 'The action request is submited successfully.',
+    'quick_button_ajax_success_title' => 'Request successful!',
+    'quick_button_ajax_success_message' => 'The action request is submited successfully.',
 ];

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -192,8 +192,8 @@ return [
     'pivot_selector_required_validation_message' => 'The pivot field is required.',
 
     // Quick button messages
-    'quick_button_ajax_error_title' => 'Request failed!',
-    'quick_button_ajax_error_message' => 'There was an error while executing request. Please retry.',
-    'quick_button_ajax_success_title' => 'Request successful!',
-    'quick_button_ajax_success_message' => 'The action request is submited successfully.',
+    'quick_button_ajax_error_title' => 'Request Failed!',
+    'quick_button_ajax_error_message' => 'There was an error processing your request.',
+    'quick_button_ajax_success_title' => 'Request Completed!',
+    'quick_button_ajax_success_message' => 'Your request was completed with success.',
 ];

--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -190,4 +190,10 @@ return [
 
     // The pivot selector required validation message
     'pivot_selector_required_validation_message' => 'The pivot field is required.',
+
+    // Quick button messages
+    'quick_button_ajax_error_title' => 'Request failed!',
+    'quick_button_ajax_error_message' => 'There was an error while executing request. Please retry.',
+    'quick_button_ajax_success_title'                   => 'Request successful!',
+    'quick_button_ajax_success_message'                 => 'The action request is submited successfully.',
 ];

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -23,6 +23,24 @@
         $wrapper['href'] = ($wrapper['href'])($entry, $crud);
     }
     $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
+    //if ajax enabled
+    $ajax_enabled = $button->meta['ajax'] ?? false;
+    if($ajax_enabled) {
+        $wrapper['data-route'] = $wrapper['href'];
+		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'POST';
+
+        $wrapper['href'] = 'javascript:void(0)';
+        $wrapper['onclick'] = 'sendQuickRequest(this)';
+		$wrapper['data-button-type'] = 'quick';
+
+        //success message
+        $wrapper['data-success-title'] = $button->meta['ajax']['success_title'] ?? trans('backpack::crud.quick_button_ajax_success_title');
+        $wrapper['data-success-message'] = $button->meta['ajax']['success_message'] ?? trans('backpack::crud.quick_button_ajax_success_message');
+        //error message
+        $wrapper['data-error-title'] = $button->meta['ajax']['error_title'] ?? trans('backpack::crud.quick_button_ajax_error_title');
+        $wrapper['data-error-message']  = $button->meta['ajax']['error_message'] ?? trans('backpack::crud.quick_button_ajax_error_message');
+    }
+    //endif ajax enabled
 @endphp
 
 @if ($access === true || $crud->hasAccess($access, isset($entry) ? $entry : null))
@@ -36,4 +54,76 @@
         @if ($icon) <i class="{{ $icon }}"></i> @endif
         {{ $label }}
     </{{ $wrapper['element'] }}>
+@endif
+
+
+@if($ajax_enabled)
+{{-- Button Javascript --}}
+{{-- - used right away in AJAX operations (ex: List) --}}
+{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+@bassetBlock('backpack/crud/buttons/quick-button-'.app()->getLocale().'.js')
+<script>
+	if (typeof sendQuickRequest != 'function') {
+	  $("[data-button-type=quick]").unbind('click');
+
+	  function sendQuickRequest(button) {
+		// e.preventDefault();
+		var route = $(button).attr('data-route');
+				$.ajax({
+			      url: route,
+			      type: $(button).attr('data-method'),
+			      success: function(result) {
+			          if (result) {
+			          	  // Show a success notification bubble
+			              new Noty({
+		                    type: "success",
+							text: '<strong>'+$(button).attr('data-success-title')+'</strong><br>'+$(button).attr('data-success-message'),
+		                  }).show();
+
+			          } else {
+			              // if the result is an array, it means
+			              // we have notification bubbles to show
+			          	  if (result instanceof Object) {
+			          	  	// trigger one or more bubble notifications
+			          	  	Object.entries(result).forEach(function(entry, index) {
+			          	  	  var type = entry[0];
+			          	  	  entry[1].forEach(function(message, i) {
+					          	  new Noty({
+				                    type: type,
+				                    text: message
+				                  }).show();
+			          	  	  });
+			          	  	});
+			          	  } else {// Show an error alert
+				              swal({
+				              	title: $(button).attr('data-error-title'),
+	                            text: $(button).attr('data-error-message'),
+				              	icon: "error",
+				              	timer: 4000,
+				              	buttons: false,
+				              });
+			          	  }
+			          }
+			      },
+			      error: function(result) {
+			          // Show an alert with the result
+			          swal({
+						title: $(button).attr('data-error-title'),
+	                    text: $(button).attr('data-error-message'),
+		              	icon: "error",
+		              	timer: 4000,
+		              	buttons: false,
+		              });
+			      }
+			  });
+
+      }
+	}
+
+	// make it so that the function above is run after each DataTable draw event
+	// crud.addFunctionToDataTablesDrawEventQueue('sendQuickRequest');
+</script>
+@endBassetBlock
+@if (!request()->ajax()) @endpush @endif
 @endif

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -77,15 +77,20 @@
                         crud.table.draw(false);
                     }
                     let message;
-                    if(result.message){
-                        //if message is returned from the API
-                        message = result.message;
-                    }else{
-                        //if message is not returned from the API
+                    let defaultMessage = function(button) {
+                        // since this is inside a closure, we don't execute until we manually call it.
                         let buttonSuccessTitle = button.getAttribute('data-success-title');
                         let buttonSuccessMessage =  button.getAttribute('data-success-message');
-                        message = `<strong>${buttonSuccessTitle}</strong><br/>${buttonSuccessMessage}`;
+                        return `<strong>${buttonSuccessTitle}</strong><br/>${buttonSuccessMessage}`;
                     }
+                    
+                    //if message is returned from the API use that message
+                    if(result.message){
+                        message = result.message;
+                    }
+                    
+                    // if message variable has no value, we build the default message, otherwise use the previous set value without calling defaultMessage()
+                    message ??= defaultMessage(button);
 			        new Noty({
 		            	type: "success",
 						text: message,

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -27,7 +27,7 @@
     $buttonAjaxConfiguration = $button->meta['ajax'] ?? false;
     if($buttonAjaxConfiguration) {
         $wrapper['data-route'] = $wrapper['href'];
-		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'POST';
+		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'GET';
         $wrapper['data-refresh-table'] = $button->meta['ajax']['refreshCrudTable'] ?? false;
 
         $wrapper['href'] = 'javascript:void(0)';

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -73,43 +73,16 @@
 			      url: route,
 			      type: $(button).attr('data-method'),
 			      success: function(result) {
-			          if (result) {
-			          	  // Show a success notification bubble
-			              new Noty({
-		                    type: "success",
-							text: '<strong>'+$(button).attr('data-success-title')+'</strong><br>'+$(button).attr('data-success-message'),
-		                  }).show();
-
-			          } else {
-			              // if the result is an array, it means
-			              // we have notification bubbles to show
-			          	  if (result instanceof Object) {
-			          	  	// trigger one or more bubble notifications
-			          	  	Object.entries(result).forEach(function(entry, index) {
-			          	  	  var type = entry[0];
-			          	  	  entry[1].forEach(function(message, i) {
-					          	  new Noty({
-				                    type: type,
-				                    text: message
-				                  }).show();
-			          	  	  });
-			          	  	});
-			          	  } else {// Show an error alert
-				              swal({
-				              	title: $(button).attr('data-error-title'),
-	                            text: $(button).attr('data-error-message'),
-				              	icon: "error",
-				              	timer: 4000,
-				              	buttons: false,
-				              });
-			          	  }
-			          }
+			        new Noty({
+		            	type: "success",
+						text: result.message?result.message:'<strong>'+$(button).attr('data-success-title')+'</strong><br>'+$(button).attr('data-success-message'),
+		            }).show();
 			      },
 			      error: function(result) {
 			          // Show an alert with the result
 			          swal({
 						title: $(button).attr('data-error-title'),
-	                    text: $(button).attr('data-error-message'),
+	                    text: result.responseJSON.message?result.responseJSON.message:$(button).attr('data-error-message'),
 		              	icon: "error",
 		              	timer: 4000,
 		              	buttons: false,

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -28,6 +28,7 @@
     if($ajax_enabled) {
         $wrapper['data-route'] = $wrapper['href'];
 		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'POST';
+        $wrapper['data-refresh-table'] = $button->meta['ajax']['removesEntryFromTable'] ?? false;
 
         $wrapper['href'] = 'javascript:void(0)';
         $wrapper['onclick'] = 'sendQuickButtonAjaxRequest(this)';
@@ -67,12 +68,14 @@
 	  $("[data-button-type=quick]").unbind('click');
 
 	  function sendQuickButtonAjaxRequest(button) {
-		// e.preventDefault();
 		var route = $(button).attr('data-route');
 				$.ajax({
 			      url: route,
 			      type: $(button).attr('data-method'),
 			      success: function(result) {
+                    if($(button).attr('data-refresh-table') && typeof crud != 'undefined' && typeof crud.table != 'undefined'){
+                        crud.table.draw(false);
+                    }
 			        new Noty({
 		            	type: "success",
 						text: result.message?result.message:'<strong>'+$(button).attr('data-success-title')+'</strong><br>'+$(button).attr('data-success-message'),

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -65,61 +65,56 @@
 @bassetBlock('backpack/crud/buttons/quick-button.js')
 <script>
 	if (typeof sendQuickButtonAjaxRequest != 'function') {
-	  $("[data-button-type=quick-ajax]").unbind('click');
+        $("[data-button-type=quick-ajax]").unbind('click');
 
-	  function sendQuickButtonAjaxRequest(button) {
-		var route = $(button).attr('data-route');
-				$.ajax({
-			      url: route,
-			      type: $(button).attr('data-method'),
-			      success: function(result) {
+        function sendQuickButtonAjaxRequest(button) {
+            let route = $(button).attr('data-route');
+
+            const defaultButtonMessage = function(button, type) {
+                let buttonTitle = button.getAttribute(`data-${type}-title`);
+                let buttonMessage =  button.getAttribute(`data-${type}-message`);
+                return `<strong>${buttonTitle}</strong><br/>${buttonMessage}`;
+            }
+
+            $.ajax({
+                url: route,
+                type: $(button).attr('data-method'),
+                success: function(result) {
+
                     if($(button).attr('data-refresh-table') && typeof crud != 'undefined' && typeof crud.table != 'undefined'){
                         crud.table.draw(false);
                     }
                     let message;
-                    let defaultMessage = function(button) {
-                        // since this is inside a closure, we don't execute until we manually call it.
-                        let buttonSuccessTitle = button.getAttribute('data-success-title');
-                        let buttonSuccessMessage =  button.getAttribute('data-success-message');
-                        return `<strong>${buttonSuccessTitle}</strong><br/>${buttonSuccessMessage}`;
-                    }
-
                     //if message is returned from the API use that message
                     if(result.message){
                         message = result.message;
                     }
 
-                    // if message variable has no value, we build the default message, otherwise use the previous set value without calling defaultMessage()
-                    message ??= defaultMessage(button);
-			        new Noty({
-		            	type: "success",
-						text: message,
-		            }).show();
-			      },
-			      error: function(result) {
-                    let errorMessage;
-                    let defaultErrorMessage = function(button) {
-                        // since this is inside a closure, we don't execute until we manually call it.
-                        let buttonErrorTitle = button.getAttribute('data-error-title');
-                        let buttonErrorMessage =  button.getAttribute('data-error-message');
-                        return `<strong>${buttonErrorTitle}</strong><br/>${buttonErrorMessage}`;
-                    }
+                    message ??= defaultButtonMessage(button, 'success');
+
+                    new Noty({
+                        type: "success",
+                        text: message,
+                    }).show();
+                },
+                error: function(result) {
+
+                    let message;
 
                     //if message is returned from the API use that message
                     if(result.responseJSON.message){
-                        errorMessage = result.responseJSON.message;
+                        message = result.responseJSON.message;
                     }
 
-                    // if errorMessage variable has no value, we build the default error message, otherwise use the previous set value without calling defaultErrorMessage()
-                    errorMessage ??= defaultErrorMessage(button);
-			        new Noty({
-		            	type: "error",
-						text: errorMessage,
-		            }).show();
-			      }
-			  });
+                    message ??= defaultButtonMessage(button, 'error');
 
-      }
+                    new Noty({
+                        type: "error",
+                        text: message,
+                    }).show();
+                }
+            });
+        }
 	}
 </script>
 @endBassetBlock

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -83,12 +83,12 @@
                         let buttonSuccessMessage =  button.getAttribute('data-success-message');
                         return `<strong>${buttonSuccessTitle}</strong><br/>${buttonSuccessMessage}`;
                     }
-                    
+
                     //if message is returned from the API use that message
                     if(result.message){
                         message = result.message;
                     }
-                    
+
                     // if message variable has no value, we build the default message, otherwise use the previous set value without calling defaultMessage()
                     message ??= defaultMessage(button);
 			        new Noty({
@@ -97,16 +97,25 @@
 		            }).show();
 			      },
 			      error: function(result) {
-                      let buttonErrorMessage = button.getAttribute('data-error-message');
-                      buttonErrorMessage = result.responseJSON.message ? result.responseJSON.message : buttonErrorMessage;
-			          // Show an alert with the result
-			          swal({
-						title: button.getAttribute('data-error-title'),
-	                    text: buttonErrorMessage,
-		              	icon: "error",
-		              	timer: 4000,
-		              	buttons: false,
-		              });
+                    let errorMessage;
+                    let defaultErrorMessage = function(button) {
+                        // since this is inside a closure, we don't execute until we manually call it.
+                        let buttonErrorTitle = button.getAttribute('data-error-title');
+                        let buttonErrorMessage =  button.getAttribute('data-error-message');
+                        return `<strong>${buttonErrorTitle}</strong><br/>${buttonErrorMessage}`;
+                    }
+
+                    //if message is returned from the API use that message
+                    if(result.responseJSON.message){
+                        errorMessage = result.responseJSON.message;
+                    }
+
+                    // if errorMessage variable has no value, we build the default error message, otherwise use the previous set value without calling defaultErrorMessage()
+                    errorMessage ??= defaultErrorMessage(button);
+			        new Noty({
+		            	type: "error",
+						text: errorMessage,
+		            }).show();
 			      }
 			  });
 

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -30,7 +30,7 @@
 		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'POST';
 
         $wrapper['href'] = 'javascript:void(0)';
-        $wrapper['onclick'] = 'sendQuickRequest(this)';
+        $wrapper['onclick'] = 'sendQuickButtonAjaxRequest(this)';
 		$wrapper['data-button-type'] = 'quick';
 
         //success message
@@ -59,15 +59,14 @@
 
 @if($ajax_enabled)
 {{-- Button Javascript --}}
-{{-- - used right away in AJAX operations (ex: List) --}}
-{{-- - pushed to the end of the page, after jQuery is loaded, for non-AJAX operations (ex: Show) --}}
+{{-- Pushed to the end of the page, after jQuery is loaded --}}
 @push('after_scripts') @if (request()->ajax()) @endpush @endif
-@bassetBlock('backpack/crud/buttons/quick-button-'.app()->getLocale().'.js')
+@bassetBlock('backpack/crud/buttons/quick-button.js')
 <script>
-	if (typeof sendQuickRequest != 'function') {
+	if (typeof sendQuickButtonAjaxRequest != 'function') {
 	  $("[data-button-type=quick]").unbind('click');
 
-	  function sendQuickRequest(button) {
+	  function sendQuickButtonAjaxRequest(button) {
 		// e.preventDefault();
 		var route = $(button).attr('data-route');
 				$.ajax({
@@ -120,9 +119,6 @@
 
       }
 	}
-
-	// make it so that the function above is run after each DataTable draw event
-	// crud.addFunctionToDataTablesDrawEventQueue('sendQuickRequest');
 </script>
 @endBassetBlock
 @if (!request()->ajax()) @endpush @endif

--- a/src/resources/views/crud/buttons/quick.blade.php
+++ b/src/resources/views/crud/buttons/quick.blade.php
@@ -97,10 +97,12 @@
 		            }).show();
 			      },
 			      error: function(result) {
+                      let buttonErrorMessage = button.getAttribute('data-error-message');
+                      buttonErrorMessage = result.responseJSON.message ? result.responseJSON.message : buttonErrorMessage;
 			          // Show an alert with the result
 			          swal({
-						title: $(button).attr('data-error-title'),
-	                    text: result.responseJSON.message?result.responseJSON.message:$(button).attr('data-error-message'),
+						title: button.getAttribute('data-error-title'),
+	                    text: buttonErrorMessage,
 		              	icon: "error",
 		              	timer: 4000,
 		              	buttons: false,


### PR DESCRIPTION
## WHY

The quick button is good for us(lazy devs), but Ajax support was missing.

Creating an Ajax button manually takes time. What if one project needs multiple Ajax buttons?
Everyone loves seamless UI(but with less effort).

### AFTER 
Now, We can create buttons quickly that support Ajax calling. Just add one attribute to have it.
- On success: it shows a notification.
- On Failure: it shows an alert.

https://github.com/Laravel-Backpack/CRUD/assets/8214221/54ac49b9-1b78-45fe-a3b1-d69d375a27f5

### Is it a breaking change?

NO

### How can we test the before & after?
It picks the URL from the same old href attribute, which was either user-provided or autogenerated.

Example:
I created an operation and used the following button to send invoices.
```php
CRUD::button('send')->stack('line')->view('crud::buttons.quick')->meta([
            'access' => true,
            'label' => 'Send Invoice',
            'icon' => 'la la-envelope',
            'ajax' => true,
        ]);
```

**OR**

```php
CRUD::button('send')->stack('line')->view('crud::buttons.quick')->meta([
            'access' => true,
            'label' => 'Send Invoice',
            'icon' => 'la la-envelope',
            'wrapper' => [
                'href' => url(('admin/dashboard')), // to change URL(nothing new)
            ],
            'ajax' => [
               // optional attributes
                'method' => 'GET',
                'refreshCrudTable' => true, // to refresh table on success
                'success_title' => "asas\'sds\"",
                'success_message' => 'The payment reminder has been sent successfully.',
                'error_title' => 'Error',
                'error_message' => 'There was an error sending the payment reminder. Please try again.',
            ],
        ]);
```