### PR TITLE
Fix mobile icons - folder path

### DIFF
--- a/src/app/Console/Commands/PublishHeaderMetas.php
+++ b/src/app/Console/Commands/PublishHeaderMetas.php
@@ -32,7 +32,7 @@ class PublishHeaderMetas extends Command
         $appColor = $this->ask('What is the application color ?', '#161c2d');
         $pathPrefix = $this->ask('Where should icon files be published relative to public folder?');
 
-        $pathPrefix = Str::finish($pathPrefix ?? '', '/');
+        $pathPrefix = Str::start(Str::finish($pathPrefix ?? '', '/'), '/');
 
         // laravel adds a dummy favicon with 0 bytes. we need to remove it otherwise our script would skip publishing the favicon on new Laravel installations.
         // we will check the favicon file size, to make sure it's not a "valid" favicon. we will only delete the favicon if it has 0 bytes in size.


### PR DESCRIPTION
## WHY

While writing an article on this [feature](https://github.com/Laravel-Backpack/CRUD/pull/5552), I found a BUG.

### BEFORE - What was wrong? What was happening before this PR?

if icons were published to a sub-folder, Icon paths were incorrect for the following stubs:
- `browserconfig.stub`
- `manifest.stub`

## HOW

### How did you achieve that, in technical terms?

Just prepend a forward slash '/' if publishing to a sub-folder.

### Is it a breaking change?

NO