### PR TITLE
Improve identifiable attribute

### DIFF
--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -84,7 +84,7 @@ final class DatabaseSchema
             return $table;
         }
 
-        if(empty($table)) {
+        if (empty($table)) {
             return new Table($tableName, []);
         }
 

--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -80,8 +80,12 @@ final class DatabaseSchema
             return new Table($tableName, []);
         }
 
-        if (! is_array($table) || empty($table)) {
+        if (! is_array($table)) {
             return $table;
+        }
+
+        if(empty($table)) {
+            return new Table($tableName, []);
         }
 
         $schemaManager = self::getSchemaManager($connection);

--- a/src/app/Models/Traits/HasIdentifiableAttribute.php
+++ b/src/app/Models/Traits/HasIdentifiableAttribute.php
@@ -29,7 +29,7 @@ trait HasIdentifiableAttribute
      * Get the most likely column in the db table that could be used as an identifiable attribute.
      *
      * @return string The name of the column in the database that is most likely to be a good identifying attribute.
-     * 
+     *
      * @throws \Exception
      */
     private static function guessIdentifiableColumnName()
@@ -67,7 +67,7 @@ trait HasIdentifiableAttribute
 
         // in case everything fails we just return the first column in database
         $firstColumnInTable = Arr::first($columnNames);
-        if(! empty($firstColumnInTable)) {
+        if (! empty($firstColumnInTable)) {
             return $firstColumnInTable;
         }
 

--- a/src/app/Models/Traits/HasIdentifiableAttribute.php
+++ b/src/app/Models/Traits/HasIdentifiableAttribute.php
@@ -29,6 +29,8 @@ trait HasIdentifiableAttribute
      * Get the most likely column in the db table that could be used as an identifiable attribute.
      *
      * @return string The name of the column in the database that is most likely to be a good identifying attribute.
+     * 
+     * @throws \Exception
      */
     private static function guessIdentifiableColumnName()
     {
@@ -64,6 +66,13 @@ trait HasIdentifiableAttribute
         }
 
         // in case everything fails we just return the first column in database
-        return Arr::first($columnNames);
+        $firstColumnInTable = Arr::first($columnNames);
+        if(! empty($firstColumnInTable)) {
+            return $firstColumnInTable;
+        }
+
+        // if there are no columns in the table, we need to throw an exception as there is nothing we can use to
+        // correlate with the entry. Developer need to tell Backpack what attribute to use as identifier.
+        throw new \Exception("There are no columns in the table «{$table}». Please add a column to the table or define a 'public function identifiableAttribute()' in the model.");
     }
 }

--- a/src/app/Models/Traits/HasIdentifiableAttribute.php
+++ b/src/app/Models/Traits/HasIdentifiableAttribute.php
@@ -72,7 +72,7 @@ trait HasIdentifiableAttribute
         }
 
         // if there are no columns in the table, we need to throw an exception as there is nothing we can use to
-        // correlate with the entry. Developer need to tell Backpack what attribute to use as identifier.
+        // correlate with the entry. Developer need to tell Backpack what attribute to use.
         throw new \Exception("There are no columns in the table «{$table}». Please add a column to the table or define a 'public function identifiableAttribute()' in the model.");
     }
 }

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -12,9 +12,10 @@ use Illuminate\Http\Request;
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Fields
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\FieldsProtectedMethods
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\FieldsPrivateMethods
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Input
  * @covers Backpack\CRUD\app\Library\CrudPanel\CrudField
  */
-class CrudPanelFieldsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel
+class CrudPanelFieldsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
 {
     private $oneTextFieldArray = [
         'name' => 'field1',

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -15,7 +15,7 @@ use Illuminate\Http\Request;
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Input
  * @covers Backpack\CRUD\app\Library\CrudPanel\CrudField
  */
-class CrudPanelFieldsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
+class CrudPanelFieldsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel
 {
     private $oneTextFieldArray = [
         'name' => 'field1',


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Identifiable attribute is the heavy weight of the fields/columns attributes. It's the one that if not defined by developer will do a database query to attempt to set itself up. 

I was writing  some tests, and one my goals was to speed up the test suite. While on my journey I've noticed that some tests only required the database setup because of the identifiable attribute. 

The solution is easy, just set `identifiableAttribute` on the test models, but while not doing that, I was presented with a myriad of different errors that wouldn't point the developer on the right direction on why that error was triggering. 

### AFTER - What is happening after this PR?

It steamed from above, from our "db cache layer". When the table wasn't found or was empty (no columns), a bad conditional would trigger a `trying to call function xxx() on array ... `. It will now properly return an empty `Table` object and let the script continue.
Our purpose is not to validate schemas or anything, we just get what we are told to. It's empty, it's empty, fine for us. 

The second "issue" is a consequence from fixing the previous, we would assume that "there is at least one column so we return the first column we can find", but in case there are no columns, there is no first column to return, so we should properly tell developer to define the `identifiableAttribute` in their model. 

### Is it a breaking change?

No I don't think so. You couldn't get the second issue unless the first one is fixed. If you get the first it means you didn't run your migrations or something like that because that table does not exist/is empty.
