### PR TITLE
Remove DB dependency from column tests

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Columns.php
+++ b/src/app/Library/CrudPanel/Traits/Columns.php
@@ -371,8 +371,8 @@ trait Columns
     {
         $column = $this->makeSureColumnHasName($column);
         $column = $this->makeSureColumnHasKey($column);
-        $column = $this->makeSureColumnHasLabel($column);
         $column = $this->makeSureColumnHasEntity($column);
+        $column = $this->makeSureColumnHasLabel($column);
         $column = $this->makeSureColumnHasModel($column);
         $column = $this->makeSureColumnHasAttribute($column);
         $column = $this->makeSureColumnHasRelationType($column);

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -161,13 +161,10 @@ trait ColumnsProtectedMethods
     }
 
     /**
-     * If a column definition is missing the wrapper element, set the default (empty).
-     * The wrapper is the HTML element that wrappes around the column text.
-     * By defining this array a developer can wrap the text into an anchor (link),
-     * span, div or whatever they want.
-     *
+     * @deprecated Never used. Will be removed in a future version.
      * @param  array  $column  Column definition array.
      * @return array Column definition array with wrapper.
+     * @codeCoverageIgnore
      */
     protected function makeSureColumnHasWrapper($column)
     {

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -162,8 +162,10 @@ trait ColumnsProtectedMethods
 
     /**
      * @deprecated Never used. Will be removed in a future version.
+     *
      * @param  array  $column  Column definition array.
      * @return array Column definition array with wrapper.
+     *
      * @codeCoverageIgnore
      */
     protected function makeSureColumnHasWrapper($column)

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -53,6 +53,15 @@ abstract class BaseTestClass extends TestCase
         $this->crudPanel->setRequest($request);
     }
 
+    protected function makeAnArticleModel(array $attributes = [])
+    {
+        $attributes = array_merge([
+            'id' => 1,
+            'content' => 'Some Content',
+        ], $attributes);
+        return \Backpack\CRUD\Tests\config\Models\Article::make($attributes);
+    }
+
     // allow us to run crud panel private/protected methods like `inferFieldTypeFromDbColumnType`
     public function invokeMethod(&$object, $methodName, array $parameters = [])
     {

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -59,6 +59,7 @@ abstract class BaseTestClass extends TestCase
             'id' => 1,
             'content' => 'Some Content',
         ], $attributes);
+
         return \Backpack\CRUD\Tests\config\Models\Article::make($attributes);
     }
 

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -12,7 +12,7 @@ use Backpack\CRUD\Tests\config\Models\User;
  * @covers Backpack\CRUD\app\Library\CrudPanel\CrudColumn
  * @covers Backpack\CRUD\app\Library\CrudPanel\CrudPanel
  */
-class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel
+class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel
 {
     private $oneColumnArray = [
         'name' => 'column1',
@@ -737,7 +737,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $columnArray = $this->crudPanel->columns()['articles'];
         $reflection = new \ReflectionFunction($columnArray['wrapper']['href']);
         $arguments = $reflection->getClosureUsedVariables();
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('articles.show', $arguments['route']);
         $this->assertCount(1, $arguments['parameters']);
@@ -752,7 +752,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $arguments = $reflection->getClosureUsedVariables();
         $this->assertEquals('articles.show', $arguments['route']);
         $this->assertCount(3, $arguments['parameters']);
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show?test=testing&test2=testing2', $url);
     }
@@ -761,7 +761,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
     {
         $this->crudPanel->column('articles')->entity('articles')->linkTo('article.show.detail', ['detail' => 'testing', 'otherParam' => 'test']);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show/testing?otherParam=test', $url);
     }
@@ -772,7 +772,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
                         ->entity('articles')
                         ->linkTo('article.show.detail', ['detail' => fn ($entry, $related_key) => $related_key, 'otherParam' => fn ($entry) => $entry->content]);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show/1?otherParam=Some%20Content', $url);
     }
@@ -783,7 +783,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
                         ->entity('articles')
                         ->linkTo('article.show.detail', ['id' => 123, 'detail' => fn ($entry, $related_key) => $related_key, 'otherParam' => fn ($entry) => $entry->content]);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/123/show/1?otherParam=Some%20Content', $url);
     }
@@ -794,7 +794,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
                         ->entity('articles')
                         ->linkTo('article.show.detail', ['id' => 123, 'otherParam' => fn ($entry) => $entry->content]);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/123/show/1?otherParam=Some%20Content', $url);
     }
@@ -805,7 +805,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
                         ->entity('articles')
                         ->linkTo(fn ($entry) => route('articles.show', $entry->content));
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/Some%20Content/show', $url);
     }
@@ -819,7 +819,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
             'linkTo' => fn ($entry) => route('articles.show', ['id' => $entry->id, 'test' => 'testing']),
         ]);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show?test=testing', $url);
     }
