### PR TITLE
do not add order by primary key if there are group by in the query

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -134,13 +134,14 @@ trait Search
         $orderBy = $this->query->toBase()->orders;
         $table = $this->model->getTable();
         $key = $this->model->getKeyName();
+        $groupBy = $this->query->toBase()->groups;
 
         $hasOrderByPrimaryKey = collect($orderBy)->some(function ($item) use ($key, $table) {
             return (isset($item['column']) && $item['column'] === $key)
                 || (isset($item['sql']) && str_contains($item['sql'], "$table.$key"));
         });
 
-        if (! $hasOrderByPrimaryKey) {
+        if (! $hasOrderByPrimaryKey && empty($groupBy)) {
             $this->orderByWithPrefix($key, 'DESC');
         }
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/community-forum/discussions/1107

In some rdms with `sql_mode=only_full_group_by` enabled, adding the primary key order resulted in an error, as the `id` column was not part of the `group by` clause. 

In that regard, `id` never makes sense as part of a `group by` clause, as it should always be unique anyway. 

### AFTER - What is happening after this PR?

If there is a `group by` in the query we don't apply the default `order by id`.
