### PR TITLE
Fix column default for mariadb

### DIFF
--- a/src/app/Library/Database/DatabaseSchema.php
+++ b/src/app/Library/Database/DatabaseSchema.php
@@ -95,7 +95,7 @@ final class DatabaseSchema
             return $index['columns'];
         }, $indexes);
 
-        $table = new Table($tableName, $table);
+        $table = new Table($tableName, $table, $schemaManager);
 
         $indexes = Arr::flatten($indexes);
         $table->setIndexes(array_unique($indexes));

--- a/src/app/Library/Database/Table.php
+++ b/src/app/Library/Database/Table.php
@@ -30,10 +30,10 @@ final class Table
 
                 public function getDefault()
                 {
-                    return isset($this->schemaManager) ? 
-                        (is_a($this->schemaManager->getConnection(), \Illuminate\Database\MariaDbConnection::class) && 
+                    return isset($this->schemaManager) ?
+                        (is_a($this->schemaManager->getConnection(), \Illuminate\Database\MariaDbConnection::class) &&
                             is_string($this->column['default']) &&
-                            $this->column['nullable'] === true &&  
+                            $this->column['nullable'] === true &&
                             ($this->column['default'] === 'null' || $this->column['default'] === 'NULL') ? null : $this->column['default']) : $this->column['default'];
                 }
 

--- a/src/app/Library/Database/Table.php
+++ b/src/app/Library/Database/Table.php
@@ -8,13 +8,13 @@ final class Table
     private array $columns = [];
     private array $indexes = [];
 
-    public function __construct(string $name, array $columns = [])
+    public function __construct(string $name, array $columns = [], $schemaManager = null)
     {
         $this->name = $name;
         foreach ($columns as $column) {
-            $this->columns[$column['name']] = new class($column)
+            $this->columns[$column['name']] = new class($column, $schemaManager)
             {
-                public function __construct(private array $column)
+                public function __construct(private array $column, private $schemaManager)
                 {
                 }
 
@@ -30,7 +30,11 @@ final class Table
 
                 public function getDefault()
                 {
-                    return $this->column['default'];
+                    return isset($this->schemaManager) ? 
+                        (is_a($this->schemaManager->getConnection(), \Illuminate\Database\MariaDbConnection::class) && 
+                            is_string($this->column['default']) &&
+                            $this->column['nullable'] === true &&  
+                            ($this->column['default'] === 'null' || $this->column['default'] === 'NULL') ? null : $this->column['default']) : $this->column['default'];
                 }
 
                 public function getUnsigned()


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

reported in https://github.com/laravel-backpack/crud/issues/5659

Mariadb connections return `'NULL'` (string) when there is no default for the column, so it would populate our fields with the `NULL` string, instead of they actually beeing `null` (empty)

### AFTER - What is happening after this PR?

it properly checks if it's a mariadb connection, if it is, we parse the value to ensure we return the expected null as in other rdbms. 

