### PR TITLE
fix fake field casting when translations are enabled

### DIFF
--- a/src/app/Models/Traits/HasFakeFields.php
+++ b/src/app/Models/Traits/HasFakeFields.php
@@ -26,7 +26,7 @@ trait HasFakeFields
 
             $column_contents = $this->{$column};
 
-            if ($this->shouldDecodeFake($column)) {
+            if ($this->shouldDecodeFake($column) || ($this->translationEnabled() && $this->isTranslatableAttribute($column))) {
                 $column_contents = json_decode($column_contents);
             }
 
@@ -67,7 +67,7 @@ trait HasFakeFields
      */
     public function shouldDecodeFake($column)
     {
-        return ! in_array($column, array_keys($this->casts));
+        return ! in_array($column, array_keys($this->getCasts()));
     }
 
     /**
@@ -78,6 +78,6 @@ trait HasFakeFields
      */
     public function shouldEncodeFake($column)
     {
-        return ! in_array($column, array_keys($this->casts));
+        return ! in_array($column, array_keys($this->getCasts()));
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Spatie/Laravel-Translatable introduced a Breaking Change (IMO), and broke our functionality. TLDR: Casts are now "forced" into the model, and our functionality was expecting the previous behavior (casts only available upon calling `getCasts()`). 

### AFTER - What is happening after this PR?

I've added a workaround in our Fake Fields functionality, so hopefully we can circumvent this issue.


## HOW

### How did you achieve that, in technical terms?

Check if the column is translatable, if it is, ignore the cast. 



### Is it a breaking change?

I don't think so, no. 
