### PR TITLE
remove translatable fields from casting and add tests

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Input.php
+++ b/src/app/Library/CrudPanel/Traits/Input.php
@@ -218,6 +218,7 @@ trait Input
         $model = $model ? $model : $this->model;
         $fields = $this->getCleanStateFields();
         $casted_attributes = $model->getCastedAttributes();
+        $translatableAttributes = $model->translationEnabled() ? $model->getTranslatableAttributes() : [];
 
         foreach ($fields as $field) {
             // Test the field is castable
@@ -226,7 +227,7 @@ trait Input
                 $jsonCastables = ['array', 'object', 'json'];
                 $fieldCasting = $casted_attributes[$field['name']];
 
-                if (in_array($fieldCasting, $jsonCastables) && isset($input[$field['name']]) && ! empty($input[$field['name']]) && ! is_array($input[$field['name']])) {
+                if (in_array($fieldCasting, $jsonCastables) && isset($input[$field['name']]) && ! empty($input[$field['name']]) && ! is_array($input[$field['name']]) && ! in_array($field['name'], $translatableAttributes)) {
                     try {
                         $input[$field['name']] = json_decode($input[$field['name']]);
                     } catch (\Exception $e) {

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -41,6 +41,7 @@ abstract class BaseTestClass extends TestCase
             BackpackServiceProvider::class,
             AlertsServiceProvider::class,
             TestsServiceProvider::class,
+            \Spatie\Translatable\TranslatableServiceProvider::class,
         ];
     }
 

--- a/tests/Unit/CrudPanel/TranslatableFieldsTest.php
+++ b/tests/Unit/CrudPanel/TranslatableFieldsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
+use Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel;
+use Backpack\CRUD\Tests\config\Models\TranslatableModel;
+
+/**
+ * @covers Backpack\CRUD\app\Models\Traits\HasTranslatableFields
+ */
+class TranslatableFieldsTest extends BaseDBCrudPanel
+{
+    /**
+     * Setup function for each test.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->crudPanel->setModel(TranslatableModel::class);
+
+        $this->crudPanel->field('title');
+        $this->crudPanel->field('description');
+    }
+
+    public function testFieldsGetsTranslated()
+    {
+        $this->crudPanel->create([
+            'title'       => 'english title',
+            'description' => 'english description',
+        ]);
+
+        $model = TranslatableModel::first();
+
+        $this->assertEquals('english title', $model->title);
+
+        config(['app.locale' => 'fr']);
+
+        $this->assertEquals('english title', $model->title);
+
+        $this->crudPanel->update(1, ['title' => 'french title']);
+
+        $model->refresh();
+
+        $this->assertEquals('french title', $model->title);
+    }
+}

--- a/tests/Unit/CrudPanel/TranslatableFieldsTest.php
+++ b/tests/Unit/CrudPanel/TranslatableFieldsTest.php
@@ -26,7 +26,7 @@ class TranslatableFieldsTest extends BaseDBCrudPanel
     public function testFieldsGetsTranslated()
     {
         $this->crudPanel->create([
-            'title'       => 'english title',
+            'title' => 'english title',
             'description' => 'english description',
         ]);
 

--- a/tests/config/Models/TranslatableModel.php
+++ b/tests/config/Models/TranslatableModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Config\Models;
+
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
+use Illuminate\Database\Eloquent\Model;
+
+class TranslatableModel extends Model
+{
+    use CrudTrait;
+    use HasTranslations;
+
+    protected $fillable = [
+        'title',
+        'description',
+    ];
+
+    protected $translatable = [
+        'title',
+        'description',
+    ];
+
+    public $timestamps = false;
+
+    protected $table = 'translatable';
+}

--- a/tests/config/database/migrations/2024_07_30_000001_create_translatable_table.php
+++ b/tests/config/database/migrations/2024_07_30_000001_create_translatable_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTranslatableTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('translatable', function (Blueprint $table) {
+            $table->increments('id');
+            $table->json('title');
+            $table->json('description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('translatable');
+    }
+}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In continuation of the work on #5770 

 Basically since spatie introduced "auto-casts" in the translatable model, some of our functionality was broken. 

We have previously fixed the issue found in the failing test suite, but we didn't had everything covered, so this one escaped us. 

### AFTER - What is happening after this PR?

I've now added a test for it too, and fields can be properly translated again.

## HOW

### How did you achieve that, in technical terms?

Added a check on our "decode" script (used for other functionalities), to not cast if the attribute is translatable. 

### Is it a breaking change?

No
