### PR TITLE
update url column - add rel=noreferrer and fix attribute definition

### DIFF
--- a/src/resources/views/crud/columns/url.blade.php
+++ b/src/resources/views/crud/columns/url.blade.php
@@ -1,7 +1,12 @@
 @php
     $column['value'] = $column['value'] ?? data_get($entry, $column['name']);
-    $column['wrapper']['element'] = $column['wrapper']['element'] ?? 'a';
-    $column['wrapper']['target'] = $column['wrapper']['target'] ?? '_blank';
+    $column['wrapper']['element'] = $column['wrapper']['element'] ?? $column['element'] ?? 'a';
+    $column['wrapper']['target'] = $column['wrapper']['target'] ?? $column['target'] ?? '_blank';
     $column['wrapper']['href'] = $column['value'];
+    $rel = $column['wrapper']['rel'] ?? $column['rel'] ?? null;
+
+    if($rel !== false)  {
+        $column['wrapper']['rel'] = $rel ?? 'noreferrer';
+    }
 @endphp
 @include('crud::columns.text')


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/community-forum/issues/507

### BEFORE - What was wrong? What was happening before this PR?

The url column could leak your admin panel url if developer didn't took care of adding the `rel` attribute to the column wrapper. 

In addition, the docs stated that you could use `'target' => '_blank'` in your column definition, but that was not actually working because the column was just checking the values in the wrapper. 

### AFTER - What is happening after this PR?

We add by default a `rel="noreferrer"` to the url column type and the column now checks for `target`, `element` and `rel` on the column definition, not only in the wrapper. 

### Is it a breaking change?

I think it is not. 

DOCS: https://github.com/Laravel-Backpack/docs/pull/600