### PR TITLE
Run CI tests on PHP 8.4 and fix deprecations

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,19 +11,19 @@ permissions:
 jobs:
     test:
         runs-on: ubuntu-latest
-        
+
         strategy:
             # if one job fails, abort the next ones too, because they'll probably fail - best to save the minutes
             fail-fast: false  # to change to: true
-          
+
             # run all combinations of the following, to make sure they're working together
             matrix:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
-                php: ['8.1', '8.2', '8.3']
+                php: ['8.1', '8.2', '8.3', '8.4']
                 laravel: [^10.0, ^11.0]
                 dbal: [^3.0]
                 phpunit: [10.*]
-                dependency-version: [stable] # to add: lowest 
+                dependency-version: [stable] # to add: lowest
                 exclude:
                     -   laravel: "^11.0"
                         php: "8.1"
@@ -31,7 +31,7 @@ jobs:
 
 
         name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}, PHPUnit ${{ matrix.phpunit }}, DBAL ${{ matrix.dbal }} --prefer-${{ matrix.dependency-version }}
-        
+
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v4

--- a/src/app/Console/Commands/Traits/PrettyCommandOutput.php
+++ b/src/app/Console/Commands/Traits/PrettyCommandOutput.php
@@ -116,7 +116,7 @@ trait PrettyCommandOutput
      *
      * @return void
      */
-    public function listChoice(string $question, array $options, string $default = 'no', string $hint = null)
+    public function listChoice(string $question, array $options, string $default = 'no', ?string $hint = null)
     {
         foreach ($options as $key => $option) {
             $value = $key + 1;

--- a/src/app/Library/Auth/PasswordBroker.php
+++ b/src/app/Library/Auth/PasswordBroker.php
@@ -20,7 +20,7 @@ class PasswordBroker extends OriginalPasswordBroker
      * @param  array  $credentials
      * @return string
      */
-    public function sendResetLink(array $credentials, Closure $callback = null)
+    public function sendResetLink(array $credentials, ?Closure $callback = null)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of

--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -22,7 +22,7 @@ final class DatabaseSchema
         return self::$schema[$connection][$table] ?? null;
     }
 
-    public static function getTables(string $connection = null): array
+    public static function getTables(?string $connection = null): array
     {
         $connection = $connection ?: config('database.default');
 
@@ -53,7 +53,7 @@ final class DatabaseSchema
         return self::getIndexColumnNames($connection, $table);
     }
 
-    public function getManager(string $connection = null)
+    public function getManager(?string $connection = null)
     {
         $connection = $connection ?: config('database.default');
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Tests were not run on the latest PHP version (8.4; see https://www.php.net/releases/8.4/en.php).

### AFTER - What is happening after this PR?

Tests are run and less deprecations are triggered.


## HOW

### How did you achieve that, in technical terms?

- Fix implicit nullable parameter declarations; see also https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated



### Is it a breaking change?

No


### How can we test the before & after?



If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
