### PR TITLE
allow user to choose locale and timezone

### DIFF
--- a/src/resources/views/crud/columns/date.blade.php
+++ b/src/resources/views/crud/columns/date.blade.php
@@ -5,6 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['format'] = $column['format'] ?? backpack_theme_config('default_date_format');
+    $column['locale'] = $column['locale'] ?? App::getLocale();
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {
@@ -12,9 +13,14 @@
     }
 
     if(!empty($column['value'])) {
-        $date = \Carbon\Carbon::parse($column['value'])
-            ->locale(App::getLocale())
-            ->isoFormat($column['format']);
+        $date = \Carbon\Carbon::parse($column['value']);
+
+        if ($column['format'] instanceof \Closure) {
+            $date = $column['format']($date, $entry);
+        } else {
+            $date = $date->locale($column['locale'])
+                ->isoFormat($column['format']);
+        }
 
         $column['text'] = $column['prefix'].$date.$column['suffix'];
     }

--- a/src/resources/views/crud/columns/datetime.blade.php
+++ b/src/resources/views/crud/columns/datetime.blade.php
@@ -5,6 +5,7 @@
     $column['prefix'] = $column['prefix'] ?? '';
     $column['suffix'] = $column['suffix'] ?? '';
     $column['format'] = $column['format'] ?? backpack_theme_config('default_datetime_format');
+    $column['locale'] = $column['locale'] ?? App::getLocale();
     $column['text'] = $column['default'] ?? '-';
 
     if($column['value'] instanceof \Closure) {
@@ -12,9 +13,14 @@
     }
 
     if(!empty($column['value'])) {
-        $date = \Carbon\Carbon::parse($column['value'])
-            ->locale(App::getLocale())
-            ->isoFormat($column['format']);
+        $date = \Carbon\Carbon::parse($column['value']);
+
+        if ($column['format'] instanceof \Closure) {
+            $date = $column['format']($date, $entry);
+        } else {
+            $date = $date->locale($column['locale'])
+                ->isoFormat($column['format']);
+        }
 
         $column['text'] = $column['prefix'].$date.$column['suffix'];
     }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Users could not choose locale, were forced to use iso format and could not set a custom format

### AFTER - What is happening after this PR?

Users have the option of locale, though it still defaults to the app locale or can use an entirely custom format


## HOW

### How did you achieve that, in technical terms?

You can set the locale on the column or you can set a closure for a format to do it entirely custom. You can have it set a timezone or return a diff instead of a time itself


### Is it a breaking change?

No


### How can we test the before & after?

You can set a format custom function. I set a column like this:
`CRUD::column('created_at')->format(fn($date) => $date->timezone('America/New_York')->toDateTimeString());`

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
