### PR TITLE
fix switch when no color is given

### DIFF
--- a/src/resources/views/crud/fields/switch.blade.php
+++ b/src/resources/views/crud/fields/switch.blade.php
@@ -3,7 +3,7 @@
     $field['value'] = old_empty_or_null($field['name'], '') ?? $field['value'] ?? $field['default'] ?? '0';
     $field['onLabel'] = $field['onLabel'] ?? '';
     $field['offLabel'] = $field['offLabel'] ?? '';
-    $field['color'] = $field['color'] ?? 'var(--bg-switch-checked-color)';
+    $field['color'] = $field['color'] ?? 'var(--bg-switch-checked-color, black)';
 @endphp
 
 {{-- Wrapper --}}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When no color was given to the switch column, and `--bg-switch-checked-color` is not defined in the CSS, the switch column wasn't visible at all:

![CleanShot 2025-01-22 at 11 38 44@2x](https://github.com/user-attachments/assets/42e8b12a-603b-4590-a44a-0b6f329bc389)


### AFTER - What is happening after this PR?

In that niche use case, the switch is visible and defaults to absolute black:

![CleanShot 2025-01-22 at 11 39 19@2x](https://github.com/user-attachments/assets/542f6a06-db13-47c9-8b20-3ed0b14112c8)



## HOW

### How did you achieve that, in technical terms?

Set a default to the CSS variable.



### Is it a breaking change?

No.


### How can we test the before & after?

You can disable our purple stylesheet in our demo - then that CSS variable will not exist. In that case, in our MonsterCrudController, the switch will no longer be visible.