### PR TITLE
fix responsive table on resize

### DIFF
--- a/src/resources/views/crud/inc/datatables_logic.blade.php
+++ b/src/resources/views/crud/inc/datatables_logic.blade.php
@@ -398,14 +398,20 @@
         // the table should have the has-hidden-columns class
         crud.table.on( 'responsive-resize', function ( e, datatable, columns ) {
             if (crud.table.responsive.hasHidden()) {
+                let firstVisibleColumn = $('.dtr-control').closest('tr').find('td').filter(function() {
+                    return $(this).is(':visible');
+                }).first();
+
+                // move the dtr-control to the first visible column
+                $('.dtr-control').prependTo(firstVisibleColumn);
                 $('.dtr-control').removeClass('d-none'); 
                 $('.dtr-control').addClass('d-inline');
                 $("#crudTable").removeClass('has-hidden-columns').addClass('has-hidden-columns');
-             } else {
-              $('.dtr-control').removeClass('d-none').removeClass('d-inline').addClass('d-none');  
-              $("#crudTable").removeClass('has-hidden-columns');
-             }
-        } );
+            } else {
+                $('.dtr-control').removeClass('d-none').removeClass('d-inline').addClass('d-none');  
+                $("#crudTable").removeClass('has-hidden-columns');
+            }
+        });
       @else
         // make sure the column headings have the same width as the actual columns
         // after the user manually resizes the window


### PR DESCRIPTION
## WHY

fixes #5755 

### BEFORE - What was wrong? What was happening before this PR?

After the datatables resize plugin did the work and the first column was hidden, we didn't moved the responsive controls to a visible column, so they just "disappeared" with the hidden column.

### AFTER - What is happening after this PR?

The responsive controls are always moved to the first visible column. 


## HOW

### How did you achieve that, in technical terms?

By using javascript to move the buttons after the resize happened. 



### Is it a breaking change?

No

