### PR TITLE
show selected files in upload multiple field

### DIFF
--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -19,7 +19,7 @@
 		}
 	@endphp
 	@if (count($values))
-    <div class="well well-sm existing-file">
+    <div class="well well-sm existing-file mb-2">
     	@foreach($values as $key => $file_path)
     		<div class="file-preview">
     			@if (isset($field['temporary']))
@@ -234,7 +234,7 @@
 				
 					// if existing files is not on the page, create a new div a prepend it to the fileInput
 					if(existingFiles.length === 0) {
-						existingFiles = $('<div class="well well-sm existing-file"></div>');
+						existingFiles = $('<div class="well well-sm existing-file mb-2"></div>');
 						existingFiles.insertBefore(element.find('input[type=hidden]'));
 						existingFiles.html(files);
 					}else {

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -127,6 +127,7 @@
 
 		.backstrap-file-label[has-selected-files=true] .badge {
 			margin-right: 5px;
+			margin-bottom: 5px;
 		}
 
 		.backstrap-file-label::after {

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -158,10 +158,11 @@
         		var clearFileButton = element.find(".file-clear-button");
         		var fileInput = element.find("input[type=file]");
         		var inputLabel = element.find("label.backstrap-file-label");
+				let existingFiles = fileInput.parent().siblings('.existing-file');
 
 				if(fileInput.attr('data-row-number')) {
 					let selectedFiles = [];
-					fileInput.parent().siblings('.existing-file').find('a.file-clear-button').each(function(item) {
+					existingFiles.find('a.file-clear-button').each(function(item) {
 						selectedFiles.push($(this).data('filename'));
 					});
 
@@ -228,27 +229,18 @@
 					// create a bunch of span elements with the selected files names to display in the label
 					let files = '';
 					selectedFiles.forEach(file => {
-						files += '<span class="badge text-bg-secondary badge-primary">'+file.name+'</span> ';
+						files += '<span class="badge mt-1 mb-1 text-bg-secondary badge-primary">'+file.name+'</span> ';
 					});
-					
-					if(selectedFiles.length > 0) {
-						inputLabel.attr('has-selected-files', 'true');
-						// register a click event on the label that will trigger the file input click event
-						// this allow the user to open the file dialog again when they click on the labels
-						// the reason for this is that when you have a lot of select files, or files
-						// with big names, the input will resize to fit the content, but wont open
-						// the file dialog when user clicks on labels or in the "expanded" input
-						inputLabel.on('click', function() {
-							fileInput.click();
-						});
-					}else{
-						inputLabel.removeAttr('has-selected-files');
-
-						// remove the click event we registered
-						inputLabel.off('click');
+				
+					// if existing files is not on the page, create a new div a prepend it to the fileInput
+					if(existingFiles.length === 0) {
+						existingFiles = $('<div class="well well-sm existing-file"></div>');
+						existingFiles.insertBefore(element.find('input[type=hidden]'));
+						existingFiles.html(files);
+					}else {
+						// if existing files is on page show the added files after the uploaded ones
+						existingFiles.append(files);
 					}
-					
-					inputLabel.html(files);
 
 		        	// remove the hidden input, so that the setXAttribute method is no longer triggered
 					$(this).next("input[type=hidden]:not([name='clear_"+fieldName+"[]'])").remove();

--- a/src/resources/views/crud/fields/upload_multiple.blade.php
+++ b/src/resources/views/crud/fields/upload_multiple.blade.php
@@ -120,6 +120,15 @@
 			font-weight: 400!important;
 		}
 
+		.backstrap-file-label[has-selected-files=true] {
+			display: inline-table;
+			width: 100%;
+		}
+
+		.backstrap-file-label[has-selected-files=true] .badge {
+			margin-right: 5px;
+		}
+
 		.backstrap-file-label::after {
 			position: absolute;
 			top: 0;
@@ -201,14 +210,12 @@
 					}
 		        	// if the file container is empty, remove it
 		        	if ($.trim(container.html())=='') {
-						//$('<input type="hidden" name="'+fieldName+'[]" value="">').insertBefore(fileInput);
 		        		container.remove();
 		        	}
 		        	$("<input type='hidden' class='clear-files' name='clear_"+fieldName+"[]' value='"+$(this).data('filename')+"'>").insertAfter(fileInput);
 		        });
 
 		        fileInput.change(function() {
-	                inputLabel.html("{{trans('backpack::crud.upload_multiple_files_selected')}}");
 					let selectedFiles = [];
 
 					Array.from($(this)[0].files).forEach(file => {
@@ -216,6 +223,32 @@
 					});
 
 					element.find('input').first().val(JSON.stringify(selectedFiles)).trigger('change');
+
+					// create a bunch of span elements with the selected files names to display in the label
+					let files = '';
+					selectedFiles.forEach(file => {
+						files += '<span class="badge text-bg-secondary badge-primary">'+file.name+'</span> ';
+					});
+					
+					if(selectedFiles.length > 0) {
+						inputLabel.attr('has-selected-files', 'true');
+						// register a click event on the label that will trigger the file input click event
+						// this allow the user to open the file dialog again when they click on the labels
+						// the reason for this is that when you have a lot of select files, or files
+						// with big names, the input will resize to fit the content, but wont open
+						// the file dialog when user clicks on labels or in the "expanded" input
+						inputLabel.on('click', function() {
+							fileInput.click();
+						});
+					}else{
+						inputLabel.removeAttr('has-selected-files');
+
+						// remove the click event we registered
+						inputLabel.off('click');
+					}
+					
+					inputLabel.html(files);
+
 		        	// remove the hidden input, so that the setXAttribute method is no longer triggered
 					$(this).next("input[type=hidden]:not([name='clear_"+fieldName+"[]'])").remove();
 		        });


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There is a high visual discrepancy between the selection of files in `upload` vs `upload_multiple` as highlighted here: https://github.com/Laravel-Backpack/CRUD/issues/5550

![image](https://github.com/user-attachments/assets/6770efcc-e6d5-4c29-9b29-065da8622e5f)

As one can see in the screenshot, it's not possible to know what files are selected when the field is multiple. And if one asked me, I would say that's more important to "double-check" selected files after selecting a bunch of them, than when you specifically select a file. 

I've had this hitch before, and had managed to work around it by using a tidy bit of javascript that populates a similar span on top of the field ... but meh 🤷 
I think this is something we can/should maintain in house.

### AFTER - What is happening after this PR?

Selected files display as badges on the input. I tried without the badge, as "text" only like in the `upload` field, but it gets a bit messy to read and reason about when one file starts and other ends. 

![image](https://github.com/user-attachments/assets/bab3232f-3167-4a71-af56-cd4f56263a89)

![image](https://github.com/user-attachments/assets/47003140-341c-4422-912f-38e77c5ec0b5)

I think the field `upload` should probably also get a `badge` instead of only the text? What you think @tabacitu ? 

![image](https://github.com/user-attachments/assets/bdc8f566-7ca3-4c0a-9c7a-ee6d45b7070f)

 

### Is it a breaking change?

Well, theoretically is visually different ... but I wouldn't consider this a BC ? 
