### PR TITLE
Revert change to fix image href

### DIFF
--- a/src/resources/views/crud/columns/image.blade.php
+++ b/src/resources/views/crud/columns/image.blade.php
@@ -9,7 +9,6 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['temporary'] = $column['temporary'] ?? false;
     $column['expiration'] = $column['expiration'] ?? 1;
-    $column['disk'] = $column['disk'] ?? config('filesystems.default');
 
     if($column['value'] instanceof \Closure) {
       $column['value'] = $column['value']($entry);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

href is broken by the change on this line
```
$column['disk'] = $column['disk'] ?? config('filesystems.default');
```

### AFTER - What is happening after this PR?

href is working as normal


## HOW

### How did you achieve that, in technical terms?

Revert the change



### Is it a breaking change?

No


### How can we test the before & after?

Check is return the correct URL of column image

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
