### PR TITLE
Bump DataTables version & fix header alignment

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -175,6 +175,19 @@ form .select2.select2-container {
     border: 0;
 }
 
+#crudTable_wrapper > div.table-footer > div:nth-child(1) > div.dt-length {
+    display: flex;
+    gap: .50rem;
+}
+
+#crudTable_wrapper > div.table-footer > div:nth-child(1) > div.dt-length select {
+   width: 4rem;
+}
+
+#crudTable_wrapper > div.table-footer > div:nth-child(1) > div.dt-length > label{
+    white-space: nowrap;
+}
+
 /*/Table - List View/*/
 .navbar-filters {
     min-height: 25px;

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -192,6 +192,10 @@ table.fixedHeader-floating, table.fixedHeader-locked {
     white-space: nowrap;
 }
 
+div.dt-container div.dt-paging ul.pagination  {
+    justify-content: flex-end;
+}
+
 /*/Table - List View/*/
 .navbar-filters {
     min-height: 25px;

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -65,7 +65,7 @@ form .select2.select2-container {
     position: relative;
 }
 
-#crudTable_processing.dataTables_processing.card {
+#crudTable_processing.dt-processing.card {
     all: unset;
     position: absolute;
     background: rgba(255, 255, 255, 0.9);
@@ -77,7 +77,11 @@ form .select2.select2-container {
     border-radius: 5px;
 }
 
-#crudTable_processing.dataTables_processing.card > img {
+table.fixedHeader-floating, table.fixedHeader-locked {
+    background-color: white;
+}
+
+#crudTable_processing.dt-processing.card > img {
     margin: 0;
     position: absolute;
     top: 50%;
@@ -85,7 +89,7 @@ form .select2.select2-container {
     transform: translate(-50%, -50%);
 }
 
-#crudTable_processing.dataTables_processing.card > div {
+#crudTable_processing.dt-processing.card > div {
     display: none !important;
 }
 

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -181,7 +181,6 @@ table.fixedHeader-floating, table.fixedHeader-locked {
 
 #crudTable_wrapper > div.table-footer > div:nth-child(1) > div.dt-length {
     display: flex;
-    gap: .50rem;
 }
 
 #crudTable_wrapper > div.table-footer > div:nth-child(1) > div.dt-length select {

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -6,20 +6,19 @@
  @endphp
 
   {{-- DATA TABLES SCRIPT --}}
-@push('after_scripts')
-    @basset("https://cdn.datatables.net/2.1.8/js/dataTables.min.js")
-    @basset("https://cdn.datatables.net/2.1.8/js/dataTables.bootstrap5.min.js")
-    @basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
-    @basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
-    @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
-@endpush
+
+@basset("https://cdn.datatables.net/2.1.8/js/dataTables.min.js")
+@basset("https://cdn.datatables.net/2.1.8/js/dataTables.bootstrap5.min.js")
+@basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
+@basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
+@basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
+
 
 @push('before_styles')
     @basset('https://cdn.datatables.net/2.1.8/css/dataTables.bootstrap5.min.css')
     @basset("https://cdn.datatables.net/responsive/3.0.3/css/responsive.dataTables.min.css")
     @basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
 @endpush
-@push('after_scripts')
   <script>
     // here we will check if the cached dataTables paginator length is conformable with current paginator settings.
     // datatables caches the ajax responses with pageLength in LocalStorage so when changing this
@@ -342,7 +341,7 @@
       window.crud.updateUrl(location.href);
 
       // move search bar
-      $(".dt-search input").remove();
+      $("#datatable_search_stack input").remove();
       $(".dt-search input").appendTo($('#datatable_search_stack .input-icon'));
       $("#datatable_search_stack input").removeClass('form-control-sm');
       $(".dt-search").remove();
@@ -525,4 +524,3 @@
   </script>
  
   @include('crud::inc.details_row_logic')
-@endpush

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -441,7 +441,6 @@
       // when datatables-colvis (column visibility) is toggled
       // rebuild the datatable using the datatable-responsive plugin
       $('#crudTable').on( 'column-visibility.dt',   function (event) {
-        console.log('column-visibility.dt');
          crud.table.responsive.rebuild();
       } ).dataTable();
 

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -6,15 +6,20 @@
  @endphp
 
   {{-- DATA TABLES SCRIPT --}}
-@basset("https://cdn.datatables.net/2.1.8/js/dataTables.min.js")
-@basset("https://cdn.datatables.net/2.1.8/js/dataTables.bootstrap5.min.js")
-@basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
-@basset("https://cdn.datatables.net/responsive/3.0.3/css/responsive.dataTables.min.css")
-@basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
-@basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
+@push('after_scripts')
+    @basset("https://cdn.datatables.net/2.1.8/js/dataTables.min.js")
+    @basset("https://cdn.datatables.net/2.1.8/js/dataTables.bootstrap5.min.js")
+    @basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
+    @basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
+    @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
+@endpush
 
-  @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
-
+@push('before_styles')
+    @basset('https://cdn.datatables.net/2.1.8/css/dataTables.bootstrap5.min.css')
+    @basset("https://cdn.datatables.net/responsive/3.0.3/css/responsive.dataTables.min.css")
+    @basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
+@endpush
+@push('after_scripts')
   <script>
     // here we will check if the cached dataTables paginator length is conformable with current paginator settings.
     // datatables caches the ajax responses with pageLength in LocalStorage so when changing this
@@ -346,7 +351,7 @@
       $("#crudTable_wrapper .table-footer .btn-secondary").removeClass('btn-secondary');
 
       // remove forced overflow on load
-      $(".navbar.navbar-filters + div").css('overflow','initial');
+      $(".navbar.navbar-filters + div").css('overflow','hidden');
 
       // move "showing x out of y" info to header
       @if($crud->getSubheading())
@@ -520,5 +525,6 @@
         });
     }
   </script>
