### PR TITLE
only transform collections in enum column

### DIFF
--- a/src/resources/views/crud/columns/enum.blade.php
+++ b/src/resources/views/crud/columns/enum.blade.php
@@ -11,7 +11,7 @@
                 }
                 
                 $column['value'] = isset($column['enum_function']) ? $enumClass->{$column['enum_function']}() : $column['value'];
-            }else{
+            }elseif($column['value'] instanceof \Illuminate\Support\Collection) {
                 $column['value'] = $column['value']->transform(function($item) use ($column) {
                     return $item instanceof \BackedEnum ? $item->value : $item->name;
                 })->toArray();


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

fixes a buggy I introduced in the enum column 😞 

We should only transform in the value is a `Collection`. 