### PR TITLE
Fix datatable dom property

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -812,10 +812,6 @@ div.dt-scroll-body {
     margin-bottom: 0;
 }
 
-.dt-buttons {
-    margin-bottom: 8px;
-}
-
 /* Adjust table headers */
 .dataTable thead th {
     font-size: 0.70em;
@@ -823,7 +819,7 @@ div.dt-scroll-body {
 }
 
 /* Make export and column visibility buttons smaller */
-.dataTables_wrapper .dt-buttons .btn {
+.dt-container .dt-buttons .btn-group .btn {
     padding: 0.25rem 0.5rem;
     font-size: 0.875rem;
 }

--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -305,10 +305,20 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
                   "colvis": "{{ trans('backpack::crud.export.column_visibility') }}"
               },
           },
-        dom:
-            "<'row hidden'<'col-sm-6'i><'col-sm-6 d-print-none'f>>" +
-            "<'table-content row'<'col-sm-12'tr>>" +
-            "<'table-footer row mt-2 d-print-none align-items-center '<'col-sm-12 col-md-4'l><'col-sm-0 col-md-4 text-center'B><'col-sm-12 col-md-4 'p>>",
+        layout: {
+            topStart: null,
+            topEnd: null,
+            bottomStart: 'pageLength',
+            bottomEnd: {
+                paging: {
+                    firstLast: false,
+                }
+            },
+            bottom: {
+            info: false
+            }
+        },
+        
         buttons: []
     };
     

--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -308,17 +308,20 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
         layout: {
             topStart: null,
             topEnd: null,
-            bottomStart: 'pageLength',
-            bottomEnd: {
-                paging: {
-                    firstLast: false,
+            bottomEnd: null,
+            bottomStart: null,
+            bottom: [
+                'pageLength',
+                {
+                    buttons: config.exportButtons ? window.crud.exportButtonsConfig : []
+                },
+                {
+                    paging: {
+                        firstLast: false,
+                    }
                 }
-            },
-            bottom: {
-            info: false
-            }
+            ]
         },
-        
         buttons: []
     };
     
@@ -416,7 +419,7 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
     
     // Configure export buttons if present
     if (config.exportButtons) {
-        dataTableConfig.buttons = window.crud.exportButtonsConfig;
+        dataTableConfig.layout.bottom.buttons = window.crud.exportButtonsConfig;
     }
     
     
@@ -536,8 +539,6 @@ function setupTableUI(tableId, config) {
         }
     });
     window.dispatchEvent(event);
-    // move the bottom buttons before pagination
-    $(`#bottom_buttons_${tableId}`).insertBefore($(`#${tableId}_wrapper .row:last-child`));
 }
 
 // Function to set up table event handlers

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -37,6 +37,7 @@
             {
                 extend: 'collection',
                 text: '<i class="la la-download"></i> {{ trans('backpack::crud.export.export') }}',
+                className: 'buttons-collection dropdown-toggle',
                 dropup: true,
                 buttons: [
                     {
@@ -134,6 +135,7 @@
             ,{
                 extend: 'colvis',
                 text: '<i class="la la-eye-slash"></i> {{ trans('backpack::crud.export.column_visibility') }}',
+                className: 'buttons-collection dropdown-toggle',
                 columns: function ( idx, data, node ) {
                     return $(node).attr('data-can-be-visible-in-table') == 'true';
                 },
@@ -148,14 +150,12 @@
             var table = window.crud.tables[tableId];
             
             if (!table || !table.buttons) return;
-            
             table.buttons().each(function(button) {
                 if (button.node.className.indexOf('buttons-columnVisibility') == -1 && button.node.nodeName=='BUTTON') {
-                    button.node.className = button.node.className + " btn-sm";
+                    button.node.className = button.node.className.replace('btn-secondary', 'btn-sm');
                 }
             });
-            
-            $(`#${tableId}_wrapper .dt-buttons`).appendTo($('.datatable_button_stack'));
+
             $('.dt-buttons').addClass('d-xs-block')
                             .addClass('d-sm-inline-block')
                             .addClass('d-md-inline-block')


### PR DESCRIPTION
The `dom` property we were using to define the layout of the datatable is deprecated in the current version and will be removed in next one. 

For that reason it was not possible to remove the `Next` and `Previous` buttons from the pagination. 

I've change it to use the proper `layout` property.