### PR TITLE
Remove publishing of public assets

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -141,7 +141,6 @@ class BackpackServiceProvider extends ServiceProvider
     public function publishFiles()
     {
         $backpack_views = [__DIR__.'/resources/views' => resource_path('views/vendor/backpack')];
-        $backpack_public_assets = [__DIR__.'/public' => public_path()];
         $backpack_lang_files = [__DIR__.'/resources/lang' => app()->langPath().'/vendor/backpack'];
         $backpack_config_files = [__DIR__.'/config' => config_path()];
 
@@ -159,7 +158,6 @@ class BackpackServiceProvider extends ServiceProvider
         $minimum = array_merge(
             // $backpack_views,
             // $backpack_lang_files,
-            $backpack_public_assets,
             $backpack_config_files,
             $backpack_menu_contents_view,
             $backpack_custom_routes_file,
@@ -171,7 +169,6 @@ class BackpackServiceProvider extends ServiceProvider
         $this->publishes($backpack_lang_files, 'lang');
         $this->publishes($backpack_views, 'views');
         $this->publishes($backpack_menu_contents_view, 'menu_contents');
-        $this->publishes($backpack_public_assets, 'public');
         $this->publishes($backpack_custom_routes_file, 'custom_routes');
         $this->publishes($gravatar_assets, 'gravatar');
         $this->publishes($minimum, 'minimum');


### PR DESCRIPTION
The commit removes the automatic publishing of Backpack's public assets during the `backpack:install -q -n` command. This change ensures that asset deployment is only handled by the `backpack:publish-header-metas` command, as intended. See https://github.com/Laravel-Backpack/CRUD/pull/5552#issuecomment-2271093574

## WHY

### BEFORE - What was wrong? What was happening before this PR?

Previously, when running the `backpack:install -q -n` command, public assets were automatically deployed to the `public/` directory, even though this was not desired. This behavior led to unnecessary asset installation during the general installation process, which was redundant and could cause conflicts with other commands like `backpack:publish-header-metas`.

### AFTER - What is happening after this PR?

After this PR, the `backpack:install -q -n` command no longer deploys public assets by default. The responsibility for asset deployment now lies solely with the `backpack:publish-header-metas` command, giving developers more control over when and where assets are deployed.

## HOW

### How did you achieve that, in technical terms?

I removed the logic responsible for publishing the public assets from the `backpack:install` command in the `BackpackServiceProvider` class. This ensures that assets are no longer automatically published during the installation process.

### Is it a breaking change?

No, this is not a breaking change. The change simply prevents unwanted asset deployment during the installation process. The `backpack:publish-header-metas` command should be used for asset deployment instead.

### How can we test the before & after?

To test before the PR:

1. Run the `php artisan backpack:install -q -n` command.
2. Check the `public/` directory and observe that public assets are automatically installed.

To test after the PR:

1. Run the `php artisan backpack:install -q -n` command.
2. Check the `public/` directory and confirm that no assets are installed.
3. Run the `php artisan backpack:publish-header-metas` command.
4. Confirm that the assets are correctly deployed to the `public/` directory.

--
cc @pxpm  