### PR TITLE
Fix relation inferring for nested relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -160,6 +160,7 @@ trait Input
             Arr::set($relationDetails, $key, $fieldDetails);
             unset($inferredRelation);
         }
+
         return $relationDetails;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -126,6 +126,14 @@ trait Input
                     // when it's a nested belongsTo relation we want to make sure
                     // the key used to store the values is the main relation key
                     $key = Str::beforeLast($this->getOnlyRelationEntity($field), '.');
+                    dump($field);
+                    if (! isset($field['parentFieldName'])) {
+                        $mainField = $field;
+                        $mainField['entity'] = Str::beforeLast($field['entity'], '.');
+
+                        $inferredRelation = $this->inferRelationTypeFromRelationship($mainField);
+                        dump($inferredRelation);
+                    }
 
                     break;
             }
@@ -134,12 +142,11 @@ trait Input
             if ($key === $relationMethod) {
                 continue;
             }
-
+            dump('inferred shouldn be set', $inferredRelation ?? 'not set');
             $fieldDetails = Arr::get($relationDetails, $key, []);
-
             $fieldDetails['values'][$attributeName] = Arr::get($input, $fieldName);
             $fieldDetails['model'] = $fieldDetails['model'] ?? $field['model'];
-            $fieldDetails['relation_type'] = $fieldDetails['relation_type'] ?? $field['relation_type'];
+            $fieldDetails['relation_type'] = $fieldDetails['relation_type'] ?? $inferredRelation ?? $field['relation_type'];
             $fieldDetails['crudFields'][] = $field;
             $fieldDetails['entity'] = $this->getOnlyRelationEntity($field);
 
@@ -151,7 +158,9 @@ trait Input
             }
 
             Arr::set($relationDetails, $key, $fieldDetails);
+            //unset($inferredRelation);
         }
+        //dd($relationDetails);
 
         return $relationDetails;
     }

--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -126,13 +126,12 @@ trait Input
                     // when it's a nested belongsTo relation we want to make sure
                     // the key used to store the values is the main relation key
                     $key = Str::beforeLast($this->getOnlyRelationEntity($field), '.');
-                    dump($field);
-                    if (! isset($field['parentFieldName'])) {
+                    //dump($field);
+                    if (! isset($field['parentFieldName']) && isset($field['entity'])) {
                         $mainField = $field;
                         $mainField['entity'] = Str::beforeLast($field['entity'], '.');
 
                         $inferredRelation = $this->inferRelationTypeFromRelationship($mainField);
-                        dump($inferredRelation);
                     }
 
                     break;
@@ -140,9 +139,10 @@ trait Input
 
             // we don't need to re-setup this relation method values, we just want the relations
             if ($key === $relationMethod) {
+                unset($inferredRelation);
                 continue;
             }
-            dump('inferred shouldn be set', $inferredRelation ?? 'not set');
+
             $fieldDetails = Arr::get($relationDetails, $key, []);
             $fieldDetails['values'][$attributeName] = Arr::get($input, $fieldName);
             $fieldDetails['model'] = $fieldDetails['model'] ?? $field['model'];
@@ -158,10 +158,8 @@ trait Input
             }
 
             Arr::set($relationDetails, $key, $fieldDetails);
-            //unset($inferredRelation);
+            unset($inferredRelation);
         }
-        //dd($relationDetails);
-
         return $relationDetails;
     }
 

--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -126,7 +126,7 @@ trait Input
                     // when it's a nested belongsTo relation we want to make sure
                     // the key used to store the values is the main relation key
                     $key = Str::beforeLast($this->getOnlyRelationEntity($field), '.');
-                    //dump($field);
+
                     if (! isset($field['parentFieldName']) && isset($field['entity'])) {
                         $mainField = $field;
                         $mainField['entity'] = Str::beforeLast($field['entity'], '.');

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -979,6 +979,45 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->assertEquals($account_details->bangsPivot->count(), 0);
     }
 
+    public function testCreateHasOneWithNestedRelationAsTheFirstField()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setOperation('create');
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships);
+        $this->crudPanel->addFields([
+            [
+                'name' => 'accountDetails.article',
+            ],
+            [
+                'name' => 'accountDetails.nickname',
+            ],
+            [
+                'name' => 'accountDetails.profile_picture',
+            ],
+        ]);
+
+        $faker = Factory::create();
+
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
+            'remember_token' => null,
+            'roles' => [1, 2],
+            'accountDetails' => [
+                'article' => 1,
+                'nickname' => 'i_have_has_one',
+                'profile_picture' => 'ohh my picture 1.jpg',
+            ],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+        $updateFields = $this->crudPanel->getUpdateFields($entry->id);
+        $account_details = $entry->accountDetails()->first();
+
+        $this->assertEquals($account_details->article, Article::find(1));
+    }
+
     public function testMorphOneRelationship()
     {
         $this->crudPanel->setModel(User::class);


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

This branched while working on an different issue. Basically this nested relation was only properly working in certain conditions. 

For it to work, it was required to have a "non-relation nested" field before the "nested relation" field. If the first nested field was a relation, our inferring process wouldn't work as expected. 

A practical example is for example an `HasOne` relation, let's say `UserModel HasOne AddressModel`. Address have a `name` field and a `city` (BelongsTo CityModel). 

If you defined the `city` field before the `name`, the script would fail to properly identify `nested relation` and would not save the relation.

### AFTER - What is happening after this PR?

No matter if you define the relation first, or if there is no other field other than the nested relation, it would work anyways.


## HOW

### How did you achieve that, in technical terms?

When we found a nested relation that required handling (BelongsTo for eg), we will get the "main relation" and use it to define the `relationDetails` that contain the whole relatioships to be saved.



### Is it a breaking change?

No, as tests are working and all of this is covered. This is a different scenario, as you can see, the added test would fail before this PR, and now is passing. 

![image](https://github.com/user-attachments/assets/23b6e756-9ce9-480c-8b1e-cf9d8906fafc)


### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
