### PR TITLE
move the attribute processing to save()

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -60,9 +60,6 @@ class CrudColumn
             $this->setAttributeValue('name', $name);
         }
 
-        // guess all attributes that weren't explicitly defined
-        $this->attributes = $this->crud()->makeSureColumnHasNeededAttributes($this->attributes);
-
         $this->save();
     }
 
@@ -272,9 +269,23 @@ class CrudColumn
             $this->crud()->setColumnDetails($key, $this->attributes);
         } else {
             $this->crud()->addColumn($this->attributes);
+            $this->attributes = $this->getFreshAttributes();
         }
 
         return $this;
+    }
+
+    /**
+     * Get the fresh attributes for the current column.
+     *
+     * @return array
+     */
+    private function getFreshAttributes()
+    {
+        $key = isset($this->attributes['key']) ? 'key' : 'name';
+        $search = $this->attributes['key'] ?? $this->attributes['name'];
+
+        return $this->crud()->firstColumnWhere($key, $search);
     }
 
     // -------------

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -405,9 +405,23 @@ class CrudField
             $this->crud()->modifyField($key, $this->attributes);
         } else {
             $this->crud()->addField($this->attributes);
+            $this->attributes = $this->getFreshAttributes();
         }
 
         return $this;
+    }
+
+    /**
+     * Get the fresh attributes for the current field.
+     *
+     * @return array
+     */
+    private function getFreshAttributes()
+    {
+        $key = isset($this->attributes['key']) ? 'key' : 'name';
+        $search = $this->attributes['key'] ?? $this->attributes['name'];
+
+        return $this->crud()->firstFieldWhere($key, $search);
     }
 
     // -----------------


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in https://github.com/Laravel-Backpack/CRUD/issues/5579 calling the `makeSureXXXHasAllAttributes` in the constructor would lead to "unecessary" calls to that function. In a sense that only the first call does the job, the others would just return early from a bunch of functions. 

### AFTER - What is happening after this PR?

I've removed the duplicated calls by not calling the method in the CrudField/CrudColumn constructor, it will still run the "mandatory" call to initialize the field/column in the CrudPanel. 