### PR TITLE
fix belongsToMany with subfields dynamic relation

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -153,7 +153,7 @@ trait Create
                             }
                             foreach ($values as $value) {
                                 // if it's an existing pivot, update it
-                                $attributes = $this->preparePivotAttributesForSave($value, $relation, $item->getKey(), $keyName);
+                                $attributes = $this->preparePivotAttributesForSave($value, $relation, $item->getKey(), $keyName, $relationMethod);
                                 if (isset($value[$keyName])) {
                                     $relation->newPivot()->where($keyName, $value[$keyName])->update($attributes);
                                 } else {
@@ -188,16 +188,16 @@ trait Create
         }
     }
 
-    private function preparePivotAttributesForSave(array $attributes, BelongsToMany|MorphToMany $relation, string|int $relatedItemKey, $pivotKeyName)
+    private function preparePivotAttributesForSave(array $attributes, BelongsToMany|MorphToMany $relation, string|int $relatedItemKey, $pivotKeyName, $relationMethod): array
     {
         $attributes[$relation->getForeignPivotKeyName()] = $relatedItemKey;
-        $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relation->getRelationName()];
+        $attributes[$relation->getRelatedPivotKeyName()] = $attributes[$relationMethod];
 
         if ($relation instanceof MorphToMany) {
             $attributes[$relation->getMorphType()] = $relation->getMorphClass();
         }
 
-        return Arr::except($attributes, [$relation->getRelationName(), $pivotKeyName]);
+        return Arr::except($attributes, [$relationMethod, $pivotKeyName]);
     }
 
     /**


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We added support for dynamic relations and a bunch of tests, but it's enough to leave one scenario behind and an error pops up. 

The scenario `BelongsToMany` with `subfields` with `allow_duplicated_pivots` had an issue, since it was not covered yet by the tests, I didn't spot it.

### AFTER - What is happening after this PR?

Fixed the issue, and added tests for those scenarios. All green, all good 👍 
