### PR TITLE
count the group by columns instead of select.*

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -260,7 +260,8 @@ trait Query
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
         // select minimum possible columns for the count
-        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? $modelTable.'.*' : $modelTable.'.'.$this->model->getKeyName();
+        $columns = $crudQuery->groups ? $crudQuery->groups : $modelTable.'.'.$this->model->getKeyName();
+        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? $columns : $modelTable.'.'.$this->model->getKeyName();
         $subQuery->select($minimumColumns);
 
         // in case there are raw expressions we need to add them too.
@@ -269,7 +270,6 @@ trait Query
         }
 
         // re-set the previous query bindings
-        //dump($crudQuery->getColumns(), get_class($crudQuery), get_class($subQuery));
         foreach ($crudQuery->getRawBindings() as $type => $binding) {
             $subQuery->setBindings($binding, $type);
         }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When having `GROUP BY` clauses we cannot add any other column to the count that's not on the `GROUP BY` clause, so our method of `select something.*` don't work as it would select columns that wont belong to the group by clause.

### AFTER - What is happening after this PR?

It's working, it selects the "grouped columns" and don't any other columns to the select that are not in group by. 
