### PR TITLE
fix warn before leaving - remove backpack dynamic inputs from serialization

### DIFF
--- a/src/config/backpack/operations/create.php
+++ b/src/config/backpack/operations/create.php
@@ -32,7 +32,9 @@ return [
     // Should we show a cancel button to the user?
     'showCancelButton' => true,
 
-    // Should we warn a user before leaving the page with unsaved changes?
+    // Should we warn the user before leaving the page with unsaved changes?
+    // NOTE: this works by removing all fields from the form data serialization where field name starts with "_" (underscore). Usualy backpack internal attributes.
+    // if you have fields that start with an underscore, you need to change the field name, or this functionality wont detect changes in that field.
     'warnBeforeLeaving' => false,
 
     // Before saving the entry, how would you like the request to be stripped?

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -100,7 +100,15 @@
 
       // Retrieves the current form data
       function getFormData() {
-        return new URLSearchParams(new FormData(document.querySelector("main form"))).toString();
+        let formData = new FormData(document.querySelector("main form"));
+        // remove entries from formData that start with "_"
+        let pairs = [...formData].map(pair => pair[0]);
+        for (let pair of pairs) {
+          if (pair.startsWith('_')) {
+            formData.delete(pair);
+          }
+        }
+        return new URLSearchParams(formData).toString();
       }
 
       // Prevents unloading of page if form data was changed

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -101,7 +101,7 @@
       // Retrieves the current form data
       function getFormData() {
         let formData = new FormData(document.querySelector("main form"));
-        // remove entries from formData that start with "_"
+        // remove internal inputs from formData, the ones that start with "_", like _token, _http_referrer, etc.
         let pairs = [...formData].map(pair => pair[0]);
         for (let pair of pairs) {
           if (pair.startsWith('_')) {
@@ -122,8 +122,8 @@
       }
 
       @if($crud->getOperationSetting('warnBeforeLeaving'))
-      const initData = getFormData();
-      window.addEventListener('beforeunload', preventUnload);
+        const initData = getFormData();
+        window.addEventListener('beforeunload', preventUnload);
       @endif
 
       // Save button has multiple actions: save and exit, save and edit, save and new


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in: https://github.com/Laravel-Backpack/CRUD/issues/5370

The `warnBeforeLeaving` setting in `create/update` operation would "trigger" the warning in unwanted situations, for example in case the form had `tabs`, if user opens the page, change the tab and try to leave the page without touching any field, the "prevention script" would wrongly warn the user.

That was due to attributes like `_current_tab`. 


### AFTER - What is happening after this PR?

The script removes all fields from the form serialization that start with `_` (underscore). 

### Is it a breaking change?

I don't think so no, there was a bug we are fixing. 
