### PR TITLE
Fix DataTable header when responsive is disabled

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -367,6 +367,10 @@
           formatActionColumnAsDropdown();
          }
 
+        if (! crud.table.responsive.hasHidden()) {
+            crud.table.columns().header()[0].style.paddingLeft = '0.6rem';
+        }
+
          if (crud.table.responsive.hasHidden()) {
             $('.dtr-control').removeClass('d-none'); 
             $('.dtr-control').addClass('d-inline');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in https://github.com/Laravel-Backpack/CRUD/issues/1489#issuecomment-2549964963

When responsive table was disabled, the table headers were a bit misaligned from the table row contents. 

### AFTER - What is happening after this PR?

They are now re-aligned when responsive table is disabled. 
