### PR TITLE
Allow BelongsToMany/MorphToMany to store duplicate pivots

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -3,6 +3,7 @@
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
@@ -18,7 +19,7 @@ trait Create
      * Insert a row in the database.
      *
      * @param  array  $input  All input values to be inserted.
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return Model
      */
     public function create($input)
     {
@@ -95,7 +96,7 @@ trait Create
     /**
      * Create relations for the provided model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $item  The current CRUD model.
+     * @param  Model  $item  The current CRUD model.
      * @param  array  $formattedRelations  The form data.
      * @return bool|null
      */
@@ -131,32 +132,69 @@ trait Create
                 case 'BelongsToMany':
                 case 'MorphToMany':
                     $values = $relationDetails['values'][$relationMethod] ?? [];
-                    $values = is_string($values) ? json_decode($values, true) : $values;
+                    $values = is_string($values) ? (json_decode($values, true) ?? []) : $values;
+                    $field = $relationDetails['crudFields'][0] ?? [];
 
-                    // disabling ConvertEmptyStringsToNull middleware may return null from json_decode() if an empty string is used.
-                    // we need to make sure no null value can go foward so we reassure that values is not null after json_decode()
-                    $values = $values ?? [];
-
-                    $relationValues = [];
-
+                    // if the values are multidimensional, we have additional pivot data.
                     if (is_array($values) && is_multidimensional_array($values)) {
+                        // if the field allow duplicated pivots, we can't use sync or attach from laravel, we need to manually handle the pivot data.
+                        if ($field['allow_duplicate_pivots'] ?? false) {
+                            $keyName = $field['pivot_key_name'] ?? 'id';
+                            $sentIds = array_filter(array_column($values, $keyName));
+                            $dbValues = $relation->get()->pluck($keyName)->all();
+                            $toDelete = array_diff($dbValues, $sentIds);
+
+                            if (! empty($toDelete)) {
+                                foreach($toDelete as $id) {
+                                    $relation->newPivot()->where($keyName, $id)->delete();
+                                }
+                            }
+                            foreach($values as $value) { 
+                                // if it's an existing pivot, update it
+                                if(isset($value[$keyName])) {
+                                    $relation->newPivot()->where($keyName, $value[$keyName])->update($this->preparePivotAttributesForUpdate($value, $relation));
+                                } else {
+                                   $relation->newPivot()->create($this->preparePivotAttributesForCreate($value, $relation, $item->getKey()));
+                                }
+                            }
+                            break;
+                        }
+
+                        $belongsToManyValues = [];
+
                         foreach ($values as $value) {
                             if (isset($value[$relationMethod])) {
-                                $relationValues[$value[$relationMethod]] = Arr::except($value, $relationMethod);
+                                $belongsToManyValues[$value[$relationMethod]] = Arr::except($value, $relationMethod);
                             }
                         }
-                    }
 
+                        $item->{$relationMethod}()->sync($belongsToManyValues);
+                       
+                        break;
+                    }
+                  
                     // if there is no relation data, and the values array is single dimensional we have
-                    // an array of keys with no aditional pivot data. sync those.
-                    if (empty($relationValues)) {
-                        $relationValues = array_values($values);
+                    // an array of keys with no additional pivot data. sync those.
+                    if (empty($belongsToManyValues)) {
+                        $belongsToManyValues = array_values($values);
                     }
-
-                    $item->{$relationMethod}()->sync($relationValues);
+                    $item->{$relationMethod}()->sync($belongsToManyValues);
                     break;
             }
         }
+    }
+
+    private function preparePivotAttributesForCreate(array $attributes, BelongsToMany $relation, string|int $relatedItemKey) {
+        $attributes[$relation->getForeignPivotKeyName()] = $relatedItemKey;
+        $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relation->getRelationName()];
+        $pivotKeyName = $attributes['pivot_key_name'] ?? 'id';
+        return Arr::except($attributes, [$relation->getRelationName(), 'pivot_key_name', $pivotKeyName]);
+    }
+
+    private function preparePivotAttributesForUpdate(array $attributes, BelongsToMany $relation) {
+        $pivotKeyName = $attributes['pivot_key_name'] ?? 'id';
+        $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relation->getRelationName()];
+        return Arr::except($attributes, [$relation->getRelationName(), 'pivot_key_name', $pivotKeyName, $relation->getForeignPivotKeyName()]);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -163,25 +163,25 @@ trait Create
                             break;
                         }
 
