### PR TITLE
Add bp-section for language dropdowns

### DIFF
--- a/src/resources/views/crud/inc/edit_translation_notice.blade.php
+++ b/src/resources/views/crud/inc/edit_translation_notice.blade.php
@@ -46,7 +46,7 @@
             }
         }
     @endphp
-<div class="mb-2 text-left text-start">
+<div class="mb-2 text-left text-start" bp-section="update-operation-language-dropdown">
     <div class="btn-group col-md-2 text-left text-start"  style="margin-top:0.8em; display:inline;">
         <button 
             type="button" 

--- a/src/resources/views/crud/show.blade.php
+++ b/src/resources/views/crud/show.blade.php
@@ -34,7 +34,7 @@
 	<div class="">
 	@if ($crud->model->translationEnabled())
 		<div class="row">
-			<div class="col-md-12 mb-2">
+			<div class="col-md-12 mb-2" bp-section="show-operation-language-dropdown">
 				{{-- Change translation button group --}}
 				<div class="btn-group float-right">
 				<button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Couldn't target the language dropdowns with CSS or JS because they had no identifiers.

### AFTER - What is happening after this PR?

You can.
