### PR TITLE
Dont call mutators as methods

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -369,6 +369,7 @@ class CrudPanel
                 if (! $result instanceof Relation) {
                     throw new Exception('Not a relation');
                 }
+
                 return $result->getRelated();
             } catch (Exception $e) {
                 return $obj;

--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -366,7 +366,9 @@ class CrudPanel
         $result = array_reduce(array_splice($relationArray, 0, $length), function ($obj, $method) {
             try {
                 $result = $obj->$method();
-
+                if (! $result instanceof Relation) {
+                    throw new Exception('Not a relation');
+                }
                 return $result->getRelated();
             } catch (Exception $e) {
                 return $obj;

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -24,7 +24,7 @@ trait Relationships
             // here we are going to iterate through all relation parts to check
             foreach ($parts as $i => $part) {
                 $relation = $model->$part();
-                if(! is_a($relation, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                if (! is_a($relation, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
                     return $model;
                 }
                 $model = $relation->getRelated();
@@ -382,9 +382,9 @@ trait Relationships
         foreach ($parts as $i => $part) {
             try {
                 $model = $model->$part();
-                
-                if(! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
-                   return false;
+
+                if (! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                    return false;
                 }
 
                 $model = $model->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -65,10 +65,10 @@ trait Relationships
     public function getOnlyRelationEntity($field)
     {
         $entity = isset($field['baseEntity']) ? $field['baseEntity'].'.'.$field['entity'] : $field['entity'];
-        $model = $this->getRelationModel($entity, -1);
-        $lastSegmentAfterDot = Str::of($field['entity'])->afterLast('.');
+        $model = new ($this->getRelationModel($entity, -1));
+        $lastSegmentAfterDot = Str::of($field['entity'])->afterLast('.')->value();
 
-        if (! method_exists($model, $lastSegmentAfterDot)) {
+        if (! $this->modelMethodIsRelationship($model, $lastSegmentAfterDot)) {
             return (string) Str::of($field['entity'])->beforeLast('.');
         }
 
@@ -328,8 +328,11 @@ trait Relationships
      */
     private function modelMethodIsRelationship($model, $method)
     {
-        if (! method_exists($model, $method) && $model->isRelation($method)) {
-            return $method;
+        if (! method_exists($model, $method)) {
+            if($model->isRelation($method)) {
+                return $method;
+            }
+            return false;
         }
 
         $methodReflection = new \ReflectionMethod($model, $method);
@@ -382,9 +385,9 @@ trait Relationships
         foreach ($parts as $i => $part) {
             try {
                 $model = $model->$part();
-
-                if (! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
-                    return false;
+                
+                if(! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                   return true;
                 }
 
                 $model = $model->getRelated();

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -24,6 +24,9 @@ trait Relationships
             // here we are going to iterate through all relation parts to check
             foreach ($parts as $i => $part) {
                 $relation = $model->$part();
+                if(! is_a($relation, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                    return $model;
+                }
                 $model = $relation->getRelated();
             }
 
@@ -378,7 +381,13 @@ trait Relationships
         // if the attribute is present in the relation string.
         foreach ($parts as $i => $part) {
             try {
-                $model = $model->$part()->getRelated();
+                $model = $model->$part();
+                
+                if(! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                   return false;
+                }
+
+                $model = $model->getRelated();
             } catch (\Exception $e) {
                 // return true if the last part of a relation string is not a method on the model
                 // so it's probably the attribute that we should show

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -329,9 +329,10 @@ trait Relationships
     private function modelMethodIsRelationship($model, $method)
     {
         if (! method_exists($model, $method)) {
-            if($model->isRelation($method)) {
+            if ($model->isRelation($method)) {
                 return $method;
             }
+
             return false;
         }
 
@@ -385,9 +386,9 @@ trait Relationships
         foreach ($parts as $i => $part) {
             try {
                 $model = $model->$part();
-                
-                if(! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
-                   return true;
+
+                if (! is_a($model, \Illuminate\Database\Eloquent\Relations\Relation::class, true)) {
+                    return true;
                 }
 
                 $model = $model->getRelated();

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -370,6 +370,45 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCru
         }
     }
 
+    public function testAddRelationByNameWithMutator()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addColumn('accountDetails.nicknamutator');
+        if (backpack_pro()) {
+            $this->assertEquals(['accountDetails__nicknamutator' => [
+            'name' => 'accountDetails.nicknamutator',
+            'label' => 'AccountDetails.nicknamutator',
+            'type' => 'relationship',
+            'key' => 'accountDetails__nicknamutator',
+            'priority' => 0,
+            'attribute' => 'nicknamutator',
+            'tableColumn' => false,
+            'orderable' => false,
+            'searchLogic' => false,
+            'relation_type' => 'HasOne',
+            'entity' => 'accountDetails.nicknamutator',
+            'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
+        ]], $this->crudPanel->columns());
+        } else {
+            $this->assertEquals(['accountDetails__nicknamutator' => [
+            'name' => 'accountDetails.nicknamutator',
+            'label' => 'AccountDetails.nicknamutator',
+            'type' => 'text',
+            'key' => 'accountDetails__nicknamutator',
+            'priority' => 0,
+            'attribute' => 'nicknamutator',
+            'tableColumn' => false,
+            'orderable' => false,
+            'searchLogic' => false,
+            'relation_type' => 'HasOne',
+            'entity' => 'accountDetails.nicknamutator',
+            'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
+        ]], $this->crudPanel->columns());
+        }
+    }
+
+
+
     public function testAddRelationColumn()
     {
         $this->crudPanel->setModel(User::class);

--- a/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelColumnsTest.php
@@ -376,38 +376,36 @@ class CrudPanelColumnsTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCru
         $this->crudPanel->addColumn('accountDetails.nicknamutator');
         if (backpack_pro()) {
             $this->assertEquals(['accountDetails__nicknamutator' => [
-            'name' => 'accountDetails.nicknamutator',
-            'label' => 'AccountDetails.nicknamutator',
-            'type' => 'relationship',
-            'key' => 'accountDetails__nicknamutator',
-            'priority' => 0,
-            'attribute' => 'nicknamutator',
-            'tableColumn' => false,
-            'orderable' => false,
-            'searchLogic' => false,
-            'relation_type' => 'HasOne',
-            'entity' => 'accountDetails.nicknamutator',
-            'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
-        ]], $this->crudPanel->columns());
+                'name' => 'accountDetails.nicknamutator',
+                'label' => 'AccountDetails.nicknamutator',
+                'type' => 'relationship',
+                'key' => 'accountDetails__nicknamutator',
+                'priority' => 0,
+                'attribute' => 'nicknamutator',
+                'tableColumn' => false,
+                'orderable' => false,
+                'searchLogic' => false,
+                'relation_type' => 'HasOne',
+                'entity' => 'accountDetails.nicknamutator',
+                'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
+            ]], $this->crudPanel->columns());
         } else {
             $this->assertEquals(['accountDetails__nicknamutator' => [
-            'name' => 'accountDetails.nicknamutator',
-            'label' => 'AccountDetails.nicknamutator',
-            'type' => 'text',
-            'key' => 'accountDetails__nicknamutator',
-            'priority' => 0,
-            'attribute' => 'nicknamutator',
-            'tableColumn' => false,
-            'orderable' => false,
-            'searchLogic' => false,
-            'relation_type' => 'HasOne',
-            'entity' => 'accountDetails.nicknamutator',
-            'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
-        ]], $this->crudPanel->columns());
+                'name' => 'accountDetails.nicknamutator',
+                'label' => 'AccountDetails.nicknamutator',
+                'type' => 'text',
+                'key' => 'accountDetails__nicknamutator',
+                'priority' => 0,
+                'attribute' => 'nicknamutator',
+                'tableColumn' => false,
+                'orderable' => false,
+                'searchLogic' => false,
+                'relation_type' => 'HasOne',
+                'entity' => 'accountDetails.nicknamutator',
+                'model' => 'Backpack\CRUD\Tests\Config\Models\AccountDetails',
+            ]], $this->crudPanel->columns());
         }
     }
-
-
 
     public function testAddRelationColumn()
     {

--- a/tests/config/Models/AccountDetails.php
+++ b/tests/config/Models/AccountDetails.php
@@ -3,8 +3,8 @@
 namespace Backpack\CRUD\Tests\Config\Models;
 
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
 
 class AccountDetails extends Model
 {

--- a/tests/config/Models/AccountDetails.php
+++ b/tests/config/Models/AccountDetails.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\Tests\Config\Models;
 
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class AccountDetails extends Model
 {
@@ -48,5 +49,10 @@ class AccountDetails extends Model
     public function bangsPivot()
     {
         return $this->belongsToMany('Backpack\CRUD\Tests\config\Models\Bang', 'account_details_bangs_pivot')->withPivot('pivot_field');
+    }
+
+    public function nicknamutator(): Attribute
+    {
+        return Attribute::get(fn ($value) => strtoupper($value));
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Not previously tested, broken 🤷‍♂️ 

We had a use-case outside of our test suite that was reported in #5645 

When developer added an `Attribute` (an accessor/mutator) as the last parameter of a relation string, we would wrongfully interpret it as a relationship. 

### AFTER - What is happening after this PR?

We properly infer that's not a relationship. Added tests for that scenario too, nothing else is broken, we should be fine 👍 

## HOW

### How did you achieve that, in technical terms?

Wrote the test, expect it to fail, it failed, fixed the relevant code, all green 🟢 

### Is it a breaking change?

No

### How can we test the before & after?

As @karandatwani92 pointed out in https://github.com/Laravel-Backpack/CRUD/issues/5645#issuecomment-2324393867
