### PR TITLE
fix: remove duplicate word in Backpack config comment

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -28,7 +28,7 @@ return [
 
     // The web middleware (group) used in all base & CRUD routes
     // If you've modified your "web" middleware group (ex: removed sessions), you can use a different
-    // route group, that has all the the middleware listed below in the comments.
+    // route group, that has all the middleware listed below in the comments.
     'web_middleware' => 'web',
     // Or you can comment the above, and uncomment the complete list below.
     // 'web_middleware' => [


### PR DESCRIPTION
## WHY

This PR fixes a small typo in the config/backpack/base.php file by removing a duplicated word ("the the") from a comment:

### BEFORE - What was wrong? What was happening before this PR?

"... all the the middleware listed below ..."

### AFTER - What is happening after this PR?

"... all the middleware listed below ..."
