### PR TITLE
Show the correct tab for subfield errors

### DIFF
--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -7,8 +7,8 @@
         foreach(session()->get('errors')->getBags() as $bag => $errorMessages) {
             foreach($errorMessages->getMessages() as $fieldName => $messages) {
 
-                # Transform subfield $fieldNames into the correct CRUD fieldName format 
-                # preg_split by the array separator .digits. and take only the first element
+                // extract the "parent" field name by separating the field name string by `.digit.` (eg. relation.0.fieldName)
+                // and take the first element,  AKA the "parent" name. In the above example: `relation` 
                 $fieldName = preg_split('/\.\d+\./',$fieldName)[0];
 
                 if(array_key_exists($fieldName, $crud->getCurrentFields()) && array_key_exists('tab', $crud->getCurrentFields()[$fieldName])) {

--- a/src/resources/views/crud/inc/show_tabbed_fields.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_fields.blade.php
@@ -6,6 +6,11 @@
         }
         foreach(session()->get('errors')->getBags() as $bag => $errorMessages) {
             foreach($errorMessages->getMessages() as $fieldName => $messages) {
+
+                # Transform subfield $fieldNames into the correct CRUD fieldName format 
+                # preg_split by the array separator .digits. and take only the first element
+                $fieldName = preg_split('/\.\d+\./',$fieldName)[0];
+
                 if(array_key_exists($fieldName, $crud->getCurrentFields()) && array_key_exists('tab', $crud->getCurrentFields()[$fieldName])) {
                     return $crud->getCurrentFields()[$fieldName]['tab'];
                 }


### PR DESCRIPTION
## WHY

To correctly detect the crud fieldName for subfields with validation errors and display the relevant tab to maintain consistency with the behaviour of other fields that have validation errors.

### BEFORE - What was wrong? What was happening before this PR?

When the first error is on a subfield, I expect that tab to be the active tab as it would be with other fields.
Because the fieldname is in dot notation array format, this does not match the crud fieldname e.g. someRelation.0.name does not match the fieldName someRelation, therefore the error is skipped when determining the tab to activate

### AFTER - What is happening after this PR?

The crud fieldName is parsed from the current field under test and will match the parent fieldName, allowing it to set the active tab appropriately.


## HOW

### How did you achieve that, in technical terms?

I stripped the crud fieldName from the start of the subfield name
`$fieldName = preg_split('/\.\d+\./',$fieldName)[0];`


### Is it a breaking change?

No


### How can we test the before & after?

Create a validation error on a subfield that is not on the first tab.
Before: the errors are shown, but the subfield's tab is not active.
After: The tab with the subfield is the active tab.

