### PR TITLE
Do not error on arrayed field names

### DIFF
--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -56,6 +56,10 @@ class CrudField
             $name = $nameOrDefinitionArray;
         }
 
+        if(is_array($name)) {
+            $name = implode(',', $name);
+        }
+        
         $field = $this->crud()->firstFieldWhere('name', $name);
 
         // if field exists

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -57,7 +57,7 @@ class CrudField
         }
 
         if (is_array($name)) {
-            $name = implode(',', $name);
+            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($name));
         }
 
         $field = $this->crud()->firstFieldWhere('name', $name);

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -56,10 +56,10 @@ class CrudField
             $name = $nameOrDefinitionArray;
         }
 
-        if(is_array($name)) {
+        if (is_array($name)) {
             $name = implode(',', $name);
         }
-        
+
         $field = $this->crud()->firstFieldWhere('name', $name);
 
         // if field exists

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -119,6 +119,10 @@ trait FieldsProtectedMethods
             abort(500, 'All fields must have their name defined');
         }
 
+        if(is_array($field['name'])) {
+            $field['name'] = implode(',', $field['name']);
+        }
+
         $field['name'] = Str::replace(' ', '', $field['name']);
 
         return $field;

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -119,7 +119,7 @@ trait FieldsProtectedMethods
             abort(500, 'All fields must have their name defined');
         }
 
-        if(is_array($field['name'])) {
+        if (is_array($field['name'])) {
             $field['name'] = implode(',', $field['name']);
         }
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -120,7 +120,7 @@ trait FieldsProtectedMethods
         }
 
         if (is_array($field['name'])) {
-            $field['name'] = implode(',', $field['name']);
+            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($field['name']));
         }
 
         $field['name'] = Str::replace(' ', '', $field['name']);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We removed the support for field names as array, but we didn't properly handled the errors when developer defined the field name using an array. That led to https://github.com/Laravel-Backpack/CRUD/issues/5181

### AFTER - What is happening after this PR?

we throw proper errors when developer define the field name as an array.


### Is it a breaking change?

no