### PR TITLE
Allow developer to configure the behavior of actions buttons dropdown

### DIFF
--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -49,8 +49,15 @@ return [
     // Nest action buttons within a dropdown in actions column
     'lineButtonsAsDropdown' => false,
 
-    // What is the minimum threshold of action buttons for nesting into a dropdown
-    'lineButtonsAsDropdownThreshold' => 1,
+    // What is the minimum actions for the dropdown to be created
+    // Example: when minimum to drop is «2»,  any row with less than «2» action buttons
+    // will not create a dropdown, but will show the buttons inline
+    'lineButtonsAsDropdownMinimumToDrop' => 1,
+
+    // Force «X» actions to be shown inline before the dropdown is created
+    // Example: when setting this to «2», the first «2» actions will be shown inline
+    // and the rest will be moved to the dropdown
+    'lineButtonsAsDropdownDropAfter' => 0,
 
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -52,12 +52,12 @@ return [
     // What is the minimum actions for the dropdown to be created
     // Example: when minimum to drop is «2»,  any row with less than «2» action buttons
     // will not create a dropdown, but will show the buttons inline
-    'lineButtonsAsDropdownMinimumToDrop' => 1,
+    'lineButtonsAsDropdownMinimum' => 1,
 
     // Force «X» actions to be shown inline before the dropdown is created
     // Example: when setting this to «2», the first «2» actions will be shown inline
     // and the rest will be moved to the dropdown
-    'lineButtonsAsDropdownDropAfter' => 0,
+    'lineButtonsAsDropdownShowBefore' => 0,
 
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -49,6 +49,9 @@ return [
     // Nest action buttons within a dropdown in actions column
     'lineButtonsAsDropdown' => false,
 
+    // What is the minimum threshold of action buttons for nesting into a dropdown
+    'lineButtonsAsDropdownThreshold' => 1,
+
     // Show a "Reset" button next to the List operation subheading
     // (Showing 1 to 25 of 9999 entries. Reset)
     // that allows the user to erase local storage for that datatable,

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -407,17 +407,17 @@
         const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
         if (actionColumnIndex === -1) return;
 
-        const minimumToDrop = $('#crudTable').data('line-buttons-as-dropdown-minimum-to-drop');
-        const dropAfter = $('#crudTable').data('line-buttons-as-dropdown-drop-after');
+        const minimumButtonsToBuildDropdown = $('#crudTable').data('line-buttons-as-dropdown-minimum');
+        const buttonsToShowBeforeDropdown = $('#crudTable').data('line-buttons-as-dropdown-show-before-dropdown');
 
         $('#crudTable tbody tr').each(function (i, tr) {
             const actionCell = $(tr).find('td').eq(actionColumnIndex);
             const actionButtons = actionCell.find('a.btn.btn-link');
             if (actionCell.find('.actions-buttons-column').length) return;
-            if (actionButtons.length < minimumToDrop) return;
+            if (actionButtons.length < minimumButtonsToBuildDropdown) return;
 
             // Prepare buttons as dropdown items
-            const dropdownItems = actionButtons.slice(dropAfter).map((index, action) => {
+            const dropdownItems = actionButtons.slice(buttonsToShowBeforeDropdown).map((index, action) => {
                 $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                 $(action).find('i').addClass('me-2 text-primary');
                 return action;
@@ -432,7 +432,7 @@
                 actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
                 
                 // Move the remaining buttons outside the dropdown
-                const remainingButtons = actionButtons.slice(0, dropAfter);
+                const remainingButtons = actionButtons.slice(0, buttonsToShowBeforeDropdown);
                 actionCell.prepend(remainingButtons);
             }
         });

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -407,16 +407,20 @@
         const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
         if (actionColumnIndex === -1) return;
 
+        const minimumThreshold = $('#crudTable').data('line-buttons-as-dropdown-threshold');
+
         $('#crudTable tbody tr').each(function (i, tr) {
             const actionCell = $(tr).find('td').eq(actionColumnIndex);
+            const actionButtons = actionCell.find('a.btn.btn-link');
             if(actionCell.find('.actions-buttons-column').length) return;
+            if(actionButtons.length < minimumThreshold) return;
 
             // Wrap the cell with the component needed for the dropdown
             actionCell.wrapInner('<div class="nav-item dropdown"></div>');
             actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
             
             // Prepare buttons as dropdown items
-            actionCell.find('a.btn.btn-link').each((index, action) => {
+            actionButtons.each((index, action) => {
                 $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                 $(action).find('i').addClass('me-2 text-primary');
             });

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -401,30 +401,40 @@
       @endif
 
     });
-
+ 
     function formatActionColumnAsDropdown() {
         // Get action column
         const actionColumnIndex = $('#crudTable').find('th[data-action-column=true]').index();
         if (actionColumnIndex === -1) return;
 
-        const minimumThreshold = $('#crudTable').data('line-buttons-as-dropdown-threshold');
+        const minimumToDrop = $('#crudTable').data('line-buttons-as-dropdown-minimum-to-drop');
+        const dropAfter = $('#crudTable').data('line-buttons-as-dropdown-drop-after');
 
         $('#crudTable tbody tr').each(function (i, tr) {
             const actionCell = $(tr).find('td').eq(actionColumnIndex);
             const actionButtons = actionCell.find('a.btn.btn-link');
-            if(actionCell.find('.actions-buttons-column').length) return;
-            if(actionButtons.length < minimumThreshold) return;
+            if (actionCell.find('.actions-buttons-column').length) return;
+            if (actionButtons.length < minimumToDrop) return;
 
-            // Wrap the cell with the component needed for the dropdown
-            actionCell.wrapInner('<div class="nav-item dropdown"></div>');
-            actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
-            
             // Prepare buttons as dropdown items
-            actionButtons.each((index, action) => {
+            const dropdownItems = actionButtons.slice(dropAfter).map((index, action) => {
                 $(action).addClass('dropdown-item').removeClass('btn btn-sm btn-link');
                 $(action).find('i').addClass('me-2 text-primary');
+                return action;
             });
-            actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+
+            // Only create dropdown if there are items to drop
+            if (dropdownItems.length > 0) {
+                // Wrap the cell with the component needed for the dropdown
+                actionCell.wrapInner('<div class="nav-item dropdown"></div>');
+                actionCell.wrapInner('<div class="dropdown-menu dropdown-menu-left"></div>');
+
+                actionCell.prepend('<a class="btn btn-sm px-2 py-1 btn-outline-primary dropdown-toggle actions-buttons-column" href="#" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">{{ trans('backpack::crud.actions') }}</a>');
+                
+                // Move the remaining buttons outside the dropdown
+                const remainingButtons = actionButtons.slice(0, dropAfter);
+                actionCell.prepend(remainingButtons);
+            }
         });
     }
   </script>

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -62,7 +62,8 @@
               data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
               data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"
               data-has-line-buttons-as-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdown') }}"
-              data-line-buttons-as-dropdown-threshold="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownThreshold') }}"
+              data-line-buttons-as-dropdown-minimum-to-drop="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownMinimumToDrop') }}"
+              data-line-buttons-as-dropdown-drop-after="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownDropAfter') }}"
               cellspacing="0">
             <thead>
               <tr>

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -62,6 +62,7 @@
               data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
               data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"
               data-has-line-buttons-as-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdown') }}"
+              data-line-buttons-as-dropdown-threshold="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownThreshold') }}"
               cellspacing="0">
             <thead>
               <tr>

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -62,8 +62,8 @@
               data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
               data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"
               data-has-line-buttons-as-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdown') }}"
-              data-line-buttons-as-dropdown-minimum-to-drop="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownMinimumToDrop') }}"
-              data-line-buttons-as-dropdown-drop-after="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownDropAfter') }}"
+              data-line-buttons-as-dropdown-minimum="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownMinimum') }}"
+              data-line-buttons-as-dropdown-show-before-dropdown="{{ (int) $crud->getOperationSetting('lineButtonsAsDropdownShowBefore') }}"
               cellspacing="0">
             <thead>
               <tr>


### PR DESCRIPTION
## WHY
superseeds: #5568 

### BEFORE - What was wrong? What was happening before this PR?

The PR #5568  introduces a way for developers to control the behavior of line buttons when displayed as a dropdown. 

While reviewing it I noticed that a very much likely use case for line buttons was to "force" some X amount of buttons to display inline and create the dropdown for the remaining. 

### AFTER - What is happening after this PR?

In addition to what the PR #5568 introduced (the minimum amount of items to drop, eg: less than 2 actions don't create a dropdown), it also introduces a way for developers to force the first X actions to display inline.

![image](https://github.com/user-attachments/assets/a5b40819-bd2d-4277-bb81-bdf226f22aa2)

Docs for it can be found here: https://github.com/Laravel-Backpack/docs/pull/598


## HOW

### How did you achieve that, in technical terms?

Added a new config: `lineButtonsAsDropdownDropAfter` in addition to the `lineButtonsAsDropdownMinimumToDrop`

### Is it a breaking change?

No, the same defaults are kept (all buttons display in a dropdown). 

