### PR TITLE
Heading partial

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable.blade.php
@@ -3,9 +3,10 @@
     $tableId = $tableId ?? 'crudTable';
 @endphp
 <section class="header-operation datatable-header animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-          <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-          <p class="ms-2 ml-2 mb-0" id="datatable_info_stack_{{$tableId}}" bp-section="page-subheading">{!! $crud->getSubheading() ?? '' !!}</p>
-        </section>
+  <h1 class="text-capitalize mb-0" bp-section="page-heading">{{ $crud->getHeading() ?? $crud->entity_name_plural }}</h1>
+  <p class="ms-2 ml-2 mb-0" id="datatable_info_stack_{{$tableId}}" bp-section="page-subheading">{{ $crud->getSubheading() ?? '' }}</p>
+</section>
+
 <div class="row mb-2 align-items-center">
   <div class="col-sm-9">
     @if ( $crud->buttons()->where('stack', 'top')->count() ||  $crud->exportButtons())

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -12,19 +12,9 @@
 @endphp
 
 @section('header')
-    <section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.add').' '.$crud->entity_name !!}.</p>
-        @if ($crud->hasAccess('list'))
-            <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small>
-                    <a href="{{ url($crud->route) }}" class="d-print-none font-sm">
-                        <span><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></span>
-                    </a>
-                </small>
-            </p>
-        @endif
-    </section>
+    @include('crud::inc.header', [
+        'subtitle_fallback' => trans('backpack::crud.add').' '.$crud->entity_name,
+    ])
 @endsection
 
 @section('content')

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -12,15 +12,9 @@
 @endphp
 
 @section('header')
-    <section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</p>
-        @if ($crud->hasAccess('list'))
-            <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-            </p>
-        @endif
-    </section>
+    @include('crud::inc.header', [
+        'subtitle_fallback' => trans('backpack::crud.edit').' '.$crud->entity_name,
+    ])
 @endsection
 
 @section('content')

--- a/src/resources/views/crud/inc/form_page.blade.php
+++ b/src/resources/views/crud/inc/form_page.blade.php
@@ -12,17 +12,9 @@
 @endphp
 
 @section('header')
-<section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-    <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-    <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? Str::of($operation)->headline() !!}.</p>
-    @if ($crud->hasAccess('list'))
-        <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-            <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i
-                        class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i>
-                    {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-        </p>
-    @endif
-</section>
+    @include('crud::inc.header', [
+        'subtitle_fallback' => Str::of($operation)->headline(),
+    ])
 @endsection
 
 @section('content')

--- a/src/resources/views/crud/inc/header.blade.php
+++ b/src/resources/views/crud/inc/header.blade.php
@@ -1,0 +1,9 @@
+<section class="header-operation container-fluid animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
+    <h1 class="text-capitalize mb-0" bp-section="page-heading">{{ $crud->getHeading() ?? $crud->entity_name_plural }}</h1>
+    <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{{ $crud->getSubheading() ?? $subtitle_fallback }}.</p>
+    @if ($crud->hasAccess('list'))
+        <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
+            <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+        </p>
+    @endif
+</section>

--- a/src/resources/views/crud/reorder.blade.php
+++ b/src/resources/views/crud/reorder.blade.php
@@ -14,15 +14,9 @@
 @endphp
 
 @section('header')
-    <section class="header-operation container-fluid animated fadeIn d-flex align-items-baseline d-print-none" bp-section="page-header">
-        <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-        <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.reorder').' '.$crud->entity_name_plural !!}</p>
-        @if ($crud->hasAccess('list'))
-            <p class="ms-2 ml-2 mb-0" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-            </p>
-        @endif
-    </section>
+    @include('crud::inc.header', [
+        'subtitle_fallback' => trans('backpack::crud.reorder').' '.$crud->entity_name_plural,
+    ])
 @endsection
 
 @section('content')

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -13,15 +13,9 @@
 
 @section('header')
     <div class="container-fluid d-flex justify-content-between my-3">
-        <section class="header-operation animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
-            <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
-            <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? mb_ucfirst(trans('backpack::crud.preview')).' '.$crud->entity_name !!}</p>
-            @if ($crud->hasAccess('list'))
-                <p class="ms-2 ml-2 mb-0" bp-section="page-subheading-back-button">
-                    <small><a href="{{ url($crud->route) }}" class="font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
-                </p>
-            @endif
-        </section>
+        @include('crud::inc.header', [
+            'subtitle_fallback' => trans('backpack::crud.preview').' '.$crud->entity_name,
+        ])
         <a href="javascript: window.print();" class="btn float-end float-right"><i class="la la-print"></i></a>
     </div>
 @endsection


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The header was vulnerable to cross site scripting. #5839

### AFTER - What is happening after this PR?

The header escapes its contents, but can also be published if the developer wants to restore the previous behaviour.

## HOW

### How did you achieve that, in technical terms?

- Extracted a header template include and replace its uses
- Introduced a `subtitle_fallback` variable that can be passed from the including template

### Is it a breaking change?

Yes. On their next upgrade users might want to adjust any published templates.

### How can we test the before & after?

Set an entity name to an XSS attack.

```php
$this->crud->setEntityNameStrings('', '<img src="x" onerror="alert(\'XSS\')">');
```

View the edit page for then entity, it should show the HTML rather than triggering a JavaScript alert.