### PR TITLE
Fix typo in dd helper method docblocks

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -459,7 +459,7 @@ class CrudButton implements Arrayable
     }
 
     /**
-     * Dump and die. Duumps the current object to the screen,
+     * Dump and die. Dumps the current object to the screen,
      * so that the developer can see its contents, then stops
      * the execution.
      *

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -213,7 +213,7 @@ class CrudColumn
     }
 
     /**
-     * Dump and die. Duumps the current object to the screen,
+     * Dump and die. Dumps the current object to the screen,
      * so that the developer can see its contents, then stops
      * the execution.
      *

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -429,7 +429,7 @@ class CrudField
     }
 
     /**
-     * Dump and die. Duumps the current object to the screen,
+     * Dump and die. Dumps the current object to the screen,
      * so that the developer can see its contents, then stops
      * the execution.
      *

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -582,7 +582,7 @@ class CrudFilter
     }
 
     /**
-     * Dump and die. Duumps the current object to the screen,
+     * Dump and die. Dumps the current object to the screen,
      * so that the developer can see its contents, then stops
      * the execution.
      *

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -283,7 +283,7 @@ class Widget extends Fluent
     }
 
     /**
-     * Dump and die. Duumps the current object to the screen,
+     * Dump and die. Dumps the current object to the screen,
      * so that the developer can see its contents, then stops
      * the execution.
      *


### PR DESCRIPTION
## WHY

Typos in DocBlocks reduce readability of the code and makes it harder to understand underlying methods actions and intents.

### BEFORE - What was wrong? What was happening before this PR?

`dd` method in `Backpack\CRUD\app\Library` DocBlocks had a typo in them

### AFTER - What is happening after this PR?

`dd` method in `Backpack\CRUD\app\Library` DocBlocks don't have a typo in them


## HOW

### How did you achieve that, in technical terms?

I used my great english skills and my keyboard backspace (™ pending) button to remove extra `u` from the word `Duumps`.

### Is it a breaking change?

No


### How can we test the before & after?

Use built in feature in every developer called `eyes`. Confirm that typo is truly gone.

