### PR TITLE
Attribute to set `key` to livewire widget.

### DIFF
--- a/src/resources/views/ui/widgets/livewire.blade.php
+++ b/src/resources/views/ui/widgets/livewire.blade.php
@@ -6,7 +6,11 @@
 @includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
 
 <div class="{{ $widget['class'] ?? 'card' }}" @foreach($widget['attributes'] ?? [] as $key => $value) {{ $key }}="{{ $value }}" @endforeach>
-    @livewire($widget['content'], $widget['parameters'] ?? [])
+    @if(isset($widget['key']))
+        @livewire($widget['content'], $widget['parameters'] ?? [], key($widget['key']))
+    @else
+        @livewire($widget['content'], $widget['parameters'] ?? [])
+    @endif
 </div>
 
 @includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))
@@ -15,7 +19,7 @@
     @pushOnce('after_styles')
         @livewireStyles
     @endPushOnce
-    
+
     @pushOnce('after_scripts')
         @livewireScripts
     @endpushOnce


### PR DESCRIPTION
## WHY

I have a livewire component, and I need to set a **key** to the livewire component, but the widget gives no way to set one.

### AFTER - What is happening after this PR?

Now I can, with the added `key` attribute.

```diff
Widget::make([
   'type'        => 'livewire',
   'content'   => 'livewire-line-chart',
   'parameters'      => ['lineChartModel' => $lineChartModel],
   'livewireAssets' => false,
   'wrapperClass' => 'col-md-12',
+  'key'=>$lineChartModel->reactiveKey(),
]);
```

### Is it a breaking change?
NO


### How can we test the before & after?

Just remove or pass the key.