### PR TITLE
Fix validation `$attributes` getting values from wrong variable

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -163,7 +163,7 @@ trait Validation
     {
         $rules = $rules ?? $this->getOperationSetting('validationRules') ?? [];
         $messages = $messages ?? $this->getOperationSetting('validationMessages') ?? [];
-        $attributes = $messages ?? $this->getOperationSetting('validationAttributes') ?? [];
+        $attributes = $attributes ?? $this->getOperationSetting('validationAttributes') ?? [];
 
         $request = (new $request)->createFrom($this->getRequest());
         $extendedRules = $this->mergeRules($request, $rules);

--- a/tests/Unit/CrudPanel/CrudPanelValidationTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelValidationTest.php
@@ -69,6 +69,18 @@ class CrudPanelValidationTest extends \Backpack\CRUD\Tests\config\CrudPanel\Base
         $this->assertEquals(['email'], array_keys($this->crudPanel->getOperationSetting('validationRules')));
     }
 
+    public function testItCanGetTheValidationAttributesFromFields()
+    {
+        $this->crudPanel->addField([
+            'name' => 'email',
+            'validationAttribute' => 'emailed',
+        ]);
+
+        $this->crudPanel->setValidation();
+
+        $this->assertEquals(['email' => 'emailed'], $this->crudPanel->getOperationSetting('validationAttributes'));
+    }
+
     public function testItMergesAllKindsOfValidation()
     {
         $this->crudPanel->setModel(User::class);

--- a/tests/Unit/CrudPanel/CrudPanelValidationTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelValidationTest.php
@@ -81,6 +81,23 @@ class CrudPanelValidationTest extends \Backpack\CRUD\Tests\config\CrudPanel\Base
         $this->assertEquals(['email' => 'emailed'], $this->crudPanel->getOperationSetting('validationAttributes'));
     }
 
+    public function testItCanGetTheValidationAttributesFromSubfields()
+    {
+        $this->crudPanel->addField([
+            'name' => 'email',
+            'subfields' => [
+                [
+                    'name' => 'test',
+                    'validationAttribute' => 'emailed',
+                ],
+            ],
+        ]);
+
+        $this->crudPanel->setValidation();
+
+        $this->assertEquals(['email.*.test' => 'emailed'], $this->crudPanel->getOperationSetting('validationAttributes'));
+    }
+
     public function testItMergesAllKindsOfValidation()
     {
         $this->crudPanel->setModel(User::class);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Spotted this while writing tests. Tests that should pass were failing. We had a bug in the `$attributes` variable transformation 🫨 

### AFTER - What is happening after this PR?

We correctly use the assigned variable for validation attributes.
