### PR TITLE
remove raw order, let eloquent process the ordering

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -178,7 +178,7 @@ trait Query
         $column_direction = strtolower($column_direction);
 
         if ($this->query->getQuery()->joins !== null) {
-            return $this->query->orderByRaw("\"{$this->model->getTableWithPrefix()}\".\"{$column_name}\" {$column_direction}");
+            return $this->query->orderBy("{$this->model->getTableWithPrefix()}.{$column_name}", $column_direction);
         }
 
         return $this->query->orderBy($column_name, $column_direction);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

After a change I did in https://github.com/Laravel-Backpack/CRUD/commit/ab969cddf3023d629e51adc11b4aebbd9a2526f6 broke the ordering for tables with joins as reported by https://github.com/Laravel-Backpack/CRUD/issues/5621

We have tests in place for that, the "behavior" is correct, but the string wrapped in double quotes will break the query itself, but didn't broke the tests because we were asserting against hardcoded string by using `orderByRaw`. 

### AFTER - What is happening after this PR?

Removed the `orderByRaw` and use the `orderBy` eloquent method to generate the orderBy. 