### PR TITLE
pass view to the filter options

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -363,6 +363,7 @@ class CrudFilter
     public function view($value)
     {
         $this->view = $value;
+        $this->options['view'] = $value;
 
         return $this->save();
     }


### PR DESCRIPTION
## WHY

Fixes #5638 

### BEFORE - What was wrong? What was happening before this PR?

When defining a filter using array syntax, the `view` key would be fined in the filter `options`. Using the fluent syntax, the `view` key would only be set to the `view` property and not propagated as a filter option. 

### AFTER - What is happening after this PR?

When defining fluently a filter the `view` will set the property but also store itself in the `options`. 
