### PR TITLE
add Datagrid and Datalist components

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -80,6 +81,7 @@ class BackpackServiceProvider extends ServiceProvider
         ViewNamespaces::addFor('widgets', 'crud::widgets');
 
         $this->loadViewComponents();
+        $this->registerDynamicBladeComponents();
 
         $this->registerBackpackErrorViews();
 
@@ -320,6 +322,38 @@ class BackpackServiceProvider extends ServiceProvider
         $this->app->afterResolving(BladeCompiler::class, function () {
             Blade::componentNamespace('Backpack\\CRUD\\app\\View\\Components', 'backpack');
         });
+    }
+
+    /**
+     * Register dynamic Blade components from the Components directory.
+     *
+     * Any Blade component classes that are in that directory will be registered
+     * as dynamic components with the 'bp-{component-name}' prefix.
+     */
+    private function registerDynamicBladeComponents()
+    {
+        $path = __DIR__ . '/app/View/Components';
+        $namespace = 'Backpack\\CRUD\\app\\View\\Components';
+
+        if (! is_dir($path)) {
+            return;
+        }
+
+        foreach (File::allFiles($path) as $file) {
+            $relativePath = str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                Str::after($file->getRealPath(), realpath($path) . DIRECTORY_SEPARATOR)
+            );
+
+            $class = $namespace . '\\' . $relativePath;
+
+            // Check if the class exists and is a subclass of Illuminate\View\Component
+            // This ensures that only valid Blade components are registered.
+            if (class_exists($class) && is_subclass_of($class, \Illuminate\View\Component::class)) {
+                Blade::component('bp-'.Str::kebab(class_basename($class)), $class);
+            }
+        }
     }
 
     /**

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -332,7 +332,7 @@ class BackpackServiceProvider extends ServiceProvider
      */
     private function registerDynamicBladeComponents()
     {
-        $path = __DIR__ . '/app/View/Components';
+        $path = __DIR__.'/app/View/Components';
         $namespace = 'Backpack\\CRUD\\app\\View\\Components';
 
         if (! is_dir($path)) {
@@ -343,10 +343,10 @@ class BackpackServiceProvider extends ServiceProvider
             $relativePath = str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($file->getRealPath(), realpath($path) . DIRECTORY_SEPARATOR)
+                Str::after($file->getRealPath(), realpath($path).DIRECTORY_SEPARATOR)
             );
 
-            $class = $namespace . '\\' . $relativePath;
+            $class = $namespace.'\\'.$relativePath;
 
             // Check if the class exists and is a subclass of Illuminate\View\Component
             // This ensures that only valid Blade components are registered.

--- a/src/ViewNamespaces.php
+++ b/src/ViewNamespaces.php
@@ -89,4 +89,25 @@ class ViewNamespaces
             return $item.'.'.$viewName;
         }, self::getFor($domain));
     }
+
+    /**
+     * Get view paths for a domain and view name with fallback support.
+     * This is useful for @includeFirst() calls that need a guaranteed fallback.
+     *
+     * @param  string  $domain  (eg. fields, filters, buttons, columns)
+     * @param  string  $viewName  (eg. text, select, checkbox)
+     * @param  string|null  $fallbackViewPath  (eg. 'crud::columns.text')
+     * @return array
+     */
+    public static function getViewPathsWithFallbackFor(string $domain, string $viewName, string $fallbackViewPath = null)
+    {
+        $paths = self::getViewPathsFor($domain, $viewName);
+
+        // Add fallback if provided and not already in the list
+        if ($fallbackViewPath && !in_array($fallbackViewPath, $paths)) {
+            $paths[] = $fallbackViewPath;
+        }
+
+        return $paths;
+    }
 }

--- a/src/app/Library/CrudPanel/CrudButton.php
+++ b/src/app/Library/CrudPanel/CrudButton.php
@@ -297,10 +297,10 @@ class CrudButton implements Arrayable
      * @param  object|null  $entry  The eloquent Model for the current entry or null if no current entry.
      * @return \Illuminate\Contracts\View\View
      */