-                        $belongsToManyValues = [];
+                        $relationToManyValues = [];
 
                         foreach ($values as $value) {
                             if (isset($value[$relationMethod])) {
-                                $belongsToManyValues[$value[$relationMethod]] = Arr::except($value, $relationMethod);
+                                $relationToManyValues[$value[$relationMethod]] = Arr::except($value, $relationMethod);
                             }
                         }
 
-                        $item->{$relationMethod}()->sync($belongsToManyValues);
+                        $item->{$relationMethod}()->sync($relationToManyValues);
 
                         break;
                     }
 
                     // if there is no relation data, and the values array is single dimensional we have
                     // an array of keys with no additional pivot data. sync those.
-                    if (empty($belongsToManyValues)) {
-                        $belongsToManyValues = array_values($values);
+                    if (empty($relationToManyValues)) {
+                        $relationToManyValues = array_values($values);
                     }
-                    $item->{$relationMethod}()->sync($belongsToManyValues);
+                    $item->{$relationMethod}()->sync($relationToManyValues);
                     break;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -172,7 +172,7 @@ trait Create
                         }
 
                         $item->{$relationMethod}()->sync($relationToManyValues);
-
+                        unset($relationToManyValues);
                         break;
                     }
 
@@ -182,6 +182,7 @@ trait Create
                         $relationToManyValues = array_values($values);
                     }
                     $item->{$relationMethod}()->sync($relationToManyValues);
+                    unset($relationToManyValues);
                     break;
             }
         }

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -143,9 +143,9 @@ trait Create
                             $keyName = $field['pivot_key_name'] ?? 'id';
                             $sentIds = array_filter(array_column($values, $keyName));
                             $dbValues = $relation->newPivotQuery()->pluck($keyName)->toArray();
-                            
+
                             $toDelete = array_diff($dbValues, $sentIds);
