### PR TITLE
Added general chip blade file and chip widget

### DIFF
--- a/src/resources/views/crud/chips/general.blade.php
+++ b/src/resources/views/crud/chips/general.blade.php
@@ -1,0 +1,48 @@
+@php
+    $text = $text ?? null;
+    $title = $title ?? null;
+    $target = $target ?? "_self";
+    $url = $url ?? null;
+    $details = $details ?? [];
+    $image = $image ?? null;
+    $showImage = isset($showImage) ? $showImage : !empty($image);
+@endphp
+
+<div class="row align-items-center">
+    @if ($showImage)
+        <div class="col-auto">
+            <div class="d-block">
+                @if ($url)
+                    <a href="{{ $url }}" title="{{ $title }}" target="{{ $target }}" class="d-inline-block">
+                @endif
+                @if ($image)
+                <span class="avatar avatar-2 rounded" style="background-image: url({{ $image }})"> </span>
+                @else
+                <span class="avatar avatar-2 rounded bg-secondary text-white">
+                    {{ $title ? mb_substr($title, 0, 1, 'UTF-8') : 'A' }}
+                </span>
+                @endif
+                @if ($url)
+                    </a>
+                @endif
+            </div>
+        </div>
+    @endif
+    <div class="col text-truncate">
+        <div class="d-block">
+            <a @if ($url) href="{{ $url }}" @endif class="mb-1 d-inline-block @if (!$url) text-dark @endif" title="{{ $title }}" target="{{ $target }}">
+                {{ $text }}
+            </a>
+        </div>
+        <div class="d-block text-secondary text-truncate mt-n1">
+            @foreach ($details as $key => $detail)
+                <small class="d-inline-block me-1">
+                    <i class="{{ $detail['icon'] }}" title="{{ $detail['title'] ?? '' }}"></i>
+                    <a @if (isset($detail['url']) && $detail['url'] != null) href="{{ $detail['url'] }}" @endif
+                        class="text-reset"
+                        title="{{ $detail['title'] ?? '' }}">{{ $detail['text'] }}</a>
+                </small>
+            @endforeach
+        </div>
+    </div>
+</div>

--- a/src/resources/views/crud/chips/general.blade.php
+++ b/src/resources/views/crud/chips/general.blade.php
@@ -1,14 +1,21 @@
 @php
+    // the main text showing in the chip
     $text = $text ?? null;
     $title = $title ?? null;
-    $target = $target ?? "_self";
+
+    // the URL for the main text and image (if any)
     $url = $url ?? null;
-    $details = $details ?? [];
+    $target = $target ?? "_self";
+
+    // the image (if any)
     $image = $image ?? null;
     $showImage = isset($showImage) ? $showImage : !empty($image);
+
+    // the details that show up on the second row (if any)
+    $details = $details ?? [];
 @endphp
 
-<div class="row align-items-center">
+<div class="row align-items-center bp-chip">
     @if ($showImage)
         <div class="col-auto">
             <div class="d-block">

--- a/src/resources/views/crud/chips/general.blade.php
+++ b/src/resources/views/crud/chips/general.blade.php
@@ -1,53 +1,83 @@
 @php
-    // the main text showing in the chip
-    $text = $text ?? null;
-    $title = $title ?? null;
+    $defaultHeading = [
+        'content' => null, // text to show in the heading
+        'element' => 'a',
+        'class' => 'mb-1 d-inline-block',
+    ];
 
-    // the URL for the main text and image (if any)
-    $url = $url ?? null;
-    $target = $target ?? "_self";
+    $defaultImage = [
+        'content' => null, // image url
+        'element' => 'a',
+        'class' => 'avatar avatar-2 rounded',
+    ];
 
-    // the image (if any)
-    $image = $image ?? null;
-    $showImage = isset($showImage) ? $showImage : !empty($image);
+    // merge any passed parameters with the defaults
+    $heading = array_merge($defaultHeading, $heading ?? []); // the main heading showing in the chip
+    $image = array_merge($defaultImage, $image ?? []); // the image that shows up in the chip (if any)
+    $details = $details ?? []; // the details that show up on the second row (if any)
 
