### PR TITLE
add searchDelay option to datatables search

### DIFF
--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -22,6 +22,9 @@ return [
     // show search bar in the top-right corner?
     'searchableTable' => true,
 
+    // how much time should the system wait before triggering the search function after the user stops typing?
+    'searchDelay' => 400,
+
     // the time the table will be persisted in minutes
     // after this the table info is cleared from localStorage.
     // use false to never force localStorage clear. (default)

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -261,6 +261,7 @@
           },
           processing: true,
           serverSide: true,
+          searchDelay: {{ $crud->getOperationSetting('searchDelay') }},
           @if($crud->getOperationSetting('showEntryCount') === false)
             pagingType: "simple",
           @endif


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was not possible to configure the debounce time for datatables search. 

### AFTER - What is happening after this PR?

Datatables provides the `searchDelay` option, that's 400ms by default. I just created a setting for it, so developers can easily increase or decrease the value depending on their needs. https://datatables.net/reference/option/searchDelay


## HOW

### How did you achieve that, in technical terms?

Added a operation setting that allow developer to configure the debounce time. 



### Is it a breaking change?

no
