### PR TITLE
Added a minimum threshold for nesting action buttons

### DIFF
--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -49,6 +49,9 @@ return [
     // Nest action buttons within a dropdown in actions column
     'lineButtonsAsDropdown' => false,
 
+    // What is the minimum threshold of action buttons for nesting into a dropdown
+    'lineButtonsAsDropdownThreshold' => 1,
+
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)
     // that allows the user to erase local storage for that datatable,

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -407,16 +407,20 @@
         const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
         if (actionColumnIndex === -1) return;
 
+        const minimumThreshold = $('#crudTable').data('line-buttons-as-dropdown-threshold');
+
         $('#crudTable tbody tr').each(function (i, tr) {
             const actionCell = $(tr).find('td').eq(actionColumnIndex);
+            const actionButtons = actionCell.find('a.btn.btn-link');
             if(actionCell.find('.actions-buttons-column').length) return;
+            if(actionButtons.length < minimumThreshold) return;
 
             // Wrap the cell with the component needed for the dropdown
             actionCell.wrapInner('<div class="nav-item dropdown"></div>');
             actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
             
             // Prepare buttons as dropdown items
-            actionCell.find('a.btn.btn-link').each((index, action) => {
+            actionButtons.each((index, action) => {
                 $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                 $(action).find('i').addClass('me-2 text-primary');
             });

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -60,6 +60,7 @@
               data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
               data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"
               data-has-line-buttons-as-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdown') }}"
+              data-line-buttons-as-dropdown-threshold="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownThreshold') }}"
               cellspacing="0">
             <thead>
               <tr>


### PR DESCRIPTION
## WHY
If you have the nest action buttons within a dropdown enabled globally, you probably have some cruds with just 1 action button and you don't want a dropdown with just a button.

### BEFORE - What was wrong? What was happening before this PR?
No matter the number of action buttons, the links were nested within a dropdown.

### AFTER - What is happening after this PR?
Give the ability to disable the dropdown by setting the minimum threshold for buttons.

## HOW

### How did you achieve that, in technical terms?
Added a minimum threshold and check the number of buttons before nesting.

### Is it a breaking change?
No, because the threshold is set to 1 which preserves the current behavior

### How can we test the before & after?
Create a CRUD with 2 operations, list and create/update/delete or show