### PR TITLE
Drop support for Laravel 10 and 11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,9 +26,6 @@ jobs:
                 phpunit: [10.*, 11.*]
                 dependency-version: [stable] # to add: lowest
                 exclude:
-                    -   laravel: "^12.0"
-                        php: "8.2"
-                        dbal: "^3.0"
                     -   phpunit: "10.*"
                         laravel: "^12.0"
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,11 +23,8 @@ jobs:
                 php: ['8.2', '8.3', '8.4']
                 laravel: [^12.0]
                 dbal: [^3.0]
-                phpunit: [10.*, 11.*]
+                phpunit: [11.*]
                 dependency-version: [stable] # to add: lowest
-                exclude:
-                    -   phpunit: "10.*"
-                        laravel: "^12.0"
 
         name: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}, PHPUnit ${{ matrix.phpunit }}, DBAL ${{ matrix.dbal }} --prefer-${{ matrix.dependency-version }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,7 +22,7 @@ jobs:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
                 php: ['8.2', '8.3', '8.4']
                 laravel: [^12.0]
-                dbal: [^3.0]
+                dbal: [^4.0]
                 phpunit: [11.*]
                 dependency-version: [stable] # to add: lowest
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,23 +20,15 @@ jobs:
             # run all combinations of the following, to make sure they're working together
             matrix:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
-                php: ['8.1', '8.2', '8.3', '8.4']
-                laravel: [^10.0, ^11.0, ^12.0]
+                php: ['8.2', '8.3', '8.4']
+                laravel: [^12.0]
                 dbal: [^3.0]
                 phpunit: [10.*, 11.*]
                 dependency-version: [stable] # to add: lowest
                 exclude:
-                    -   laravel: "^11.0"
-                        php: "8.1"
-                        dbal: "^3.0"
-                    -   laravel: "^12.0"
-                        php: "8.1"
-                        dbal: "^3.0"
                     -   laravel: "^12.0"
                         php: "8.2"
                         dbal: "^3.0"
-                    -   phpunit: "11.*"
-                        laravel: "^10.0"
                     -   phpunit: "10.*"
                         laravel: "^12.0"
 

--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,12 @@
         "backpack/basset": "^2.0.0-alpha",
         "creativeorange/gravatar": "^1.0",
         "prologue/alerts": "^1.0",
-        "doctrine/dbal": "^3.0|^4.0",
+        "doctrine/dbal": "^4.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^9.0|^11.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^11.0",
+        "orchestra/testbench": "^10.0",
         "spatie/laravel-translatable": "^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "^10.0|^11.0|^12",
+        "laravel/framework": "^12",
         "backpack/basset": "^2.0.0-alpha",
         "creativeorange/gravatar": "^1.0",
         "prologue/alerts": "^1.0",


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

We supported L10 and L11 as well. Which could make it very difficult for us to support L13 when it comes - too many versions of Laravel (and PHP) supported.

### AFTER - What is happening after this PR?

We don't.