### PR TITLE
Use CRUD request instead of global request instance

### DIFF
--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -301,7 +301,7 @@ trait SaveActions
     public function setSaveAction($forceSaveAction = null)
     {
         $saveAction = $forceSaveAction ?:
-            \Request::input('_save_action', $this->getFallBackSaveAction());
+            $this->getRequest()->input('_save_action', $this->getFallBackSaveAction());
 
         $showBubble = $this->getOperationSetting('showSaveActionChange') ?? config('backpack.crud.operations.'.$this->getCurrentOperation().'.showSaveActionChange') ?? true;
 
@@ -323,7 +323,7 @@ trait SaveActions
      */
     public function performSaveAction($itemId = null)
     {
-        $request = \Request::instance();
+        $request = $this->getRequest();
         $saveAction = $request->input('_save_action', $this->getFallBackSaveAction());
         $itemId = $itemId ?: $request->input('id');
         $actions = $this->getOperationSetting('save_actions');

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -81,9 +81,7 @@ trait SaveActions
         $orderCounter = $this->getOperationSetting('save_actions') !== null ? (count($this->getOperationSetting('save_actions')) + 1) : 1;
         //check for some mandatory fields
         $saveAction['name'] ?? abort(500, 'Please define save action name.');
-        $saveAction['redirect'] = $saveAction['redirect'] ?? function ($crud, $request, $itemId) {
-            return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
-        };
+        $saveAction['redirect'] = $saveAction['redirect'] ?? fn ($crud, $request, $itemId) => $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
         $saveAction['visible'] = $saveAction['visible'] ?? true;
         $saveAction['button_text'] = $saveAction['button_text'] ?? $saveAction['name'];
         $saveAction['order'] = isset($saveAction['order']) ? $this->orderSaveAction($saveAction['name'], $saveAction['order']) : $orderCounter;
@@ -235,7 +233,7 @@ trait SaveActions
         $actions = $this->getOrderedSaveActions();
         foreach ($actions as $actionName => $action) {
             $visible = $action['visible'];
-            if (is_callable($visible)) {
+            if ($visible instanceof \Closure) {
                 $actions[$actionName]['visible'] = $visible($this);
             }
         }
@@ -332,13 +330,13 @@ trait SaveActions
         $redirectUrl = $this->route;
 
         if (isset($actions[$saveAction])) {
-            if (is_callable($actions[$saveAction]['redirect'])) {
+            if ($actions[$saveAction]['redirect'] instanceof \Closure) {
                 $redirectUrl = $actions[$saveAction]['redirect']($this, $request, $itemId);
             }
 
             //allow the save action to define default http_referrer (url for the save_and_back button)
             if (isset($actions[$saveAction]['referrer_url'])) {
-                if (is_callable($actions[$saveAction]['referrer_url'])) {
+                if ($actions[$saveAction]['referrer_url'] instanceof \Closure) {
                     $referrer_url = $actions[$saveAction]['referrer_url']($this, $request, $itemId);
                 }
             }

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -373,7 +373,7 @@ trait SaveActions
                     return $crud->hasAccess('list');
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    return $request->request->has('_http_referrer') ? $request->request->get('_http_referrer') : $crud->route;
+                    return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
                 },
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
@@ -383,13 +383,13 @@ trait SaveActions
                     return $crud->hasAccess('update');
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    $itemId = $itemId ?: $request->request->get('id');
+                    $itemId = $itemId ?: $request->get('id');
                     $redirectUrl = $crud->route.'/'.$itemId.'/edit';
-                    if ($request->request->has('_locale')) {
-                        $redirectUrl .= '?_locale='.$request->request->get('_locale');
+                    if ($request->has('_locale')) {
+                        $redirectUrl .= '?_locale='.$request->get('_locale');
                     }
-                    if ($request->request->has('_current_tab')) {
-                        $redirectUrl = $redirectUrl.'#'.$request->request->get('_current_tab');
+                    if ($request->has('_current_tab')) {
+                        $redirectUrl = $redirectUrl.'#'.$request->get('_current_tab');
                     }
 
                     return $redirectUrl;

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -5,6 +5,7 @@ namespace Backpack\CRUD\Tests;
 use Backpack\Basset\BassetServiceProvider;
 use Backpack\CRUD\BackpackServiceProvider;
 use Backpack\CRUD\Tests\config\TestsServiceProvider;
+use Prologue\Alerts\AlertsServiceProvider;
 use Illuminate\Routing\Route as RouteInstance;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
@@ -38,6 +39,7 @@ abstract class BaseTestClass extends TestCase
         return [
             BassetServiceProvider::class,
             BackpackServiceProvider::class,
+            AlertsServiceProvider::class,
             TestsServiceProvider::class,
         ];
     }

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -5,10 +5,10 @@ namespace Backpack\CRUD\Tests;
 use Backpack\Basset\BassetServiceProvider;
 use Backpack\CRUD\BackpackServiceProvider;
 use Backpack\CRUD\Tests\config\TestsServiceProvider;
-use Prologue\Alerts\AlertsServiceProvider;
 use Illuminate\Routing\Route as RouteInstance;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
+use Prologue\Alerts\AlertsServiceProvider;
 
 abstract class BaseTestClass extends TestCase
 {

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Request;
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Input
  * @covers Backpack\CRUD\app\Library\CrudPanel\CrudField
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Input
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Views
  */
 class CrudPanelFieldsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
 {

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -194,6 +194,19 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
         $this->assertEquals('save_and_back', $this->crudPanel->getSaveAction()['active']['value']);
     }
 
+    public function testItCanSetTheSaveActionInSessionFromRequest()
+    {
+        $this->setupDefaultSaveActionsOnCrudPanel();
+        
+        $this->setupUserCreateRequest();
+
+        $this->crudPanel->getRequest()->merge(['_save_action' => 'save_action_one']);
+
+        $this->crudPanel->setSaveAction();
+
+        $this->assertEquals('save_action_one', session()->get('create.saveAction'));
+    }
+
     private function setupDefaultSaveActionsOnCrudPanel()
     {
         $this->crudPanel->allowAccess(['create', 'update', 'list']);

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -166,7 +166,7 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
 
     public function testItCanGetSaveActionFromSession()
     {
-        $this->setupDefaultSaveActionsOnCrudPanel();  
+        $this->setupDefaultSaveActionsOnCrudPanel();
         $this->crudPanel->addSaveAction($this->singleSaveAction);
 
         session()->put('create.saveAction', 'save_action_one');
@@ -197,7 +197,7 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
     public function testItCanSetTheSaveActionInSessionFromRequest()
     {
         $this->setupDefaultSaveActionsOnCrudPanel();
-        
+
         $this->setupUserCreateRequest();
 
         $this->crudPanel->getRequest()->merge(['_save_action' => 'save_action_one']);

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -186,4 +186,17 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
         ];
         $this->assertEquals($expected, $saveActions);
     }
+
+    public function testItGetsTheFirstSaveActionIfTheRequiredActionIsNotASaveAction()
+    {
+        $this->setupDefaultSaveActionsOnCrudPanel();
+        session()->put('create.saveAction', 'not_a_save_action');
+        $this->assertEquals('save_and_back', $this->crudPanel->getSaveAction()['active']['value']);
+    }
+
+    private function setupDefaultSaveActionsOnCrudPanel()
+    {
+        $this->crudPanel->allowAccess(['create', 'update', 'list']);
+        $this->crudPanel->setupDefaultSaveActions();
+    }
 }

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -213,7 +213,7 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
     public function testItCanPerformTheSaveActionAndReturnTheRedirect()
     {
         $this->setupDefaultSaveActionsOnCrudPanel();
-        
+
         $redirect = $this->crudPanel->performSaveAction();
         $this->assertEquals(url('/'), $redirect->getTargetUrl());
     }
@@ -221,13 +221,13 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
     public function testItCanPerformTheSaveActionAndReturnTheRedirectFromTheRequest()
     {
         $this->setupDefaultSaveActionsOnCrudPanel();
-        
+
         $this->setupUserCreateRequest();
 
         $this->crudPanel->addSaveAction($this->singleSaveAction);
 
         $this->crudPanel->getRequest()->merge(['_save_action' => 'save_action_one']);
-        
+
         $redirect = $this->crudPanel->performSaveAction();
 
         $this->assertEquals('https://backpackforlaravel.com', $redirect->getTargetUrl());
@@ -236,13 +236,13 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
     public function testItCanSetGetTheRefeererFromSaveAction()
     {
         $this->setupDefaultSaveActionsOnCrudPanel();
-        
+
         $this->crudPanel->addSaveAction($this->singleSaveAction);
 
         $this->crudPanel->getRequest()->merge(['_save_action' => 'save_action_one']);
 
         $this->crudPanel->performSaveAction();
-        
+
         $referer = session('referrer_url_override');
 
         $this->assertEquals('https://backpackforlaravel.com', $referer);
@@ -264,7 +264,7 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
             'success' => true,
             'redirect_url' => null,
             'referrer_url' => false,
-            'data' => null
+            'data' => null,
         ], json_decode($response->getContent(), true));
     }
 

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -156,10 +156,9 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
 
     public function testItCanHideSaveActions()
     {
-        $this->crudPanel->allowAccess(['create', 'update', 'list']);
+        $this->setupDefaultSaveActionsOnCrudPanel();
         $saveAction = $this->singleSaveAction;
         $saveAction['visible'] = false;
-        $this->crudPanel->setupDefaultSaveActions();
         $this->crudPanel->addSaveAction($saveAction);
         $this->assertCount(4, $this->crudPanel->getOperationSetting('save_actions'));
         $this->assertCount(3, $this->crudPanel->getVisibleSaveActions());
@@ -167,9 +166,11 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
 
     public function testItCanGetSaveActionFromSession()
     {
-        $this->crudPanel->allowAccess(['create', 'update', 'list']);
+        $this->setupDefaultSaveActionsOnCrudPanel();  
         $this->crudPanel->addSaveAction($this->singleSaveAction);
-        $this->crudPanel->setupDefaultSaveActions();
+
+        session()->put('create.saveAction', 'save_action_one');
+
         $saveActions = $this->crudPanel->getSaveAction();
 
         $expected = [

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -270,7 +270,6 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
         ], json_decode($response->getContent(), true));
     }
 
-    
     #[DataProvider('saveActionsDataProvider')]
     public function testSaveActionsRedirectAndRefererUrl($action, $redirect, $referrer)
     {
@@ -283,7 +282,6 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
         $this->assertEquals($redirect, $redirectUrl->getTargetUrl());
 
         $this->assertEquals($referrer, session('referrer_url_override') ?? false);
-       
     }
 
     public static function saveActionsDataProvider()

--- a/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSaveActionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\SaveActions
  */
@@ -266,6 +268,43 @@ class CrudPanelSaveActionsTest extends \Backpack\CRUD\Tests\config\CrudPanel\Bas
             'referrer_url' => false,
             'data' => null,
         ], json_decode($response->getContent(), true));
+    }
+
+    
+    #[DataProvider('saveActionsDataProvider')]
+    public function testSaveActionsRedirectAndRefererUrl($action, $redirect, $referrer)
+    {
+        $this->setupDefaultSaveActionsOnCrudPanel();
+
+        $this->crudPanel->getRequest()->merge(['_save_action' => $action, 'id' => 1, '_locale' => 'pt', '_current_tab' => 'tab1']);
+
+        $redirectUrl = $this->crudPanel->performSaveAction();
+
+        $this->assertEquals($redirect, $redirectUrl->getTargetUrl());
+
+        $this->assertEquals($referrer, session('referrer_url_override') ?? false);
+       
+    }
+
+    public static function saveActionsDataProvider()
+    {
+        return [
+            [
+                'action' => 'save_and_back',
+                'redirect' => 'http://localhost',
+                'referrer' => false,
+            ],
+            [
+                'action' => 'save_and_edit',
+                'redirect' => 'http://localhost/1/edit?_locale=pt#tab1',
+                'referrer' => 'http://localhost/1/edit',
+            ],
+            [
+                'action' => 'save_and_new',
+                'redirect' => 'http://localhost/create',
+                'referrer' => false,
+            ],
+        ];
     }
 
     private function setupDefaultSaveActionsOnCrudPanel()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Apart from some miscellaneous tests added here, the relevant part of this PR is the change in SaveActions where we used the global request facade instead of the CrudPanel request instance. 

### AFTER - What is happening after this PR?

Small changes included changing the `is_callable` checks to proper `instanceof \Closure`. 
The biggest change is using `CrudPanel::getRequest()` instead of using the `\Request` facade directly. Here is the few places where we used the request facade directly: https://github.com/search?q=repo%3ALaravel-Backpack%2FCRUD+%5CRequest%3A%3A&type=code

Also, in the same file, we are already using `getRequest()` in other place:  https://github.com/Laravel-Backpack/CRUD/blob/ab969cddf3023d629e51adc11b4aebbd9a2526f6/src/app/Library/CrudPanel/Traits/SaveActions.php#L348