@@ -833,7 +833,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
             'linkTo' => 'articles.show',
         ]);
         $columnArray = $this->crudPanel->columns()['articles'];
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show', $url);
     }
@@ -857,7 +857,7 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBC
         $arguments = $reflection->getClosureUsedVariables();
         $this->assertEquals('articles.show', $arguments['route']);
         $this->assertCount(3, $arguments['parameters']);
-        $this->crudPanel->entry = Article::first();
+        $this->crudPanel->entry = $this->makeAnArticleModel();
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show?test=testing&test2=Some%20Content', $url);
     }

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -597,11 +597,64 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCru
         $this->assertEquals(['column2', 'column1', 'column3'], array_keys($this->crudPanel->columns()));
     }
 
+    public function testItDoesNotAttemptToGetEntityWhenColumnNameIsArray()
+    {
+        $this->crudPanel->addColumn(['name' => ['test1', 'test2'], 'label' => 'Column1', 'type' => 'text', 'key' => 'column1']);
+        $this->assertArrayNotHasKey('entity', $this->crudPanel->firstColumnWhere('key', 'column1'));
+    }
+
+    public function testItCanInferTheEntityFromColumnNameUsingEntity_idConvention()
+    {
+        $this->crudPanel->addColumn('article_id');
+
+        $this->assertEquals('article', $this->crudPanel->firstColumnWhere('name', 'article_id')['entity']);
+    }
+
+    public function testItAlwaysHasDatabaseColumnWhenDriverIsNotSql()
+    {
+        $this->crudPanel = new \Backpack\CRUD\Tests\config\CrudPanel\NoSqlDriverCrudPanel();
+        $this->crudPanel->setModel(User::class);
+
+        $this->assertTrue($this->invokeMethod($this->crudPanel, 'hasDatabaseColumn', ['test', 'test']));
+    }
+
+    public function testItCanGetTheColumnTypeFromModelCasts()
+    {
+        $this->crudPanel->addColumn('arrayCast');
+        $this->crudPanel->addColumn('jsonCast');
+        $this->crudPanel->addColumn('dateCast');
+        $this->crudPanel->addColumn('booleanCast');
+        $this->crudPanel->addColumn('datetimeCast');
+        $this->crudPanel->addColumn('numberCast');
+
+        $this->assertEquals('array', $this->crudPanel->firstColumnWhere('name', 'arrayCast')['type']);
+        $this->assertEquals('json', $this->crudPanel->firstColumnWhere('name', 'jsonCast')['type']);
+        $this->assertEquals('date', $this->crudPanel->firstColumnWhere('name', 'dateCast')['type']);
+        $this->assertEquals('check', $this->crudPanel->firstColumnWhere('name', 'booleanCast')['type']);
+        $this->assertEquals('datetime', $this->crudPanel->firstColumnWhere('name', 'datetimeCast')['type']);
+        $this->assertEquals('number', $this->crudPanel->firstColumnWhere('name', 'numberCast')['type']);
+    }
+
+    public function testItCanGetTheColumnTypeFromModelDates()
+    {
+        $this->crudPanel->addColumn('created_at');
+
+        $this->assertEquals('datetime', $this->crudPanel->firstColumnWhere('name', 'created_at')['type']);
+    }
+
     public function testMakeFirstColumnReturnFalseWhenNoColumnsExist()
     {
         $this->assertEmpty($this->crudPanel->columns());
         $column = $this->crudPanel->makeFirstColumn();
         $this->assertFalse($column);
+    }
+
+    public function testItSetsTextColumnTypeForTranslatableColumns()
+    {
+        $this->crudPanel->setModel(\Backpack\CRUD\Tests\config\Models\TestModelWithTranslations::class);
+        $this->crudPanel->addColumn('translatableColumn');
+
+        $this->assertEquals('text', $this->crudPanel->firstColumnWhere('name', 'translatableColumn')['type']);
     }
 
     public function testItCanAddADefaultTypeToTheColumn()

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -3,7 +3,6 @@
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
 use Backpack\CRUD\app\Library\CrudPanel\CrudColumn;
-use Backpack\CRUD\Tests\config\Models\Article;
 use Backpack\CRUD\Tests\config\Models\User;
 
 /**

--- a/tests/config/Models/AccountDetails.php
+++ b/tests/config/Models/AccountDetails.php
@@ -12,6 +12,11 @@ class AccountDetails extends Model
     protected $table = 'account_details';
     protected $fillable = ['user_id', 'nickname', 'profile_picture', 'article_id', 'start_date', 'end_date'];
 
+
+    public function identifiableAttribute()
+    {
+        return 'nickname';
+    }
     /**
      * Get the user for the account details.
      */

