### PR TITLE
ensure debug is on before output the error message

### DIFF
--- a/src/resources/views/ui/errors/4xx.blade.php
+++ b/src/resources/views/ui/errors/4xx.blade.php
@@ -9,7 +9,7 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_4xx', [
+  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_4xx', [
     'href_back' => 'href="javascript:history.back()"',
     'href_homepage' => 'href="'.url('').'"',
   ]) !!}

--- a/src/resources/views/ui/errors/500.blade.php
+++ b/src/resources/views/ui/errors/500.blade.php
@@ -9,5 +9,5 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_500') !!}
+  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_500') !!}
 @endsection

--- a/src/resources/views/ui/errors/503.blade.php
+++ b/src/resources/views/ui/errors/503.blade.php
@@ -9,5 +9,5 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() ? e($exception->getMessage()) : trans('backpack::base.error_page.message_503') !!}
+  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_503') !!}
 @endsection


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/CRUD/issues/5653

### BEFORE - What was wrong? What was happening before this PR?

A user reported that in certain circumstances when `app.debug = false` the error messages were printed anyway.

### AFTER - What is happening after this PR?

We only print the error messages when `debug = true`. 