-    // the details that show up on the second row (if any)
-    $details = $details ?? [];
+    // ensure the details have the minimum info
+    foreach ($details as $key => $detail) {
+        $details[$key]['element'] = $detail['element'] ?? 'span';
+        $details[$key]['class'] = $detail['class'] ?? 'text-reset';
+    }
+
+    // if the heading has a href, target and tile, and the image does not
+    // then use those for the image as well
+    if ($image['content'] !== null && $heading['content'] !== null) {
+        $image['href'] = $image['href'] ?? $heading['href'] ?? null;
+        $image['title'] = $image['title'] ?? $heading['title'] ?? null;
+        $image['target'] = $image['target'] ?? $heading['target'] ?? null;
+    }
 @endphp
 
 <div class="row align-items-center bp-chip">
-    @if ($showImage)
+    @if ($image['content'])
         <div class="col-auto">
             <div class="d-block">
-                @if ($url)
-                    <a href="{{ $url }}" title="{{ $title }}" target="{{ $target }}" class="d-inline-block">
-                @endif
-                @if ($image)
-                <span class="avatar avatar-2 rounded" style="background-image: url({{ $image }})"> </span>
-                @else
-                <span class="avatar avatar-2 rounded bg-secondary text-white">
-                    {{ $title ? mb_substr($title, 0, 1, 'UTF-8') : 'A' }}
-                </span>
-                @endif
-                @if ($url)
-                    </a>
+                @if ($image['content'])
+                    <{{ $image['element'] }}
+                        @foreach ($image as $attribute => $value)
+                            @if ($attribute !== 'element' && $attribute !== 'content')
+                                {{ $attribute }}="{{ $value }}"
+                            @endif
+                        @endforeach
+                    >
+                        <span class="avatar avatar-2 rounded" style="background-image: url({{ $image['content'] }})"> </span>
+                    </{{ $image['element'] }}>
                 @endif
             </div>
         </div>
     @endif
     <div class="col text-truncate">
         <div class="d-block">
-            <a @if ($url) href="{{ $url }}" @endif class="mb-1 d-inline-block @if (!$url) text-dark @endif" title="{{ $title }}" target="{{ $target }}">
-                {{ $text }}
-            </a>
+            @if ($heading['content'])
+                <{{ $heading['element'] }}
+                    @foreach ($heading as $attribute => $value)
+                        @if ($attribute !== 'element' && $attribute !== 'content')
+                            {{ $attribute }}="{{ $value }}"
+                        @endif
+                    @endforeach
+                >
+                    {{ $heading['content'] }}
+                </{{ $heading['element'] }}>
+            @endif
         </div>
         <div class="d-block text-secondary text-truncate mt-n1">
             @foreach ($details as $key => $detail)
                 <small class="d-inline-block me-1">
+                    @if (isset($detail['icon']))
                     <i class="{{ $detail['icon'] }}" title="{{ $detail['title'] ?? '' }}"></i>
-                    <a @if (isset($detail['url']) && $detail['url'] != null) href="{{ $detail['url'] }}" @endif
-                        class="text-reset"
-                        title="{{ $detail['title'] ?? '' }}">{{ $detail['text'] }}</a>
+                    @endif
+                    <{{ $detail['element'] }}
+                        @foreach ($detail as $attribute => $value)
+                            @if ($attribute !== 'element' && $attribute !== 'icon' && $attribute !== 'content')
+                                {{ $attribute }}="{{ $value }}"
+                            @endif
+                        @endforeach
+                        >
+                        {{ $detail['content'] }}
+                    </{{ $detail['element'] }}>
                 </small>
             @endforeach
         </div>

--- a/src/resources/views/crud/widgets/chip.blade.php
+++ b/src/resources/views/crud/widgets/chip.blade.php
@@ -1,0 +1,17 @@
+@php
+	// preserve backwards compatibility with Widgets in Backpack 4.0
+	$widget['wrapper']['class'] = $widget['wrapper']['class'] ?? $widget['wrapperClass'] ?? 'col';
+@endphp
+
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_start'))
+
+    @if(!empty($widget['title']))
+    <h4 class="mt-4 mb-2">{{ $widget['title'] }}</h4>
+    @endif
+
+	<div class="{{ $widget['class'] ?? 'card' }}">
+        <div class="card-body">
+            @include($widget['view'], ['entry' => $widget['entry']])
+        </div>
+	</div>
+@includeWhen(!empty($widget['wrapper']), backpack_view('widgets.inc.wrapper_end'))


### PR DESCRIPTION
This PR adds two new files (and features):
- a `crud::chips.general` file, that developers can use to showcase an Eloquent entry (or anything, really);
- a `chip` widget, that developer can use to show a chip within a card, using the Widget syntax;

