### PR TITLE
Form component - use forms anywhere

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -7,6 +7,8 @@ use Backpack\CRUD\app\Http\Middleware\EnsureEmailVerification;
 use Backpack\CRUD\app\Http\Middleware\ThrottlePasswordRecovery;
 use Backpack\CRUD\app\Library\Database\DatabaseSchema;
 use Backpack\CRUD\app\Library\Datatable\Datatable;
+use Backpack\CRUD\app\Library\Form\FormComponent;
+use Backpack\CRUD\app\Library\Form\FormModalComponent;
 use Backpack\CRUD\app\Library\Uploaders\Support\UploadersRepository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Routing\Router;
@@ -64,6 +66,8 @@ class BackpackServiceProvider extends ServiceProvider
 
         Basset::addViewPath(realpath(__DIR__.'/resources/views'));
         Blade::component('datatable', Datatable::class);
+        Blade::component('form', FormComponent::class);
+        Blade::component('form-modal', FormModalComponent::class);
     }
 
     /**

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -81,17 +81,14 @@ trait CreateOperation
         return view(
             $this->crud->getFirstFieldView('form.create_form'),
             [
-                'fields'             => $this->crud->getCreateFields(),
-                'action'             => 'create',
-                'crud'               => $this->crud,
-                'modalClass'         => request()->get('modal_class'),
+                'fields' => $this->crud->getCreateFields(),
+                'action' => 'create',
+                'crud' => $this->crud,
+                'modalClass' => request()->get('modal_class'),
                 'parentLoadedAssets' => request()->get('parent_loaded_assets'),
             ]
         );
-
-    }        
-       
-
+    }
 
     /**
      * Store a newly created resource in the database.

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -27,6 +27,12 @@ trait CreateOperation
             'uses' => $controller.'@store',
             'operation' => 'create',
         ]);
+
+        Route::get($segment.'/create-form', [
+            'as' => $routeName.'.create-form',
+            'uses' => $controller.'@createForm',
+            'operation' => 'create',
+        ]);
     }
 
     /**
@@ -62,6 +68,30 @@ trait CreateOperation
         // load the view from /resources/views/vendor/backpack/crud/ if it exists, otherwise load the one in the package
         return view($this->crud->getCreateView(), $this->data);
     }
+
+    public function createForm()
+    {
+        $this->crud->hasAccessOrFail('create');
+
+        // if the request isn't an AJAX request, return a 404
+        if (! request()->ajax()) {
+            abort(404);
+        }
+
+        return view(
+            $this->crud->getFirstFieldView('form.create_form'),
+            [
+                'fields'             => $this->crud->getCreateFields(),
+                'action'             => 'create',
+                'crud'               => $this->crud,
+                'modalClass'         => request()->get('modal_class'),
+                'parentLoadedAssets' => request()->get('parent_loaded_assets'),
+            ]
+        );
+
+    }        
+       
+
 
     /**
      * Store a newly created resource in the database.

--- a/src/app/Library/Form/FormComponent.php
+++ b/src/app/Library/Form/FormComponent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\Form;
+
+use Backpack\CRUD\CrudManager;
+use Illuminate\View\Component;
+
+class FormComponent extends Component
+{
+    public $crud;
+    public $operation;
+    public $formAction;
+    public $formMethod;
+
+    /**
+     * Create a new component instance.
+     *
+     * @param string $controller The CRUD controller class name
+     * @param string $operation The operation to use (create, update, etc.)
+     * @param string|null $action Custom form action URL
+     * @param string $method Form method (post, put, etc.)
+     */
+    public function __construct(
+        public string $controller,
+        string $operation = 'create',
+        ?string $action = null,
+        string $method = 'post'
+    ) {
+        // Get CRUD panel instance from the controller
+        $this->crud = CrudManager::crudFromController($controller, $operation);
+        $this->operation = $operation;
+        $this->formAction = $action ?? url($this->crud->route);
+        $this->formMethod = $method;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return view('crud::form.form_component', [
+            'crud' => $this->crud,
+            'operation' => $this->operation,
+            'formAction' => $this->formAction,
+            'formMethod' => $this->formMethod,
+        ]);
+    }
+}

