### PR TITLE
Update column priority on move

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -297,7 +297,7 @@ trait ColumnsProtectedMethods
 
             $element = array_pop($columnsArray);
 
-            if($element['priority'] === count($columnsArray)) {
+            if ($element['priority'] === count($columnsArray)) {
                 // the priority was most likely auto-set as it corresponds to the column array count
                 // update the priority to the target column position
                 $element['priority'] = $targetColumnPosition;

--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -296,6 +296,13 @@ trait ColumnsProtectedMethods
                 array_search($targetColumnName, array_keys($columnsArray)) + 1;
 
             $element = array_pop($columnsArray);
+
+            if($element['priority'] === count($columnsArray)) {
+                // the priority was most likely auto-set as it corresponds to the column array count
+                // update the priority to the target column position
+                $element['priority'] = $targetColumnPosition;
+            }
+
             $beginningPart = array_slice($columnsArray, 0, $targetColumnPosition, true);
             $endingArrayPart = array_slice($columnsArray, $targetColumnPosition, null, true);
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Making a column first in the list wouldn't update the priority, thus it wouldn't display as reported in: https://github.com/Laravel-Backpack/CRUD/issues/5215

A concrete example is:
```php
CRUD::addColumns(['column1', 'column2', 'column3']);

// column1 - priority 1
// column2 - priority 2
// column3 - priority 3

// now we will add a new column that should be the first column:
CRUD::column('column4')->makeFirst();
// column4 - priority 4

// the column array is now:
['column4', 'column1', 'column2', 'column3'];
```
But since `column4` has lower priority than the other 3 columns, it will be hidden when there is no space on the table to display the four columns. 

### AFTER - What is happening after this PR?

Whenever you move a column, we will check if the priority was "auto-set" by counting the number of columns vs the auto-assigned priority and change the priority of the moved column accordingly. 


## HOW

### How did you achieve that, in technical terms?

I am not 100% happy with his solution, but it will work for 99% of the cases. The "real issue" is the underlying **priority** assigned by Backpack when the column is added to the crud panel.

The real fix for this would be to only assign column priorities when ALL columns have been defined, so "at the end" of setupListOperation.

Another case where "lifecycle hooks" would be the definitive solution, but we don't have them yet, so this is the "best" we can do.


### Is it a breaking change?

No


### How can we test the before & after?


