### PR TITLE
fix page lenght stalling in cache & colspan issue on the table

### DIFF
--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -110,7 +110,8 @@ trait ListOperation
             $filteredEntryCount = $this->crud->getFilteredQueryCount() ?? $totalEntryCount;
         } else {
             $totalEntryCount = $length;
-            $filteredEntryCount = $entries->count() < $length ? 0 : $length + $start + 1;
+            $entryCount = $entries->count();
+            $filteredEntryCount = $entryCount < $length ? $entryCount : $length + $start + 1;
         }
 
         // store the totalEntryCount in CrudPanel so that multiple blade files can access it

--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -23,11 +23,18 @@
     let $dtCachedInfo = JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}'))
         ? JSON.parse(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}')) : [];
     var $dtDefaultPageLength = {{ $crud->getDefaultPageLength() }};
-    let $dtStoredPageLength = localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength');
+    let $pageLength = @json($crud->getPageLengthMenu());
+    
+    let $dtStoredPageLength = parseInt(localStorage.getItem('DataTables_crudTable_/{{$crud->getRoute()}}_pageLength'));
 
     if(!$dtStoredPageLength && $dtCachedInfo.length !== 0 && $dtCachedInfo.length !== $dtDefaultPageLength) {
         localStorage.removeItem('DataTables_crudTable_/{{$crud->getRoute()}}');
     }
+
+    if($dtCachedInfo.length !== 0 && $pageLength.indexOf($dtCachedInfo.length) === -1) {
+        localStorage.removeItem('DataTables_crudTable_/{{$crud->getRoute()}}');
+    }
+
 
     // in this page we always pass the alerts to localStorage because we can be redirected with
     // persistent table, and this way we guarantee non-duplicate alerts.
@@ -226,7 +233,7 @@
         @endif
         autoWidth: false,
         pageLength: $dtDefaultPageLength,
-        lengthMenu: @json($crud->getPageLengthMenu()),
+        lengthMenu: $pageLength,
         /* Disable initial sort */
         aaSorting: [],
         language: {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/Laravel-Backpack/CRUD/issues/4951

When the `showEntryCount` was false, and the `length` of the page was smaller than the showed entries, a bug would appear because we set the filtered rows to 0, making the table behave as if it had 0 entries on it. 

Related to that, while testing I found out that the `pageLength` could stall in the datatable cache in certain conditions.

### AFTER - What is happening after this PR?

No more issues with the "empty table" state and the pageLength is not stall anymore.


## HOW

### How did you achieve that, in technical terms?

Set the `filteredCount` to the actual count in the table and added a check for pageLength cache.



### Is it a breaking change?

no
