### PR TITLE
navigate to tab when auto-focusing

### DIFF
--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -143,16 +143,23 @@
       @if( $crud->getAutoFocusOnFirstField() )
         @php
           $focusField = Arr::first($fields, function($field) {
-              return isset($field['auto_focus']) && $field['auto_focus'] == true;
+              return isset($field['auto_focus']) && $field['auto_focus'] === true;
           });
         @endphp
 
-        let focusField;
+        let focusField, focusFieldTab;
 
         @if ($focusField)
           @php
             $focusFieldName = isset($focusField['value']) && is_iterable($focusField['value']) ? $focusField['name'] . '[]' : $focusField['name'];
+            $focusFieldTab = $focusField['tab'] ?? null;
           @endphp
+            focusFieldTab = '{{ Str::slug($focusFieldTab) }}';
+
+            // if focus is not 'null' navigate to that tab before focusing.
+            if(focusFieldTab !== 'null'){
+              $('#form_tabs a[tab_name="'+focusFieldTab+'"]').tab('show');
+            }
             focusField = $('[name="{{ $focusFieldName }}"]').eq(0);
         @else
             focusField = getFirstFocusableField($('form'));


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/4550

If you set `auto_focus => true` on a field that was not on the primary tab, an error would be raised. 

### AFTER - What is happening after this PR?

We check if field has tab, if it has we navigate to the tab before focusing on the field. 