### PR TITLE
use connection name in db reorder functions

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -47,7 +47,7 @@ trait Reorder
         });
 
         // wrap the queries in a transaction to avoid partial updates
-        DB::transaction(function () use ($reorderItems, $primaryKey, $itemKeys) {
+        DB::connection($this->model->getConnectionName())->transaction(function () use ($reorderItems, $primaryKey, $itemKeys) {
             // create a string of ?,?,?,? to use as bind placeholders for item keys
             $reorderItemsBindString = implode(',', array_fill(0, count($reorderItems), '?'));
 
@@ -68,7 +68,7 @@ trait Reorder
                 // add the where clause to the query to help match the items
                 $query .= "ELSE {$column} END WHERE {$primaryKey} IN ({$reorderItemsBindString})";
 
-                DB::statement($query, $bindings);
+                DB::connection($this->model->getConnectionName())->statement($query, $bindings);
             }
         });
 


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/CRUD/issues/5656

### BEFORE - What was wrong? What was happening before this PR?

We were not using the connection defined in the model to initialize the DB call, so it was not possible to use the reorder functions in connections other than the default.

### AFTER - What is happening after this PR?

We use the connection defined on the model to initialize the db calls.

## HOW

### How did you achieve that, in technical terms?

Added the `connection()` method to the `DB::` call. 



### Is it a breaking change?

No