### PR TITLE
Add the show delete button on edit option

### DIFF
--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -16,7 +16,7 @@ return [
 
     // How would you like the validation errors to be shown?
     'groupedErrors' => true,
-    'inlineErrors'  => true,
+    'inlineErrors' => true,
 
     // when the page loads, put the cursor on the first input?
     'autoFocusOnFirstField' => true,

--- a/src/config/backpack/operations/update.php
+++ b/src/config/backpack/operations/update.php
@@ -16,7 +16,7 @@ return [
 
     // How would you like the validation errors to be shown?
     'groupedErrors' => true,
-    'inlineErrors' => true,
+    'inlineErrors'  => true,
 
     // when the page loads, put the cursor on the first input?
     'autoFocusOnFirstField' => true,
@@ -31,6 +31,9 @@ return [
 
     // Should we show a cancel button to the user?
     'showCancelButton' => true,
+
+    // Should we show the delete button on the edit form?
+    'showDeleteButton' => false,
 
     // Should we warn a user before leaving the page with unsaved changes?
     'warnBeforeLeaving' => false,


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was documented, but the option was not present in the operation config 🤷 https://backpackforlaravel.com/docs/6.x/crud-operation-update#delete-button-on-update-operation-1

### AFTER - What is happening after this PR?

It's now on the operation config file.
