### PR TITLE
fix php 8.4 dynamic relationships

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Relationships.php
+++ b/src/app/Library/CrudPanel/Traits/Relationships.php
@@ -274,7 +274,9 @@ trait Relationships
     {
         $relation = $this->getRelationInstance($field);
 
-        if (Str::afterLast($field['name'], '.') === $relation->getRelationName() || Str::endsWith($relation->getRelationName(), '{closure}')) {
+        if (Str::afterLast($field['name'], '.') === $relation->getRelationName() ||
+            Str::endsWith($relation->getRelationName(), '{closure}') || // php < 8.3
+            Str::startsWith($relation->getRelationName(), '{closure:')) { // php 8.4+
             return $relation->getForeignKeyName();
         }
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There is a different naming convention for serialized closure names between php 8.3 and 8.4. 
Our code would only properly identify a dynamic relation on php < 8.3. 

### AFTER - What is happening after this PR?

It also identifies dynamic relationships on php 8.4