-    public function getHtml($entry = null)
+    public function getHtml($entry = null, ?CrudPanel $crud = null)
     {
         $button = $this;
-        $crud = $this->crud();
+        $crud = $crud ?? $this->crud();
 
         if ($this->type == 'model_function') {
             if (is_null($entry)) {

--- a/src/app/View/Components/Datagrid.php
+++ b/src/app/View/Components/Datagrid.php
@@ -14,7 +14,7 @@ class Datagrid extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct($columns, $entry, $crud, $displayActionsColumn = true)
+    public function __construct($columns, $entry, $crud = null, $displayActionsColumn = true)
     {
         $this->columns = $columns;
         $this->entry = $entry;

--- a/src/app/View/Components/Datagrid.php
+++ b/src/app/View/Components/Datagrid.php
@@ -2,36 +2,13 @@
 
 namespace Backpack\CRUD\app\View\Components;
 
-use Illuminate\View\Component;
-
-class Datagrid extends Component
+class Datagrid extends ShowComponent
 {
-    public $entry;
-    public $crud;
-    public $columns;
-    public $displayButtons;
-
     /**
-     * Create a new component instance.
+     * Get the view name for the component.
      */
-    public function __construct($entry, $crud = null, $columns = [], $displayButtons = true)
+    protected function getViewName(): string
     {
-        $this->columns = $columns ?? $crud?->columns() ?? [];
-        $this->entry = $entry;
-        $this->crud = $crud;
-        $this->displayButtons = $displayButtons;
-    }
-
-    /**
-     * Get the view / contents that represent the component.
-     */
-    public function render()
-    {
-        // if no columns are set, don't load any view
-        if (empty($this->columns)) {
-            return '';
-        }
-
-        return view('crud::components.datagrid');
+        return 'crud::components.datagrid';
     }
 }

--- a/src/app/View/Components/Datagrid.php
+++ b/src/app/View/Components/Datagrid.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Backpack\CRUD\app\View\Components;
+
+use Illuminate\View\Component;
+
+class Datagrid extends Component
+{
+    public $columns;
+    public $entry;
+    public $crud;
+    public $displayActionsColumn;
+
+    /**
+     * Create a new component instance.
+     */
+    public function __construct($columns, $entry, $crud, $displayActionsColumn = true)
+    {
+        $this->columns = $columns;
+        $this->entry = $entry;
+        $this->crud = $crud;
+        $this->displayActionsColumn = $displayActionsColumn;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render()
+    {
+        // if no columns are set, don't load any view
+        if (empty($this->columns)) {
+            return '';
+        }
+
+        return view('crud::components.datagrid');
+    }
+}

--- a/src/app/View/Components/Datagrid.php
+++ b/src/app/View/Components/Datagrid.php
@@ -6,20 +6,20 @@ use Illuminate\View\Component;
 
 class Datagrid extends Component
 {
-    public $columns;
     public $entry;
     public $crud;
-    public $displayActionsColumn;
+    public $columns;
+    public $displayButtons;
 
     /**
      * Create a new component instance.
      */
-    public function __construct($columns, $entry, $crud = null, $displayActionsColumn = true)
+    public function __construct($entry, $crud = null, $columns = [], $displayButtons = true)
     {
-        $this->columns = $columns;
+        $this->columns = $columns ?? $crud?->columns() ?? [];
         $this->entry = $entry;
         $this->crud = $crud;
-        $this->displayActionsColumn = $displayActionsColumn;
+        $this->displayButtons = $displayButtons;
     }
 
     /**

--- a/src/app/View/Components/Datalist.php
+++ b/src/app/View/Components/Datalist.php
@@ -6,20 +6,20 @@ use Illuminate\View\Component;
 
 class Datalist extends Component
 {
-    public $columns;
     public $entry;
     public $crud;
-    public $displayActionsColumn;
+    public $columns;
+    public $displayButtons;
 
     /**
      * Create a new component instance.
      */
-    public function __construct($columns, $entry, $crud = null, $displayActionsColumn = true)
+    public function __construct($entry, $crud = null, $columns = [], $displayButtons = true)
     {
-        $this->columns = $columns;
+        $this->columns = $columns ?? $crud?->columns() ?? [];
         $this->entry = $entry;
         $this->crud = $crud;
-        $this->displayActionsColumn = $displayActionsColumn;
+        $this->displayButtons = $displayButtons;
     }
 
     /**

--- a/src/app/View/Components/Datalist.php
+++ b/src/app/View/Components/Datalist.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Backpack\CRUD\app\View\Components;
+
+use Illuminate\View\Component;
+
+class Datalist extends Component
+{
+    public $columns;
+    public $entry;
+    public $crud;
+    public $displayActionsColumn;
+
+    /**
+     * Create a new component instance.
+     */
+    public function __construct($columns, $entry, $crud, $displayActionsColumn = true)
+    {
+        $this->columns = $columns;
+        $this->entry = $entry;
+        $this->crud = $crud;
+        $this->displayActionsColumn = $displayActionsColumn;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render()
+    {
+        // if no columns are set, don't load any view
+        if (empty($this->columns)) {
+            return '';
+        }
+
+        return view('crud::components.datalist');
+    }
+}

--- a/src/app/View/Components/Datalist.php
+++ b/src/app/View/Components/Datalist.php
@@ -2,36 +2,13 @@
 
 namespace Backpack\CRUD\app\View\Components;
 
-use Illuminate\View\Component;
-
-class Datalist extends Component
+class Datalist extends ShowComponent
 {
-    public $entry;
-    public $crud;
-    public $columns;
-    public $displayButtons;
-
     /**
-     * Create a new component instance.
+     * Get the view name for the component.
      */
-    public function __construct($entry, $crud = null, $columns = [], $displayButtons = true)
+    protected function getViewName(): string
     {
-        $this->columns = $columns ?? $crud?->columns() ?? [];
-        $this->entry = $entry;
-        $this->crud = $crud;
-        $this->displayButtons = $displayButtons;
-    }
-
-    /**
-     * Get the view / contents that represent the component.
-     */
-    public function render()
-    {
-        // if no columns are set, don't load any view
-        if (empty($this->columns)) {
-            return '';
-        }
-
-        return view('crud::components.datalist');
+        return 'crud::components.datalist';
     }
 }

--- a/src/app/View/Components/Datalist.php
+++ b/src/app/View/Components/Datalist.php
@@ -14,7 +14,7 @@ class Datalist extends Component
     /**
      * Create a new component instance.
      */
-    public function __construct($columns, $entry, $crud, $displayActionsColumn = true)
+    public function __construct($columns, $entry, $crud = null, $displayActionsColumn = true)
     {
         $this->columns = $columns;
         $this->entry = $entry;

--- a/src/app/View/Components/ShowComponent.php
+++ b/src/app/View/Components/ShowComponent.php
@@ -4,6 +4,7 @@ namespace Backpack\CRUD\app\View\Components;
 
 use Backpack\CRUD\CrudManager;
 use Illuminate\View\Component;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 
@@ -18,7 +19,7 @@ abstract class ShowComponent extends Component
         public ?string $operation = 'show',
         public ?\Closure $setup = null,
         public ?CrudPanel $crud = null,
-        public array $columns = [],
+        public array|Collection $columns = [],
         public bool $displayButtons = true
     ) {
         $this->setPropertiesFromController();

--- a/src/app/View/Components/ShowComponent.php
+++ b/src/app/View/Components/ShowComponent.php
@@ -2,13 +2,10 @@
 
 namespace Backpack\CRUD\app\View\Components;
 
-use Backpack\CRUD\CrudManager;
-use Illuminate\View\Component;
-use Illuminate\Support\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
 use Backpack\CRUD\CrudManager;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\View\Component;
 
 abstract class ShowComponent extends Component

--- a/src/app/View/Components/ShowComponent.php
+++ b/src/app/View/Components/ShowComponent.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Backpack\CRUD\app\View\Components;
+
+use Backpack\CRUD\CrudManager;
+use Illuminate\View\Component;
+use Illuminate\Database\Eloquent\Model;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanel;
+
+abstract class ShowComponent extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public Model $entry,
+        public ?string $controller = null,
+        public ?string $operation = 'show',
+        public ?\Closure $setup = null,
+        public ?CrudPanel $crud = null,
+        public array $columns = [],
+        public bool $displayButtons = true
+    ) {
+        $this->setPropertiesFromController();
+    }
+
+    /**
+     * Set properties from the controller context.
+     *
+     * This method initializes the CrudPanel and sets the active controller.
+     * It also applies any setup closure provided.
+     */
+    protected function setPropertiesFromController() : void
+    {
+        // If no CrudController is provided, do nothing
+        if (!$this->controller) {
+            return;
+        }
+
+        // If no CrudPanel is provided, try to get it from the CrudManager
+        $this->crud ??= CrudManager::setupCrudPanel($this->controller, $this->operation);
+
+        // Set active controller for proper context
+        CrudManager::setActiveController($this->controller);
+
+        // If a setup closure is provided, apply it
+        if ($this->setup) {
+            if (!empty($columns)) {
+                throw new \Exception('You cannot define both setup closure and columns for a ' . class_basename(static::class) . ' component.');
+            }
+
+            ($this->setup)($this->crud, $this->entry);
+        }
+
+        $this->columns = !empty($columns) ? $columns : $this->crud?->getOperationSetting('columns', $this->operation) ?? [];
+
+        // Reset the active controller
+        CrudManager::unsetActiveController();
+    }
+
+    /**
+     * Get the view name for the component.
+     * This method must be implemented by child classes.
+     */
+    abstract protected function getViewName(): string;
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render()
+    {
+        // if no columns are set, don't load any view
+        if (empty($this->columns)) {
+            return '';
+        }
+
+        return view($this->getViewName());
+    }
+}

--- a/src/config/backpack/operations/show.php
+++ b/src/config/backpack/operations/show.php
@@ -11,6 +11,9 @@ return [
     // To override per Controller use $this->crud->setShowContentClass('class-string')
     'contentClass' => 'col-md-12',
 
+    // Which component to use for displaying the Show page?
+    'component' => 'bp-datagrid', // options: bp-datagrid, bp-datalist, or a custom component alias
+
     // Automatically add all columns from the db table?
     'setFromDb' => true,
 

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -1183,10 +1183,11 @@ div.dt-scroll-body {
 
 /* DataGrid Component */
 
+/* Base mobile-first layout: 1 column */
 .bp-datagrid {
     display: grid;
     grid-gap: 1.5rem;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: 1fr;
 }
 
 .bp-datagrid-title {
@@ -1199,50 +1200,88 @@ div.dt-scroll-body {
     margin-bottom: 0.25rem;
 }
 
-.bp-datagrid-item.size-1 {
-    grid-column: span 1 / span 1;
+/* Breakpoint 1: Small screens (≥768px) — 6 columns */
+@media (min-width: 768px) {
+    .bp-datagrid {
+        grid-template-columns: repeat(6, 1fr);
+    }
+
+    .bp-datagrid-item.size-1 {
+        grid-column: span 1 / span 1;
+    }
+
+    .bp-datagrid-item.size-2 {
+        grid-column: span 2 / span 2;
+    }
+
+    .bp-datagrid-item.size-3 {
+        grid-column: span 3 / span 3;
+    }
+
+    .bp-datagrid-item.size-4 {
+        grid-column: span 4 / span 4;
+    }
+
+    .bp-datagrid-item.size-5 {
+        grid-column: span 5 / span 5;
+    }
+
+    .bp-datagrid-item.size-6 {
+        grid-column: span 6 / span 6;
+    }
 }
 
-.bp-datagrid-item.size-2 {
-    grid-column: span 2 / span 2;
-}
+/* Breakpoint 2: Large screens (≥1024px) — 12 columns */
+@media (min-width: 1024px) {
+    .bp-datagrid {
+        grid-template-columns: repeat(12, 1fr);
+    }
 
-.bp-datagrid-item.size-3 {
-    grid-column: span 3 / span 3;
-}
+    .bp-datagrid-item.size-1 {
+        grid-column: span 1 / span 1;
+    }
 
-.bp-datagrid-item.size-4 {
-    grid-column: span 4 / span 4;
-}
+    .bp-datagrid-item.size-2 {
+        grid-column: span 2 / span 2;
+    }
 
-.bp-datagrid-item.size-5 {
-    grid-column: span 5 / span 5;
-}
+    .bp-datagrid-item.size-3 {
+        grid-column: span 3 / span 3;
+    }
 
-.bp-datagrid-item.size-6 {
-    grid-column: span 6 / span 6;
-}
+    .bp-datagrid-item.size-4 {
+        grid-column: span 4 / span 4;
+    }
 
-.bp-datagrid-item.size-7 {
-    grid-column: span 7 / span 7;
-}
+    .bp-datagrid-item.size-5 {
+        grid-column: span 5 / span 5;
+    }
 
-.bp-datagrid-item.size-8 {
-    grid-column: span 8 / span 8;
-}
+    .bp-datagrid-item.size-6 {
+        grid-column: span 6 / span 6;
+    }
 
-.bp-datagrid-item.size-9 {
-    grid-column: span 9 / span 9;
-}
+    .bp-datagrid-item.size-7 {
+        grid-column: span 7 / span 7;
+    }
 
-.bp-datagrid-item.size-10 {
-    grid-column: span 10 / span 10;
-}
+    .bp-datagrid-item.size-8 {
+        grid-column: span 8 / span 8;
+    }
 
-.bp-datagrid-item.size-11 {
-    grid-column: span 11 / span 11;
-}
+    .bp-datagrid-item.size-9 {
+        grid-column: span 9 / span 9;
+    }
 
-.bp-datagrid-item.size-12 {
-    grid-column: span 12 / span 12;
+    .bp-datagrid-item.size-10 {
+        grid-column: span 10 / span 10;
+    }
+
+    .bp-datagrid-item.size-11 {
+        grid-column: span 11 / span 11;
+    }
+
+    .bp-datagrid-item.size-12 {
+        grid-column: span 12 / span 12;
+    }
 }

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -1180,3 +1180,69 @@ div.dt-scroll-body {
     margin-left: 2px;
     margin-right: auto;
 }
+
+/* DataGrid Component */
+
+.bp-datagrid {
+    display: grid;
+    grid-gap: 1.5rem;
+    grid-template-columns: repeat(12, 1fr);
+}
+
+.bp-datagrid-title {
+    font-size: .625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    line-height: 1rem;
+    color: #66626c;
+    margin-bottom: 0.25rem;
+}
+
+.bp-datagrid-item.size-1 {
+    grid-column: span 1 / span 1;
+}
+
+.bp-datagrid-item.size-2 {
+    grid-column: span 2 / span 2;
+}
+
+.bp-datagrid-item.size-3 {
+    grid-column: span 3 / span 3;
+}
+
+.bp-datagrid-item.size-4 {
+    grid-column: span 4 / span 4;
+}
+
+.bp-datagrid-item.size-5 {
+    grid-column: span 5 / span 5;
+}
+
+.bp-datagrid-item.size-6 {
+    grid-column: span 6 / span 6;
+}
+
+.bp-datagrid-item.size-7 {
+    grid-column: span 7 / span 7;
+}
+
+.bp-datagrid-item.size-8 {
+    grid-column: span 8 / span 8;
+}
+
+.bp-datagrid-item.size-9 {
+    grid-column: span 9 / span 9;
+}
+
+.bp-datagrid-item.size-10 {
+    grid-column: span 10 / span 10;
+}
+
+.bp-datagrid-item.size-11 {
+    grid-column: span 11 / span 11;
+}
+
+.bp-datagrid-item.size-12 {
+    grid-column: span 12 / span 12;
+}

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -8,7 +8,7 @@
         </div>
     @endforeach
 
-    @if($crud && $crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+    @if($crud && $crud->buttons()->where('stack', 'line')->count() && $displayActionsColumn)
         <div class="datagrid-item">
             <div class="datagrid-title">{{ trans('backpack::crud.actions') }}</div>
             <div class="datagrid-content">

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -8,7 +8,7 @@
         </div>
     @endforeach
 
-    @if($displayButtons ?? $crud && $crud->buttons()->where('stack', 'line')->count())
+    @if($displayButtons && $crud && $crud->buttons()->where('stack', 'line')->count())
         <div class="bp-datagrid-item size-12">
             <div class="bp-datagrid-title">{{ trans('backpack::crud.actions') }}</div>
             <div class="bp-datagrid-content">

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -1,0 +1,32 @@
+<div class="datagrid p-3">
+    @foreach($columns as $column)
+        <div class="datagrid-item">
+            <div class="datagrid-title">{!! $column['label'] !!}</div>
+            <div class="datagrid-content">
+                @php
+                // create a list of paths to column blade views
+                // including the configured view_namespaces
+                $columnPaths = array_map(function($item) use ($column) {
+                    return $item.'.'.$column['type'];
+                }, \Backpack\CRUD\ViewNamespaces::getFor('columns'));
+
+                // but always fall back to the stock 'text' column
+                // if a view doesn't exist
+                if (!in_array('crud::columns.text', $columnPaths)) {
+                    $columnPaths[] = 'crud::columns.text';
+                }
+                @endphp
+                @includeFirst($columnPaths)
+            </div>
+        </div>
+    @endforeach
+
+    @if($crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+        <div class="datagrid-item">
+            <div class="datagrid-title">{{ trans('backpack::crud.actions') }}</div>
+            <div class="datagrid-content">
+                @include('crud::inc.button_stack', ['stack' => 'line'])
+            </div>
+        </div>
+    @endif
+</div>

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -8,7 +8,7 @@
         </div>
     @endforeach
 
-    @if($crud && $crud->buttons()->where('stack', 'line')->count() && $displayActionsColumn)
+    @if($displayButtons ?? $crud && $crud->buttons()->where('stack', 'line')->count())
         <div class="bp-datagrid-item size-12">
             <div class="bp-datagrid-title">{{ trans('backpack::crud.actions') }}</div>
             <div class="bp-datagrid-content">

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -1,17 +1,17 @@
-<div class="datagrid p-3">
+<div class="bp-datagrid p-3">
     @foreach($columns as $column)
-        <div class="datagrid-item">
-            <div class="datagrid-title">{!! $column['label'] !!}</div>
-            <div class="datagrid-content">
+        <div class="bp-datagrid-item size-{{ $column['size'] ?? '3' }}">
+            <div class="bp-datagrid-title">{!! $column['label'] !!}</div>
+            <div class="bp-datagrid-content">
                 @includeFirst(\Backpack\CRUD\ViewNamespaces::getViewPathsWithFallbackFor('columns', $column['type'], 'crud::columns.text'))
             </div>
         </div>
     @endforeach
 
     @if($crud && $crud->buttons()->where('stack', 'line')->count() && $displayActionsColumn)
-        <div class="datagrid-item">
-            <div class="datagrid-title">{{ trans('backpack::crud.actions') }}</div>
-            <div class="datagrid-content">
+        <div class="bp-datagrid-item size-12">
+            <div class="bp-datagrid-title">{{ trans('backpack::crud.actions') }}</div>
+            <div class="bp-datagrid-content">
                 @include('crud::inc.button_stack', ['stack' => 'line'])
             </div>
         </div>

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -8,7 +8,7 @@
         </div>
     @endforeach
 
-    @if($crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+    @if($crud && $crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
         <div class="datagrid-item">
             <div class="datagrid-title">{{ trans('backpack::crud.actions') }}</div>
             <div class="datagrid-content">

--- a/src/resources/views/crud/components/datagrid.blade.php
+++ b/src/resources/views/crud/components/datagrid.blade.php
@@ -3,20 +3,7 @@
         <div class="datagrid-item">
             <div class="datagrid-title">{!! $column['label'] !!}</div>
             <div class="datagrid-content">
-                @php
-                // create a list of paths to column blade views
-                // including the configured view_namespaces
-                $columnPaths = array_map(function($item) use ($column) {
-                    return $item.'.'.$column['type'];
-                }, \Backpack\CRUD\ViewNamespaces::getFor('columns'));
-
-                // but always fall back to the stock 'text' column
-                // if a view doesn't exist
-                if (!in_array('crud::columns.text', $columnPaths)) {
-                    $columnPaths[] = 'crud::columns.text';
-                }
-                @endphp
-                @includeFirst($columnPaths)
+                @includeFirst(\Backpack\CRUD\ViewNamespaces::getViewPathsWithFallbackFor('columns', $column['type'], 'crud::columns.text'))
             </div>
         </div>
     @endforeach

--- a/src/resources/views/crud/components/datalist.blade.php
+++ b/src/resources/views/crud/components/datalist.blade.php
@@ -6,20 +6,7 @@
                 <strong>{!! $column['label'] !!}@if(!empty($column['label'])):@endif</strong>
             </td>
             <td @if($loop->index === 0) class="border-top-0" @endif>
-                @php
-                // create a list of paths to column blade views
-                // including the configured view_namespaces
-                $columnPaths = array_map(function($item) use ($column) {
-                    return $item.'.'.$column['type'];
-                }, \Backpack\CRUD\ViewNamespaces::getFor('columns'));
-
-                // but always fall back to the stock 'text' column
-                // if a view doesn't exist
-                if (!in_array('crud::columns.text', $columnPaths)) {
-                    $columnPaths[] = 'crud::columns.text';
-                }
-                @endphp
-                @includeFirst($columnPaths)
+                @includeFirst(\Backpack\CRUD\ViewNamespaces::getViewPathsWithFallbackFor('columns', $column['type'], 'crud::columns.text'))
             </td>
         </tr>
         @endforeach

--- a/src/resources/views/crud/components/datalist.blade.php
+++ b/src/resources/views/crud/components/datalist.blade.php
@@ -1,0 +1,37 @@
+<table class="table table-striped m-0 p-0">
+    <tbody>
+        @foreach($columns as $column)
+        <tr>
+            <td @if($loop->index === 0) class="border-top-0" @endif>
+                <strong>{!! $column['label'] !!}@if(!empty($column['label'])):@endif</strong>
+            </td>
+            <td @if($loop->index === 0) class="border-top-0" @endif>
+                @php
+                // create a list of paths to column blade views
+                // including the configured view_namespaces
+                $columnPaths = array_map(function($item) use ($column) {
+                    return $item.'.'.$column['type'];
+                }, \Backpack\CRUD\ViewNamespaces::getFor('columns'));
+
+                // but always fall back to the stock 'text' column
+                // if a view doesn't exist
+                if (!in_array('crud::columns.text', $columnPaths)) {
+                    $columnPaths[] = 'crud::columns.text';
+                }
+                @endphp
+                @includeFirst($columnPaths)
+            </td>
+        </tr>
+        @endforeach
+        @if($crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+        <tr>
+            <td>
+                <strong>{{ trans('backpack::crud.actions') }}</strong>
+            </td>
+            <td>
+                @include('crud::inc.button_stack', ['stack' => 'line'])
+            </td>
+        </tr>
+        @endif
+    </tbody>
+</table>

--- a/src/resources/views/crud/components/datalist.blade.php
+++ b/src/resources/views/crud/components/datalist.blade.php
@@ -10,7 +10,8 @@
             </td>
         </tr>
         @endforeach
-        @if($crud && $crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+
+        @if($crud && $crud->buttons()->where('stack', 'line')->count() && $displayActionsColumn)
         <tr>
             <td>
                 <strong>{{ trans('backpack::crud.actions') }}</strong>

--- a/src/resources/views/crud/components/datalist.blade.php
+++ b/src/resources/views/crud/components/datalist.blade.php
@@ -11,7 +11,7 @@
         </tr>
         @endforeach
 
-        @if($crud && $crud->buttons()->where('stack', 'line')->count() && $displayActionsColumn)
+        @if($displayButtons && $crud && $crud->buttons()->where('stack', 'line')->count())
         <tr>
             <td>
                 <strong>{{ trans('backpack::crud.actions') }}</strong>

--- a/src/resources/views/crud/components/datalist.blade.php
+++ b/src/resources/views/crud/components/datalist.blade.php
@@ -10,7 +10,7 @@
             </td>
         </tr>
         @endforeach
-        @if($crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
+        @if($crud && $crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
         <tr>
             <td>
                 <strong>{{ trans('backpack::crud.actions') }}</strong>

--- a/src/resources/views/crud/inc/show_tabbed_table.blade.php
+++ b/src/resources/views/crud/inc/show_tabbed_table.blade.php
@@ -8,8 +8,6 @@
     <div class="card">
         @include('crud::inc.show_table', ['columns' => $columnsWithoutTab, 'displayActionsColumn' => false])
     </div>
-@else
-    @include('crud::inc.show_table', ['columns' => $columnsWithoutTab])
 @endif
 
 <div class="tab-container {{ $horizontalTabs ? '' : 'container'}} mb-2">

--- a/src/resources/views/crud/inc/show_table.blade.php
+++ b/src/resources/views/crud/inc/show_table.blade.php
@@ -3,5 +3,5 @@
     :columns="$columns ?? $crud->columns()"
     :entry="$entry"
     :crud="$crud"
-    :display-actions-column="$displayActionsColumn ?? true"
+    :display-buttons="$displayActionsColumn ?? true"
 />

--- a/src/resources/views/crud/inc/show_table.blade.php
+++ b/src/resources/views/crud/inc/show_table.blade.php
@@ -3,5 +3,5 @@
     :columns="$columns ?? $crud->columns()"
     :entry="$entry"
     :crud="$crud"
-    :display-actions-column="$displayActionsColumn ?? false"
+    :display-actions-column="$displayActionsColumn ?? true"
 />

--- a/src/resources/views/crud/inc/show_table.blade.php
+++ b/src/resources/views/crud/inc/show_table.blade.php
@@ -1,7 +1,7 @@
 <x-dynamic-component
     :component="$crud->getOperationSetting('component')"
-    :columns="$columns ?? $crud->columns()"
     :entry="$entry"
     :crud="$crud"
+    :columns="$columns"
     :display-buttons="$displayActionsColumn ?? true"
 />

--- a/src/resources/views/crud/inc/show_table.blade.php
+++ b/src/resources/views/crud/inc/show_table.blade.php
@@ -1,39 +1,7 @@
-@if(count($columns))
-    <table class="table table-striped m-0 p-0">
-        <tbody>
-        @foreach($columns as $column)
-            <tr>
-                <td @if($loop->index === 0) class="border-top-0" @endif>
-                    <strong>{!! $column['label'] !!}@if(!empty($column['label'])):@endif</strong>
-                </td>
-                <td @if($loop->index === 0) class="border-top-0" @endif>
-                    @php
-                        // create a list of paths to column blade views
-                        // including the configured view_namespaces
-                        $columnPaths = array_map(function($item) use ($column) {
-                            return $item.'.'.$column['type'];
-                        }, \Backpack\CRUD\ViewNamespaces::getFor('columns'));
-
-                        // but always fall back to the stock 'text' column
-                        // if a view doesn't exist
-                        if (!in_array('crud::columns.text', $columnPaths)) {
-                            $columnPaths[] = 'crud::columns.text';
-                        }
-                    @endphp
-                    @includeFirst($columnPaths)
-                </td>
-            </tr>
-        @endforeach
-        @if($crud->buttons()->where('stack', 'line')->count() && ($displayActionsColumn ?? true))
-            <tr>
-                <td>
-                    <strong>{{ trans('backpack::crud.actions') }}</strong>
-                </td>
-                <td>
-                    @include('crud::inc.button_stack', ['stack' => 'line'])
-                </td>
-            </tr>
-        @endif
-        </tbody>
-    </table>
-@endif
+<x-dynamic-component
+    :component="$crud->getOperationSetting('component')"
+    :columns="$columns ?? $crud->columns()"
+    :entry="$entry"
+    :crud="$crud"
+    :display-actions-column="$displayActionsColumn ?? false"
+/>


### PR DESCRIPTION
This PR brings the following changes to the Show operation:
- moves the table that echoes an entity's attributes... to a component we call `Datalist`
- adds a new component called `Datagrid`, as an alternative to that;
- adds a configuration option for the Show operation, where the developer can specify what component they want the Show operation to use - `bp-datagrid` or `bp-datalist`;

To test this PR, you only need to checkout this branch, then inside your `config/backpack/operations/show.blade.php` add this item and play around with the two options:

```php
    // Which component to use for displaying the Show page?
    'component' => 'bp-datagrid', // options: bp-datagrid, bp-datalist, or a custom component alias
```

# Done

## Datalist component

This looks and works exactly the same as before, I haven't changed anything, only moved the code to a component:

![CleanShot 2025-06-12 at 13 24 41@2x](https://github.com/user-attachments/assets/4ff2e8ac-a0ca-4ac5-a7ad-844ba6bc4dbf)


## Datagrid component

This looks and works similary, but shows the info in a grid, so that it takes up less space:

![CleanShot 2025-06-12 at 13 25 24@2x](https://github.com/user-attachments/assets/5ee6bc82-6861-4d1b-943e-74bd93f8aaae)


# Todo

To finish this up, we need to:

- [x] review this;
- [x] consider if we want to change some filenames as well (eg. now `show_table.blade.php` loads either the table aka datalist or the datagrid, so that's not quite accurate);
- [x] consider if we want a different alias for components (right now this adds aliases for all components in the format `bp-datagrid`, `bp-datalist` etc.);
- [x] allow the developer to specify the SIZE of a `datagrid-item`; don't know if we should make it `->size(12)` like we have in fields (for consistency) or a different way that makes more sense for the actual HTML and CSS of the datagrid;
- [x] add CSS to both `theme-coreuiv2` and `theme-coreuiv4` to show a nice grid like the `theme-tabler` does;