### PR TITLE
Remove unpkg cdn

### DIFF
--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -14,7 +14,7 @@ class ThemeServiceProvider extends ServiceProvider
     protected string $packageName = 'theme-name';
     protected array $commands = [];
     protected bool $theme = true;
-    protected null|string $componentsNamespace = null;
+    protected ?string $componentsNamespace = null;
 
     /**
      * -------------------------

--- a/src/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -11,7 +11,7 @@ use Prologue\Alerts\Facades\Alert;
 
 class VerifyEmailController extends Controller
 {
-    public null|string $redirectTo = null;
+    public ?string $redirectTo = null;
 
     /**
      * Create a new controller instance.

--- a/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
+++ b/src/app/Library/Uploaders/Support/RegisterUploadEvents.php
@@ -35,7 +35,7 @@ final class RegisterUploadEvents
     /*******************************
      * Private methods - implementation
      *******************************/
-    private function registerEvents(array|null $subfield = [], ?bool $registerModelEvents = true): void
+    private function registerEvents(?array $subfield = [], ?bool $registerModelEvents = true): void
     {
         if (! empty($subfield)) {
             $this->registerSubfieldEvent($subfield, $registerModelEvents);

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -14,7 +14,7 @@ trait HandleRepeatableUploads
 {
     public bool $handleRepeatableFiles = false;
 
-    public null|string $repeatableContainerName = null;
+    public ?string $repeatableContainerName = null;
 
     /*******************************
      * Setters - fluently configure the uploader
@@ -31,7 +31,7 @@ trait HandleRepeatableUploads
     /*******************************
      * Getters
      *******************************/
-    public function getRepeatableContainerName(): null|string
+    public function getRepeatableContainerName(): ?string
     {
         return $this->repeatableContainerName;
     }

--- a/src/app/Library/Validation/Rules/ValidFileArray.php
+++ b/src/app/Library/Validation/Rules/ValidFileArray.php
@@ -63,7 +63,7 @@ abstract class ValidFileArray extends BackpackCustomRule
         }
     }
 
-    protected function validateArrayData(string $attribute, Closure $fail, null|array $data = null, null|array $rules = null): void
+    protected function validateArrayData(string $attribute, Closure $fail, ?array $data = null, ?array $rules = null): void
     {
         $data = $data ?? $this->data;
         $rules = $rules ?? $this->getFieldRules();

--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -116,9 +116,9 @@ return [
     // JS files that are loaded in all pages, using Laravel's asset() helper
     'scripts' => [
         // 'js/example.js',
-        // 'https://unpkg.com/vue@2.4.4/dist/vue.min.js',
-        // 'https://unpkg.com/react@16/umd/react.production.min.js',
-        // 'https://unpkg.com/react-dom@16/umd/react-dom.production.min.js',
+        // 'https://cdn.jsdelivr.net/npm/vue@2.4.4/dist/vue.min.js',
+        // 'https://cdn.jsdelivr.net/npm/react@16/umd/react.production.min.js',
+        // 'https://cdn.jsdelivr.net/npm/react-dom@16/umd/react-dom.production.min.js',
     ],
 
     // JS files that are loaded in all pages, using Laravel's mix() helper

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -31,8 +31,8 @@
 {{-- FIELD CSS - will be loaded in the after_styles section --}}
 @push('crud_fields_styles')
     {{-- include summernote css --}}
-    @basset('https://unpkg.com/summernote@0.8.20/dist/summernote-lite.min.css')
-    @basset('https://unpkg.com/summernote@0.8.20/dist/font/summernote.woff2', false)
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.css')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/font/summernote.woff2', false)
     @bassetBlock('backpack/crud/fields/summernote-field.css')
     <style type="text/css">
         .note-editor.note-frame .note-status-output, .note-editor.note-airframe .note-status-output {
@@ -45,7 +45,7 @@
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
     {{-- include summernote js --}}
-    @basset('https://unpkg.com/summernote@0.8.20/dist/summernote-lite.min.js')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-lite.min.js')
     @bassetBlock('backpack/crud/fields/summernote-field.js')
     <script>
         function bpFieldInitSummernoteElement(element) {

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -26,7 +26,7 @@
   </nav>
 
 @push('crud_list_scripts')
-    @basset('https://unpkg.com/urijs@1.19.11/src/URI.min.js')
+    @basset('https://cdn.jsdelivr.net/npm/urijs@1.19.11/src/URI.min.js')
     <script>
       function addOrUpdateUriParameter(uri, parameter, value) {
             var new_url = normalizeAmpersand(uri);

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -229,7 +229,7 @@ if(!function_exists('tree_element')) {
 @endsection
 
 @section('after_scripts')
-    @basset('https://unpkg.com/jquery-ui@1.13.2/dist/jquery-ui.min.js')
+    @basset('https://cdn.jsdelivr.net/npm/jquery-ui@1.13.2/dist/jquery-ui.min.js')
     @basset(base_path('vendor/backpack/crud/src/resources/assets/libs/jquery.mjs.nestedSortable2.js'))
 
     <script type="text/javascript">

--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -1,5 +1,5 @@
 @basset('https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js')
-@basset('https://unpkg.com/@popperjs/core@2.11.6/dist/umd/popper.min.js')
+@basset('https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js')
 @basset('https://cdn.jsdelivr.net/npm/noty@3.2.0-beta-deprecated/lib/noty.min.js')
 @basset('https://cdn.jsdelivr.net/npm/sweetalert@2.1.2/dist/sweetalert.min.js')
 

--- a/src/resources/views/ui/inc/scripts.blade.php
+++ b/src/resources/views/ui/inc/scripts.blade.php
@@ -1,7 +1,7 @@
-@basset('https://unpkg.com/jquery@3.6.1/dist/jquery.min.js')
+@basset('https://cdn.jsdelivr.net/npm/jquery@3.6.1/dist/jquery.min.js')
 @basset('https://unpkg.com/@popperjs/core@2.11.6/dist/umd/popper.min.js')
-@basset('https://unpkg.com/noty@3.2.0-beta-deprecated/lib/noty.min.js')
-@basset('https://unpkg.com/sweetalert@2.1.2/dist/sweetalert.min.js')
+@basset('https://cdn.jsdelivr.net/npm/noty@3.2.0-beta-deprecated/lib/noty.min.js')
+@basset('https://cdn.jsdelivr.net/npm/sweetalert@2.1.2/dist/sweetalert.min.js')
 
 @if (backpack_theme_config('scripts') && count(backpack_theme_config('scripts')))
     @foreach (backpack_theme_config('scripts') as $path)

--- a/src/resources/views/ui/inc/styles.blade.php
+++ b/src/resources/views/ui/inc/styles.blade.php
@@ -1,5 +1,5 @@
-@basset('https://unpkg.com/animate.css@4.1.1/animate.compat.css')
-@basset('https://unpkg.com/noty@3.2.0-beta-deprecated/lib/noty.css')
+@basset('https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.compat.css')
+@basset('https://cdn.jsdelivr.net/npm/noty@3.2.0-beta-deprecated/lib/noty.css')
 
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css')
 @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-regular-400.woff2')


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We have been experience a huge amount of outages in unpkg cdn. It's very unstable and we can't rely on it anymore. 

### AFTER - What is happening after this PR?

Replaced all unpkg links with jsdelivr. 


## HOW

### How did you achieve that, in technical terms?

```bash
find /c/laragon/www/demo2/vendor/backpack/crud -type f \( -name "*.js" -o -name "*.html" -o -name "*.php" -o -name "*.vue" -o -name "*.blade.php" \) -not -path "*/tests/*" -print0 | xargs -0 sed -i 's|https://unpkg\.com/\([^/]\+\)@\([0-9.]\+\)|https://cdn.jsdelivr.net/npm/\1@\2|g'
```
