### PR TITLE
Remove misleading free licence text from Backpack Robot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -82,9 +82,6 @@ firstPRMergeComment: >
 
   The Backpack Robot
 
-
-  P.S. **Help in the Backpack community is rewarded with free Backpack commercial licenses**. It's the least we can do. If you feel you've helped the community with PRs, help & other stuff, please [apply for free licenses](https://backpackforlaravel.com/non-commercial-license) and mention this PR. You scratch my back, I scratch your back. Thank you!
-
 # It is recommend to include as many gifs and emojis as possible
 #
 # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## WHY

Misleading robot text would cause unfair stress upon Backpack core team.
### BEFORE - What was wrong? What was happening before this PR?

Robot would direct new contributors to now defunct feature of getting free licensing.

### AFTER - What is happening after this PR?

Robot no longer offers any compensation to contributors for their hard work.


## HOW

### How did you achieve that, in technical terms?

Used my keyboard backspace (™ pending) button to remove extra line about licensing from robots text configuration

### Is it a breaking change?

No

### How can we test the before & after?

Wait robot to congratulate a new contributor and check if he still offers free licensing.