--- a/src/app/Library/Form/FormComponent.php
+++ b/src/app/Library/Form/FormComponent.php
@@ -15,10 +15,10 @@ class FormComponent extends Component
     /**
      * Create a new component instance.
      *
-     * @param string $controller The CRUD controller class name
-     * @param string $operation The operation to use (create, update, etc.)
-     * @param string|null $action Custom form action URL
-     * @param string $method Form method (post, put, etc.)
+     * @param  string  $controller  The CRUD controller class name
+     * @param  string  $operation  The operation to use (create, update, etc.)
+     * @param  string|null  $action  Custom form action URL
+     * @param  string  $method  Form method (post, put, etc.)
      */
     public function __construct(
         public string $controller,

--- a/src/app/Library/Form/FormModalComponent.php
+++ b/src/app/Library/Form/FormModalComponent.php
@@ -2,20 +2,18 @@
 
 namespace Backpack\CRUD\app\Library\Form;
 
-use Backpack\CRUD\app\Library\Form\FormComponent;
-
 class FormModalComponent extends FormComponent
 {
     /**
      * Create a new component instance.
      *
-     * @param string $controller The CRUD controller class name
-     * @param string $operation The operation to use (create, update, etc.)
-     * @param string|null $action Custom form action URL
-     * @param string $method Form method (post, put, etc.)
-     * @param string $buttonText Text to display on the button that opens the modal
-     * @param string $modalTitle Title for the modal
-     * @param string $buttonClass CSS classes for the button
+     * @param  string  $controller  The CRUD controller class name
+     * @param  string  $operation  The operation to use (create, update, etc.)
+     * @param  string|null  $action  Custom form action URL
+     * @param  string  $method  Form method (post, put, etc.)
+     * @param  string  $buttonText  Text to display on the button that opens the modal
+     * @param  string  $modalTitle  Title for the modal
+     * @param  string  $buttonClass  CSS classes for the button
      */
     public function __construct(
         string $controller,

--- a/src/app/Library/Form/FormModalComponent.php
+++ b/src/app/Library/Form/FormModalComponent.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Backpack\CRUD\app\Library\Form;
+
+use Backpack\CRUD\app\Library\Form\FormComponent;
+
+class FormModalComponent extends FormComponent
+{
+    /**
+     * Create a new component instance.
+     *
+     * @param string $controller The CRUD controller class name
+     * @param string $operation The operation to use (create, update, etc.)
+     * @param string|null $action Custom form action URL
+     * @param string $method Form method (post, put, etc.)
+     * @param string $buttonText Text to display on the button that opens the modal
+     * @param string $modalTitle Title for the modal
+     * @param string $buttonClass CSS classes for the button
+     */
+    public function __construct(
+        string $controller,
+        string $operation = 'create',
+        ?string $action = null,
+        string $method = 'post',
+        public string $buttonText = 'Open Form',
+        public string $modalTitle = 'Form',
+        public string $buttonClass = 'btn btn-primary'
+    ) {
+        parent::__construct($controller, $operation, $action, $method);
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return view('crud::form.modal_form_component', [
+            'crud' => $this->crud,
+            'operation' => $this->operation,
+            'formAction' => $this->formAction,
+            'formMethod' => $this->formMethod,
+            'buttonText' => $this->buttonText,
+            'modalTitle' => $this->modalTitle,
+            'buttonClass' => $this->buttonClass,
+        ]);
+    }
+}

--- a/src/resources/views/crud/fields/form/create_form.blade.php
+++ b/src/resources/views/crud/fields/form/create_form.blade.php
@@ -1,0 +1,33 @@
+
+ <form method="post"
+        action="{{ url($crud->route) }}"
+        onsubmit="return false"
+        @if ($crud->hasUploadFields('create'))
+        enctype="multipart/form-data"
+        @endif
+>
+                    {!! csrf_field() !!}
+<input type="hidden" name="_http_referrer" value="{{ old('_http_referrer') ?? \URL::previous() ?? url($crud->route) }}">
+
+{{-- See if we're using tabs --}}
+@if ($crud->tabsEnabled() && count($crud->getTabs()))
+    @include($crud->getFirstFieldView('form.tabbed_fields'))
+    <input type="hidden" name="_current_tab" value="{{ Str::slug($crud->getTabs()[0], '') }}" />
+@else
+  <div class="card">
+    <div class="card-body row">
+      @include($crud->getFirstFieldView('form.show_fields'), ['fields' => $crud->fields()])
+    </div>
+  </div>
+@endif
+
+ </form>
+
+@foreach (app('widgets')->toArray() as $currentWidget)
+@php
+    $currentWidget = \Backpack\CRUD\app\Library\Widget::add($currentWidget);
+@endphp
+    @if($currentWidget->getAttribute('inline'))
+        @include($currentWidget->getFinalViewPath(), ['widget' => $currentWidget->toArray()])
+    @endif
+@endforeach

--- a/src/resources/views/crud/fields/form/show_fields.blade.php
+++ b/src/resources/views/crud/fields/form/show_fields.blade.php
@@ -1,0 +1,8 @@
+{{-- Show the inputs --}}
+@foreach ($fields as $field)
+    @php
+      $fieldView = $crud->getFirstFieldView($field['type'], $field['view_namespace'] ?? false);
+    @endphp
+
+    @include($fieldView, ['field' => $field, 'inlineCreate' => true])
+@endforeach

--- a/src/resources/views/crud/fields/form/tabbed_fields.blade.php
+++ b/src/resources/views/crud/fields/form/tabbed_fields.blade.php
@@ -1,0 +1,62 @@
+@php
+    $horizontalTabs = $crud->getTabsType()=='horizontal' ? true : false;
+
+    if ($errors->any() && array_key_exists(array_keys($errors->messages())[0], $crud->getCurrentFields()) &&
+        array_key_exists('tab', $crud->getCurrentFields()[array_keys($errors->messages())[0]])) {
+        $tabWithError = ($crud->getCurrentFields()[array_keys($errors->messages())[0]]['tab']);
+    }
+@endphp
+
+@push('crud_fields_styles')
+    <style>
+        .nav-tabs-custom {
+            box-shadow: none;
+        }
+        .nav-tabs-custom > .nav-tabs.nav-stacked > li {
+            margin-right: 0;
+        }
+
+        .tab-pane .form-group h1:first-child,
+        .tab-pane .form-group h2:first-child,
+        .tab-pane .form-group h3:first-child {
+            margin-top: 0;
+        }
+    </style>
+@endpush
+
+@if ($crud->getFieldsWithoutATab()->filter(function ($value, $key) { return $value['type'] != 'hidden'; })->count())
+<div class="card">
+    <div class="card-body row">
+    @include($crud->getFirstFieldView('relationship.inc.show_fields'), ['fields' => $crud->getFieldsWithoutATab()])
+    </div>
+</div>
+@else
+    @include($crud->getFirstFieldView('relationship.inc.show_fields'), ['fields' => $crud->getFieldsWithoutATab()])
+@endif
+
+<div class="tab-container {{ $horizontalTabs ? '' : 'container'}} mb-2">
+
+    <div class="nav-tabs-custom {{ $horizontalTabs ? '' : 'row'}}" id="inline_form_tabs">
+        <ul class="nav {{ $horizontalTabs ? 'nav-tabs' : 'flex-column nav-pills'}} {{ $horizontalTabs ? '' : 'col-md-3' }}" role="tablist">
+            @foreach ($crud->getTabs() as $k => $tab)
+                <li role="presentation" class="nav-item">
+                    <a href="#inline_tab_{{ Str::slug($tab, '') }}" aria-controls="inline_tab_{{ Str::slug($tab, "") }}" role="tab" tab_name="inline_{{ Str::slug($tab, "") }}" data-toggle="tab" data-bs-toggle="tab" class="nav-link {{ isset($tabWithError) ? ($tab == $tabWithError ? 'active' : '') : ($k == 0 ? 'active' : '') }}">{{ $tab }}</a>
+                </li>
+            @endforeach
+        </ul>
+
+        <div class="tab-content p-3 bg-white border {{$horizontalTabs ? '' : 'col-md-9'}}">
+
+            @foreach ($crud->getTabs() as $k => $tab)
+            <div role="tabpanel" class="tab-pane {{ isset($tabWithError) ? ($tab == $tabWithError ? ' active' : '') : ($k == 0 ? ' active' : '') }}" id="inline_tab_{{ Str::slug($tab, "") }}">
+
+                <div class="row">
+                @include($crud->getFirstFieldView('relationship.inc.show_fields'), ['fields' => $crud->getTabFields($tab)])
+                </div>
+            </div>
+            @endforeach
+
+        </div>
+    </div>
+</div>
+

--- a/src/resources/views/crud/form/form_component.blade.php
+++ b/src/resources/views/crud/form/form_component.blade.php
@@ -1,0 +1,63 @@
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}</h3>
+    </div>
+    <div class="card-body">
+        <div class="backpack-form">
+            @include('crud::inc.grouped_errors')
+
+            <form method="{{ $formMethod }}"
+                action="{{ $formAction }}"
+                @if ($crud->hasUploadFields($operation))
+                enctype="multipart/form-data"
+                @endif
+            >
+                {!! csrf_field() !!}
+                @if($formMethod !== 'post')
+                    @method($formMethod)
+                @endif
+
+                {{-- Include the form fields --}}
+                @include('crud::form_content', ['fields' => $crud->fields(), 'action' => $operation])
+                
+                {{-- This makes sure that all field assets are loaded. --}}
+                <div class="d-none" id="parentLoadedAssets">{{ json_encode(Basset::loaded()) }}</div>
+
+                {{-- Include form save buttons --}}
+                @if(!isset($hideButtons) || !$hideButtons)
+                    <div class="form-group mt-3">
+                        <button type="submit" class="btn btn-success">
+                            <span class="la la-save" role="presentation" aria-hidden="true"></span> &nbsp;
+                            <span>{{ trans('backpack::crud.save') }}</span>
+                        </button>
+                        <a href="{{ url()->previous() }}" class="btn btn-secondary">{{ trans('backpack::crud.cancel') }}</a>
+                    </div>
+                @endif
+            </form>
+        </div>
+    </div>
+</div>
+
+@push('after_scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Initialize the form fields after loading
+        if (typeof initializeFieldsWithJavascript === 'function') {
+            try {
+                initializeFieldsWithJavascript(document.querySelector('.backpack-form'));
+            } catch (e) {
+                console.error('Error initializing form fields:', e);
+            }
+        }
+
+        // Focus on first focusable field when form is loaded
+        const form = document.querySelector('.backpack-form form');
+        if (form) {
+            const firstField = form.querySelector('input:not([type=hidden]), select, textarea');
+            if (firstField) {
+                firstField.focus();
+            }
+        }
+    });
+</script>
+@endpush

--- a/src/resources/views/crud/form/modal_form_component.blade.php
+++ b/src/resources/views/crud/form/modal_form_component.blade.php
@@ -1,0 +1,213 @@
+    {{-- Button to trigger modal --}}
+    <button type="button" class="{{ $buttonClass }}" data-toggle="modal" data-bs-toggle="modal" data-target="#formModal{{ md5($controller) }}" data-bs-target="#formModal{{ md5($controller) }}">
+        {{ $buttonText }}
+    </button>
+    {{-- Modal HTML (initially hidden from DOM) --}}
+    @push('after_scripts')
+    <div class="d-none" id="modalTemplate{{ md5($controller) }}">
+        <div class="modal fade" id="formModal{{ md5($controller) }}" tabindex="-1" role="dialog" aria-labelledby="formModalLabel{{ md5($controller) }}" aria-hidden="true">
+            <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="formModalLabel{{ md5($controller) }}">{{ $modalTitle }}</h5>
+                        <button type="button" class="btn-close close" data-dismiss="modal" data-bs-dismiss="modal" aria-label="Close"></button>
+                   </div>
+                    <div class="modal-body">
+                        <div id="modal-form-errors{{ md5($controller) }}" class="alert alert-danger d-none">
+                            <ul id="modal-form-errors-list{{ md5($controller) }}"></ul>
+                        </div>
+                        <div id="modal-form-container{{ md5($controller) }}">
+                            <div class="text-center">
+                                <i class="fa fa-spinner fa-spin fa-2x"></i>
+                                <p>Loading form...</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary" id="submitForm{{ md5($controller) }}">Save</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endpush
+
+@push('after_scripts')
+<script>
+(function() {
+    // Create a unique namespace for this modal instance
+    const modalNamespace = 'modal_{{ md5($controller) }}';
+    
+    document.addEventListener('DOMContentLoaded', function() {
+    // Listen for modal show event
+    const modalEl = document.getElementById('formModal{{ md5($controller) }}');
+    const modalTemplate = document.getElementById('modalTemplate{{ md5($controller) }}');
+
+    modalEl.addEventListener('shown.bs.modal', loadModalForm);
+    
+    function loadModalForm() {
+        const formContainer = document.getElementById('modal-form-container{{ md5($controller) }}');
+        const submitButton = document.getElementById('submitForm{{ md5($controller) }}');
+    
+        submitButton.disabled = true;
+
+        // remove the d-none class from the modal not the container
+        modalTemplate.classList.remove('d-none');
+
+        submitButton.addEventListener('click', function() {
+            submitModalForm{{ md5($controller) }}();
+        });
+
+        
+        if (formContainer && !formContainer.dataset.loaded) {
+            submitButton.disabled = true;
+            // Load the form via AJAX
+            fetch('{{ url($crud->route . "/create-form") }}', {
+                method: 'GET',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+            .then(response => response.text())
+            .then(html => {
+                formContainer.innerHTML = html;
+                formContainer.dataset.loaded = 'true';
+                
+                // Initialize the form fields after loading
+                if (typeof initializeFieldsWithJavascript === 'function') {
+                    try {
+                        initializeFieldsWithJavascript(modalEl);
+                    } catch (e) {
+                        console.error('Error initializing form fields:', e);
+                    }
+                }
+                submitButton.disabled = false;
+            })
+            .catch(error => {
+                console.error('Error loading form:', error);
+                formContainer.innerHTML = '<div class="alert alert-danger">Failed to load form</div>';
+            });
+        }
+    }
+    });
+
+    // Form submission handler with a unique name
+    function submitModalForm{{ md5($controller) }}() {
+        const formContainer = document.getElementById('modal-form-container{{ md5($controller) }}');
+        const form = formContainer.querySelector('form');
+        if (!form) {
+            console.error('Form not found in modal');
+            return; 
+        }
+        const errorsContainer = document.getElementById('modal-form-errors{{ md5($controller) }}');
+        const errorsList = document.getElementById('modal-form-errors-list{{ md5($controller) }}');
+        
+        // Clear previous errors
+        errorsContainer.classList.add('d-none');
+        errorsList.innerHTML = '';
+        form.querySelectorAll('.invalid-feedback').forEach(el => el.remove());
+        form.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
+
+        // Submit form via AJAX
+        fetch(form.action, {
+            method: form.method,
+            body: new FormData(form),
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json' 
+            }
+        })
+        .then(response => {
+            if (response.headers.get('content-type') && response.headers.get('content-type').includes('application/json')) {
+                return response.json().then(data => ({ ok: response.ok, data, status: response.status }));
+            }
+            return response.text().then(text => ({ ok: response.ok, data: text, status: response.status }));
+        })
+        .then(result => {
+            if (result.ok) {
+                // Success
+                new Noty({
+                    type: 'success',
+                    text: 'Entry saved successfully!',
+                    timeout: 3000
+                }).show();
+                
+                try {
+                    const modalEl = document.getElementById('formModal{{ md5($controller) }}');
+                    const bsModal = bootstrap.Modal.getInstance(modalEl);
+                    if (bsModal) {
+                        bsModal.hide();
+                    }
+                } catch (e) {
+                    console.warn('Could not close modal automatically:', e);
+                }
+                
+                // Notify listeners - using a more specific event name
+                document.dispatchEvent(new CustomEvent('FormModalSaved_{{ md5($controller) }}', {
+                    detail: { controller: '{{ $controller }}', response: result.data }
+                }));
+                
+                // Also dispatch the general event for backward compatibility
+                document.dispatchEvent(new CustomEvent('FormModalSaved', {
+                    detail: { controller: '{{ $controller }}', response: result.data }
+                }));
+                
+                setTimeout(function() {
+                    if (window.crud && window.crud.table) {
+                        try {
+                            window.crud.table.ajax.reload();
+                        } catch (e) {
+                            console.warn('Could not reload table using ajax.reload()', e);
+                            try {
+                                window.crud.table.draw(false);
+                            } catch (e2) {
+                                console.warn('Could not reload table using draw()', e2);
+                            }
+                        }
+                    }
+                }, 100);
+            } else if (result.status === 422) {
+                // Validation errors
+                errorsContainer.classList.remove('d-none');
+                
+                for (const field in result.data.errors) {
+                    result.data.errors[field].forEach(message => {
+                        const li = document.createElement('li');
+                        li.textContent = message;
+                        errorsList.appendChild(li);
+                    });
+                    
+                    const inputField = form.querySelector(`[name="${field}"]`);
+                    if (inputField) {
+                        inputField.classList.add('is-invalid');
+                        
+                        const formGroup = inputField.closest('.form-group');
+                        if (formGroup) {
+                            result.data.errors[field].forEach(message => {
+                                const feedback = document.createElement('div');
+                                feedback.className = 'invalid-feedback d-block';
+                                feedback.textContent = message;
+                                formGroup.appendChild(feedback);
+                            });
+                        }
+                    }
+                }
+            } else {
+                errorsContainer.classList.remove('d-none');
+                const li = document.createElement('li');
+                li.textContent = 'An error occurred while saving the form.';
+                errorsList.appendChild(li);
+            }
+        })
+        .catch(error => {
+            console.error('Form submission error:', error);
+            errorsContainer.classList.remove('d-none');
+            const li = document.createElement('li');
+            li.textContent = 'A network error occurred.';
+            errorsList.appendChild(li);
+        });
+    }
+})(); // End IIFE
+</script>
+@endpush

--- a/src/resources/views/crud/form_content.blade.php
+++ b/src/resources/views/crud/form_content.blade.php
@@ -172,14 +172,15 @@
         @else
             focusField = getFirstFocusableField($('form'));
         @endif
+        if(focusField.length !== 0) {
+          const fieldOffset = focusField.offset().top;
+          const scrollTolerance = $(window).height() / 2;
 
-        const fieldOffset = focusField.offset().top;
-        const scrollTolerance = $(window).height() / 2;
+          triggerFocusOnFirstInputField(focusField);
 
-        triggerFocusOnFirstInputField(focusField);
-
-        if( fieldOffset > scrollTolerance ){
-            $('html, body').animate({scrollTop: (fieldOffset - 30)});
+          if( fieldOffset > scrollTolerance ){
+              $('html, body').animate({scrollTop: (fieldOffset - 30)});
+          }
         }
       @endif
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It was almost impossible to use the backpack forms anywhere else other than the create operation.

O opened the PR to get early feedback from @tabacitu 

### AFTER - What is happening after this PR?

This PR adds two new components. FormComponent e FormModalComponent. 

The first one display the form whenever the component is added on page, eg:

![image](https://github.com/user-attachments/assets/3ff9fc5f-3baa-4184-82cf-699520e32162)

The second one, the modal, brings a button that open the form in a modal, and uses ajax for handling: 

![image](https://github.com/user-attachments/assets/de6b24d6-18e3-4f5a-848b-cbd09cf70aeb)


### Is it a breaking change?

Theoretically no.


### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
