### PR TITLE
Streamline the eager load of relationships in crud objects

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -258,11 +258,7 @@ trait Columns
      */
     public function getColumnsRelationships()
     {
-        $columns = $this->columns();
-
-        return collect($columns)->pluck('entity')->reject(function ($value, $key) {
-            return ! $value;
-        })->toArray();
+        return $this->getRelationshipsFromCrudObjects('columns');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -5,8 +5,8 @@ namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 use Backpack\CRUD\app\Exceptions\BackpackProRequiredException;
 use Exception;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+
 /**
  * Properties and methods used by the List operation.
  */
@@ -70,8 +70,8 @@ trait Read
     public function getEntry($id)
     {
         if (! $this->entry) {
-            if($this->getOperationSetting('eagerLoadRelationships')) {
-            	$this->eagerLoadRelationshipFields();
+            if ($this->getOperationSetting('eagerLoadRelationships')) {
+                $this->eagerLoadRelationshipFields();
             }
             $this->entry = $this->getModelWithCrudPanelQuery()->findOrFail($id);
             $this->entry = $this->entry->withFakes();
@@ -146,8 +146,8 @@ trait Read
 
         foreach ($crudObjects as $crudObjectName => $attributes) {
             $relationString = isset($attributes['entity']) && $attributes['entity'] !== false ? $attributes['entity'] : '';
-            
-            if(!$relationString) {
+
+            if (! $relationString) {
                 continue;
             }
 
@@ -156,7 +156,6 @@ trait Read
             }
 
             $relationAttribute = $attributes['attribute'] ?? null;
-
 
             if ($relationAttribute) {
                 $relationString = Str::endsWith($relationString, $relationAttribute) ? Str::beforeLast($relationString, '.') : $relationString;

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -2,8 +2,8 @@
 
 /**
  * Configurations for Backpack's ListOperation.
- *
- * @see https://backpackforlaravel.com/docs/crud-operation-list
+ * 
+ * @see https://backpackforlaravel.com/docs/crud-operation-list-entries
  */
 
 return [
@@ -64,4 +64,8 @@ return [
     // Display the `Showing X of XX entries (filtered  from X entries)`?
     // Setting this to false will improve performance on big datasets.
     'showEntryCount' => true,
+
+    // when list operation load the information from database, should Backpack eager load the relations ? 
+    // this setting is enabled by default as it reduces the amount of queries required to load the page
+    'eagerLoadRelationships' => true,
 ];

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -2,7 +2,7 @@
 
 /**
  * Configurations for Backpack's ListOperation.
- * 
+ *
  * @see https://backpackforlaravel.com/docs/crud-operation-list-entries
  */
 
@@ -65,7 +65,7 @@ return [
     // Setting this to false will improve performance on big datasets.
     'showEntryCount' => true,
 
-    // when list operation load the information from database, should Backpack eager load the relations ? 
+    // when list operation load the information from database, should Backpack eager load the relations ?
     // this setting is enabled by default as it reduces the amount of queries required to load the page
     'eagerLoadRelationships' => true,
 ];

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -39,6 +39,10 @@ return [
     // that allows the user to fill the form from another language?
     'showTranslationNotice' => true,
 
+    // when loading an update form, should Backpack eager load the relationship information from database? 
+    // this is generally a good thing to enable, as it helps to reduce the number of queries.
+    'eagerLoadRelationships' => false,
+
     // Before saving the entry, how would you like the request to be stripped?
     //  - false - use Backpack's default (ONLY save inputs that have fields)
     //  - invokable class - custom stripping (the return should be an array with input names)

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -39,7 +39,7 @@ return [
     // that allows the user to fill the form from another language?
     'showTranslationNotice' => true,
 
-    // when loading an update form, should Backpack eager load the relationship information from database? 
+    // when loading an update form, should Backpack eager load the relationship information from database?
     // this is generally a good thing to enable, as it helps to reduce the number of queries.
     'eagerLoadRelationships' => false,
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We could only eager load relationships in in `columns` crud object type and that prevented us from eager loading the relationships for fields in the update form. 

### AFTER - What is happening after this PR?

We can eager load relationships for multiple object types (eg: columns and fields), and by consequence we can now eager load relationships on the update form.


## HOW

### How did you achieve that, in technical terms?

Generalizing the eager load method and creating some additional helper methods we can now eager load columns and fields. 

Added settings to disable this behavior on the relevant operations, for list operation it eager loads by default to keep previous behavior, and in update is disabled by default to avoid potentially breaking changes. 
We have the opportunity to enable it by default in the next version for update. 

### Is it a breaking change?

I don't think so, no.

### How can we test the before & after?

Enable the feature in `config/backpack/opeations/update.php`. Create a monster with a few relationships, like 3 or 4 belongs to many entries. See the number of queries in main vs this branch. 
