### PR TITLE
[Propose] - Quick button with confirmation modal

### DIFF
--- a/src/resources/views/crud/buttons/quick-confirm.blade.php
+++ b/src/resources/views/crud/buttons/quick-confirm.blade.php
@@ -1,0 +1,163 @@
+@php
+    $access = (function() use ($crud, $button) {
+        if (isset($button->meta['access']) && $button->meta['access'] !== null && $button->meta['access'] !== false) {
+            return $button->meta['access'];
+        }
+        return !is_null($crud->get(Str::of($button->name)->studly().'.access'))  ? Str::of($button->name)->studly() : $button->name;
+    })();
+    $icon = $button->meta['icon'] ?? '';
+    $label = $button->meta['label'] ?? Str::of($button->name)->headline();
+
+    $defaultHref = url($crud->route. ($entry?->getKey() ? '/'.$entry?->getKey().'/' : '/') . Str::of($button->name)->kebab());
+    $defaultClass = match ($button->stack) {
+        'line' => 'btn btn-sm btn-link',
+        'top' => 'btn btn-outline-primary',
+        'bottom' => 'btn btn-sm btn-secondary',
+        default => 'btn btn-outline-primary',
+    };
+
+    $wrapper = $button->meta['wrapper'] ?? [];
+    $wrapper['element'] = $wrapper['element'] ?? 'a';
+    $wrapper['href'] = $wrapper['href'] ?? $defaultHref;
+    if (is_a($wrapper['href'], \Closure::class, true)) {
+        $wrapper['href'] = ($wrapper['href'])($entry, $crud);
+    }
+    $wrapper['class'] = $wrapper['class'] ?? $defaultClass;
+    //if ajax enabled
+    $buttonAjaxConfiguration = $button->meta['ajax'] ?? false;
+    if($buttonAjaxConfiguration) {
+        $wrapper['data-route'] = $wrapper['href'];
+		$wrapper['data-method'] = $button->meta['ajax']['method'] ?? 'GET';
+        $wrapper['data-refresh-table'] = $button->meta['ajax']['refreshCrudTable'] ?? false;
+
+        $wrapper['href'] = 'javascript:void(0)';
+        $wrapper['onclick'] = 'sendQuickConfirmButtonAjaxRequest(this)';
+		$wrapper['data-button-type'] = 'quick-confirm-ajax';
+
+        //success message
+        $wrapper['data-success-title'] = $button->meta['ajax']['success_title'] ?? trans('backpack::crud.quick_button_ajax_success_title');
+        $wrapper['data-success-message'] = $button->meta['ajax']['success_message'] ?? trans('backpack::crud.quick_button_ajax_success_message');
+        //error message
+        $wrapper['data-error-title'] = $button->meta['ajax']['error_title'] ?? trans('backpack::crud.quick_button_ajax_error_title');
+        $wrapper['data-error-message']  = $button->meta['ajax']['error_message'] ?? trans('backpack::crud.quick_button_ajax_error_message');
+
+        $wrapper['data-confirm'] = false;
+        if (isset($button->meta['ajax']['confirm'])) {
+            $wrapper['data-confirm'] = boolval($button->meta['ajax']['confirm']);
+        }
+    }
+    //endif ajax enabled
+@endphp
+
+@if ($access === true || $crud->hasAccess($access, isset($entry) ? $entry : null))
+    <{{ $wrapper['element'] }}
+        bp-button="{{ $button->name }}"
+        @foreach ($wrapper as $attribute => $value)
+            @if (is_string($attribute))
+            {{ $attribute }}="{{ $value }}"
+            @endif
+        @endforeach
+        >
+        @if ($icon) <i class="{{ $icon }}"></i> @endif
+        <span>{{ $label }}</span>
+    </{{ $wrapper['element'] }}>
+@endif
+
+
+@if($buttonAjaxConfiguration)
+{{-- Button Javascript --}}
+{{-- Pushed to the end of the page, after jQuery is loaded --}}
+@push('after_scripts') @if (request()->ajax()) @endpush @endif
+@bassetBlock('backpack/crud/buttons/quick-confirm-button.js')
+<script>
+	if (typeof sendQuickConfirmButtonAjaxRequest != 'function') {
+        $("[data-button-type=quick-confirm-ajax]").unbind('click');
+
+        function sendQuickConfirmButtonAjaxRequest(button) {
+            let needsConfirmation = $(button).attr('data-confirm');
+
+            if (!needsConfirmation) {
+                executeAjaxButtonRequest(button);
+                return;
+            }
+
+            swal({
+                title: "{!! trans('backpack::base.warning') !!}",
+                text: "Are you sure?",
+                icon: "warning",
+                buttons: {
+                    cancel: {
+                        text: "Cancel",
+                        value: null,
+                        visible: true,
+                        className: "bg-secondary",
+                        closeModal: true,
+                    },
+                    confirm: {
+                        text: "Confirm",
+                        value: true,
+                        visible: true,
+                        className: "bg-danger",
+                    },
+                },
+                dangerMode: true,
+            }).then((value) => {
+                if (value) {
+                    executeAjaxButtonRequest(button);
+                }
+            });
+        }
+
+        function executeAjaxButtonRequest(button) {
+            let route = $(button).attr('data-route');
+
+            const defaultButtonMessage = function(button, type) {
+                let buttonTitle = button.getAttribute(`data-${type}-title`);
+                let buttonMessage =  button.getAttribute(`data-${type}-message`);
+                return `<strong>${buttonTitle}</strong><br/>${buttonMessage}`;
+            };
+
+            $.ajax({
+                url: route,
+                type: $(button).attr('data-method'),
+                success: function(result) {
+
+                    if($(button).attr('data-refresh-table') && typeof crud != 'undefined' && typeof crud.table != 'undefined'){
+                        crud.table.draw(false);
+                    }
+                    let message;
+                    //if message is returned from the API use that message
+                    if(result.message){
+                        message = result.message;
+                    }
+
+                    message ??= defaultButtonMessage(button, 'success');
+
+                    new Noty({
+                        type: "success",
+                        text: message,
+                    }).show();
+                },
+                error: function(result) {
+
+                    let message;
+
+                    //if message is returned from the API use that message
+                    if(result.responseJSON.message){
+                        message = result.responseJSON.message;
+                    }
+
+                    message ??= defaultButtonMessage(button, 'error');
+
+                    new Noty({
+                        type: "error",
+                        text: message,
+                    }).show();
+                }
+            });
+        }
+	}
+</script>
+@endBassetBlock
+@if (!request()->ajax()) @endpush @endif
+@endif


### PR DESCRIPTION
I have some ajax buttons that require extra attention when pressed. For this i would like to implement a confirmation modal, similar to delete buttons.

If this is accepted, i will integrate it into the default quick button with proper translations.

Button configuration example:
```
CRUD::button('cancel')->stack('line')->view('crud::buttons.quick-confirm')->meta([
    'access' => 'cancel',
    'icon' => 'las la-ban',
    'wrapper' => [
        'href' => fn($entry, $crud) => route('cancel', ['id' => $entry->id]),
    ],
    'ajax' => [
        'method' => 'POST',
        'confirm' => true
    ]
]);
```