### PR TITLE
Use shorthand nullability typings for better readability

### DIFF
--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -14,7 +14,7 @@ class ThemeServiceProvider extends ServiceProvider
     protected string $packageName = 'theme-name';
     protected array $commands = [];
     protected bool $theme = true;
-    protected null|string $componentsNamespace = null;
+    protected ?string $componentsNamespace = null;
 
     /**
      * -------------------------

--- a/src/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -11,7 +11,7 @@ use Prologue\Alerts\Facades\Alert;
 
 class VerifyEmailController extends Controller
 {
-    public null|string $redirectTo = null;
+    public ?string $redirectTo = null;
 
     /**
      * Create a new controller instance.

--- a/src/app/Library/CrudPanel/Traits/Filters.php
+++ b/src/app/Library/CrudPanel/Traits/Filters.php
@@ -136,7 +136,7 @@ trait Filters
 
     /**
      * @param  string  $name
-     * @return null|CrudFilter
+     * @return ?CrudFilter
      */
     public function getFilter($name)
     {

--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -17,7 +17,7 @@ trait Input
      * Returns the direct inputs parsed for model and relationship creation.
      *
      * @param  array  $inputs
-     * @param  null|array  $relationDetails
+     * @param  ?array  $relationDetails
      * @param  bool|string  $relationMethod
      * @return array
      */

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -25,7 +25,7 @@ final class RegisterUploadEvents
         }
     }
 
-    public static function handle(CrudField|CrudColumn $crudObject, array $uploaderConfiguration, string $macro, ?array $subfield = null, ?bool $registerModelEvents = true): void
+    public static function handle(CrudField|CrudColumn $crudObject, array $uploaderConfiguration, string $macro, ?array $subfield = null, bool $registerModelEvents = true): void
     {
         $instance = new self($crudObject, $uploaderConfiguration, $macro);
 

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -14,7 +14,7 @@ trait HandleRepeatableUploads
 {
     public bool $handleRepeatableFiles = false;
 
-    public null|string $repeatableContainerName = null;
+    public ?string $repeatableContainerName = null;
 
     /*******************************
      * Setters - fluently configure the uploader
@@ -31,7 +31,7 @@ trait HandleRepeatableUploads
     /*******************************
      * Getters
      *******************************/
-    public function getRepeatableContainerName(): null|string
+    public function getRepeatableContainerName(): ?string
     {
         return $this->repeatableContainerName;
     }

--- a/src/app/Library/Validation/Rules/ValidFileArray.php
+++ b/src/app/Library/Validation/Rules/ValidFileArray.php
@@ -63,7 +63,7 @@ abstract class ValidFileArray extends BackpackCustomRule
         }
     }
 
-    protected function validateArrayData(string $attribute, Closure $fail, null|array $data = null, null|array $rules = null): void
+    protected function validateArrayData(string $attribute, Closure $fail, ?array $data = null, ?array $rules = null): void
     {
         $data = $data ?? $this->data;
         $rules = $rules ?? $this->getFieldRules();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When working on #5732, I encountered some other (nullable) types that could be simplified, to improve readability.

### AFTER - What is happening after this PR?

Cleaner code.


## HOW

### How did you achieve that, in technical terms?

Use shorthand.



### Is it a breaking change?

No (or not really); only the change in `RegisterUploadEvents::handle` is a change in behavior, due to no longer allowing `null`; however explicit `null` passing seems unlikely and unwanted here.


### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
