### PR TITLE
[Fix] - Correctly set `multiple` parameter for `AsEnumCollection` cast in `enum` field

### DIFF
--- a/src/resources/views/crud/fields/enum.blade.php
+++ b/src/resources/views/crud/fields/enum.blade.php
@@ -6,7 +6,7 @@
 
     $allowMultipleValues = $field['multiple'] ?? false;
 
-    $possible_values = (function() use ($entity_model, $field) {
+    $possible_values = (function() use ($entity_model, $field, &$allowMultipleValues) {
         $fieldName = $field['baseFieldName'] ?? $field['name'];
         // if developer provided the options, use them, no need to guess.
         if(isset($field['options'])) {


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?
Enum field did not set `multiple` parameter for `AsEnumCollection` cast

### Is it a breaking change?
No


### How can we test the before & after?
Cast an attribute as `AsEnumCollection` and add the field `enum` to a CRUD