### PR TITLE
dont escape when developer error header is present

### DIFF
--- a/src/app/Exceptions/BackpackProRequiredException.php
+++ b/src/app/Exceptions/BackpackProRequiredException.php
@@ -20,6 +20,6 @@ class BackpackProRequiredException extends \Exception
                 break;
         }
 
-        return abort(500, $this->getMessage());
+        return abort(500, $this->getMessage(), ['developer-error-exception']);
     }
 }

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -184,7 +184,7 @@ class CrudButton implements Arrayable
                 break;
 
             default:
-                abort(500, "Unknown button position - please use 'beginning' or 'end'.");
+                abort(500, "Unknown button position - please use 'beginning' or 'end'.", ['developer-error-exception']);
         }
 
         return $this;
@@ -314,7 +314,7 @@ class CrudButton implements Arrayable
             return view($button->getFinalViewPath(), compact('button', 'crud', 'entry'));
         }
 
-        abort(500, 'Unknown button type');
+        abort(500, 'Unknown button type', ['developer-error-exception']);
     }
 
     /**
@@ -342,7 +342,7 @@ class CrudButton implements Arrayable
             }
         }
 
-        abort(500, 'Button view and fallbacks do not exist for '.$this->name.' button.');
+        abort(500, 'Button view and fallbacks do not exist for '.$this->name.' button.', ['developer-error-exception']);
     }
 
     /**

--- a/src/app/Library/CrudPanel/CrudColumn.php
+++ b/src/app/Library/CrudPanel/CrudColumn.php
@@ -88,7 +88,7 @@ class CrudColumn
     public function key(string $key)
     {
         if (! isset($this->attributes['name'])) {
-            abort(500, 'Column name must be defined before changing the key.');
+            abort(500, 'Column name must be defined before changing the key.', ['developer-error-exception']);
         }
 
         $columns = $this->crud()->columns();

--- a/src/app/Library/CrudPanel/CrudField.php
+++ b/src/app/Library/CrudPanel/CrudField.php
@@ -46,7 +46,7 @@ class CrudField
     public function __construct($nameOrDefinitionArray)
     {
         if (empty($nameOrDefinitionArray)) {
-            abort(500, 'Field name can\'t be empty.');
+            abort(500, 'Field name can\'t be empty.', ['developer-error-exception']);
         }
 
         if (is_array($nameOrDefinitionArray)) {
@@ -57,7 +57,7 @@ class CrudField
         }
 
         if (is_array($name)) {
-            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($name));
+            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($name), ['developer-error-exception']);
         }
 
         $field = $this->crud()->firstFieldWhere('name', $name);
@@ -325,7 +325,7 @@ class CrudField
         $morphField = $this->crud()->fields()[$this->attributes['name']];
 
         if (empty($morphField) || ($morphField['relation_type'] ?? '') !== 'MorphTo') {
-            throw new \Exception('Trying to configure the morphType on a non-morphTo field. Check if field and relation name matches.');
+            abort(500, 'Trying to configure the morphType on a non-morphTo field. Check if field and relation name matches.', ['developer-error-exception']);
         }
         [$morphTypeField, $morphIdField] = $morphField['subfields'];
 
@@ -351,7 +351,7 @@ class CrudField
         $morphField = $this->crud()->fields()[$this->attributes['name']];
 
         if (empty($morphField) || ($morphField['relation_type'] ?? '') !== 'MorphTo') {
-            throw new \Exception('Trying to configure the morphType on a non-morphTo field. Check if field and relation name matches.');
+            abort(500, 'Trying to configure the morphType on a non-morphTo field. Check if field and relation name matches.', ['developer-error-exception']);
         }
 
         [$morphTypeField, $morphIdField] = $morphField['subfields'];

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -558,7 +558,7 @@ class CrudFilter
                 break;
 
             default:
-                abort(500, 'Unknown filter operator.');
+                abort(500, 'Unknown filter operator.', ['developer-error-exception']);
                 break;
         }
     }

--- a/src/app/Library/CrudPanel/Traits/Buttons.php
+++ b/src/app/Library/CrudPanel/Traits/Buttons.php
@@ -38,7 +38,7 @@ trait Buttons
         // we parse the ordered buttons
         collect($order)->each(function ($btnKey) use ($newButtons, $stackButtons) {
             if (! $button = $stackButtons->where('name', $btnKey)->first()) {
-                abort(500, 'Button name [«'.$btnKey.'»] not found.');
+                abort(500, 'Button name [«'.$btnKey.'»] not found.', ['developer-error-exception']);
             }
             $newButtons->push($button);
         });
@@ -117,7 +117,7 @@ trait Buttons
         $button = $this->buttons()->firstWhere('name', $name);
 
         if (! $button) {
-            abort(500, 'CRUD Button "'.$name.'" not found. Please ensure the button exists before you modify it.');
+            abort(500, 'CRUD Button "'.$name.'" not found. Please ensure the button exists before you modify it.', ['developer-error-exception']);
         }
 
         if (is_array($modifications)) {

--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -475,7 +475,7 @@ trait Fields
         if (is_string($setting) && class_exists($setting)) {
             $setting = new $setting();
 
-            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting).' is not invokable.');
+            return is_callable($setting) ? $setting($request) : abort(500, get_class($setting).' is not invokable.', ['developer-error-exception']);
         }
 
         return $request->only($this->getAllFieldNames());

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -320,8 +320,8 @@ trait FieldsProtectedMethods
                     if ($field['allow_duplicate_pivots'] ?? false) {
                         $pivotSelectorField['allow_duplicate_pivots'] = true;
                         $field['subfields'] = Arr::prepend($field['subfields'], [
-                            'name'    => $field['pivot_key_name'] ?? 'id',
-                            'type'    => 'hidden',
+                            'name' => $field['pivot_key_name'] ?? 'id',
+                            'type' => 'hidden',
                             'wrapper' => [
                                 'class' => 'd-none',
                             ],

--- a/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/FieldsProtectedMethods.php
@@ -108,7 +108,7 @@ trait FieldsProtectedMethods
     protected function makeSureFieldHasName($field)
     {
         if (empty($field)) {
-            abort(500, 'Field name can\'t be empty');
+            abort(500, 'Field name can\'t be empty', ['developer-error-exception']);
         }
 
         if (is_string($field)) {
@@ -116,11 +116,11 @@ trait FieldsProtectedMethods
         }
 
         if (is_array($field) && ! isset($field['name'])) {
-            abort(500, 'All fields must have their name defined');
+            abort(500, 'All fields must have their name defined', ['developer-error-exception']);
         }
 
         if (is_array($field['name'])) {
-            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($field['name']));
+            abort(500, 'Field name can\'t be an array. It should be a string. Error in field: '.json_encode($field['name']), ['developer-error-exception']);
         }
 
         $field['name'] = Str::replace(' ', '', $field['name']);
@@ -265,12 +265,12 @@ trait FieldsProtectedMethods
         }
 
         if (! is_multidimensional_array($field['subfields'], true)) {
-            abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields.');
+            abort(500, 'Subfields of «'.$field['name'].'» are malformed. Make sure you provide an array of subfields.', ['developer-error-exception']);
         }
 
         foreach ($field['subfields'] as $key => $subfield) {
             if (empty($subfield) || ! isset($subfield['name'])) {
-                abort(500, 'A subfield of «'.$field['name'].'» is malformed. Subfield attribute name can\'t be empty.');
+                abort(500, 'A subfield of «'.$field['name'].'» is malformed. Subfield attribute name can\'t be empty.', ['developer-error-exception']);
             }
 
             // make sure the field definition is an array
@@ -320,8 +320,8 @@ trait FieldsProtectedMethods
                     if ($field['allow_duplicate_pivots'] ?? false) {
                         $pivotSelectorField['allow_duplicate_pivots'] = true;
                         $field['subfields'] = Arr::prepend($field['subfields'], [
-                            'name' => $field['pivot_key_name'] ?? 'id',
-                            'type' => 'hidden',
+                            'name'    => $field['pivot_key_name'] ?? 'id',
+                            'type'    => 'hidden',
                             'wrapper' => [
                                 'class' => 'd-none',
                             ],

--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -73,11 +73,11 @@ trait Filters
 
         // check if another filter with the same name exists
         if (! isset($options['name'])) {
-            abort(500, 'All your filters need names.');
+            abort(500, 'All your filters need names.', ['developer-error-exception']);
         }
 
         if ($this->filters()->contains('name', $options['name'])) {
-            abort(500, "Sorry, you can't have two filters with the same name.");
+            abort(500, "Sorry, you can't have two filters with the same name.", ['developer-error-exception']);
         }
 
         // add a new filter to the interface
@@ -168,7 +168,7 @@ trait Filters
         $filter = $this->filters()->firstWhere('name', $name);
 
         if (! $filter) {
-            abort(500, 'CRUD Filter "'.$name.'" not found. Please check the filter exists before you modify it.');
+            abort(500, 'CRUD Filter "'.$name.'" not found. Please check the filter exists before you modify it.', ['developer-error-exception']);
         }
 
         if (is_array($modifications)) {

--- a/src/app/Library/CrudPanel/Traits/Macroable.php
+++ b/src/app/Library/CrudPanel/Traits/Macroable.php
@@ -21,7 +21,7 @@ trait Macroable
     public static function macro($name, $macro)
     {
         if (method_exists(new static(), $name)) {
-            abort(500, "Cannot register '$name' macro. '$name()' already exists on ".get_called_class());
+            abort(500, "Cannot register '$name' macro. '$name()' already exists on ".get_called_class(), ['developer-error-exception']);
         }
 
         static::parentMacro($name, $macro);

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -385,7 +385,7 @@ trait Read
     private function abortIfInvalidPageLength($value)
     {
         if ($value === 0 || (is_array($value) && in_array(0, $value))) {
-            abort(500, 'You should not use 0 as a key in paginator. If you are looking for "ALL" option, use -1 instead.');
+            abort(500, 'You should not use 0 as a key in paginator. If you are looking for "ALL" option, use -1 instead.', ['developer-error-exception']);
         }
     }
 

--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -33,7 +33,7 @@ trait Relationships
             return $relation;
         }
 
-        abort(500, 'Looks like field <code>'.$field['name'].'</code> is not properly defined. The <code>'.$field['entity'].'()</code> relationship doesn\'t seem to exist on the <code>'.get_class($model).'</code> model.');
+        abort(500, 'Looks like field <code>'.$field['name'].'</code> is not properly defined. The <code>'.$field['entity'].'()</code> relationship doesn\'t seem to exist on the <code>'.get_class($model).'</code> model.', ['developer-error-exception']);
     }
 
     /**

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -80,7 +80,7 @@ trait SaveActions
     {
         $orderCounter = $this->getOperationSetting('save_actions') !== null ? (count($this->getOperationSetting('save_actions')) + 1) : 1;
         //check for some mandatory fields
-        $saveAction['name'] ?? abort(500, 'Please define save action name.');
+        $saveAction['name'] ?? abort(500, 'Please define save action name.', ['developer-error-exception']);
         $saveAction['redirect'] = $saveAction['redirect'] ?? fn ($crud, $request, $itemId) => $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
         $saveAction['visible'] = $saveAction['visible'] ?? true;
         $saveAction['button_text'] = $saveAction['button_text'] ?? $saveAction['name'];
@@ -291,7 +291,7 @@ trait SaveActions
         }
 
         return [
-            'active' => $saveCurrent,
+            'active'  => $saveCurrent,
             'options' => $dropdownOptions,
         ];
     }
@@ -349,8 +349,8 @@ trait SaveActions
         // if the request is AJAX, return a JSON response
         if ($this->getRequest()->ajax()) {
             return response()->json([
-                'success' => true,
-                'data' => $this->entry,
+                'success'      => true,
+                'data'         => $this->entry,
                 'redirect_url' => $redirectUrl,
                 'referrer_url' => $referrer_url ?? false,
             ]);
@@ -372,7 +372,7 @@ trait SaveActions
     {
         $defaultSaveActions = [
             [
-                'name' => 'save_and_back',
+                'name'    => 'save_and_back',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('list');
                 },
@@ -382,7 +382,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
             [
-                'name' => 'save_and_edit',
+                'name'    => 'save_and_edit',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('update');
                 },
@@ -404,7 +404,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_edit'),
             ],
             [
-                'name' => 'save_and_new',
+                'name'    => 'save_and_new',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('create');
                 },

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -291,7 +291,7 @@ trait SaveActions
         }
 
         return [
-            'active'  => $saveCurrent,
+            'active' => $saveCurrent,
             'options' => $dropdownOptions,
         ];
     }
@@ -349,8 +349,8 @@ trait SaveActions
         // if the request is AJAX, return a JSON response
         if ($this->getRequest()->ajax()) {
             return response()->json([
-                'success'      => true,
-                'data'         => $this->entry,
+                'success' => true,
+                'data' => $this->entry,
                 'redirect_url' => $redirectUrl,
                 'referrer_url' => $referrer_url ?? false,
             ]);
@@ -372,7 +372,7 @@ trait SaveActions
     {
         $defaultSaveActions = [
             [
-                'name'    => 'save_and_back',
+                'name' => 'save_and_back',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('list');
                 },
@@ -382,7 +382,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ],
             [
-                'name'    => 'save_and_edit',
+                'name' => 'save_and_edit',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('update');
                 },
@@ -404,7 +404,7 @@ trait SaveActions
                 'button_text' => trans('backpack::crud.save_action_save_and_edit'),
             ],
             [
-                'name'    => 'save_and_new',
+                'name' => 'save_and_new',
                 'visible' => function ($crud) {
                     return $crud->hasAccess('create');
                 },

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -395,10 +395,10 @@ trait Search
         }
 
         return [
-            'draw'            => (isset($this->getRequest()['draw']) ? (int) $this->getRequest()['draw'] : 0),
-            'recordsTotal'    => $totalRows,
+            'draw' => (isset($this->getRequest()['draw']) ? (int) $this->getRequest()['draw'] : 0),
+            'recordsTotal' => $totalRows,
             'recordsFiltered' => $filteredRows,
-            'data'            => $rows,
+            'data' => $rows,
         ];
     }
 

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -25,7 +25,7 @@ trait Search
         return $this->query->where(function ($query) use ($searchTerm) {
             foreach ($this->columns() as $column) {
                 if (! isset($column['type'])) {
-                    abort(400, 'Missing column type when trying to apply search term.');
+                    abort(500, 'Missing column type when trying to apply search term.', ['developer-error-exception']);
                 }
 
                 $this->applySearchLogicForColumn($query, $column, $searchTerm);
@@ -395,10 +395,10 @@ trait Search
         }
 
         return [
-            'draw' => (isset($this->getRequest()['draw']) ? (int) $this->getRequest()['draw'] : 0),
-            'recordsTotal' => $totalRows,
+            'draw'            => (isset($this->getRequest()['draw']) ? (int) $this->getRequest()['draw'] : 0),
+            'recordsTotal'    => $totalRows,
             'recordsFiltered' => $filteredRows,
-            'data' => $rows,
+            'data'            => $rows,
         ];
     }
 

--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -73,7 +73,7 @@ trait Validation
         } elseif (is_string($classOrRulesArray) && class_exists($classOrRulesArray) && is_a($classOrRulesArray, FormRequest::class, true)) {
             $this->setValidationFromRequest($classOrRulesArray);
         } else {
-            abort(500, 'Please pass setValidation() nothing, a rules array or a FormRequest class.');
+            abort(500, 'Please pass setValidation() nothing, a rules array or a FormRequest class.', ['developer-error-exception']);
         }
     }
 

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -21,7 +21,7 @@ final class RegisterUploadEvents
         $this->crudObjectType = is_a($crudObject, CrudField::class) ? 'field' : (is_a($crudObject, CrudColumn::class) ? 'column' : null);
 
         if (! $this->crudObjectType) {
-            abort(500, 'Upload handlers only work for CrudField and CrudColumn classes.');
+            abort(500, 'Upload handlers only work for CrudField and CrudColumn classes.', ['developer-error-exception']);
         }
     }
 

--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -172,7 +172,7 @@ class Widget extends Fluent
         if (! backpack_pro()) {
             throw new BackpackProRequiredException('Cannot find the widget view: '.$this->attributes['type'].'. Please check for typos.'.(backpack_pro() ? '' : ' If you are trying to use a PRO widget, please first purchase and install the backpack/pro addon from backpackforlaravel.com'), 1);
         }
-        abort(500, 'Cannot find the view for «'.$this->attributes['type'].'» widget type. Please check for typos.');
+        abort(500, 'Cannot find the view for «'.$this->attributes['type'].'» widget type. Please check for typos.', ['developer-error-exception']);
     }
 
     // -------

--- a/src/app/Models/Traits/HasEnumFields.php
+++ b/src/app/Models/Traits/HasEnumFields.php
@@ -27,7 +27,7 @@ trait HasEnumFields
 
             $type = $connection->select($select)[0]->Type;
         } catch (\Exception $e) {
-            abort(500, 'Enum field type is not supported - it only works on MySQL. Please use select_from_array instead.');
+            abort(500, 'Enum field type is not supported - it only works on MySQL. Please use select_from_array instead.', ['developer-error-exception']);
         }
 
         preg_match('/^enum\((.*)\)$/', $type, $matches);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -272,7 +272,7 @@ if (! function_exists('backpack_view')) {
             return '- Called in: '.Str::after($functionFile, base_path()).' on line: '.$functionLine;
         })();
 
-        abort(500, $errorMessage.$errorDetails);
+        abort(500, $errorMessage.$errorDetails, ['developer-error-exception']);
     }
 }
 

--- a/src/resources/views/ui/errors/4xx.blade.php
+++ b/src/resources/views/ui/errors/4xx.blade.php
@@ -2,6 +2,7 @@
 
 @php
   $error_number ??= 400;
+  $shouldEscape = ! in_array('developer-error-exception', $exception->getHeaders());
 @endphp
 
 @section('title')
@@ -9,7 +10,7 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_4xx', [
+  {!! $exception?->getMessage() && config('app.debug') ? ($shouldEscape ? e($exception->getMessage()) : $exception->getMessage()) : trans('backpack::base.error_page.message_4xx', [
     'href_back' => 'href="javascript:history.back()"',
     'href_homepage' => 'href="'.url('').'"',
   ]) !!}

--- a/src/resources/views/ui/errors/500.blade.php
+++ b/src/resources/views/ui/errors/500.blade.php
@@ -2,6 +2,7 @@
 
 @php
   $error_number = 500;
+  $shouldEscape = ! in_array('developer-error-exception', $exception->getHeaders());
 @endphp
 
 @section('title')
@@ -9,5 +10,5 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_500') !!}
+  {!! $exception?->getMessage() && config('app.debug') ? ($shouldEscape ? e($exception->getMessage()) : $exception->getMessage()) : trans('backpack::base.error_page.message_500') !!}
 @endsection

--- a/src/resources/views/ui/errors/503.blade.php
+++ b/src/resources/views/ui/errors/503.blade.php
@@ -2,6 +2,7 @@
 
 @php
   $error_number = 503;
+  $shouldEscape = ! in_array('developer-error-exception', $exception->getHeaders());
 @endphp
 
 @section('title')
@@ -9,5 +10,5 @@
 @endsection
 
 @section('description')
-  {!! $exception?->getMessage() && config('app.debug') ? e($exception->getMessage()) : trans('backpack::base.error_page.message_503') !!}
+  {!! $exception?->getMessage() && config('app.debug') ? ($shouldEscape ? e($exception->getMessage()) : $exception->getMessage()) : trans('backpack::base.error_page.message_503') !!}
 @endsection

--- a/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelButtonsTest.php
@@ -362,7 +362,7 @@ class CrudPanelButtonsTest extends BaseCrudPanel
         } catch (\Throwable $e) {
         }
         $this->assertEquals(
-            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Unknown button position - please use \'beginning\' or \'end\'.'),
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Unknown button position - please use \'beginning\' or \'end\'.', null, ['developer-error-exception']),
             $e
         );
     }

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -658,7 +658,7 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         } catch (\Throwable $e) {
         }
         $this->assertEquals(
-            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Looks like field <code>doesNotExist</code> is not properly defined. The <code>doesNotExist()</code> relationship doesn\'t seem to exist on the <code>Backpack\CRUD\Tests\Config\Models\TestModel</code> model.'),
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Looks like field <code>doesNotExist</code> is not properly defined. The <code>doesNotExist()</code> relationship doesn\'t seem to exist on the <code>Backpack\CRUD\Tests\Config\Models\TestModel</code> model.', null, ['developer-error-exception']),
             $e
         );
     }
@@ -903,7 +903,7 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         } catch (\Throwable $e) {
         }
         $this->assertEquals(
-            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Field name can\'t be empty.'),
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Field name can\'t be empty.', null, ['developer-error-exception']),
             $e
         );
     }

--- a/tests/Unit/CrudPanel/CrudPanelMacroTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelMacroTest.php
@@ -27,7 +27,7 @@ class CrudPanelMacroTest extends BaseCrudPanel
         } catch (\Throwable $e) {
         }
         $this->assertEquals(
-            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Cannot register \'setModel\' macro. \'setModel()\' already exists on Backpack\CRUD\app\Library\CrudPanel\CrudPanel'),
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Cannot register \'setModel\' macro. \'setModel()\' already exists on Backpack\CRUD\app\Library\CrudPanel\CrudPanel', null, ['developer-error-exception']),
             $e
         );
     }

--- a/tests/Unit/CrudPanel/CrudPanelValidationTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelValidationTest.php
@@ -203,7 +203,7 @@ class CrudPanelValidationTest extends \Backpack\CRUD\Tests\config\CrudPanel\Base
         } catch (\Throwable $e) {
         }
         $this->assertEquals(
-            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Please pass setValidation() nothing, a rules array or a FormRequest class.'),
+            new \Symfony\Component\HttpKernel\Exception\HttpException(500, 'Please pass setValidation() nothing, a rules array or a FormRequest class.', null, ['developer-error-exception']),
             $e
         );
     }


### PR DESCRIPTION
## WHY

fixes: https://github.com/Laravel-Backpack/CRUD/issues/5142

### BEFORE - What was wrong? What was happening before this PR?

All errors have the message escaped. In some scenarios we would like to display some html, like a link to docs or similar.

### AFTER - What is happening after this PR?

We introduce a way to have "internal" exceptions, errors that occur when developer missed some configuration.


## HOW

### How did you achieve that, in technical terms?

Introduced a header `developer-error-exception` that when present in the exception we don't escape the message, since those errors are internally triggered by backpack, and we control the contents. 



### Is it a breaking change?

I don't think so, no.
