### PR TITLE
allow datatable url configuration

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -45,6 +45,7 @@ trait ListOperation
 
         $this->crud->operation('list', function () {
             $this->crud->loadDefaultOperationSettingsFromConfig();
+            $this->crud->setOperationSetting('datatablesUrl', $this->crud->getRoute());
         });
     }
 

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -20,13 +20,13 @@
     // datatables caches the ajax responses with pageLength in LocalStorage so when changing this
     // settings in controller users get unexpected results. To avoid that we will reset
     // the table cache when both lengths don't match.
-    let $dtCachedInfo = JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}'))
-        ? JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}')) : [];
+    let $dtCachedInfo = JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getOperationSetting("datatablesUrl")}}'))
+        ? JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getOperationSetting("datatablesUrl")}}')) : [];
     var $dtDefaultPageLength = {{ $crud->getDefaultPageLength() }};
-    let $dtStoredPageLength = localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength');
+    let $dtStoredPageLength = localStorage.getItem('DataTables_crudTable_/{{$crud->getOperationSetting("datatablesUrl")}}_pageLength');
 
     if(!$dtStoredPageLength && $dtCachedInfo.length !== 0 && $dtCachedInfo.length !== $dtDefaultPageLength) {
-        localStorage.removeItem('DataTables_crudTable_/{{$crud->getRoute()}}');
+        localStorage.removeItem('DataTables_crudTable_/{{$crud->getOperationSetting("datatablesUrl")}}');
     }
 
     // in this page we always pass the alerts to localStorage because we can be redirected with
@@ -51,7 +51,7 @@
 
     @if ($crud->getPersistentTable())
 
-        var saved_list_url = localStorage.getItem('{{ Str::slug($crud->getRoute()) }}_list_url');
+        var saved_list_url = localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url');
 
         //check if saved url has any parameter or is empty after clearing filters.
         if (saved_list_url && saved_list_url.indexOf('?') < 1) {
@@ -71,7 +71,7 @@
     }
 
     @if($crud->getPersistentTableDuration())
-        var saved_list_url_time = localStorage.getItem('{{ Str::slug($crud->getRoute()) }}_list_url_time');
+        var saved_list_url_time = localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url_time');
 
         if (saved_list_url_time) {
             var $current_date = new Date();
@@ -118,7 +118,7 @@
         fn.apply(window, args);
       },
       updateUrl : function (url) {
-        let urlStart = "{{ url($crud->route) }}";
+        let urlStart = "{{ url($crud->getOperationSetting("datatablesUrl")) }}";
         let urlEnd = url.replace(urlStart, '');
         urlEnd = urlEnd.replace('/search', '');
         let newUrl = urlStart + urlEnd;
@@ -139,7 +139,7 @@
         }
         window.history.pushState({}, '', newUrl);
         @if ($crud->getPersistentTable())
