### PR TITLE
ensure reordered items match the bindings number

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -40,6 +40,12 @@ trait Reorder
             return $item;
         })->toArray();
 
+        $sentIds = array_column($reorderItems, $primaryKey);
+
+        $itemKeys = $itemKeys->filter(function ($id) use ($sentIds) {
+            return in_array($id, $sentIds);
+        });
+
         // wrap the queries in a transaction to avoid partial updates
         DB::transaction(function () use ($reorderItems, $primaryKey, $itemKeys) {
             // create a string of ?,?,?,? to use as bind placeholders for item keys


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in #5634 

We used ALL the entries to build the bindings, and when developer filtered the collection that would throw a "parameter number mismatch" error. 

### AFTER - What is happening after this PR?

We only add the number of bindings corresponding to the number of reordered items. 


## HOW

### How did you achieve that, in technical terms?

Removed "extra", non reordered items from the keys we fetched from database.



### Is it a breaking change?

I don't think so, no. 
