### PR TITLE
Update text.blade.php to tolerate Enum values

### DIFF
--- a/src/resources/views/crud/columns/text.blade.php
+++ b/src/resources/views/crud/columns/text.blade.php
@@ -15,6 +15,10 @@
         $column['value'] = json_encode($column['value']);
     }
 
+    if ($column['value'] instanceof \UnitEnum) {
+        $column['value'] = $column['value']->value;
+    }
+
     if(!empty($column['value'])) {
         $column['text'] = $column['prefix'].Str::limit($column['value'], $column['limit'], '…').$column['suffix'];
     }


### PR DESCRIPTION
At the moment, the whole view breaks in case the column has a type Enum. This happens because the Str::limit function here https://github.com/Laravel-Backpack/CRUD/blob/main/src/resources/views/crud/columns/text.blade.php#L19 expects the value to be a string and we are passing an Enum. This change shows Enum values correctly.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

If the column was of type Enum, the view broke because it tried to use the Str::limit() function on an Enum value when it expected an string value. Even if the casts were set correctly in the Model (https://backpackforlaravel.com/docs/6.x/crud-fields#enum-1), this view still broke as it does not handle the Enum type.

### AFTER - What is happening after this PR?

The change checks if the value is of type Enum and changes it to the string representation of the Enum value for this view so that Str::limit() function and other related functions do not fail on this view.


## HOW

### How did you achieve that, in technical terms?

I added a simple if check to see if the incoming value is of type Enum and is handled accordingly.



### Is it a breaking change?

No


### How can we test the before & after?

Create a column of type Enum in the model and load the view before this change. You will see a faliure of the Str::limit() function in the file [src/resources/views/crud/columns/text.blade.php:](https://github.com/Laravel-Backpack/CRUD/blob/9ed23aa14c8c6b813e5927e6adbe971d5de93994/src/resources/views/crud/columns/text.blade.php#L19).

![image](https://github.com/user-attachments/assets/9800e903-a17a-4976-b495-92f35d1859dd)

After my change, the Enum value is correctly transformed to the text value representation for rendering correctly without the error.

![958F4A01-5CC9-4942-BA98-9FEAE23949BC_1_201_a](https://github.com/user-attachments/assets/214d39b6-41ab-4657-82c1-7e0626117c4c)