--- a/tests/config/Models/AccountDetails.php
+++ b/tests/config/Models/AccountDetails.php
@@ -12,11 +12,11 @@ class AccountDetails extends Model
     protected $table = 'account_details';
     protected $fillable = ['user_id', 'nickname', 'profile_picture', 'article_id', 'start_date', 'end_date'];
 
-
     public function identifiableAttribute()
     {
         return 'nickname';
     }
+
     /**
      * Get the user for the account details.
      */

--- a/tests/config/Models/Article.php
+++ b/tests/config/Models/Article.php
@@ -10,7 +10,7 @@ class Article extends Model
     use CrudTrait;
 
     protected $table = 'articles';
-    protected $fillable = ['user_id', 'content', 'metas', 'tags', 'extras', 'cast_metas', 'cast_tags', 'cast_extras'];
+    protected $fillable = ['id', 'user_id', 'content', 'metas', 'tags', 'extras', 'cast_metas', 'cast_tags', 'cast_extras'];
     protected $casts = [
         'cast_metas' => 'object',
         'cast_tags' => 'object',

--- a/tests/config/Models/TestModel.php
+++ b/tests/config/Models/TestModel.php
@@ -14,7 +14,7 @@ class TestModel extends \Illuminate\Database\Eloquent\Model
         'dateCast' => 'date',
         'booleanCast' => 'boolean',
         'datetimeCast' => 'datetime',
-        'numberCast' => 'int',
+        'numberCast' => 'timestamp',
     ];
 
     protected $dates = [

--- a/tests/config/Models/TestModel.php
+++ b/tests/config/Models/TestModel.php
@@ -8,8 +8,26 @@ class TestModel extends \Illuminate\Database\Eloquent\Model
 {
     use CrudTrait;
 
+    protected $casts = [
+        'arrayCast' => 'array',
+        'jsonCast' => 'json',
+        'dateCast' => 'date',
+        'booleanCast' => 'boolean',
+        'datetimeCast' => 'datetime',
+        'numberCast' => 'int',
+    ];
+
+    protected $dates = [
+        'someDate',
+    ];
+
     public function buttonModelFunction()
     {
         return 'model function button test';
+    }
+
+    public function article()
+    {
+        return $this->belongsTo('Backpack\CRUD\Tests\Config\Models\Article');
     }
 }

--- a/tests/config/Models/TestModelWithTranslations.php
+++ b/tests/config/Models/TestModelWithTranslations.php
@@ -2,17 +2,15 @@
 
 namespace Backpack\CRUD\Tests\Config\Models;
 
-use Backpack\CRUD\app\Models\Traits\CrudTrait;
-
 class TestModelWithTranslations extends TestModel
 {
-   public function translationEnabledForModel()
-   {
+    public function translationEnabledForModel()
+    {
         return true;
-   }
+    }
 
-   public function getTranslations()
-   {
-         return ['translatableColumn'];
-   }
+    public function getTranslations()
+    {
+        return ['translatableColumn'];
+    }
 }

--- a/tests/config/Models/TestModelWithTranslations.php
+++ b/tests/config/Models/TestModelWithTranslations.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Config\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+
+class TestModelWithTranslations extends TestModel
+{
+   public function translationEnabledForModel()
+   {
+        return true;
+   }
+
+   public function getTranslations()
+   {
+         return ['translatableColumn'];
+   }
+}

--- a/tests/config/Models/TestModelWithTranslations.php
+++ b/tests/config/Models/TestModelWithTranslations.php
@@ -9,8 +9,8 @@ class TestModelWithTranslations extends TestModel
         return true;
     }
 
-    public function getTranslations()
-    {
-        return ['translatableColumn'];
-    }
+   public function getTranslations()
+   {
+         return ['translatableColumn' => null];
+   }
 }

--- a/tests/config/Models/TestModelWithTranslations.php
+++ b/tests/config/Models/TestModelWithTranslations.php
@@ -9,8 +9,8 @@ class TestModelWithTranslations extends TestModel
         return true;
     }
 
-   public function getTranslations()
-   {
-         return ['translatableColumn' => null];
-   }
+    public function getTranslations()
+    {
+        return ['translatableColumn' => null];
+    }
 }

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -13,6 +13,10 @@ class User extends Model
 
     protected $fillable = ['name', 'email', 'password', 'extras'];
 
+    public function identifiableAttribute()
+    {
+        return 'name';
+    }
     /**
      * Get the account details associated with the user.
      */

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -17,6 +17,7 @@ class User extends Model
     {
         return 'name';
     }
+
     /**
      * Get the account details associated with the user.
      */


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Removed the database dependency from column tests and added a bunch of more tests. 

Deprecated `makeSureColumnHasWrapper()` because it was never used, and it's not actually a "necessary" attribute. 