-            localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url', newUrl);
+            localStorage.setItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url', newUrl);
         @endif
       },
       dataTableConfiguration: {
@@ -193,7 +193,7 @@
 
         stateSaveParams: function(settings, data) {
 
-            localStorage.setItem('{{ Str::slug($crud->getRoute()) }}_list_url_time', data.time);
+            localStorage.setItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url_time', data.time);
 
             data.columns.forEach(function(item, index) {
                 var columnHeading = crud.table.columns().header()[index];
@@ -211,11 +211,11 @@
 
             //if the save time as expired we force datatabled to clear localStorage
             if($saved_time < $current_date) {
-                if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url')) {
-                    localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url');
+                if (localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl"))}}_list_url')) {
+                    localStorage.removeItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url');
                 }
-                if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url_time')) {
-                    localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url_time');
+                if (localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl"))}}_list_url_time')) {
+                    localStorage.removeItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url_time');
                 }
                return false;
             }
@@ -267,7 +267,7 @@
           @endif
           searching: @json($crud->getOperationSetting('searchableTable') ?? true),
           ajax: {
-              "url": "{!! url($crud->route.'/search').'?'.Request::getQueryString() !!}",
+              "url": "{!! url($crud->getOperationSetting("datatablesUrl").'/search').'?'.Request::getQueryString() !!}",
               "type": "POST",
               "data": {
                 "totalEntryCount": "{{$crud->getOperationSetting('totalEntryCount') ?? false}}"
@@ -310,7 +310,7 @@
 
       @if($crud->getOperationSetting('resetButton') ?? true)
         // create the reset button
-        var crudTableResetButton = '<a href="{{url($crud->route)}}" class="ml-1 ms-1" id="crudTable_reset_button">{{ trans('backpack::crud.reset') }}</a>';
+        var crudTableResetButton = '<a href="{{url($crud->getOperationSetting("datatablesUrl"))}}" class="ml-1 ms-1" id="crudTable_reset_button">{{ trans('backpack::crud.reset') }}</a>';
 
         $('#datatable_info_stack').append(crudTableResetButton);
 
@@ -318,16 +318,16 @@
         $('#crudTable_reset_button').on('click', function() {
 
           //clear the filters
-          if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url')) {
-              localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url');
+          if (localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl"))}}_list_url')) {
+              localStorage.removeItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url');
           }
-          if (localStorage.getItem('{{ Str::slug($crud->getRoute())}}_list_url_time')) {
-              localStorage.removeItem('{{ Str::slug($crud->getRoute()) }}_list_url_time');
+          if (localStorage.getItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl"))}}_list_url_time')) {
+              localStorage.removeItem('{{ Str::slug($crud->getOperationSetting("datatablesUrl")) }}_list_url_time');
           }
 
           //clear the table sorting/ordering/visibility
-          if(localStorage.getItem('DataTables_crudTable_/{{ $crud->getRoute() }}')) {
-              localStorage.removeItem('DataTables_crudTable_/{{ $crud->getRoute() }}');
+          if(localStorage.getItem('DataTables_crudTable_/{{ $crud->getOperationSetting("datatablesUrl") }}')) {
+              localStorage.removeItem('DataTables_crudTable_/{{ $crud->getOperationSetting("datatablesUrl") }}');
           }
         });
       @endif
@@ -348,7 +348,7 @@
         // so in next requests we know if the length changed by user
         // or by developer in the controller.
         $('#crudTable').on( 'length.dt', function ( e, settings, len ) {
-            localStorage.setItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength', len);
+            localStorage.setItem('DataTables_crudTable_/{{$crud->getOperationSetting("datatablesUrl")}}_pageLength', len);
         });
 
         $('#crudTable').on( 'page.dt', function () {

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -111,7 +111,7 @@
       		e.preventDefault();
 
 		    	// behaviour for ajax table
-		    	var new_url = '{{ url($crud->route.'/search') }}';
+		    	var new_url = '{{ url($crud->getOperationSetting("datatablesUrl").'/search') }}';
 		    	var ajax_table = $("#crudTable").DataTable();
 
   				// replace the datatables ajax url with new_url and reload it


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Datatables url was hardcoded to `CRUD::getRoute()`, by that reason it was not possible to use datatables in any other place than the main crud route, eg: `$this->crud->setRoute('monsters')`, would only allow a datatable in that specific url, trying to add a datatable in `monsters/some-page` would break things like filters, and require "hacking solutions" to try to overcome the search functionality. 

### AFTER - What is happening after this PR?

The datatable can be setup in any additional page by configuring the `datatablesUrl`, for that reason it's now possible to have filters and search without convoluted solutions. 


## HOW

### How did you achieve that, in technical terms?

Replaced all `$crud->getRoute()` calls in datatables and filter scripts by `$crud->getOperationSetting('datatablesUrl')` and setup a default `datatablesUrl` ($crud->getRoute())` to keep it backward compatible. 


### Is it a breaking change?

No