### PR TITLE
Add toggle to JSON

### DIFF
--- a/src/resources/views/crud/columns/json.blade.php
+++ b/src/resources/views/crud/columns/json.blade.php
@@ -6,6 +6,11 @@
     $column['suffix'] = $column['suffix'] ?? '';
     $column['wrapper']['element'] = $column['wrapper']['element'] ?? 'pre';
     $column['text'] = $column['default'] ?? '-';
+    $column['toggle'] = $column['toggle'] ?? false;
+
+    if ($column['toggle']) {
+        $column['wrapper']['class'] = 'd-none mt-2';
+    }
 
     if(is_string($column['value'])) {
         $column['value'] = json_decode($column['value'], true);
@@ -20,6 +25,9 @@
     }
 @endphp
 
+@if ($column['toggle'])
+<button type="button" class="btn btn-sm btn-info" onclick="this.nextElementSibling.classList.toggle('d-none');this.textContent=='Show'?this.textContent='Hide':this.textContent='Show'">Show</button>
+@endif
 @includeWhen(!empty($column['wrapper']), 'crud::columns.inc.wrapper_start')
 @if($column['escaped'])
 {{ $column['text'] }}


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

JSON columns could take up a lot of space

### AFTER - What is happening after this PR?

You can choose to hide them by default


## HOW

### How did you achieve that, in technical terms?

Added a new `toggle` option to JSON fields



### Is it a breaking change?

No


### How can we test the before & after?

Set `toggle` to `true` on a JSON field

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
