### PR TITLE
add text-wrap to details row

### DIFF
--- a/src/resources/views/crud/details_row.blade.php
+++ b/src/resources/views/crud/details_row.blade.php
@@ -1,5 +1,5 @@
 <div class="m-t-10 m-b-10 p-l-10 p-r-10 p-t-10 p-b-10" bp-section="crud-details-row">
-	<div class="row">
+	<div class="row text-wrap">
 		@php
 			$widgets = app('widgets')->where('section', 'details_row');
 		@endphp


### PR DESCRIPTION
## WHY

reported in https://github.com/Laravel-Backpack/demo/issues/656

### BEFORE - What was wrong? What was happening before this PR?

details row text would expand the table as needed, breaking the page design. 

### AFTER - What is happening after this PR?

text is wrapped inside the details row container
