### PR TITLE
add responsive script to draw event

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -366,11 +366,19 @@
          if ($('#crudTable').data('has-line-buttons-as-dropdown')) {
           formatActionColumnAsDropdown();
          }
+
+         if (crud.table.responsive.hasHidden()) {
+            $('.dtr-control').removeClass('d-none'); 
+            $('.dtr-control').addClass('d-inline');
+            $("#crudTable").removeClass('has-hidden-columns').addClass('has-hidden-columns');
+         }
+
       }).dataTable();
 
       // when datatables-colvis (column visibility) is toggled
       // rebuild the datatable using the datatable-responsive plugin
       $('#crudTable').on( 'column-visibility.dt',   function (event) {
+        console.log('column-visibility.dt');
          crud.table.responsive.rebuild();
       } ).dataTable();
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

After the table was re-drawn, eg: an entry deleted from the table, the responsive plugin doesn't kick in (as there are no layout changes to columns, it's just less one row). 

For that reason, we need to add the responsive table check that enable the "responsive trigger" (three dots), to run on datatables draw event.

### AFTER - What is happening after this PR?

It correctly display the responsive trigger when there are hidden columns.


## HOW

### How did you achieve that, in technical terms?

Added a check in table draw event.



### Is it a breaking change?

No
