### PR TITLE
fix enum field array conversion

### DIFF
--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -74,8 +74,9 @@
             })->toArray(),
             default => null
         };
-        $field['value'] = is_array($field['value']) ? $field['value'] : [$field['value']];
     }
+    $field['value'] = is_array($field['value']) ? $field['value'] : (!empty($field['value']) ? [$field['value']] : []);
+
 @endphp
 
 @include('crud::fields.inc.wrapper_start')


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Yesterday we added the ability to enum field/column to work with `AsEnumCollection`. 
This introduced this small bug. 😢 

### AFTER - What is happening after this PR?

Everything is working I hope. 👍 
