### PR TITLE
Fix ReorderOperation - replace upsert with 4 update queries

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -32,18 +32,18 @@ trait Reorder
             $item['parent_id'] = empty($item['parent_id']) ? null : (int) $item['parent_id'];
             $item['depth'] = empty($item['depth']) ? null : (int) $item['depth'];
             $item['lft'] = empty($item['left']) ? null : (int) $item['left'];
-            $item['rgt'] = empty($item['right']) ? null : (int) $item['right'];            
+            $item['rgt'] = empty($item['right']) ? null : (int) $item['right'];
             // unset mapped items properties.
             unset($item['item_id'], $item['left'], $item['right']);
 
             return $item;
         })->toArray();
-        
+
         DB::transaction(function () use ($reorderItems, $primaryKey, $itemKeys) {
             $reorderItemsBindString = implode(',', array_fill(0, count($reorderItems), '?'));
-            foreach(['parent_id', 'depth', 'lft', 'rgt'] as $column) {
+            foreach (['parent_id', 'depth', 'lft', 'rgt'] as $column) {
                 $query = '';
-                $bindings = [];  
+                $bindings = [];
                 $query .= "UPDATE {$this->model->getTable()} SET {$column} = CASE ";
                 foreach ($reorderItems as $item) {
                     $query .= "WHEN {$primaryKey} = ? THEN ? ";
@@ -55,7 +55,7 @@ trait Reorder
                 DB::statement($query, $bindings);
             }
         });
-        
+
         return count($reorderItems);
     }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Recently I changed the ReorderOperation to use `upsert()` instead of iterating each model and do thousands of queries. It boosts the performance by magnitudes, but it has it's drawbacks. The main one being it tries to create first before attempting to update. 

I mistakenly fixed "my test use case" but as a general solution my last change is not a good one 😞 

### AFTER - What is happening after this PR?

Instead of doing it all with one upsert, we do it in 4 database UPDATE operations using CASE statements. That allow us to keep the performance benefits vs thousands of queries, and doesn't have the draw back of touching un-wanted columns as it performs the updates only in the tracked columns. 

A query for each of the attributes look like this:
```sql
UPDATE table SET parent_id = CASE
WHEN id = 1 THEN parent_id_value_for_id_1
WHEN id = 2 THEN parent_id_value_for_id_2
ELSE parent_id END WHERE id IN (1,2)
```
We do 4 of this, one for each attribute (lft, rgt, parent_id, depth).

## HOW

### How did you achieve that, in technical terms?

Using a raw sql, but using php casting to integers and sql bindings (similar to any laravel query through the query builder).



### Is it a breaking change?

No I don't think so.


### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
