### PR TITLE
Fix CrudPanel button() when instantiating with an array of attributes

### DIFF
--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -42,7 +42,10 @@ class CrudButton implements Arrayable
             extract($nameOrAttributes);
         }
 
-        $this->name = $name ?? $nameOrAttributes ?? 'button_'.rand(1, 999999999);
+        // if $name was not extracted and there is no string to use as name, generate a random one
+        $name ??= is_string($nameOrAttributes) ? $nameOrAttributes : 'button_'.rand(1, 999999999);
+
+        $this->name = $name;
         $this->stack = $stack ?? 'top';
         $this->type = $type ?? 'view';
         $this->content = $content;

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -42,7 +42,7 @@ class CrudButton implements Arrayable
             extract($nameOrAttributes);
         }
 
-        $this->name = $nameOrAttributes ?? 'button_'.rand(1, 999999999);
+        $this->name = $name ?? $nameOrAttributes ?? 'button_'.rand(1, 999999999);
         $this->stack = $stack ?? 'top';
         $this->type = $type ?? 'view';
         $this->content = $content;

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -283,7 +283,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
         $button1->makeLast();
         $this->assertEquals($button2->toArray(), $this->crudPanel->buttons()->first()->toArray());
     }
-    
+
     public function testItThrowsExceptionWhenModifyingUnknownButton()
     {
         $this->addDefaultButtons();
@@ -294,13 +294,13 @@ class CrudPanelButtonsTest extends BaseCrudPanel
             $button->name = 'newName';
         });
     }
-    
+
     public function testItCanAddAButtonFromAModelFunction()
     {
         $this->crudPanel->addButtonFromModelFunction('line', 'buttonModelFunction', 'buttonModelFunction');
         $this->assertEquals('buttonModelFunction', $this->crudPanel->buttons()->first()->content);
     }
-    
+
     public function testItDoesNotMoveFieldWhenTargetIsUnknown()
     {
         $this->addDefaultButtons();
@@ -308,7 +308,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
         $firstButtonName = $this->crudPanel->buttons()->first()->name;
 
         $this->crudPanel->moveButton('unknownButton', 'before', 'topViewButton');
-        
+
         $this->assertCount(4, $this->crudPanel->buttons());
         $this->assertEquals($firstButtonName, $this->crudPanel->buttons()->first()->name);
     }

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -340,6 +340,12 @@ class CrudPanelButtonsTest extends BaseCrudPanel
         $this->assertFalse($this->crudPanel->hasButtonWhere('name', 'unknownButton'));
     }
 
+    public function testItGenerateARandomButtonNameIfOneNotProvided()
+    {
+        $button = $this->crudPanel->button(['stack' => 'line', 'type' => 'view', 'content' => 'crud::buttons.test']);
+        $this->assertTrue(str_starts_with($button->name, 'button_'));
+    }
+
     private function getButtonByName($name)
     {
         return $this->crudPanel->buttons()->first(function ($value) use ($name) {

--- a/tests/config/Models/TestModel.php
+++ b/tests/config/Models/TestModel.php
@@ -7,4 +7,9 @@ use Backpack\CRUD\app\Models\Traits\CrudTrait;
 class TestModel extends \Illuminate\Database\Eloquent\Model
 {
     use CrudTrait;
+
+    public function buttonModelFunction()
+    {
+        return 'model function button test';
+    }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Calling `CRUD::button(['name' => 'smt', 'stack' => 'top'])` would generate a button with:
```php
[
    'name' => ['name' => 'smt', 'stack' => 'top'],
   // .. all the other default attributes generated
]
```

`$nameOrAttributes` even after extraction would still an array with all the attributes, consequently when we init the button the button name was set to the array of attributes. 

Notice this does not affect `CRUD::addButton( ['name' => 'smt', 'stack' => 'top'])` or `CRUD::button('smt')->stack('top')` sintaxes. 

### AFTER - What is happening after this PR?

It properly generates the button: 
```php
[
    'name' => 'smt', 
    'stack' => 'top',
   // .. all the other default attributes generated
]
```

## HOW

### How did you achieve that, in technical terms?

button name will first use the extracted `$name` variable, and only after fallback to `$nameOrAttributes`, assuming it's name, otherwise generate a random button name.


### Is it a breaking change?

No


### How can we test the before & after?

Add a button with `CRUD::button( ['name' => 'smt', 'stack' => 'top'])`
