### PR TITLE
Cast data to float to fix data type issue

### DIFF
--- a/src/resources/views/crud/columns/number.blade.php
+++ b/src/resources/views/crud/columns/number.blade.php
@@ -14,7 +14,8 @@
     }
     
     if (!is_null($column['value'])) {
-        $column['value'] = number_format($column['value'], $column['decimals'], $column['dec_point'], $column['thousands_sep']);
+	$column['value'] = (float) $column['value'];
+	$column['value'] = number_format($column['value'], $column['decimals'], $column['dec_point'], $column['thousands_sep']);
         $column['text'] = $column['prefix'].$column['value'].$column['suffix'];
     }
 @endphp


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Experiencing this error after generating CRUD for a specific model/records
number_format(): Argument #1 ($num) must be of type float, string given
vendor\backpack\crud\src\resources\views\crud\columns\number.blade.php

### AFTER - What is happening after this PR?

Performed type casting to comply with expected data type argument


## HOW

### How did you achieve that, in technical terms?

Performed data type casting



### Is it a breaking change?

No


### How can we test the before & after?

manual testing, no automated testing script  created