-                            
+
                             if (! empty($toDelete)) {
                                 foreach ($toDelete as $id) {
                                     $relation->newPivot()->where($keyName, $id)->delete();

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -145,16 +145,16 @@ trait Create
                             $toDelete = array_diff($dbValues, $sentIds);
 
                             if (! empty($toDelete)) {
-                                foreach($toDelete as $id) {
+                                foreach ($toDelete as $id) {
                                     $relation->newPivot()->where($keyName, $id)->delete();
                                 }
                             }
-                            foreach($values as $value) { 
+                            foreach ($values as $value) {
                                 // if it's an existing pivot, update it
-                                if(isset($value[$keyName])) {
+                                if (isset($value[$keyName])) {
                                     $relation->newPivot()->where($keyName, $value[$keyName])->update($this->preparePivotAttributesForUpdate($value, $relation));
                                 } else {
-                                   $relation->newPivot()->create($this->preparePivotAttributesForCreate($value, $relation, $item->getKey()));
+                                    $relation->newPivot()->create($this->preparePivotAttributesForCreate($value, $relation, $item->getKey()));
                                 }
                             }
                             break;
@@ -169,10 +169,10 @@ trait Create
                         }
 
                         $item->{$relationMethod}()->sync($belongsToManyValues);
-                       
+
                         break;
                     }
-                  
+
                     // if there is no relation data, and the values array is single dimensional we have
                     // an array of keys with no additional pivot data. sync those.
                     if (empty($belongsToManyValues)) {
@@ -184,16 +184,20 @@ trait Create
         }
     }
 
-    private function preparePivotAttributesForCreate(array $attributes, BelongsToMany $relation, string|int $relatedItemKey) {
+    private function preparePivotAttributesForCreate(array $attributes, BelongsToMany $relation, string|int $relatedItemKey)
+    {
         $attributes[$relation->getForeignPivotKeyName()] = $relatedItemKey;
         $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relation->getRelationName()];
         $pivotKeyName = $attributes['pivot_key_name'] ?? 'id';
+
         return Arr::except($attributes, [$relation->getRelationName(), 'pivot_key_name', $pivotKeyName]);
     }
 
-    private function preparePivotAttributesForUpdate(array $attributes, BelongsToMany $relation) {
+    private function preparePivotAttributesForUpdate(array $attributes, BelongsToMany $relation)
+    {
         $pivotKeyName = $attributes['pivot_key_name'] ?? 'id';
         $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relation->getRelationName()];
+
         return Arr::except($attributes, [$relation->getRelationName(), 'pivot_key_name', $pivotKeyName, $relation->getForeignPivotKeyName()]);
     }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -313,8 +313,8 @@ trait FieldsProtectedMethods
                         break;
                     }
 
-                    if ($field['allow_multiple_pivots'] ?? false) {
-                        $pivotSelectorField['allow_multiple_pivots'] = true;
+                    if ($field['allow_duplicate_pivots'] ?? false) {
+                        $pivotSelectorField['allow_duplicate_pivots'] = true;
                         $field['subfields'] = Arr::prepend($field['subfields'], [
                             'name' => $field['pivot_key_name'] ?? 'id',
                             'type' => 'hidden',

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -313,6 +313,20 @@ trait FieldsProtectedMethods
                         break;
                     }
 
+                    if($field['allow_multiple_pivots'] ?? false) {
+                        $pivotSelectorField['allow_multiple_pivots'] = true;
+                        $field['subfields'] = Arr::prepend($field['subfields'], [
+                                'name' => $field['pivot_key_name'] ?? 'id',
+                                'type' => 'hidden',
+                        ]);
+
+                        $field['subfields'] = Arr::prepend($field['subfields'], [
+                            'name' => 'pivot_key_name',
+                            'type' => 'hidden',
+                            'value' => $field['pivot_key_name'] ?? 'id',
+                        ]);
+                    }
+
                     $this->setupFieldValidation($pivotSelectorField, $field['name']);
                     $field['subfields'] = Arr::prepend($field['subfields'], $pivotSelectorField);
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -313,11 +313,11 @@ trait FieldsProtectedMethods
                         break;
                     }
 
-                    if($field['allow_multiple_pivots'] ?? false) {
+                    if ($field['allow_multiple_pivots'] ?? false) {
                         $pivotSelectorField['allow_multiple_pivots'] = true;
                         $field['subfields'] = Arr::prepend($field['subfields'], [
-                                'name' => $field['pivot_key_name'] ?? 'id',
-                                'type' => 'hidden',
+                            'name' => $field['pivot_key_name'] ?? 'id',
+                            'type' => 'hidden',
                         ]);
 
                         $field['subfields'] = Arr::prepend($field['subfields'], [

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -319,8 +319,8 @@ trait FieldsProtectedMethods
                             'name' => $field['pivot_key_name'] ?? 'id',
                             'type' => 'hidden',
                             'wrapper' => [
-                                'class' => 'd-none'
-                            ]
+                                'class' => 'd-none',
+                            ],
                         ]);
                     }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -319,12 +319,6 @@ trait FieldsProtectedMethods
                             'name' => $field['pivot_key_name'] ?? 'id',
                             'type' => 'hidden',
                         ]);
-
-                        $field['subfields'] = Arr::prepend($field['subfields'], [
-                            'name' => 'pivot_key_name',
-                            'type' => 'hidden',
-                            'value' => $field['pivot_key_name'] ?? 'id',
-                        ]);
                     }
 
                     $this->setupFieldValidation($pivotSelectorField, $field['name']);

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -318,6 +318,9 @@ trait FieldsProtectedMethods
                         $field['subfields'] = Arr::prepend($field['subfields'], [
                             'name' => $field['pivot_key_name'] ?? 'id',
                             'type' => 'hidden',
+                            'wrapper' => [
+                                'class' => 'd-none'
+                            ]
                         ]);
                     }
 

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -471,27 +471,27 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     public function testMorphToManyCreatableRelationshipWithMultiple()
     {
         $inputData = $this->getPivotInputData(['recommendsDuplicate' => [
-                [
-                    'recommendsDuplicate' => 1,
-                    'text' => 'my pivot recommend field 1',
-                ],
-                [
-                    'recommendsDuplicate' => 2,
-                    'text' => 'my pivot recommend field 2',
-                ],
-                [
-                    'recommendsDuplicate' => 1,
-                    'text' => 'my pivot recommend field 1x1',
-                ],
-            ]
-            ], true, true);
+            [
+                'recommendsDuplicate' => 1,
+                'text' => 'my pivot recommend field 1',
+            ],
+            [
+                'recommendsDuplicate' => 2,
+                'text' => 'my pivot recommend field 2',
+            ],
+            [
+                'recommendsDuplicate' => 1,
+                'text' => 'my pivot recommend field 1x1',
+            ],
+        ],
+        ], true, true);
 
         $entry = $this->crudPanel->create($inputData);
 
         $entry = $entry->fresh();
 
         $this->assertCount(3, $entry->recommendsDuplicate);
