### PR TITLE
Handle dynamic model relations

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -210,7 +210,7 @@ trait ColumnsProtectedMethods
         }
 
         // if there's a method on the model with this name
-        if (method_exists($this->model, $column['name'])) {
+        if (method_exists($this->model, $column['name']) || $this->model->isRelation($column['name'])) {
             // check model method for possibility of being a relationship
             $column['entity'] = $this->modelMethodIsRelationship($this->model, $column['name']);
 

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -149,7 +149,7 @@ trait FieldsProtectedMethods
 
         //if the name is dot notation we are sure it's a relationship
         if (strpos($field['name'], '.') !== false) {
-            $possibleMethodName = Str::of($field['name'])->before('.');
+            $possibleMethodName = Str::of($field['name'])->before('.')->value();
             // check model method for possibility of being a relationship
             $field['entity'] = $this->modelMethodIsRelationship($model, $possibleMethodName) ? $field['name'] : false;
 
@@ -157,7 +157,7 @@ trait FieldsProtectedMethods
         }
 
         // if there's a method on the model with this name
-        if (method_exists($model, $field['name'])) {
+        if (method_exists($model, $field['name']) || $model->isRelation($field['name'])) {
             // check model method for possibility of being a relationship
             $field['entity'] = $this->modelMethodIsRelationship($model, $field['name']);
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -271,7 +271,7 @@ trait Relationships
     {
         $relation = $this->getRelationInstance($field);
 
-        if (Str::afterLast($field['name'], '.') === $relation->getRelationName() || Str::endsWith($relation->getRelationName(), '{closure}') ) {
+        if (Str::afterLast($field['name'], '.') === $relation->getRelationName() || Str::endsWith($relation->getRelationName(), '{closure}')) {
             return $relation->getForeignKeyName();
         }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -271,7 +271,7 @@ trait Relationships
     {
         $relation = $this->getRelationInstance($field);
 
-        if (Str::afterLast($field['name'], '.') === $relation->getRelationName()) {
+        if (Str::afterLast($field['name'], '.') === $relation->getRelationName() || Str::endsWith($relation->getRelationName(), '{closure}') ) {
             return $relation->getForeignKeyName();
         }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -19,7 +19,7 @@ trait Relationships
         $possible_method = Str::before($entity, '.');
         $model = isset($field['baseModel']) ? app($field['baseModel']) : $this->model;
 
-        if (method_exists($model, $possible_method)) {
+        if (method_exists($model, $possible_method) || $model->isRelation($possible_method)) {
             $parts = explode('.', $entity);
             // here we are going to iterate through all relation parts to check
             foreach ($parts as $i => $part) {
@@ -328,6 +328,10 @@ trait Relationships
      */
     private function modelMethodIsRelationship($model, $method)
     {
+        if($model->isRelation($method)) {
+            return $method;
+        }
+        
         $methodReflection = new \ReflectionMethod($model, $method);
 
         // relationship methods function does not have parameters

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -325,7 +325,7 @@ trait Relationships
      */
     private function modelMethodIsRelationship($model, $method)
     {
-        if(! method_exists($model, $method) && $model->isRelation($method)) {
+        if (! method_exists($model, $method) && $model->isRelation($method)) {
             return $method;
         }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -319,19 +319,16 @@ trait Relationships
      * If the return type extends the Relation class is for sure a relation
      * Otherwise we just assume it's a relation.
      *
-     * DEV NOTE: In future versions we will return `false` when no return type is set and make the return type mandatory for relationships.
-     *           This function should be refactored to only check if $returnType is a subclass of Illuminate\Database\Eloquent\Relations\Relation.
-     *
      * @param  $model
      * @param  $method
      * @return bool|string
      */
     private function modelMethodIsRelationship($model, $method)
     {
-        if($model->isRelation($method)) {
+        if(! method_exists($model, $method) && $model->isRelation($method)) {
             return $method;
         }
-        
+
         $methodReflection = new \ReflectionMethod($model, $method);
 
         // relationship methods function does not have parameters

--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -110,7 +110,7 @@ trait Update
     {
         [$relatedModel, $relationMethod] = $this->getModelAndMethodFromEntity($model, $field);
 
-        if (! method_exists($relatedModel, $relationMethod)) {
+        if (! method_exists($relatedModel, $relationMethod) && ! $relatedModel->isRelation($relationMethod)) {
             return $relatedModel->{$relationMethod};
         }
 
@@ -157,7 +157,7 @@ trait Update
                 break;
             case 'HasOne':
             case 'MorphOne':
-                if (! method_exists($relatedModel, $relationMethod)) {
+                if (! method_exists($relatedModel, $relationMethod) && ! $relatedModel->isRelation($relationMethod)) {
                     return;
                 }
 

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -928,4 +928,21 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCru
         $url = $columnArray['wrapper']['href']($this->crudPanel, $columnArray, $this->crudPanel->entry, 1);
         $this->assertEquals('http://localhost/admin/articles/1/show?test=testing&test2=Some%20Content', $url);
     }
+
+    public function testItCanInferFieldAttributesFromADynamicRelation()
+    {
+        User::resolveRelationUsing('dynamicRelation', function ($user) {
+            return $user->belongsTo(\Backpack\CRUD\Tests\config\Models\Bang::class);
+        });
+
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addColumn('dynamicRelation');
+
+        $column = $this->crudPanel->columns()['dynamicRelation'];
+
+        $this->assertEquals('dynamicRelation', $column['name']);
+        $this->assertEquals('name', $column['attribute']);
+        $this->assertEquals('relationship', $column['type']);
+        $this->assertEquals('BelongsTo', $column['relation_type']);
+    }
 }

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -279,7 +279,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     }
 
     public function testCreateWithOneToManyDynamicRelationship()
-    {   
+    {
         Article::resolveRelationUsing('dynamicRelation', function ($article) {
             return $article->belongsTo(\Backpack\CRUD\Tests\config\Models\User::class, 'user_id');
         });
@@ -1924,8 +1924,6 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
 
         $this->assertEquals($entry->dynamicRelation()->first()->name, Bang::find(1)->name);
     }
-
-
 
     private function getPivotInputData(array $pivotRelationData, bool $initCrud = true, bool $allowDuplicates = false)
     {

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -979,6 +979,28 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         $this->crudPanel->addField('test1, test2');
         $this->assertEquals(['test1', 'test2'], $this->crudPanel->getAllFieldNames());
     }
+
+    public function testItCanInferFieldAttributesFromADynamicRelation()
+    {
+        User::resolveRelationUsing('dynamicRelation', function ($user) {
+            return $user->hasOne(\Backpack\CRUD\Tests\config\Models\AccountDetails::class);
+        });
+
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addField('dynamicRelation.nickname');
+
+        $this->assertEquals([
+            'name' => 'dynamicRelation[nickname]',
+            'type' => 'relationship',
+            'entity' => 'dynamicRelation.nickname',
+            'relation_type' => 'HasOne',
+            'attribute' => 'nickname',
+            'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
+            'multiple' => false,
+            'pivot' => false,
+            'label' => 'DynamicRelation.nickname',
+        ], $this->crudPanel->fields()['dynamicRelation.nickname']);
+    }
 }
 
 class Invokable

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -640,7 +640,7 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         $this->assertIsArray($result);
         $this->assertSame(['invokable' => 'invokable'], $result);
     }
-    
+
     public function testItDoesNotUseProtectedMethodsAsRelationshipMethods()
     {
         $this->crudPanel->setModel(User::class);

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -640,7 +640,7 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         $this->assertIsArray($result);
         $this->assertSame(['invokable' => 'invokable'], $result);
     }
-
+    
     public function testItDoesNotUseProtectedMethodsAsRelationshipMethods()
     {
         $this->crudPanel->setModel(User::class);

--- a/tests/config/Models/User.php
+++ b/tests/config/Models/User.php
@@ -11,7 +11,7 @@ class User extends Model
 
     protected $table = 'users';
 
-    protected $fillable = ['name', 'email', 'password', 'extras'];
+    protected $fillable = ['name', 'email', 'password', 'extras', 'bang_relation_field'];
 
     public function identifiableAttribute()
     {


### PR DESCRIPTION
## WHY

Fixes #5635 

### BEFORE - What was wrong? What was happening before this PR?

We were not identifying dynamic relations on models. 
Developers could do `Model::resolveRelationUsing('something', fn($item) => $item->belongsTo())` and expect that `CRUD::field('something')` would work as if they were defining any other relationship field for relations that are explicitly defined on the model `public function something() { return $this->belongsTo(); }`

### AFTER - What is happening after this PR?

We can properly identify dynamic relations on models. 🥳 

## HOW

### How did you achieve that, in technical terms?

Changed the relevant functions that identify and work with relations to account for the fact that there might be dynamic relationships defined .

### Is it a breaking change?

I don't think so, no. Tests are green, added more tests to account for this. 


### How can we test the before & after?

Define a dynamic relation on your model, and then try `CRUD::field('relationName')` and it won't work before this PR. 

