### PR TITLE
hide search input if table is not searchable

### DIFF
--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -35,6 +35,7 @@
               </div>
             @endif
           </div>
+          @if($crud->getOperationSetting('searchableTable'))
           <div class="col-sm-3">
             <div id="datatable_search_stack" class="mt-sm-0 mt-2 d-print-none">
               <div class="input-icon">
@@ -45,6 +46,7 @@
               </div>
             </div>
           </div>
+          @endif
         </div>
 
         {{-- Backpack List Filters --}}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/theme-tabler/issues/148

We were only "hidding" the <input> when `searchableTable` was `false`. In themes that add additional icons to the input, those wouldn't be hidden. 

### AFTER - What is happening after this PR?

This forces the whole block of search to don't be in page at all if table search is disabled. 
