### PR TITLE
fix page lenght in persistent tables

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -31,7 +31,7 @@
         localStorage.removeItem('DataTables_crudTable_/{{$crud->getRoute()}}');
     }
 
-    if($dtCachedInfo.length !== 0 && $pageLength.indexOf($dtCachedInfo.length) === -1) {
+    if($dtCachedInfo.length !== 0 && $pageLength[0].indexOf($dtCachedInfo.length) === -1) {
         localStorage.removeItem('DataTables_crudTable_/{{$crud->getRoute()}}');
     }
 


### PR DESCRIPTION
## WHY

fixes #5762 

### BEFORE - What was wrong? What was happening before this PR?

As reported in #5762, page length was not properly checked, and it would break the ability to store datatables persistent settings. 

### AFTER - What is happening after this PR?

As proposed in the mentioned PR, we just need to check in the correct array element, and not in the whole array.


### Is it a breaking change?

No.