### PR TITLE
do not cast the items key to int

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -29,8 +29,8 @@ trait Reorder
         $reorderItems = collect($request)->filter(function ($item) use ($itemKeys) {
             return $item['item_id'] !== '' && $item['item_id'] !== null && $itemKeys->contains($item['item_id']);
         })->map(function ($item) use ($primaryKey) {
-            $item[$primaryKey] = (int) $item['item_id'];
-            $item['parent_id'] = empty($item['parent_id']) ? null : (int) $item['parent_id'];
+            $item[$primaryKey] = $item['item_id'];
+            $item['parent_id'] = empty($item['parent_id']) ? null : $item['parent_id'];
             $item['depth'] = empty($item['depth']) ? null : (int) $item['depth'];
             $item['lft'] = empty($item['left']) ? null : (int) $item['left'];
             $item['rgt'] = empty($item['right']) ? null : (int) $item['right'];


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Casting the keys to `int` would make the reorder break while keys are strings, expectable, dumb me 🤷 

### AFTER - What is happening after this PR?

We don't cast it, we just use it. 👍 


## HOW

### How did you achieve that, in technical terms?

Removed the cast to int. 



### Is it a breaking change?

No


### How can we test the before & after?

Reorder something with string primary keys (eg: uuid)
