### PR TITLE
fix table without export buttons

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -97,9 +97,9 @@ div[id$="_wrapper"] .dt-processing {
     top: 0 !important;
     left: 0 !important;
     right: 0 !important;
-    bottom: 60px !important;
+    bottom: 40px !important;
     width: 100% !important;
-    height: calc(100% - 60px) !important;
+    height: calc(100% - 40px) !important;
     transform: none !important;
     margin: 0 !important;
     z-index: 1000 !important;

--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -310,19 +310,25 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
             topEnd: null,
             bottomEnd: null,
             bottomStart: null,
-            bottom: [
+            bottom: config.exportButtons ? [
                 'pageLength',
                 {
-                    buttons: config.exportButtons ? window.crud.exportButtonsConfig : []
+                    buttons: window.crud.exportButtonsConfig
                 },
                 {
                     paging: {
                         firstLast: false,
                     }
                 }
+            ] : [
+                'pageLength',
+                {
+                    paging: {
+                        firstLast: false,
+                    }
+                }
             ]
-        },
-        buttons: []
+        }
     };
     
     // Add responsive details if needed
@@ -552,6 +558,14 @@ function setupTableUI(tableId, config) {
         new $.fn.dataTable.Buttons(window.crud.tables[tableId], {
             buttons: window.crud.exportButtonsConfig
         });
+        
+        if (typeof window.crud.moveExportButtonsToTopRight === 'function') {
+            config.addFunctionToDataTablesDrawEventQueue('moveExportButtonsToTopRight');
+        }
+        if (typeof window.crud.setupExportHandlers === 'function') {
+            config.addFunctionToDataTablesDrawEventQueue('setupExportHandlers');
+        }
+        
         // Initialize the buttons and place them in the correct container
         if (typeof window.crud.moveExportButtonsToTopRight === 'function') {
             window.crud.moveExportButtonsToTopRight(tableId);

--- a/src/resources/views/crud/inc/export_buttons.blade.php
+++ b/src/resources/views/crud/inc/export_buttons.blade.php
@@ -186,9 +186,6 @@
                             .addClass('d-md-inline-block')
                             .addClass('d-lg-inline-block');
         };
-    
-        // Add the function to the draw event queue
-        window.crud.defaultTableConfig.addFunctionToDataTablesDrawEventQueue('moveExportButtonsToTopRight');
 
         window.crud.setupExportHandlers = function(tableId) {
             tableId = tableId || 'crudTable';
@@ -229,9 +226,6 @@
                 }
             });
         };
-
-        // Add the export handler setup to the draw event queue
-        window.crud.defaultTableConfig.addFunctionToDataTablesDrawEventQueue('setupExportHandlers');
     </script>
     @push('after_styles')
         @basset('https://cdn.datatables.net/buttons/3.2.0/css/buttons.bootstrap5.min.css')


### PR DESCRIPTION
When a Datatable had the export buttons disabled, we would wrongly setup functions in the draw queue that would make the table fail to load. 

By removing those functions when there is no export buttons, everything works again 🙏 