### PR TITLE
add debounce to filters

### DIFF
--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -68,10 +68,37 @@
         // and we have a function that will do this update for us after all filters had been cleared.
         if(update_url) {
           // replace the datatables ajax url with new_url and reload it
-          crud.table.ajax.url(new_url).load();
+          callOnce(function() { refreshDatatablesOnFilterChange(new_url) }, 300, 'refreshDatatablesOnFilterChange');
         }
 
         return new_url;
+      }
+
+      /**
+       * calls the function func once within the within time window.
+       * this is a debounce function which actually calls the func as
+       * opposed to returning a function that would call func.
+       * 
+       * @param func    the function to call
+       * @param within  the time window in milliseconds, defaults to 300
+       * @param timerId an optional key, defaults to func
+       * 
+       * FROM: https://stackoverflow.com/questions/27787768/debounce-function-in-jquery
+       */
+      function callOnce(func, within=300, timerId=null){
+          window.callOnceTimers = window.callOnceTimers || {};
+          if (timerId == null) 
+              timerId = func;
+          var timer = window.callOnceTimers[timerId];
+          clearTimeout(timer);
+          timer = setTimeout(() => func(), within);
+          window.callOnceTimers[timerId] = timer;
+      }
+
+      function refreshDatatablesOnFilterChange(url)
+      {
+        // replace the datatables ajax url with new_url and reload it
+        crud.table.ajax.url(url).load();
       }
 
 

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -85,14 +85,13 @@
        * 
        * FROM: https://stackoverflow.com/questions/27787768/debounce-function-in-jquery
        */
-      function callOnce(func, within=300, timerId=null){
+      function callOnce(func, within = 300, timerId = null) {
           window.callOnceTimers = window.callOnceTimers || {};
-          if (timerId == null) 
-              timerId = func;
-          var timer = window.callOnceTimers[timerId];
-          clearTimeout(timer);
-          timer = setTimeout(() => func(), within);
-          window.callOnceTimers[timerId] = timer;
+          timerId = timerId || func;
+          if (window.callOnceTimers[timerId]) {
+            clearTimeout(window.callOnceTimers[timerId]);
+          }
+          window.callOnceTimers[timerId] = setTimeout(func, within);
       }
 
       function refreshDatatablesOnFilterChange(url)

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -53,7 +53,7 @@
 
       }
 
-      function updateDatatablesOnFilterChange(filterName, filterValue, update_url = false) {
+      function updateDatatablesOnFilterChange(filterName, filterValue, update_url = false, debounce = 500) {
         // behaviour for ajax table
         var current_url = crud.table.ajax.url();
         var new_url = addOrUpdateUriParameter(current_url, filterName, filterValue);
@@ -68,7 +68,7 @@
         // and we have a function that will do this update for us after all filters had been cleared.
         if(update_url) {
           // replace the datatables ajax url with new_url and reload it
-          callOnce(function() { refreshDatatablesOnFilterChange(new_url) }, 300, 'refreshDatatablesOnFilterChange');
+          callOnce(function() { refreshDatatablesOnFilterChange(new_url) }, debounce, 'refreshDatatablesOnFilterChange');
         }
 
         return new_url;

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -68,7 +68,7 @@
         // and we have a function that will do this update for us after all filters had been cleared.
         if(update_url) {
           // replace the datatables ajax url with new_url and reload it
-          callOnce(function() { refreshDatatablesOnFilterChange(new_url) }, debounce, 'refreshDatatablesOnFilterChange');
+          callFunctionOnce(function() { refreshDatatablesOnFilterChange(new_url) }, debounce, 'refreshDatatablesOnFilterChange');
         }
 
         return new_url;
@@ -85,7 +85,7 @@
        * 
        * FROM: https://stackoverflow.com/questions/27787768/debounce-function-in-jquery
        */
-      function callOnce(func, within = 300, timerId = null) {
+      function callFunctionOnce(func, within = 300, timerId = null) {
           window.callOnceTimers = window.callOnceTimers || {};
           timerId = timerId || func;
           if (window.callOnceTimers[timerId]) {


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/community-forum/issues/131

### BEFORE - What was wrong? What was happening before this PR?

It was annoying that anytime you click on a simple/checkbox filter, or raised/lowered the number in the range filter, a request was made to the server. That turned the experience a little bit cumbersome to use, plus very resource intensive. 

### AFTER - What is happening after this PR?

filters use now a "debounce function", so less calls are made to the search endpoint. there is a companion PRO PR: https://github.com/Laravel-Backpack/PRO/pull/280


## HOW

### How did you achieve that, in technical terms?

Used a debounce function, that prevents the same function to be called more than once in the given time period. That is now configurable setting `debounce` on the filter. 



### Is it a breaking change?

I think no. 