### PR TITLE
Add set query() method

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\app\Library\CrudPanel\Traits;
 
+use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 
 trait Query
@@ -59,6 +60,13 @@ trait Query
         }
         call_user_func_array([$this->query, $function], array_slice(func_get_args(), 1));
         call_user_func_array([$this->totalQuery, $function], array_slice(func_get_args(), 1));
+
+        return $this;
+    }
+
+    public function setQuery(QueryBuilder $query)
+    {
+        $this->query = $query;
 
         return $this;
     }

--- a/tests/Unit/CrudPanel/CrudPanelQueryTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelQueryTest.php
@@ -180,10 +180,11 @@ class CrudPanelQueryTest extends BaseCrudPanel
 
         $this->assertEquals(5, $this->crudPanel->getTotalQueryCount());
     }
+
     public function testItCanSetTheQueryOnTheCrudPanel()
     {
         $this->assertEquals(User::query()->toSql(), $this->crudPanel->query->toSql());
-        
+
         $this->crudPanel->setQuery(User::query()->where('id', 1));
 
         $this->assertEquals(User::query()->where('id', 1)->toSql(), $this->crudPanel->query->toSql());

--- a/tests/Unit/CrudPanel/CrudPanelQueryTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelQueryTest.php
@@ -180,4 +180,12 @@ class CrudPanelQueryTest extends BaseCrudPanel
 
         $this->assertEquals(5, $this->crudPanel->getTotalQueryCount());
     }
+    public function testItCanSetTheQueryOnTheCrudPanel()
+    {
+        $this->assertEquals(User::query()->toSql(), $this->crudPanel->query->toSql());
+        
+        $this->crudPanel->setQuery(User::query()->where('id', 1));
+
+        $this->assertEquals(User::query()->where('id', 1)->toSql(), $this->crudPanel->query->toSql());
+    }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There was nothing "wrong" technically, but there was no way to **fluently** set the query. Developers could do: `$this->crud->query = Model::query()`, but no way to fluently do the same. 

### AFTER - What is happening after this PR?

Added the `setQuery` method to help fluently change the crud panel query. 


## HOW

### How did you achieve that, in technical terms?

Created a method and added tests for it. 



### Is it a breaking change?

 No