-
+ 
   @include('crud::inc.details_row_logic')
+@endpush

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -405,7 +405,6 @@
       // on DataTable draw event run all functions in the queue
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {
-        console.log('draw.dt');
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
@@ -423,6 +422,15 @@
             $("#crudTable").removeClass('has-hidden-columns').addClass('has-hidden-columns');
          }
 
+         // in datatables 2.0.3 the implementation was changed to use `replaceChildren`, for that reason scripts 
+         // that came with the response are no longer executed, like the delete button script or any other ajax 
+         // button created by the developer. For that reason, we move them to the end of the body
+         // ensuring they are re-evaluated on each draw event.
+        document.getElementById('crudTable').querySelectorAll('script').forEach(function(script) {
+            const newScript = document.createElement('script');
+            newScript.text = script.text;
+            document.body.appendChild(newScript);
+        });
       }).dataTable();
 
       // when datatables-colvis (column visibility) is toggled

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -448,7 +448,6 @@
         // when columns are hidden by reponsive plugin,
         // the table should have the has-hidden-columns class
         crud.table.on( 'responsive-resize', function ( e, datatable, columns ) {
-            console.log('responsive-resize', crud.table.responsive.hasHidden());
             if (crud.table.responsive.hasHidden()) {
                 $('.dtr-control').each(function() {
                     var $this = $(this);

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -6,12 +6,12 @@
  @endphp
 
   {{-- DATA TABLES SCRIPT --}}
-  @basset('https://cdn.datatables.net/1.13.1/js/jquery.dataTables.min.js')
-  @basset('https://cdn.datatables.net/1.13.1/js/dataTables.bootstrap5.min.js')
-  @basset('https://cdn.datatables.net/responsive/2.4.0/js/dataTables.responsive.min.js')
-  @basset('https://cdn.datatables.net/responsive/2.4.0/css/responsive.dataTables.min.css')
-  @basset('https://cdn.datatables.net/fixedheader/3.3.1/js/dataTables.fixedHeader.min.js')
-  @basset('https://cdn.datatables.net/fixedheader/3.3.1/css/fixedHeader.dataTables.min.css')
+@basset("https://cdn.datatables.net/2.1.8/js/dataTables.js")
+@basset("https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css")
+@basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
+@basset("https://cdn.datatables.net/responsive/3.0.3/css/responsive.dataTables.min.css")
+    @basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
+  @basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
 
   @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
 
@@ -154,7 +154,7 @@
         @if ($crud->getResponsiveTable())
         responsive: {
             details: {
-                display: $.fn.dataTable.Responsive.display.modal( {
+                display: DataTable.Responsive.display.modal( {
                     header: function ( row ) {
                         // show the content of the first column
                         // as the modal header
@@ -405,6 +405,7 @@
       // on DataTable draw event run all functions in the queue
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {
+        console.log('draw.dt');
          crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
          });
@@ -435,6 +436,7 @@
         // when columns are hidden by reponsive plugin,
         // the table should have the has-hidden-columns class
         crud.table.on( 'responsive-resize', function ( e, datatable, columns ) {
+            console.log('responsive-resize', crud.table.responsive.hasHidden());
             if (crud.table.responsive.hasHidden()) {
                 $('.dtr-control').each(function() {
                     var $this = $(this);

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -6,12 +6,12 @@
  @endphp
 
   {{-- DATA TABLES SCRIPT --}}
-@basset("https://cdn.datatables.net/2.1.8/js/dataTables.js")
-@basset("https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css")
+@basset("https://cdn.datatables.net/2.1.8/js/dataTables.min.js")
+@basset("https://cdn.datatables.net/2.1.8/js/dataTables.bootstrap5.min.js")
 @basset("https://cdn.datatables.net/responsive/3.0.3/js/dataTables.responsive.min.js")
 @basset("https://cdn.datatables.net/responsive/3.0.3/css/responsive.dataTables.min.css")
-    @basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
-  @basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
+@basset('https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css')
+@basset('https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js')
 
   @basset(base_path('vendor/backpack/crud/src/resources/assets/img/spinner.svg'), false)
 
@@ -337,10 +337,10 @@
       window.crud.updateUrl(location.href);
 
       // move search bar
-      $("#datatable_search_stack input").remove();
-      $("#crudTable_filter input").appendTo($('#datatable_search_stack .input-icon'));
+      $(".dt-search input").remove();
+      $(".dt-search input").appendTo($('#datatable_search_stack .input-icon'));
       $("#datatable_search_stack input").removeClass('form-control-sm');
-      $("#crudTable_filter").remove();
+      $(".dt-search").remove();
 
       // remove btn-secondary from export and column visibility buttons
       $("#crudTable_wrapper .table-footer .btn-secondary").removeClass('btn-secondary');

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -303,6 +303,7 @@
                 "totalEntryCount": "{{$crud->getOperationSetting('totalEntryCount') ?? false}}"
             },
           },
+          pagingType: "simple_numbers",
           dom:
             "<'row hidden'<'col-sm-6'i><'col-sm-6 d-print-none'f>>" +
             "<'table-content row'<'col-sm-12'tr>>" +
@@ -409,32 +410,33 @@
       // on DataTable draw event run all functions in the queue
       // (eg. delete and details_row buttons add functions to this queue)
       $('#crudTable').on( 'draw.dt',   function () {
-         crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
+        // in datatables 2.0.3 the implementation was changed to use `replaceChildren`, for that reason scripts 
+         // that came with the response are no longer executed, like the delete button script or any other ajax 
+         // button created by the developer. For that reason, we move them to the end of the body
+         // ensuring they are re-evaluated on each draw event.
+         document.getElementById('crudTable').querySelectorAll('script').forEach(function(script) {
+            const newScript = document.createElement('script');
+            newScript.text = script.text;
+            document.body.appendChild(newScript);
+        });
+
+        crud.functionsToRunOnDataTablesDrawEvent.forEach(function(functionName) {
             crud.executeFunctionByName(functionName);
-         });
-         if ($('#crudTable').data('has-line-buttons-as-dropdown')) {
-          formatActionColumnAsDropdown();
-         }
+        });
+
+        if ($('#crudTable').data('has-line-buttons-as-dropdown')) {
+            formatActionColumnAsDropdown();
+        }
 
         if (! crud.table.responsive.hasHidden()) {
             crud.table.columns().header()[0].style.paddingLeft = '0.6rem';
         }
 
-         if (crud.table.responsive.hasHidden()) {
+        if (crud.table.responsive.hasHidden()) {
             $('.dtr-control').removeClass('d-none'); 
             $('.dtr-control').addClass('d-inline');
             $("#crudTable").removeClass('has-hidden-columns').addClass('has-hidden-columns');
-         }
-
-         // in datatables 2.0.3 the implementation was changed to use `replaceChildren`, for that reason scripts 
-         // that came with the response are no longer executed, like the delete button script or any other ajax 
-         // button created by the developer. For that reason, we move them to the end of the body
-         // ensuring they are re-evaluated on each draw event.
-        document.getElementById('crudTable').querySelectorAll('script').forEach(function(script) {
-            const newScript = document.createElement('script');
-            newScript.text = script.text;
-            document.body.appendChild(newScript);
-        });
+        }
       }).dataTable();
 
       // when datatables-colvis (column visibility) is toggled

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -1,13 +1,17 @@
 @if ($crud->exportButtons())
-  @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.dataTables.min.css')
-  @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
-  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.bootstrap5.min.js')
-  @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
-  @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
-  @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')
-  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js')
-  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.print.min.js')
-  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.colVis.min.js')
+    @push('after_scripts')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.bootstrap5.min.js')
+        @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
+        @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
+        @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.print.min.js')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.colVis.min.js')
+    @endpush
+    @push('after_styles')
+        @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.bootstrap5.min.css')
+    @endpush  
   <script>
     let dataTablesExportStrip = text => {
         if ( typeof text !== 'string' ) {

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -1,13 +1,12 @@
 @if ($crud->exportButtons())
-  @basset('https://cdn.datatables.net/buttons/2.3.3/css/buttons.bootstrap5.min.css')
-  @basset('https://cdn.datatables.net/buttons/2.3.3/js/dataTables.buttons.min.js')
-  @basset('https://cdn.datatables.net/buttons/2.3.3/js/buttons.bootstrap5.min.js')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.dataTables.min.css')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')
-  @basset('https://cdn.datatables.net/buttons/2.3.2/js/buttons.html5.min.js')
-  @basset('https://cdn.datatables.net/buttons/2.3.2/js/buttons.print.min.js')
-  @basset('https://cdn.datatables.net/buttons/2.3.2/js/buttons.colVis.min.js')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.print.min.js')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.colVis.min.js')
   <script>
     let dataTablesExportStrip = text => {
         if ( typeof text !== 'string' ) {

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -1,6 +1,7 @@
 @if ($crud->exportButtons())
   @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.dataTables.min.css')
   @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
+  @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.bootstrap5.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
   @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -1,159 +1,158 @@
 @if ($crud->exportButtons())
-    @push('after_scripts')
-        @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
-        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.bootstrap5.min.js')
-        @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
-        @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
-        @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')
-        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js')
-        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.print.min.js')
-        @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.colVis.min.js')
-    @endpush
+    @basset('https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js')
+    @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.bootstrap5.min.js')
+    @basset('https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js')
+    @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/pdfmake.min.js')
+    @basset('https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.18/vfs_fonts.js')
+    @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js')
+    @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.print.min.js')
+    @basset('https://cdn.datatables.net/buttons/3.2.0/js/buttons.colVis.min.js')
+    <script>
+        let dataTablesExportStrip = text => {
+            if ( typeof text !== 'string' ) {
+                return text;
+            }
+    
+            return text
+                .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                .replace(/<!\-\-.*?\-\->/g, '')
+                .replace(/<[^>]*>/g, '')
+                .replace(/^\s+|\s+$/g, '')
+                .replace(/\s+([,.;:!\?])/g, '$1')
+                .replace(/\s+/g, ' ')
+                .replace(/[\n|\r]/g, ' ');
+        };
+    
+        let dataTablesExportFormat = {
+            body: (data, row, column, node) => 
+                node.querySelector('input[type*="text"]')?.value ??
+                node.querySelector('input[type*="checkbox"]:not(.crud_bulk_actions_line_checkbox)')?.checked ??
+                node.querySelector('select')?.selectedOptions[0]?.value ??
+                dataTablesExportStrip(data),
+        };
+    
+        window.crud.dataTableConfiguration.buttons = [
+            @if($crud->get('list.showExportButton'))
+            {
+                extend: 'collection',
+                text: '<i class="la la-download"></i> {{ trans('backpack::crud.export.export') }}',
+                dropup: true,
+                buttons: [
+                    {
+                        name: 'copyHtml5',
+                        extend: 'copyHtml5',
+                        exportOptions: {
+                            columns: function ( idx, data, node ) {
+                                var $column = crud.table.column( idx );
+                                    return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                            },
+                            format: dataTablesExportFormat,
+                        },
+                        action: function(e, dt, button, config) {
+                            crud.responsiveToggle(dt);
+                            $.fn.DataTable.ext.buttons.copyHtml5.action.call(this, e, dt, button, config);
+                            crud.responsiveToggle(dt);
+                        }
+                    },
+                    {
+                        name: 'excelHtml5',
+                        extend: 'excelHtml5',
+                        exportOptions: {
+                            columns: function ( idx, data, node ) {
+                                var $column = crud.table.column( idx );
+                                    return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                            },
+                            format: dataTablesExportFormat,
+                        },
+                        action: function(e, dt, button, config) {
+                            crud.responsiveToggle(dt);
+                            $.fn.DataTable.ext.buttons.excelHtml5.action.call(this, e, dt, button, config);
+                            crud.responsiveToggle(dt);
+                        }
+                    },
+                    {
+                        name: 'csvHtml5',
+                        extend: 'csvHtml5',
+                        exportOptions: {
+                            columns: function ( idx, data, node ) {
+                                var $column = crud.table.column( idx );
+                                    return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                            },
+                            format: dataTablesExportFormat,
+                        },
+                        action: function(e, dt, button, config) {
+                            crud.responsiveToggle(dt);
+                            $.fn.DataTable.ext.buttons.csvHtml5.action.call(this, e, dt, button, config);
+                            crud.responsiveToggle(dt);
+                        }
+                    },
+                    {
+                        name: 'pdfHtml5',
+                        extend: 'pdfHtml5',
+                        exportOptions: {
+                            columns: function ( idx, data, node ) {
+                                var $column = crud.table.column( idx );
+                                    return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                            },
+                            format: dataTablesExportFormat,
+                        },
+                        orientation: 'landscape',
+                        action: function(e, dt, button, config) {
+                            crud.responsiveToggle(dt);
+                            $.fn.DataTable.ext.buttons.pdfHtml5.action.call(this, e, dt, button, config);
+                            crud.responsiveToggle(dt);
+                        }
+                    },
+                    {
+                        name: 'print',
+                        extend: 'print',
+                        exportOptions: {
+                            columns: function ( idx, data, node ) {
+                                var $column = crud.table.column( idx );
+                                    return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
+                            },
+                            format: dataTablesExportFormat,
+                        },
+                        action: function(e, dt, button, config) {
+                            crud.responsiveToggle(dt);
+                            $.fn.DataTable.ext.buttons.print.action.call(this, e, dt, button, config);
+                            crud.responsiveToggle(dt);
+                        }
+                    }
+                ]
+            }
+            @endif
+            @if($crud->get('list.showTableColumnPicker'))
+            ,{
+                extend: 'colvis',
+                text: '<i class="la la-eye-slash"></i> {{ trans('backpack::crud.export.column_visibility') }}',
+                columns: function ( idx, data, node ) {
+                    return $(node).attr('data-can-be-visible-in-table') == 'true';
+                },
+                dropup: true
+            }
+            @endif
+        ];
+    
+        // move the datatable buttons in the top-right corner and make them smaller
+        function moveExportButtonsToTopRight() {
+            console.log(window)
+            window.crud.table.buttons().each(function(button) {
+            if (button.node.className.indexOf('buttons-columnVisibility') == -1 && button.node.nodeName=='BUTTON')
+            {
+                button.node.className = button.node.className + " btn-sm";
+            }
+            })
+            $(".dt-buttons").appendTo($('#datatable_button_stack' ));
+            $('.dt-buttons').addClass('d-xs-block')
+                            .addClass('d-sm-inline-block')
+                            .addClass('d-md-inline-block')
+                            .addClass('d-lg-inline-block');
+        }
+    
+        crud.addFunctionToDataTablesDrawEventQueue('moveExportButtonsToTopRight');
+        </script>
     @push('after_styles')
         @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.bootstrap5.min.css')
-    @endpush  
-  <script>
-    let dataTablesExportStrip = text => {
-        if ( typeof text !== 'string' ) {
-            return text;
-        }
-
-        return text
-            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-            .replace(/<!\-\-.*?\-\->/g, '')
-            .replace(/<[^>]*>/g, '')
-            .replace(/^\s+|\s+$/g, '')
-            .replace(/\s+([,.;:!\?])/g, '$1')
-            .replace(/\s+/g, ' ')
-            .replace(/[\n|\r]/g, ' ');
-    };
-
-    let dataTablesExportFormat = {
-        body: (data, row, column, node) => 
-            node.querySelector('input[type*="text"]')?.value ??
-            node.querySelector('input[type*="checkbox"]:not(.crud_bulk_actions_line_checkbox)')?.checked ??
-            node.querySelector('select')?.selectedOptions[0]?.value ??
-            dataTablesExportStrip(data),
-    };
-
-    window.crud.dataTableConfiguration.buttons = [
-        @if($crud->get('list.showExportButton'))
-        {
-            extend: 'collection',
-            text: '<i class="la la-download"></i> {{ trans('backpack::crud.export.export') }}',
-            dropup: true,
-            buttons: [
-                {
-                    name: 'copyHtml5',
-                    extend: 'copyHtml5',
-                    exportOptions: {
-                        columns: function ( idx, data, node ) {
-                            var $column = crud.table.column( idx );
-                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        },
-                        format: dataTablesExportFormat,
-                    },
-                    action: function(e, dt, button, config) {
-                        crud.responsiveToggle(dt);
-                        $.fn.DataTable.ext.buttons.copyHtml5.action.call(this, e, dt, button, config);
-                        crud.responsiveToggle(dt);
-                    }
-                },
-                {
-                    name: 'excelHtml5',
-                    extend: 'excelHtml5',
-                    exportOptions: {
-                        columns: function ( idx, data, node ) {
-                            var $column = crud.table.column( idx );
-                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        },
-                        format: dataTablesExportFormat,
-                    },
-                    action: function(e, dt, button, config) {
-                        crud.responsiveToggle(dt);
-                        $.fn.DataTable.ext.buttons.excelHtml5.action.call(this, e, dt, button, config);
-                        crud.responsiveToggle(dt);
-                    }
-                },
-                {
-                    name: 'csvHtml5',
-                    extend: 'csvHtml5',
-                    exportOptions: {
-                        columns: function ( idx, data, node ) {
-                            var $column = crud.table.column( idx );
-                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        },
-                        format: dataTablesExportFormat,
-                    },
-                    action: function(e, dt, button, config) {
-                        crud.responsiveToggle(dt);
-                        $.fn.DataTable.ext.buttons.csvHtml5.action.call(this, e, dt, button, config);
-                        crud.responsiveToggle(dt);
-                    }
-                },
-                {
-                    name: 'pdfHtml5',
-                    extend: 'pdfHtml5',
-                    exportOptions: {
-                        columns: function ( idx, data, node ) {
-                            var $column = crud.table.column( idx );
-                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        },
-                        format: dataTablesExportFormat,
-                    },
-                    orientation: 'landscape',
-                    action: function(e, dt, button, config) {
-                        crud.responsiveToggle(dt);
-                        $.fn.DataTable.ext.buttons.pdfHtml5.action.call(this, e, dt, button, config);
-                        crud.responsiveToggle(dt);
-                    }
-                },
-                {
-                    name: 'print',
-                    extend: 'print',
-                    exportOptions: {
-                        columns: function ( idx, data, node ) {
-                            var $column = crud.table.column( idx );
-                                return  ($column.visible() && $(node).attr('data-visible-in-export') != 'false') || $(node).attr('data-force-export') == 'true';
-                        },
-                        format: dataTablesExportFormat,
-                    },
-                    action: function(e, dt, button, config) {
-                        crud.responsiveToggle(dt);
-                        $.fn.DataTable.ext.buttons.print.action.call(this, e, dt, button, config);
-                        crud.responsiveToggle(dt);
-                    }
-                }
-            ]
-        }
-        @endif
-        @if($crud->get('list.showTableColumnPicker'))
-        ,{
-            extend: 'colvis',
-            text: '<i class="la la-eye-slash"></i> {{ trans('backpack::crud.export.column_visibility') }}',
-            columns: function ( idx, data, node ) {
-                return $(node).attr('data-can-be-visible-in-table') == 'true';
-            },
-            dropup: true
-        }
-        @endif
-    ];
-
-    // move the datatable buttons in the top-right corner and make them smaller
-    function moveExportButtonsToTopRight() {
-      crud.table.buttons().each(function(button) {
-        if (button.node.className.indexOf('buttons-columnVisibility') == -1 && button.node.nodeName=='BUTTON')
-        {
-          button.node.className = button.node.className + " btn-sm";
-        }
-      })
-      $(".dt-buttons").appendTo($('#datatable_button_stack' ));
-      $('.dt-buttons').addClass('d-xs-block')
-                      .addClass('d-sm-inline-block')
-                      .addClass('d-md-inline-block')
-                      .addClass('d-lg-inline-block');
-    }
-
-    crud.addFunctionToDataTablesDrawEventQueue('moveExportButtonsToTopRight');
-  </script>
+    @endpush
 @endif

--- a/src/resources/views/crud/list.blade.php
+++ b/src/resources/views/crud/list.blade.php
@@ -151,9 +151,6 @@
 
 @section('after_styles')
   {{-- DATA TABLES --}}
-  @basset('https://cdn.datatables.net/1.13.1/css/dataTables.bootstrap5.min.css')
-  @basset('https://cdn.datatables.net/fixedheader/3.3.1/css/fixedHeader.dataTables.min.css')
-  @basset('https://cdn.datatables.net/responsive/2.4.0/css/responsive.dataTables.min.css')
 
   {{-- CRUD LIST CONTENT - crud_list_styles stack --}}
   @stack('crud_list_styles')


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We were lagging ALOT in datatables versions. Major improvements and bug fixes had been made in the meanwhile, and we were not benefiting from it. Eg: the fixed header alignment: https://github.com/Laravel-Backpack/CRUD/issues/4853

The reason was the amount of hours I need to spend to track and fix the issues that popped up just by bumping the datatables version in the cdn url. It's done 👍 

### AFTER - What is happening after this PR?

We are on the bleeding egde of datatables, future upgrades will be WAY easier. It looks to me that the table performs a little better. 

### Is it a breaking change?

I don't think so 🤷‍♂️ 
