### PR TITLE
feat: allow using int and string on ids

### DIFF
--- a/src/app/Http/Controllers/Operations/ShowOperation.php
+++ b/src/app/Http/Controllers/Operations/ShowOperation.php
@@ -65,7 +65,7 @@ trait ShowOperation
     /**
      * Display the specified resource.
      *
-     * @param  int  $id
+     * @param  int|string  $id
      * @return \Illuminate\Contracts\View\View
      */
     public function show($id)

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -57,7 +57,7 @@ trait UpdateOperation
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  int  $id
+     * @param  int|string  $id
      * @return \Illuminate\Contracts\View\View
      */
     public function edit($id)

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -64,7 +64,7 @@ trait Read
     /**
      * Find and retrieve an entry in the database or fail.
      *
-     * @param int The id of the row in the db to fetch.
+     * @param int|string The id of the row in the db to fetch.
      * @return \Illuminate\Database\Eloquent\Model The row in the db.
      */
     public function getEntry($id)
@@ -116,7 +116,7 @@ trait Read
     /**
      * Find and retrieve an entry in the database or fail.
      *
-     * @param int The id of the row in the db to fetch.
+     * @param int|string The id of the row in the db to fetch.
      * @return \Illuminate\Database\Eloquent\Model The row in the db.
      */
     public function getEntryWithoutFakes($id)


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Follow up after https://github.com/Chemaclass/CRUD/commit/c50874ea5de72e4e8a89874fcfef1efe288fa0e6

uuid/ulid are string based not int

### AFTER - What is happening after this PR?

The id will support int and string


## HOW

### How did you achieve that, in technical terms?

Updating the PHPDoc



### Is it a breaking change?

Nope


### How can we test the before & after?

Everything should work as before.
