### PR TITLE
ensure proper crud identification

### DIFF
--- a/src/CrudPanelManager.php
+++ b/src/CrudPanelManager.php
@@ -213,7 +213,8 @@ final class CrudPanelManager
 
         foreach ($trace as $step) {
             if (isset($step['class']) &&
-                is_a($step['class'], CrudControllerContract::class, true)) {
+                is_a($step['class'], CrudControllerContract::class, true) &&
+                ! is_a($step['class'], CrudController::class, true)) {
                 $controller = (string) $step['class'];
                 break;
             }
@@ -228,7 +229,7 @@ final class CrudPanelManager
         $cruds = $this->getCrudPanels();
 
         if (! empty($cruds)) {
-            $crudPanel = reset($cruds);
+            $crudPanel = end($cruds);
 
             return $crudPanel;
         }


### PR DESCRIPTION
This PR aims to fix the crud identification method, by making sure it's more resilient by:
- removing the actual "CrudController" (the one extended by crud controllers) from beeing picked up
- instead of returning the "first controller" from the array, we return the last one. There was actually no reason to return the first controller and returning the last is more accurate.