### PR TITLE
map the ui files

### DIFF
--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -63,6 +63,26 @@ class BackpackServiceProvider extends ServiceProvider
         $this->sendUsageStats();
 
         Basset::addViewPath(realpath(__DIR__.'/resources/views'));
+
+        foreach (config('backpack.ui.styles', []) as $style) {
+            if (is_array($style)) {
+                foreach ($style as $file) {
+                    Basset::map($file);
+                }
+            } else {
+                Basset::map($style);
+            }
+        }
+
+        foreach (config('backpack.ui.scripts', []) as $script) {
+            if (is_array($script)) {
+                foreach ($script as $file) {
+                    Basset::map($file);
+                }
+            } else {
+                Basset::map($script);
+            }
+        }
     }
 
     /**

--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -92,6 +92,26 @@ class ThemeServiceProvider extends ServiceProvider
 
         // Add basset view path
         Basset::addViewPath($this->packageViewsPath());
+
+        foreach (config($this->vendorNameDotPackageName().'.styles', []) as $path) {
+            if (is_array($path)) {
+                foreach ($path as $style) {
+                    Basset::map($style, $style);
+                }
+            } else {
+                Basset::map($path, $path);
+            }
+        }
+
+        foreach (config($this->vendorNameDotPackageName().'.scripts', []) as $path) {
+            if (is_array($path)) {
+                foreach ($path as $script) {
+                    Basset::map($script, $script);
+                }
+            } else {
+                Basset::map($path, $path);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
UI assets were not mapped, so they would only be "downloaded" when first encountered on page, not during the `basset:cache` command.