-        
+
         $this->assertEquals(1, $entry->recommendsDuplicate[0]->id);
         $this->assertEquals(1, $entry->recommendsDuplicate[2]->id);
 
@@ -504,7 +504,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
             [
                 'recommendsDuplicate' => 2,
                 'text' => 'I changed the recommend and the pivot text 2',
-                'id' => 2
+                'id' => 2,
             ],
             [
                 'recommendsDuplicate' => 3,
@@ -514,16 +514,15 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ];
 
         $this->crudPanel->update($entry->id, $inputData);
-        
+
         $entry = $entry->fresh();
-   
+
         $this->assertCount(3, $entry->recommendsDuplicate);
         $this->assertDatabaseCount('recommendables', 3);
-      
+
         $this->assertEquals('I changed the recommend and the pivot text', $entry->recommendsDuplicate[0]->pivot->text);
         $this->assertEquals('I changed the recommend and the pivot text 2', $entry->recommendsDuplicate[1]->pivot->text);
         $this->assertEquals('new recommend and the pivot text 3', $entry->recommendsDuplicate[2]->pivot->text);
-
     }
 
     public function testBelongsToManyWithPivotDataRelationship()

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -512,29 +512,29 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     public function testBelongsToManyWithMultipleSameRelationIdAndPivotDataRelationship()
     {
         $inputData = $this->getPivotInputData(['superArticlesDuplicates' => [
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my first article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my second article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 2,
-                    'notes' => 'my first article2 note',
-                    'id' => null,
-                ],
-            ]
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my first article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my second article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 2,
+                'notes' => 'my first article2 note',
+                'id' => null,
+            ],
+        ],
         ], true, true);
 
         $entry = $this->crudPanel->create($inputData);
         $relationField = $this->crudPanel->getUpdateFields($entry->id)['superArticlesDuplicates'];
 
         $this->assertCount(3, $relationField['value']);
-        
+
         $entry = $entry->fresh();
 
         $this->assertCount(3, $entry->superArticlesDuplicates);
@@ -543,22 +543,22 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->assertEquals('my first article2 note', $entry->superArticles[2]->pivot->notes);
 
         $inputData = $this->getPivotInputData(['superArticlesDuplicates' => [
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my first article note updated',
-                    'id' => 1,
-                ],
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my second article note updated',
-                    'id' => 2,
-                ],
-                [
-                    'superArticlesDuplicates' => 2,
-                    'notes' => 'my first article2 note updated',
-                    'id' => 3,
-                ],
-            ]
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my first article note updated',
+                'id' => 1,
+            ],
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my second article note updated',
+                'id' => 2,
+            ],
+            [
+                'superArticlesDuplicates' => 2,
+                'notes' => 'my first article2 note updated',
+                'id' => 3,
+            ],
+        ],
         ], false, true);
 
         $entry = $this->crudPanel->update($entry->id, $inputData);
@@ -576,29 +576,29 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     public function testBelongsToManyAlwaysSaveSinglePivotWhenMultipleNotAllowed()
     {
         $inputData = $this->getPivotInputData(['superArticlesDuplicates' => [
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my first article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my second article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 2,
-                    'notes' => 'my first article2 note',
-                    'id' => null,
-                ],
-            ]
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my first article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my second article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 2,
+                'notes' => 'my first article2 note',
+                'id' => null,
+            ],
+        ],
         ]);
 
         $entry = $this->crudPanel->create($inputData);
         $relationField = $this->crudPanel->getUpdateFields($entry->id)['superArticlesDuplicates'];
 
         $this->assertCount(2, $relationField['value']);
-        
+
         $entry = $entry->fresh();
 
         $this->assertCount(2, $entry->superArticlesDuplicates);
@@ -609,46 +609,46 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     public function testBelongsToManyDeletesPivotData()
     {
         $inputData = $this->getPivotInputData(['superArticlesDuplicates' => [
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my first article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my second article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 2,
-                    'notes' => 'my first article2 note',
-                    'id' => null,
-                ],
-            ]
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my first article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my second article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 2,
+                'notes' => 'my first article2 note',
+                'id' => null,
+            ],
+        ],
         ], true, true);
 
         $entry = $this->crudPanel->create($inputData);
         $relationField = $this->crudPanel->getUpdateFields($entry->id)['superArticlesDuplicates'];
 
         $this->assertCount(3, $relationField['value']);
