### PR TITLE
Made ```boolean``` field similar to ```boolean``` column

### DIFF
--- a/src/resources/views/crud/fields/boolean.blade.php
+++ b/src/resources/views/crud/fields/boolean.blade.php
@@ -1,5 +1,6 @@
 @php
     $field['value'] = old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '0';
+    $field['allows_null'] = false;
     $field['options'][0] ??= Lang::has('backpack::crud.no') ? trans('backpack::crud.no') : 'No';
     $field['options'][1] ??= Lang::has('backpack::crud.yes') ? trans('backpack::crud.yes') : 'Yes';
 @endphp


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The ```boolean``` field does not feel the same as the ```boolean``` column

### AFTER - What is happening after this PR?

Made the field more similar to the column

### Is it a breaking change?

Yes
