### PR TITLE
add enum collection cast support

### DIFF
--- a/src/resources/views/crud/columns/enum.blade.php
+++ b/src/resources/views/crud/columns/enum.blade.php
@@ -11,8 +11,68 @@
                 }
                 
                 $column['value'] = isset($column['enum_function']) ? $enumClass->{$column['enum_function']}() : $column['value'];
+            }else{
+                $column['value'] = $column['value']->transform(function($item) use ($column) {
+                    return $item instanceof \BackedEnum ? $item->value : $item->name;
+                })->toArray();
             }
         }
+    }
+
+    if(!isset($column['options'])) {
+        $column['options'] = (function() use ($entry, $column) {
+
+            // if we are in a PHP version where PHP enums are not available, it can only be a database enum
+            if(! function_exists('enum_exists')) {
+                $options = $entity_model::getPossibleEnumValues($column['name']);
+                return array_combine($options, $options);
+            }
+                    // developer can provide the enum class so that we extract the available options from it
+            $enumClassReflection = isset($column['enum_class']) ? new \ReflectionEnum($column['enum_class']) : false;
+
+            if(! $enumClassReflection) {
+                // check for model casting
+                $possibleEnumCast = $entry->getCasts()[$column['name']] ?? false;
+
+                if($possibleEnumCast) {
+                    if(class_exists($possibleEnumCast)) {
+                        $enumClassReflection = new \ReflectionEnum($possibleEnumCast);
+                    }else{
+                        // It's an `AsEnumCollection` cast
+                        if(str_contains($possibleEnumCast, ':')) {
+                            $enumClassReflection = new \ReflectionEnum(explode(':', $possibleEnumCast)[1]);
+                            $allowMultipleValues = true;
+                        }   
+                    }
+                }
+            }
+
+            if($enumClassReflection) {
+                $options = array_map(function($item) use ($enumClassReflection) {
+                    return $enumClassReflection->isBacked() ? [$item->getBackingValue() => $item->name] : $item->name;
+                },$enumClassReflection->getCases());
+                $options = is_multidimensional_array($options) ? array_replace(...$options) : array_combine($options, $options);
+            }
+
+            if(isset($column['enum_function']) && isset($options)) {
+                $options = array_map(function($item) use ($column, $enumClassReflection) {
+                    if ($enumClassReflection->hasConstant($item)) {
+                        return $enumClassReflection->getConstant($item)->{$column['enum_function']}();
+                    }
+                    return $item;
+                }, $options);
+                return $options;
+            }
+
+            // if we have the enum options return them
+            if(isset($options)) {
+                return $options;
+            }
+
+            // no enum options, can only be database enum
+            $options = $entity_model::getPossibleEnumValues($column['name']);
+            return array_combine($options, $options);
+        })();
     }
 @endphp
 

--- a/src/resources/views/crud/columns/enum.blade.php
+++ b/src/resources/views/crud/columns/enum.blade.php
@@ -19,7 +19,7 @@
         }
     }
 
-    if(!isset($column['options'])) {
+    if(!isset($column['options']) && is_array($column['value'])) {
         $column['options'] = (function() use ($entry, $column) {
 
             // if we are in a PHP version where PHP enums are not available, it can only be a database enum


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/Laravel-Backpack/community-forum/discussions/1258

Backpack didn't support `AsEnumCollection` cast. https://laravel.com/docs/11.x/eloquent-mutators#casting-arrays-of-enums

### AFTER - What is happening after this PR?

Backpack supports enum collection casts now 👍

## HOW

### How did you achieve that, in technical terms?

Added a new "match" for `AsEnumCollection`, and added the needed code to get the displaying options.


### Is it a breaking change?

I don't think so.
