### PR TITLE
allow configurable page headings using tokens

### DIFF
--- a/src/resources/lang/en/crud.php
+++ b/src/resources/lang/en/crud.php
@@ -20,6 +20,10 @@ return [
     'save_action_save_and_preview' => 'Save and preview',
     'save_action_changed_notification' => 'Default behaviour after saving has been changed.',
 
+    // headings
+    'page_heading' => ':plural',
+    'page_subheading' => ':action :singular',
+
     // Create form
     'add' => 'Add',
     'back_to_all' => 'Back to all ',

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -13,17 +13,11 @@
 
 @section('header')
     <section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</p>
-        @if ($crud->hasAccess('list'))
-            <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small>
-                    <a href="{{ url($crud->route) }}" class="d-print-none font-sm">
-                        <span><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></span>
-                    </a>
-                </small>
-            </p>
-        @endif
+        @include('crud::inc.page_headings', [
+            'singular' => $crud->entity_name, 
+            'plural' => $crud->entity_name_plural,
+            'action' => trans('backpack::crud.add')
+        ])
     </section>
 @endsection
 

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -13,13 +13,11 @@
 
 @section('header')
     <section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</p>
-        @if ($crud->hasAccess('list'))
-            <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-            </p>
-        @endif
+	@include('crud::inc.page_headings', [
+        'singular' => $crud->entity_name, 
+        'plural' => $crud->entity_name_plural,
+        'action' => trans('backpack::crud.edit')
+    ])
     </section>
 @endsection
 

--- a/src/resources/views/crud/inc/page_headings.blade.php
+++ b/src/resources/views/crud/inc/page_headings.blade.php
@@ -1,0 +1,29 @@
+<h1 
+    class="text-capitalize mb-0" 
+    bp-section="page-heading">
+    {!! $crud->getHeading() ?? trans('backpack::crud.page_heading', [
+        'singular' => $singular, 
+        'plural' => $plural,
+        'action' => $action
+        ]) 
+    !!}
+</h1>
+<p 
+    class="ms-2 ml-2 mb-0" 
+    bp-section="page-subheading">
+    {!! $crud->getSubheading() ?? trans('backpack::crud.page_subheading', [
+        'singular' => $singular, 
+        'plural' => $plural,
+        'action' => $action
+        ]) 
+    !!}
+</p>
+@if ($backButton ?? true && $crud->hasAccess('list'))
+    <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
+        <small>
+            <a href="{{ url($crud->route) }}" class="d-print-none font-sm">
+                <span><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></span>
+            </a>
+        </small>
+    </p>
+@endif

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -13,8 +13,12 @@
 
 @section('header')
     <section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" id="datatable_info_stack" bp-section="page-subheading">{!! $crud->getSubheading() ?? '' !!}</p>
+    @include('crud::inc.page_headings', [
+            'singular' => '', 
+            'plural' => $crud->entity_name_plural,
+            'action' => '',
+            'backButton' => false
+        ])
     </section>
 @endsection
 

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -13,13 +13,11 @@
 
 @section('header')
     <section class="header-operation container-fluid animated fadeIn d-flex align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}</p>
-        @if ($crud->hasAccess('list'))
-            <p class="ms-2 ml-2 mb-0" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-            </p>
-        @endif
+    @include('crud::inc.page_headings', [
+        'singular' => $crud->entity_name, 
+        'plural' => $crud->entity_name_plural,
+        'action' => trans('backpack::crud.reorder')
+    ])
     </section>
 @endsection
 

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -14,13 +14,11 @@
 @section('header')
     <div class="container-fluid d-flex justify-content-between my-3">
         <section class="header-operation animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-            <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-            <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}</p>
-            @if ($crud->hasAccess('list'))
-                <p class="ms-2 ml-2 mb-0" bp-section="page-subheading-back-button">
-                    <small><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-                </p>
-            @endif
+		@include('crud::inc.page_headings', [
+			'singular' => $crud->entity_name, 
+			'plural' => $crud->entity_name_plural,
+			'action' => trans('backpack::crud.preview')
+		])
         </section>
         <a href="javascript: window.print();" class="btn float-end float-right"><i class="la la-print"></i></a>
     </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The main idea behind this came up from https://github.com/Laravel-Backpack/CRUD/pull/4902

We discussed it internally and aknowledge that the PR as is was not mergeable, and not everyone agreed with the change so it was postponed. 

I was doing now a cleanup and stumbled upon it. I was one of the people that liked the "idea" of the PR. So I came up with this solution. 

### AFTER - What is happening after this PR?

This gives developers the flexibility to configure the page headers beyond just changing a word at a time. 

Is this a good  idea ? At first it looks 🤷 


## HOW

### How did you achieve that, in technical terms?

Created two new language strings to represent the `page_heading` and `page_subheading` in full. By default accepted the needed parameters, but this can be extended in the future to pass additional parameters. 

At the moment the available parameters are: 
`:singular - $crud->entity_name` 
`:plural - $crud->entity_name_plural` 
`:action - trans('crud.add/edit/preview')`,



### Is it a breaking change?

Maybe not ? 