-        
+
         $inputData = $this->getPivotInputData(['superArticlesDuplicates' => [
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'new first article note',
-                    'id' => null,
-                ],
-                [
-                    'superArticlesDuplicates' => 1,
-                    'notes' => 'my second article note updated',
-                    'id' => 2,
-                ],
-                [
-                    'superArticlesDuplicates' => 3,
-                    'notes' => 'my first article2 note updated',
-                    'id' => 3,
-                ],
-            ]
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'new first article note',
+                'id' => null,
+            ],
+            [
+                'superArticlesDuplicates' => 1,
+                'notes' => 'my second article note updated',
+                'id' => 2,
+            ],
+            [
+                'superArticlesDuplicates' => 3,
+                'notes' => 'my first article2 note updated',
+                'id' => 3,
+            ],
+        ],
         ], false, true);
 
         $entry = $this->crudPanel->update($entry->id, $inputData);
@@ -1645,7 +1645,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     {
         $faker = Factory::create();
 
-        if($initCrud) {
+        if ($initCrud) {
             $this->crudPanel->setModel(User::class);
             $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
             $this->crudPanel->addField([
@@ -1656,10 +1656,10 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
                     [
                         'name' => 'notes',
                     ],
-                    
+
                 ],
             ]);
-        
+
             $article = Article::create([
                 'content' => $faker->text(),
                 'tags' => $faker->words(3, true),
@@ -1680,6 +1680,5 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         ];
 
         return array_merge($inputData, $pivotRelationData);
-
     }
 }

--- a/tests/config/Models/SuperArticlePivot.php
+++ b/tests/config/Models/SuperArticlePivot.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Backpack\CRUD\Tests\Config\Models;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;

--- a/tests/config/Models/SuperArticlePivot.php
+++ b/tests/config/Models/SuperArticlePivot.php
@@ -1,0 +1,15 @@
+<?php
+namespace Backpack\CRUD\Tests\Config\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class SuperArticlePivot extends Pivot
+{
+    protected $table = 'articles_user';
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = true;
+}

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -67,6 +67,13 @@ class User extends Model
         return $this->belongsToMany('Backpack\CRUD\Tests\config\Models\Article', 'articles_user')->withPivot(['notes', 'start_date', 'end_date']);
     }
 
+    public function superArticlesDuplicates()
+    {
+        return $this->belongsToMany('Backpack\CRUD\Tests\config\Models\Article', 'articles_user')
+                        ->withPivot(['notes', 'start_date', 'end_date', 'id'])
+                        ->using('Backpack\CRUD\Tests\config\Models\SuperArticlePivot');
+    }
+
     public function universes()
     {
         return $this->hasMany('Backpack\CRUD\Tests\config\Models\Universe');

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -51,6 +51,7 @@ class User extends Model
     {
         return $this->morphToMany('Backpack\CRUD\Tests\config\Models\Recommend', 'recommendable')->withPivot('text');
     }
+
     public function recommendsDuplicate()
     {
         return $this->morphToMany('Backpack\CRUD\Tests\config\Models\Recommend', 'recommendable')->withPivot(['text', 'id']);

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -51,6 +51,10 @@ class User extends Model
     {
         return $this->morphToMany('Backpack\CRUD\Tests\config\Models\Recommend', 'recommendable')->withPivot('text');
     }
+    public function recommendsDuplicate()
+    {
+        return $this->morphToMany('Backpack\CRUD\Tests\config\Models\Recommend', 'recommendable')->withPivot(['text', 'id']);
+    }
 
     public function bills()
     {

--- a/tests/config/database/seeds/MorphableSeeders.php
+++ b/tests/config/database/seeds/MorphableSeeders.php
@@ -25,6 +25,10 @@ class MorphableSeeders extends Seeder
             'title' => $faker->title,
             'created_at' => $now,
             'updated_at' => $now,
+        ], [
+            'title' => $faker->title,
+            'created_at' => $now,
+            'updated_at' => $now,
         ]]);
 
         DB::table('bills')->insert([[


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As several people requested previously, there is sometimes the need to allow the saving of duplicated pivots. Lately resurface by an user trying to fix that issue in #5535 

### AFTER - What is happening after this PR?

This PR introduces the ability for developers to define on their field: `allow_duplicate_pivots => true`, and Backpack will save the duplicated pivots. 
For that to work, developer need to ensure the pivot table has an "id" column, that will be added to the docs. 


### Is it a breaking change?

From this PR POV - NO


### How can we test the before & after?

I added tests for saving with and without duplicates.