### PR TITLE
Fix save actions when all actions are removed

### DIFF
--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -275,6 +275,10 @@ trait SaveActions
         //get only the save actions that pass visibility callback
         $saveOptions = $this->getVisibleSaveActions();
 
+        if (empty($saveOptions)) {
+            return [];
+        }
+
         //get the current action
         $saveCurrent = $this->getCurrentSaveAction($saveOptions);
 
@@ -287,7 +291,7 @@ trait SaveActions
         }
 
         return [
-            'active' => $saveCurrent,
+            'active'  => $saveCurrent,
             'options' => $dropdownOptions,
         ];
     }
@@ -345,8 +349,8 @@ trait SaveActions
         // if the request is AJAX, return a JSON response
         if ($this->getRequest()->ajax()) {
             return response()->json([
-                'success' => true,
-                'data' => $this->entry,
+                'success'      => true,
+                'data'         => $this->entry,
                 'redirect_url' => $redirectUrl,
                 'referrer_url' => $referrer_url ?? false,
             ]);
@@ -368,7 +372,7 @@ trait SaveActions
     {
         $defaultSaveActions = [
             [
-                'name' => 'save_and_back',
+                'name'    => 'save_and_back',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('list');
                 },
@@ -378,7 +382,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
             [
-                'name' => 'save_and_edit',
+                'name'    => 'save_and_edit',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('update');
                 },
@@ -400,7 +404,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_edit'),
             ],
             [
-                'name' => 'save_and_new',
+                'name'    => 'save_and_new',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('create');
                 },

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -291,7 +291,7 @@ trait SaveActions
         }
 
         return [
-            'active'  => $saveCurrent,
+            'active' => $saveCurrent,
             'options' => $dropdownOptions,
         ];
     }
@@ -349,8 +349,8 @@ trait SaveActions
         // if the request is AJAX, return a JSON response
         if ($this->getRequest()->ajax()) {
             return response()->json([
-                'success'      => true,
-                'data'         => $this->entry,
+                'success' => true,
+                'data' => $this->entry,
                 'redirect_url' => $redirectUrl,
                 'referrer_url' => $referrer_url ?? false,
             ]);
@@ -372,7 +372,7 @@ trait SaveActions
     {
         $defaultSaveActions = [
             [
-                'name'    => 'save_and_back',
+                'name' => 'save_and_back',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('list');
                 },
@@ -382,7 +382,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
             [
-                'name'    => 'save_and_edit',
+                'name' => 'save_and_edit',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('update');
                 },
@@ -404,7 +404,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_edit'),
             ],
             [
-                'name'    => 'save_and_new',
+                'name' => 'save_and_new',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('create');
                 },

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -1,5 +1,6 @@
-@if(isset($saveAction['active']) && !is_null($saveAction['active']['value']))
-    <div id="saveActions" class="form-group my-3">
+<div id="saveActions" class="form-group my-3">
+    @if(isset($saveAction['active']) && !is_null($saveAction['active']['value']))
+    
         <input type="hidden" name="_save_action" value="{{ $saveAction['active']['value'] }}">
 
         @if(empty($saveAction['options']))
@@ -23,16 +24,16 @@
                 </ul>
             </div>
         @endif
+    @endif
+    @if(!$crud->hasOperationSetting('showCancelButton') || $crud->getOperationSetting('showCancelButton') == true)
+        <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
+    @endif
 
-        @if(!$crud->hasOperationSetting('showCancelButton') || $crud->getOperationSetting('showCancelButton') == true)
-            <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
-        @endif
+    @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))
+        <button onclick="confirmAndDeleteEntry()" type="button" class="btn btn-danger float-right float-end"><i class="la la-trash-alt"></i> {{ trans('backpack::crud.delete') }}</button>
+    @endif
+</div>
 
-        @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))
-            <button onclick="confirmAndDeleteEntry()" type="button" class="btn btn-danger float-right float-end"><i class="la la-trash-alt"></i> {{ trans('backpack::crud.delete') }}</button>
-        @endif
-    </div>
-@endif
 
 @push('after_scripts')
 <script>


### PR DESCRIPTION
## WHY
fixes: https://github.com/Laravel-Backpack/community-forum/issues/134

### BEFORE - What was wrong? What was happening before this PR?

When removing all save actions from the form, Backpack would throw an error. 

### AFTER - What is happening after this PR?

Backpack can handle empty save actions without crashing.

![image](https://github.com/user-attachments/assets/45632632-ee32-4c5b-b7e5-bd98a4ac9898)


## HOW

### How did you achieve that, in technical terms?

Added a check for the emptiness of save actions, and adjusted the view to display the remaining buttons even if save actions are empty.



### Is it a breaking change?

I don't think so, no. 


### How can we test the before & after?

In a create/update operation, do `CRUD::removeAllSaveActions()`
