### PR TITLE
Use widgets as a way to build details row

### DIFF
--- a/src/resources/views/crud/details_row.blade.php
+++ b/src/resources/views/crud/details_row.blade.php
@@ -1,6 +1,15 @@
 <div class="m-t-10 m-b-10 p-l-10 p-r-10 p-t-10 p-b-10" bp-section="crud-details-row">
 	<div class="row">
-        @include(backpack_view('inc.widgets'), ['widgets' => app('widgets')->where('section', 'details_row')])
+		@php
+			$widgets = app('widgets')->where('section', 'details_row');
+		@endphp
+		@if($widgets->count() > 0)
+			@include(backpack_view('inc.widgets'), ['widgets' => $widgets])
+		@else
+			<div class="col-md-12">
+				{{ trans('backpack::crud.details_row') }}
+			</div>
+		@endif
 	</div>
 </div>
 <div class="clearfix"></div>

--- a/src/resources/views/crud/details_row.blade.php
+++ b/src/resources/views/crud/details_row.blade.php
@@ -1,8 +1,6 @@
 <div class="m-t-10 m-b-10 p-l-10 p-r-10 p-t-10 p-b-10" bp-section="crud-details-row">
 	<div class="row">
-		<div class="col-md-12">
-			{{ trans('backpack::crud.details_row') }}
-		</div>
+        @include(backpack_view('inc.widgets'), ['widgets' => app('widgets')->where('section', 'details_row')])
 	</div>
 </div>
 <div class="clearfix"></div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Suggested in https://github.com/Laravel-Backpack/community-forum/discussions/712

 We could get creative with details row by allowing developers to add widgets there instead of just providing a way to overwrite the view. 

At the moment, the only way to have a view, and pass additional control data was to: 
- create a view in your resources folder
- overwrite the `showDetailsRow($id)` method. 

In 10 controllers it gets cumbersome to have to overwrite the method in all of them to add some `['data' => 'my info']` to all of them. 

### AFTER - What is happening after this PR?

You can simply build a widget (a view for your details row), and pass any additional information on the widget directly instead of having to overwrite the method. 

## HOW

### How did you achieve that, in technical terms?

Just added a `@include()` widgets view, and pull the widgets from the `details_row` section.

### Is it a breaking change?

No.