### PR TITLE
fix positioning when column name contains dot.

### DIFF
--- a/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
+++ b/src/app/Library/CrudPanel/Traits/ColumnsProtectedMethods.php
@@ -291,6 +291,8 @@ trait ColumnsProtectedMethods
         $targetColumnName = is_array($targetColumn) ? $targetColumn['name'] : $targetColumn;
         $columnsArray = $this->columns();
 
+        $targetColumnName = str_replace('.', '__', $targetColumnName);
+
         if (array_key_exists($targetColumnName, $columnsArray)) {
             $targetColumnPosition = $before ? array_search($targetColumnName, array_keys($columnsArray)) :
                 array_search($targetColumnName, array_keys($columnsArray)) + 1;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in #5798 

If the column name contained a dot, it was not possible to use the move function, as the column uses the "key" (where the dot is replaced by double underscore). 

### AFTER - What is happening after this PR?

We ensure to run the same str replace we use in the key generation. 

### Is it a breaking change?

no