### PR TITLE
Fix required field asterisk on array of rules for field

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Validation.php
+++ b/src/app/Library/CrudPanel/Traits/Validation.php
@@ -201,17 +201,21 @@ trait Validation
                 foreach ($validationRules as $rule) {
                     if (is_a($rule, BackpackCustomRule::class, true)) {
                         foreach ($rule->getFieldRules() as $customValidatorRules) {
-                            $key = $this->checkIfRuleIsRequired($key, $customValidatorRules);
-                            if ($key) {
-                                $requiredFields[] = $key;
+                            if ($requiredFieldName = $this->checkIfRuleIsRequired($key, $customValidatorRules)) {
+                                // Field is required, move on to next field
+                                $requiredFields[] = $requiredFieldName;
+                                break;
                             }
                         }
 
+                        // Try next rule for field
                         continue;
                     }
-                    $key = $this->checkIfRuleIsRequired($key, $rule);
-                    if ($key) {
-                        $requiredFields[] = $key;
+
+                    if ($requiredFieldName = $this->checkIfRuleIsRequired($key, $rule)) {
+                        // Field is required, move on to next field
+                        $requiredFields[] = $requiredFieldName;
+                        break;
                     }
                 }
             }

--- a/tests/Unit/CrudPanel/CrudPanelValidationTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelValidationTest.php
@@ -234,6 +234,7 @@ class CrudPanelValidationTest extends \Backpack\CRUD\Tests\config\CrudPanel\Base
         $this->crudPanel->setValidation([
             'email' => 'required',
             'password.*.test' => 'required',
+            'not_required' => 'present',
         ]);
 
         $this->crudPanel->setValidation(UserRequest::class);
@@ -250,11 +251,29 @@ class CrudPanelValidationTest extends \Backpack\CRUD\Tests\config\CrudPanel\Base
         $this->crudPanel->setValidation([
             'email' => ValidUpload::field('required'),
             'password' => ValidUploadMultiple::field('required'),
+            'not_required' => ValidUpload::field('present'),
         ]);
 
         $this->assertEquals(['email', 'password'], array_values($this->crudPanel->getOperationSetting('requiredFields')));
         $this->assertTrue($this->crudPanel->isRequired('email'));
         $this->assertTrue($this->crudPanel->isRequired('password'));
+    }
+
+    public function testItCanGetTheRequiredFieldsFromRulesArray()
+    {
+        $this->crudPanel->setModel(User::class);
+
+        $this->crudPanel->setValidation([
+            'email' => ['required', 'string'],
+            'password' => ['string', 'required'],
+            'password_confirm' => ['same:password', ValidUploadMultiple::field('required')],
+            'not_required' => ['string', 'present', 'foobar'],
+        ]);
+
+        $this->assertEquals(['email', 'password', 'password_confirm'], array_values($this->crudPanel->getOperationSetting('requiredFields')));
+        $this->assertTrue($this->crudPanel->isRequired('email'));
+        $this->assertTrue($this->crudPanel->isRequired('password'));
+        $this->assertTrue($this->crudPanel->isRequired('password_confirm'));
     }
 
     public function testItCanValidateCustomRules()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

When using the `crud->setValidation` helper with a request class or ruleset, where properties have an array of rules applied to them, the field would only be marked as 'required' if the first element of the ruleset would be required, rather than any of them.

This is caused by the 'outer' loop variable `$key` being overwritten inside the loop, causing it to be `false` after the first (mismatched) iteration.

### AFTER - What is happening after this PR?

The field is correctly marked as required if there is any required rule in its rule array.

## HOW

### How did you achieve that, in technical terms?

By using a separate variable name for listing the field, we ensure `$key` will always be the original fieldname.
I also immediately break the loop if a field is found to be required for a slight performance benefit.

Finally I've also updated all the related tests slightly to ensure they contain a non-required field,
to ensure tests also check for false positives.

### Is it a breaking change?

No


### How can we test the before & after?

See added test: when running the first commit (new test + no fix) tests fail; then the test is fixed by the commit after


