### PR TITLE
Customizable navigation urls on panels

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -45,6 +45,12 @@ trait ListOperation
 
         $this->crud->operation('list', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
+
+            $this->crud->setOperationSetting('breadcrumbs', [
+                trans('backpack::crud.admin')       => url(config('backpack.base.route_prefix'), 'dashboard'),
+                $this->crud->entity_name_plural     => url($this->crud->route),
+                trans('backpack::crud.list')        => false,
+            ]);
         });
     }
 
@@ -59,6 +65,7 @@ trait ListOperation
 
         $this->data['crud'] = $this->crud;
         $this->data['title'] = $this->crud->getTitle() ?? mb_ucfirst($this->crud->entity_name_plural);
+        $this->data['breadcrumbs'] = $this->crud->getOperationSetting('breadcrumbs');
 
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getListView(), $this->data);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -47,9 +47,9 @@ trait ListOperation
             $this->crud->loadDefaultOperationSettingsFromConfig();
 
             $this->crud->setOperationSetting('breadcrumbs', [
-                trans('backpack::crud.admin')       => url(config('backpack.base.route_prefix'), 'dashboard'),
-                $this->crud->entity_name_plural     => url($this->crud->route),
-                trans('backpack::crud.list')        => false,
+                trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
+                $this->crud->entity_name_plural => url($this->crud->route),
+                trans('backpack::crud.list') => false,
             ]);
         });
     }

--- a/src/resources/views/crud/buttons/cancel.blade.php
+++ b/src/resources/views/crud/buttons/cancel.blade.php
@@ -1,0 +1,6 @@
+@php
+    $cancelButtonUrl = empty($crud->getOperationSetting('cancelButtonUrl')) ? ($crud->hasAccess('list') ? url($crud->route) : url()->previous()) :
+        (is_callable($crud->getOperationSetting('cancelButtonUrl')) ? $crud->getOperationSetting('cancelButtonUrl')($crud) : $crud->getOperationSetting('cancelButtonUrl'));
+@endphp
+
+<a href="{{ $cancelButtonUrl }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -18,15 +18,15 @@
                     <span class="d-none visually-hidden">Toggle Dropdown</span>
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="bpSaveButtonsGroup">
-                    @foreach( $saveAction['options'] as $value => $label)
+                    @foreach($saveAction['options'] as $value => $label)
                         <li><button class="dropdown-item" type="button" data-value="{{ $value }}">{{ $label }}</button></li>
                     @endforeach
                 </ul>
             </div>
         @endif
     @endif
-    @if(!$crud->hasOperationSetting('showCancelButton') || $crud->getOperationSetting('showCancelButton') == true)
-        <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
+    @if(!$crud->hasOperationSetting('showCancelButton') || $crud->getOperationSetting('showCancelButton') === true)
+        @include('crud::buttons.cancel')
     @endif
 
     @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))


### PR DESCRIPTION
## WHY
fixes: https://github.com/Laravel-Backpack/PRO/issues/290
### BEFORE - What was wrong? What was happening before this PR?

Some navigation elements in the Backpack UI should be "configurable" without resorting to overwrite the "core" files. 
I've add that "feeling" back when I created https://github.com/Laravel-Backpack/CRUD/pull/3248 that got rejected by @tabacitu 😢 

#290 resurfaced the problem again and make it even more evident that not only the cancel button should be easily changed by developers as also breadcrumbs aren't possible to configure without at least overwriting the controller methods. 

Our code really checks for the presence of custom breadcrumbs in the view data: https://github.com/Laravel-Backpack/CRUD/blob/dee2eeca96190ade092bc2777c95275ec3d4130c/src/resources/views/crud/edit.blade.php#L11

But the operation itself, does not expose those "configurable" breadcrumbs: https://github.com/Laravel-Backpack/CRUD/blob/dee2eeca96190ade092bc2777c95275ec3d4130c/src/app/Http/Controllers/Operations/UpdateOperation.php#L78

So if developer wanted to change the "UpdateOperation" breadcrumbs he had to overwrite the `edit($id)` function, 

Regarding the cancel button url, it can also now be configured via a setting for each individual crud panel.
Note that it's not possible to define the cancel button url as a closure for all the crud panels (in a config file). 

### AFTER - What is happening after this PR?

The proposed change here, allow for the breadcrumbs to be setup at an operation level by using operation settings. Setting the breadcrumbs of each operation on their default initialization, developer is now allowed to customize the default Backpack breadcrumbs without any overwrites. 

## HOW

### How did you achieve that, in technical terms?

Added the default breadcrumbs to an operation setting, instead of the view and then pass them to the crud views. 

Created an operation setting for the cancel button url. 

### Is it a breaking change?

Yes, if you copy the `list.blade.php` for example, and changed the default breadcrumbs there, when we set the breadcrumbs from the controller they would overwrite the changes made in the file. 
