### PR TITLE
Register field events on UpdateOperation edit form

### DIFF
--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -63,14 +63,16 @@ trait UpdateOperation
     public function edit($id)
     {
         $this->crud->hasAccessOrFail('update');
+
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
-        // get the info for that entry
 
         // register any Model Events defined on fields
         $this->crud->registerFieldEvents();
-
+        
+        // get the info for that entry
         $this->data['entry'] = $this->crud->getEntryWithLocale($id);
+
         $this->crud->setOperationSetting('fields', $this->crud->getUpdateFields());
 
         $this->data['crud'] = $this->crud;

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -66,6 +66,9 @@ trait UpdateOperation
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
         // get the info for that entry
+        
+        // register any Model Events defined on fields
+        $this->crud->registerFieldEvents();
 
         $this->data['entry'] = $this->crud->getEntryWithLocale($id);
         $this->crud->setOperationSetting('fields', $this->crud->getUpdateFields());

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -69,7 +69,7 @@ trait UpdateOperation
 
         // register any Model Events defined on fields
         $this->crud->registerFieldEvents();
-        
+
         // get the info for that entry
         $this->data['entry'] = $this->crud->getEntryWithLocale($id);
 

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -66,7 +66,7 @@ trait UpdateOperation
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
         // get the info for that entry
-        
+
         // register any Model Events defined on fields
         $this->crud->registerFieldEvents();
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was not possible to register a `retrieved` model event in fields to run when the entry is retrieved from the database to display on the edit form.

Eg:
```php
CRUD::field('something')->on('retrieved', fn($entry) => $entry->something = json_decode($entry->something))
```

One would expect that the value of the field would be the json_decoded() version, but this event was never triggered, because the field events were not registered on the update form.

### AFTER - What is happening after this PR?

It's now possible to customize model values before the fields attempt to get their respective values by registering a `retrieved` model event on the field. 

## HOW

### How did you achieve that, in technical terms?

Called the setup of the model events on the edit form endpoint too.


### Is it a breaking change?

It shouldn't, as the retrieved events were not working (and that's the only event that happen when the entry is retrieved from the database), I don't think it's possible to break anything. 
