### PR TITLE
Improve route duplicity detection

### DIFF
--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -48,6 +48,7 @@ class AddCustomRouteContent extends Command
         if (! file_exists($routeFilePath)) {
             if ($routeFilePath !== base_path($this->backpackCustomRouteFile)) {
                 $this->info('The route file <fg=blue>'.$routeFilePath.'</> does not exist. Please create it first.');
+
                 return 1;
             }
 
@@ -56,6 +57,7 @@ class AddCustomRouteContent extends Command
                 $this->call('vendor:publish', ['--provider' => \Backpack\CRUD\BackpackServiceProvider::class, '--tag' => 'custom_routes']);
             } else {
                 $this->info('The route file <fg=blue>'.$routeFilePath.'</> does not exist. Please create it first.');
+
                 return 1;
             }
         }
@@ -106,14 +108,14 @@ class AddCustomRouteContent extends Command
         $code = preg_replace('/function\(.*\)/', '', $code);
         $code = preg_replace('/fn\(.*\)/', '', $code);
         $code = preg_replace('/\[.*\]/', '', $code);
-        
+
         return $code;
     }
 
     private function cleanContentArray(array $content)
     {
         return array_filter(array_map(function ($line) {
-            $lineText = trim($line);            
+            $lineText = trim($line);
             if ($lineText === '' ||
                 $lineText === '\n' ||
                 $lineText === '\r' ||
@@ -141,9 +143,9 @@ class AddCustomRouteContent extends Command
                 $lineText = preg_replace('/fn\(.*\)/', '', $lineText);
             }
 
-            // remove everything inside [] 
+            // remove everything inside []
             $lineText = preg_replace('/\[.*\]/', '', $lineText);
-            
+
             return $lineText;
         }, $content));
     }


### PR DESCRIPTION
This steams from #5565 

Like @karandatwani92 said: 
>It doesn't say Already existed if the same route is pushed with different inverted commas. Example:
php artisan backpack:add-custom-route 'Route::get("/example", function () { return "Example Route"; });'
php artisan backpack:add-custom-route "Route::get('/example', function () { return 'Example Route'; });"

>It doesn't say Already existed if the same route has a different return. Example:
php artisan backpack:add-custom-route 'Route::get("/example", function () { return "Example Route ONE"; });'
php artisan backpack:add-custom-route 'Route::get("/example", function () { return "Example Route TWO"; });'

This is a tricky thing. This PR has fixes for this specific scenarios, but most of the time we will be looking at routes defined in a file, and not a single "string". 
The previous examples can also be re-written in the `routes/custom.php` as:
```php
Route::get('example', function() {
$somevar = 'test';
if (request()->has('something')) {
return something;
}
return something_else;
}
```
In this case, doing `php artisan backpack:add-custom-route "Route::get('/example', function () { return 'Example Route'; });"` would still not be able to identify route and would add it again, even in this PR. 

But all this "match" routes has other caveats. See the following example:
```php
Route::group('test', function() {
    Route::get('example');
}); // test/example

Route::group('another', function() {
    Route::get('example');
}); // another/example
```
If we try in this PR or in the current main version, `php artisan  backpack:add-custom-route "Route::get('/example')"`, it will say that the route already exists, it doesn't, what exists is `test/example` and `another/example`, but it will match the line. 
Similar as if you do `php artisan  backpack:add-custom-route "Route::get('another/example')"` it will **add** the route, because it's unable to understand the "chain" between route groups and routes defined inside that block. 
