### PR TITLE
Allow returning string on getCurrentEntryId()

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -15,7 +15,7 @@ trait Read
     /**
      * Find and retrieve the id of the current entry.
      *
-     * @return int|bool The id in the db or false.
+     * @return int|string|bool The id in the db or false.
      */
     public function getCurrentEntryId()
     {


### PR DESCRIPTION


## WHY

### BEFORE - What was wrong? What was happening before this PR?

The current PHPDoc works only when using int IDs
But `uuid` and `ulid`s are strings

### AFTER - What is happening after this PR?

the returning type is correct, allowing also to return string (additional to the previous types)


## HOW

### How did you achieve that, in technical terms?

Updating the phpdoc



### Is it a breaking change?

no
