### PR TITLE
fix hooks

### DIFF
--- a/src/app/Library/CrudPanel/Hooks/LifecycleHooks.php
+++ b/src/app/Library/CrudPanel/Hooks/LifecycleHooks.php
@@ -25,7 +25,8 @@ final class LifecycleHooks
 
         foreach ($hooks as $hook) {
             // Create a unique identifier for this controller+hook combination
-            $hookId = is_null($controller) ? '' : (is_string($controller) ? $controller : $controller::class.'::'.$hook);
+            // Include the full hook name (which includes operation) to ensure uniqueness per operation
+            $hookId = is_null($controller) ? $hook : (is_string($controller) ? $controller : $controller::class).'::'.$hook;
 
             // Skip if this hook has already been executed
             if (isset($this->executedHooks[$hookId])) {


### PR DESCRIPTION
We had an issue while generating the hook key, so if more than one operation registered the same hook it wouldn't properly create the identifier and the second operation wouldn't have their hooks ran. 

This was noticeable if we have 2 forms for the same controller, one for create and one for edit (as in our v7 examples). The second form (edit) wasn't able to register hooks that were previously ran by the create operation. 