### PR TITLE
add afterColumn() alias

### DIFF
--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -143,6 +143,12 @@ class CrudColumn
         return $this;
     }
 
+    /** Alias of after() */
+    public function afterColumn(string $destinationColumn)
+    {
+        $this->after($destinationColumn);
+    }
+
     /**
      * Move the current column before another column.
      *

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -732,6 +732,10 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCru
         $this->crudPanel->column('test4')->before('test1');
         $crudColumnsNames = array_column($this->crudPanel->columns(), 'name');
         $this->assertEquals($crudColumnsNames, ['test4', 'test1', 'test3', 'test2']);
+
+        $this->crudPanel->column('test5')->afterColumn('test1');
+        $crudColumnsNames = array_column($this->crudPanel->columns(), 'name');
+        $this->assertEquals($crudColumnsNames, ['test4', 'test1', 'test5', 'test3', 'test2']);
     }
 
     public function testItCanRemoveColumnAttributesFluently()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It had been a source of confusion before as seen in https://github.com/Laravel-Backpack/CRUD/issues/5498 we only had the `after()` method in the `CrudColumn` object, while we used `afterColumn` method in the CrudPanel. 

### AFTER - What is happening after this PR?

I created an `afterColumn()` alias in the `CrudColumn` object so that `CRUD::column()->afterColumn()` and `CRUD::addColumn()->afterColumn()` produce the same result.
