### PR TITLE
Test on PHP 8.5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
             # run all combinations of the following, to make sure they're working together
             matrix:
                 # os: [ubuntu-latest, macos-latest, windows-latest]
-                php: ['8.2', '8.3', '8.4']
+                php: ['8.2', '8.3', '8.4', '8.5']
                 laravel: [^12.0]
                 dbal: [^4.0]
                 phpunit: [11.*]


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Tests were not run on the latest PHP RC version (8.5; see https://www.php.net/archive/2025.php#2025-09-25-3).

### AFTER - What is happening after this PR?

Tests run on PHP 8.5, in preparation for the stable release, to allow for spotting any deprecations or other issues.


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change?

-


### How can we test the before & after?

No

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
(other repos might require similar changes)