### PR TITLE
Allow customization of reorder column names

### DIFF
--- a/src/app/Http/Controllers/Operations/ReorderOperation.php
+++ b/src/app/Http/Controllers/Operations/ReorderOperation.php
@@ -38,6 +38,12 @@ trait ReorderOperation
 
         $this->crud->operation('reorder', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
+            $this->crud->setOperationSetting('reorderColumnNames', [
+                'parent_id' => 'parent_id',
+                'lft' => 'lft',
+                'rgt' => 'rgt',
+                'depth' => 'depth',
+            ]);
         });
 
         $this->crud->operation('list', function () {

--- a/src/app/Library/CrudPanel/Traits/Reorder.php
+++ b/src/app/Library/CrudPanel/Traits/Reorder.php
@@ -36,13 +36,21 @@ trait Reorder
             $item[$columns['depth']] = empty($item['depth']) ? null : (int) $item['depth'];
             $item[$columns['lft']] = empty($item['left']) ? null : (int) $item['left'];
             $item[$columns['rgt']] = empty($item['right']) ? null : (int) $item['right'];
-            
+
             // unset mapped items properties.
-            if($columns['parent_id'] !== 'parent_id') { unset($item['parent_id']); };
-            if($columns['depth'] !== 'depth') { unset($item['depth']); }
-            if($columns['lft'] !== 'left') { unset($item['left']); }
-            if($columns['rgt'] !== 'right') { unset($item['right']); }
-            
+            if ($columns['parent_id'] !== 'parent_id') {
+                unset($item['parent_id']);
+            }
+            if ($columns['depth'] !== 'depth') {
+                unset($item['depth']);
+            }
+            if ($columns['lft'] !== 'left') {
+                unset($item['left']);
+            }
+            if ($columns['rgt'] !== 'right') {
+                unset($item['right']);
+            }
+
             // unset the item_id property
             unset($item['item_id']);
 

--- a/tests/Unit/CrudPanel/CrudPanelReorderOperationTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReorderOperationTest.php
@@ -16,6 +16,13 @@ class CrudPanelReorderOperationTest extends BaseDBCrudPanel
         $this->createReorderItems();
         $this->crudPanel->setModel(Reorder::class);
 
+        $this->crudPanel->setOperationSetting('reorderColumnNames', [
+            'parent_id' => 'parent_id',
+            'depth' => 'depth',
+            'lft' => 'lft',
+            'rgt' => 'rgt',
+        ]);
+
         $this->crudPanel->updateTreeOrder(
             [
                 [


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/community-forum/issues/13

### BEFORE - What was wrong? What was happening before this PR?

It wasn't possible to customize the columns used by the reorder operation. 

### AFTER - What is happening after this PR?

Using an operation setting `reorderColumnNames`, developer can now customize the column names used in the reorder operation.


## HOW

### How did you achieve that, in technical terms?

Introduced a setting that hold the column names for the reorder operation. The whole operation use those column names provided by developer.



### Is it a breaking change?

No, the "old" columns are the default. 
