### PR TITLE
Add miscelaneous tests for various crud functions

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -116,9 +116,9 @@ trait Columns
     }
 
     /**
-     * Move this column to be first in the columns list.
+     * Move the most recently added column to the first column.
      *
-     * @return bool|null
+     * @return bool|void
      */
     public function makeFirstColumn()
     {
@@ -290,6 +290,7 @@ trait Columns
 
     /**
      * Get a column by the id, from the associative array.
+     * The array is 0-indexed, so the first column has id 0.
      *
      * @param  int  $column_number  Placement inside the columns array.
      * @return array Column details.
@@ -309,7 +310,11 @@ trait Columns
      */
     public function getActionsColumnPriority()
     {
-        return (int) $this->getOperationSetting('actionsColumnPriority') ?? 1;
+        if($this->getOperationSetting('actionsColumnPriority') === null) {
+            return 1;
+        }
+
+        return (int) $this->getOperationSetting('actionsColumnPriority');
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -310,7 +310,7 @@ trait Columns
      */
     public function getActionsColumnPriority()
     {
-        if($this->getOperationSetting('actionsColumnPriority') === null) {
+        if ($this->getOperationSetting('actionsColumnPriority') === null) {
             return 1;
         }
 

--- a/tests/Unit/CrudPanel/CrudPanelAccessTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAccessTest.php
@@ -105,7 +105,7 @@ class CrudPanelAccessTest extends BaseCrudPanel
 
     public function testItCanUseAClosureToResolveAccess()
     {
-        $this->crudPanel->setAccessCondition('list', function() {
+        $this->crudPanel->setAccessCondition('list', function () {
             return true;
         });
 
@@ -114,20 +114,20 @@ class CrudPanelAccessTest extends BaseCrudPanel
         $this->assertTrue($this->crudPanel->hasAccess('list'));
     }
 
-     public function testItCanUseAClosureToResolveAccessForMultipleOperations()
-     {
-         $this->crudPanel->setAccessCondition(['list','create'], function() {
-             return true;
-         });
- 
-         $this->assertTrue($this->crudPanel->getAccessCondition('list') instanceof \Closure);
- 
-         $this->assertTrue($this->crudPanel->hasAccess('list'));
-     }
+    public function testItCanUseAClosureToResolveAccessForMultipleOperations()
+    {
+        $this->crudPanel->setAccessCondition(['list', 'create'], function () {
+            return true;
+        });
+
+        $this->assertTrue($this->crudPanel->getAccessCondition('list') instanceof \Closure);
+
+        $this->assertTrue($this->crudPanel->hasAccess('list'));
+    }
 
     public function testItCanCheckIfAnOperationHasAccessConditions()
     {
-        $this->crudPanel->setAccessCondition(['list','create'], function() {
+        $this->crudPanel->setAccessCondition(['list', 'create'], function () {
             return true;
         });
 
@@ -137,7 +137,7 @@ class CrudPanelAccessTest extends BaseCrudPanel
 
     public function testItCanCheckAccessToAll()
     {
-        $this->crudPanel->allowAccess(['list', 'create'], function() {
+        $this->crudPanel->allowAccess(['list', 'create'], function () {
             return true;
         });
 
@@ -147,7 +147,7 @@ class CrudPanelAccessTest extends BaseCrudPanel
 
     public function testItCanAllowAccessToSomeSpecificOperationWhileDenyingOthers()
     {
-        $this->crudPanel->allowAccess(['list', 'create'], function() {
+        $this->crudPanel->allowAccess(['list', 'create'], function () {
             return true;
         });
 

--- a/tests/Unit/CrudPanel/CrudPanelAccessTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelAccessTest.php
@@ -102,4 +102,60 @@ class CrudPanelAccessTest extends BaseCrudPanel
 
         $this->crudPanel->hasAccessOrFail($this->unknownPermission);
     }
+
+    public function testItCanUseAClosureToResolveAccess()
+    {
+        $this->crudPanel->setAccessCondition('list', function() {
+            return true;
+        });
+
+        $this->assertTrue($this->crudPanel->getAccessCondition('list') instanceof \Closure);
+
+        $this->assertTrue($this->crudPanel->hasAccess('list'));
+    }
+
+     public function testItCanUseAClosureToResolveAccessForMultipleOperations()
+     {
+         $this->crudPanel->setAccessCondition(['list','create'], function() {
+             return true;
+         });
+ 
+         $this->assertTrue($this->crudPanel->getAccessCondition('list') instanceof \Closure);
+ 
+         $this->assertTrue($this->crudPanel->hasAccess('list'));
+     }
+
+    public function testItCanCheckIfAnOperationHasAccessConditions()
+    {
+        $this->crudPanel->setAccessCondition(['list','create'], function() {
+            return true;
+        });
+
+        $this->assertTrue($this->crudPanel->hasAccessCondition('list'));
+        $this->assertFalse($this->crudPanel->hasAccessCondition('delete'));
+    }
+
+    public function testItCanCheckAccessToAll()
+    {
+        $this->crudPanel->allowAccess(['list', 'create'], function() {
+            return true;
+        });
+
+        $this->assertTrue($this->crudPanel->hasAccessToAll(['list', 'create']));
+        $this->assertFalse($this->crudPanel->hasAccessToAll(['list', 'create', 'delete']));
+    }
+
+    public function testItCanAllowAccessToSomeSpecificOperationWhileDenyingOthers()
+    {
+        $this->crudPanel->allowAccess(['list', 'create'], function() {
+            return true;
+        });
+
+        $this->assertTrue($this->crudPanel->hasAccessToAll(['list', 'create']));
+
+        $this->crudPanel->allowAccessOnlyTo('list');
+
+        $this->assertTrue($this->crudPanel->hasAccess('list'));
+        $this->assertFalse($this->crudPanel->hasAccess('create'));
+    }
 }

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -443,6 +443,69 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $this->assertNotContains($this->oneColumnArray, $this->crudPanel->columns());
     }
 
+    public function testItCanRemoveAllColumns()
+    {
+        $this->crudPanel->addColumns(['column1', 'column2', 'column3']);
+
+        $this->crudPanel->removeAllColumns();
+
+        $this->assertEmpty($this->crudPanel->columns());
+    }
+
+    public function testItCanSetColumnDetails()
+    {
+        $this->crudPanel->addColumns(['column1', 'column2', 'column3', 'column4', 'column5']);
+
+        $this->crudPanel->setColumnsDetails(['column1', 'column2'], ['label' => 'New Label']);
+        $this->crudPanel->setColumnDetails('column3', ['label' => 'Old Label']);
+        $this->crudPanel->modifyColumn('column4', ['label' => 'Alias Label']);
+        $this->crudPanel->setColumnLabel('column5', 'Setting Label');
+
+        $this->assertEquals('New Label', $this->crudPanel->columns()['column1']['label']);
+        $this->assertEquals('New Label', $this->crudPanel->columns()['column2']['label']);
+        $this->assertEquals('Old Label', $this->crudPanel->columns()['column3']['label']);
+        $this->assertEquals('Alias Label', $this->crudPanel->columns()['column4']['label']);
+        $this->assertEquals('Setting Label', $this->crudPanel->columns()['column5']['label']);
+    }
+
+    public function testItCanFindAColumnById()
+    {
+        $this->crudPanel->addColumns(['column1', 'column2', 'column3']);
+
+        $column = $this->crudPanel->findColumnById(1);
+
+        $this->assertEquals('column2', $column['name']);
+    }
+
+    public function testItCanGetAndSetActionsColumnPriority()
+    {
+        $this->assertEquals(1, $this->crudPanel->getActionsColumnPriority());
+        $this->crudPanel->setActionsColumnPriority(2);
+        $this->assertEquals(2, $this->crudPanel->getActionsColumnPriority());
+    }
+
+    public function testItCanGetAndSetColumnsRemovingPreviouslySet()
+    {
+        $this->crudPanel->addColumns(['column1', 'column2', 'column3']);
+
+        $this->crudPanel->setColumns('column4');
+
+        $this->assertEquals(1, count($this->crudPanel->columns()));
+        $this->assertEquals(['column4'], array_keys($this->crudPanel->columns()));
+
+        $this->crudPanel->setColumns(['column5', 'column6']);
+        $this->assertEquals(2, count($this->crudPanel->columns()));
+        $this->assertEquals(['column5', 'column6'], array_keys($this->crudPanel->columns()));
+
+        $this->crudPanel->setColumns(['column7', [
+            'name' => 'column8',
+        ]]);
+        $this->assertEquals(2, count($this->crudPanel->columns())) ;
+        $this->assertEquals(['column7', 'column8'], array_keys($this->crudPanel->columns()));
+    }
+
+
+
     public function testRemoveUnknownColumnName()
     {
         $unknownColumnName = 'column4';
@@ -535,6 +598,27 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $this->crudPanel->orderColumns(['column2', 'column5', 'column6']);
 
         $this->assertEquals(['column2', 'column1', 'column3'], array_keys($this->crudPanel->columns()));
+    }
+
+    public function testMakeFirstColumnReturnFalseWhenNoColumnsExist()
+    {
+        $this->assertEmpty($this->crudPanel->columns());
+        $column = $this->crudPanel->makeFirstColumn();
+        $this->assertFalse($column);
+    }
+
+    public function testItCanAddADefaultTypeToTheColumn()
+    {
+        $column = $this->crudPanel->addDefaultTypeToColumn(['name' => 'name']);
+
+        $this->assertEquals('text', $column['type']);
+    }
+
+    public function testItReturnFalseWhenTryingToAddTypeToAColumnWithoutName()
+    {
+        $column = $this->crudPanel->addDefaultTypeToColumn(['attribute' => 'name']);
+
+        $this->assertFalse($column);
     }
 
     public function testItCanChangeTheColumnKey()

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -500,11 +500,9 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $this->crudPanel->setColumns(['column7', [
             'name' => 'column8',
         ]]);
-        $this->assertEquals(2, count($this->crudPanel->columns())) ;
+        $this->assertEquals(2, count($this->crudPanel->columns()));
         $this->assertEquals(['column7', 'column8'], array_keys($this->crudPanel->columns()));
     }
-
-
 
     public function testRemoveUnknownColumnName()
     {

--- a/tests/Unit/CrudPanel/CrudPanelSettingsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSettingsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
+/**
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Settings
+ */
+class CrudPanelSettingsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
+{   
+    public function testItCanAddASettingToCrudPanel()
+    {
+        $this->crudPanel->set('create.test', 'value');
+
+        $this->assertEquals('value', $this->crudPanel->get('create.test'));
+    }
+
+    public function testItCanCheckIfASettingExist()
+    {
+        $this->crudPanel->set('create.test', 'value');
+
+        $this->assertTrue($this->crudPanel->has('create.test'));
+        $this->assertFalse($this->crudPanel->has('create.test2'));
+    }
+
+    public function testItCanGetOrSetASetting()
+    {
+        $this->crudPanel->setting('create.test', 'value');
+
+        $this->assertEquals('value', $this->crudPanel->setting('create.test'));
+    }
+
+    public function testItCanGetAllSettingOrderedByKey()
+    {
+        $this->crudPanel->set('create.test', 'value');
+        $this->crudPanel->set('create.ambat', 'value2');
+        $this->crudPanel->set('ambar.test', 'value3');
+
+        $this->assertEquals([
+            'ambar.test' => 'value3',
+            'create.test' => 'value',
+            'create.ambat' => 'value2',
+        ], $this->crudPanel->settings());
+    }
+
+    public function testItCanSetOperationSettings()
+    {
+        $this->crudPanel->setOperation('create');
+
+        $this->crudPanel->setOperationSetting('test', 'value');
+        $this->crudPanel->setOperationSetting('test', 'value', 'list');
+
+        $this->assertEquals('value', $this->crudPanel->get('create.test'));
+        $this->assertEquals('value', $this->crudPanel->get('list.test'));
+    }
+
+    public function itCanCheckIfOperationSettingsExist()
+    {
+        $this->crudPanel->setOperation('create');
+
+        $this->crudPanel->setOperationSetting('test', 'value');
+        $this->crudPanel->setOperationSetting('test', 'value', 'list');
+
+        $this->assertTrue('value', $this->crudPanel->hasOperationSetting('test'));
+        $this->assertTrue('value', $this->crudPanel->hasOperationSetting('test', 'list'));
+    }
+
+    public function testItGetsTheOperationListFromSettings() 
+    {
+        $this->crudPanel->set('create.access', 'value');
+        $this->crudPanel->set('list.access', 'value2');
+        $this->crudPanel->set('something', 'value');
+        $this->crudPanel->set('whatever.not', 'value');
+
+        $this->assertEquals(['create', 'list'], $this->invokeMethod($this->crudPanel, 'getAvailableOperationsList'));
+    }
+}

--- a/tests/Unit/CrudPanel/CrudPanelSettingsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSettingsTest.php
@@ -6,7 +6,7 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Settings
  */
 class CrudPanelSettingsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
-{   
+{
     public function testItCanAddASettingToCrudPanel()
     {
         $this->crudPanel->set('create.test', 'value');
@@ -64,7 +64,7 @@ class CrudPanelSettingsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCr
         $this->assertTrue('value', $this->crudPanel->hasOperationSetting('test', 'list'));
     }
 
-    public function testItGetsTheOperationListFromSettings() 
+    public function testItGetsTheOperationListFromSettings()
     {
         $this->crudPanel->set('create.access', 'value');
         $this->crudPanel->set('list.access', 'value2');


### PR DESCRIPTION
This adds more tests to crud suite. 

There is also a type casting bug fixed in `Columns` trait. When `actionsColumnPriority` was not set (`null)`, `(int) null` evaluates to 0, when as per doc blocks, the range should be from 1 to infinity. 
