### PR TITLE
Implement Widget Positioning Methods

### DIFF
--- a/src/app/Library/Widget.php
+++ b/src/app/Library/Widget.php
@@ -106,14 +106,74 @@ class Widget extends Fluent
         return $this;
     }
 
-    // TODO: add ability to push a widget right after another widget
+    /**
+     * Move this widget to appear right after another widget.
+     *
+     * @param  string  $destination  The name of the destination widget.
+     * @return Widget
+     */
     public function after($destination)
     {
+        $collection = $this->collection();
+        $widgets = $collection->all();
+        
+        // Check if destination widget exists
+        if (! isset($widgets[$destination])) {
+            return $this;
+        }
+        
+        // Remove current widget from collection
+        $currentWidget = $collection->pull($this->attributes['name']);
+        
+        // Find the position of the destination widget
+        $keys = array_keys($widgets);
+        $position = array_search($destination, $keys);
+        
+        // Insert after the destination
+        $before = array_slice($widgets, 0, $position + 1, true);
+        $after = array_slice($widgets, $position + 1, null, true);
+        
+        $newWidgets = $before + [$this->attributes['name'] => $currentWidget] + $after;
+        
+        // Update the collection
+        $collection->replace($newWidgets);
+        
+        return $this;
     }
 
-    // TODO: add ability to push a widget right before another widget
+    /**
+     * Move this widget to appear right before another widget.
+     *
+     * @param  string  $destination  The name of the destination widget.
+     * @return Widget
+     */
     public function before($destination)
     {
+        $collection = $this->collection();
+        $widgets = $collection->all();
+        
+        // Check if destination widget exists
+        if (! isset($widgets[$destination])) {
+            return $this;
+        }
+        
+        // Remove current widget from collection
+        $currentWidget = $collection->pull($this->attributes['name']);
+        
+        // Find the position of the destination widget
+        $keys = array_keys($widgets);
+        $position = array_search($destination, $keys);
+        
+        // Insert before the destination
+        $before = array_slice($widgets, 0, $position, true);
+        $after = array_slice($widgets, $position, null, true);
+        
+        $newWidgets = $before + [$this->attributes['name'] => $currentWidget] + $after;
+        
+        // Update the collection
+        $collection->replace($newWidgets);
+        
+        return $this;
     }
 
     /**

--- a/tests/Unit/CrudPanel/WidgetTest.php
+++ b/tests/Unit/CrudPanel/WidgetTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
+use Backpack\CRUD\app\Library\Widget;
+use Backpack\CRUD\Tests\BaseTestClass;
+
+class WidgetTest extends BaseTestClass
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Clear the widgets collection before each test
+        Widget::collection()->forget(Widget::collection()->keys()->all());
+    }
+
+    public function testAfterMethodMovesWidgetAfterDestination()
+    {
+        // Create three widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+        Widget::add(['name' => 'widget_3', 'type' => 'card']);
+
+        // Move widget_3 after widget_1
+        Widget::add('widget_3')->after('widget_1');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Expected order: widget_1, widget_3, widget_2
+        $this->assertEquals(['widget_1', 'widget_3', 'widget_2'], $keys);
+    }
+
+    public function testBeforeMethodMovesWidgetBeforeDestination()
+    {
+        // Create three widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+        Widget::add(['name' => 'widget_3', 'type' => 'card']);
+
+        // Move widget_3 before widget_1
+        Widget::add('widget_3')->before('widget_1');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Expected order: widget_3, widget_1, widget_2
+        $this->assertEquals(['widget_3', 'widget_1', 'widget_2'], $keys);
+    }
+
+    public function testAfterMethodWithNonExistentDestinationDoesNothing()
+    {
+        // Create two widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        // Try to move widget_2 after a non-existent widget
+        Widget::add('widget_2')->after('non_existent');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Order should remain unchanged
+        $this->assertEquals(['widget_1', 'widget_2'], $keys);
+    }
+
+    public function testBeforeMethodWithNonExistentDestinationDoesNothing()
+    {
+        // Create two widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        // Try to move widget_2 before a non-existent widget
+        Widget::add('widget_2')->before('non_existent');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Order should remain unchanged
+        $this->assertEquals(['widget_1', 'widget_2'], $keys);
+    }
+
+    public function testAfterMethodWorksWithMultipleWidgets()
+    {
+        // Create five widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+        Widget::add(['name' => 'widget_3', 'type' => 'card']);
+        Widget::add(['name' => 'widget_4', 'type' => 'card']);
+        Widget::add(['name' => 'widget_5', 'type' => 'card']);
+
+        // Move widget_5 after widget_2
+        Widget::add('widget_5')->after('widget_2');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Expected order: widget_1, widget_2, widget_5, widget_3, widget_4
+        $this->assertEquals(['widget_1', 'widget_2', 'widget_5', 'widget_3', 'widget_4'], $keys);
+    }
+
+    public function testBeforeMethodWorksWithMultipleWidgets()
+    {
+        // Create five widgets
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+        Widget::add(['name' => 'widget_3', 'type' => 'card']);
+        Widget::add(['name' => 'widget_4', 'type' => 'card']);
+        Widget::add(['name' => 'widget_5', 'type' => 'card']);
+
+        // Move widget_1 before widget_4
+        Widget::add('widget_1')->before('widget_4');
+
+        $keys = Widget::collection()->keys()->toArray();
+
+        // Expected order: widget_2, widget_3, widget_1, widget_4, widget_5
+        $this->assertEquals(['widget_2', 'widget_3', 'widget_1', 'widget_4', 'widget_5'], $keys);
+    }
+
+    public function testAfterMethodReturnsWidgetInstance()
+    {
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        $widget = Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        $result = $widget->after('widget_1');
+
+        $this->assertInstanceOf(Widget::class, $result);
+    }
+
+    public function testBeforeMethodReturnsWidgetInstance()
+    {
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        $widget = Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        $result = $widget->before('widget_1');
+
+        $this->assertInstanceOf(Widget::class, $result);
+    }
+
+    public function testAfterMethodCanBeChained()
+    {
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        Widget::add(['name' => 'widget_3', 'type' => 'card'])
+            ->after('widget_1')
+            ->type('div');
+
+        $widget = Widget::collection()->get('widget_3');
+
+        $this->assertEquals('div', $widget->attributes['type']);
+    }
+
+    public function testBeforeMethodCanBeChained()
+    {
+        Widget::add(['name' => 'widget_1', 'type' => 'card']);
+        Widget::add(['name' => 'widget_2', 'type' => 'card']);
+
+        Widget::add(['name' => 'widget_3', 'type' => 'card'])
+            ->before('widget_2')
+            ->type('div');
+
+        $widget = Widget::collection()->get('widget_3');
+
+        $this->assertEquals('div', $widget->attributes['type']);
+    }
+}


### PR DESCRIPTION
# Implement Widget Positioning Methods: `after()` and `before()`

## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `Widget` class had two empty placeholder methods (`after()` and `before()`) marked with TODO comments, indicating that the functionality to position widgets relative to other widgets was planned but not yet implemented. This limited developers' ability to precisely control widget ordering in their admin panels.

Developers could only use `makeFirst()` and `makeLast()` methods to position widgets at the beginning or end of a section, but had no way to insert a widget immediately before or after a specific widget in the middle of the collection.

### AFTER - What is happening after this PR?

Developers can now use the `after($destination)` and `before($destination)` methods to position widgets relative to other widgets by name. This provides fine-grained control over widget ordering, allowing for more flexible and intuitive widget management.

Example usage:
```php
// Move a widget to appear right after another widget
Widget::add('my_widget')->after('existing_widget');

// Move a widget to appear right before another widget
Widget::add('another_widget')->before('existing_widget');
```

## HOW

### How did you achieve that, in technical terms?

1. **Implemented `after($destination)` method**: This method moves the current widget to appear immediately after the specified destination widget in the collection. It:
   - Validates that the destination widget exists
   - Removes the current widget from the collection
   - Finds the position of the destination widget
   - Reconstructs the collection with the current widget inserted after the destination
   - Updates the global widget collection

2. **Implemented `before($destination)` method**: This method moves the current widget to appear immediately before the specified destination widget. It follows the same pattern as `after()` but inserts the widget before the destination instead.

3. **Added comprehensive unit tests**: Created `WidgetTest.php` with 10 test cases covering:
   - Basic functionality of both methods
   - Handling of non-existent destination widgets (graceful failure)
   - Complex scenarios with multiple widgets
   - Method chaining capabilities
   - Return type verification

### Technical Implementation Details

Both methods use the following approach:
- Access the widget collection from the service container
- Validate the destination widget exists (returns `$this` if not, allowing for graceful failure)
- Use `array_slice()` to split the collection at the appropriate position
- Reconstruct the collection with the current widget in the new position
- Use Laravel Collection's `replace()` method to update the global collection
- Return `$this` for method chaining

### Is it a breaking change?

**No**, this is not a breaking change. The methods were previously empty placeholders that did nothing, so any existing code calling these methods will continue to work (though it will now actually perform the positioning operation). This is a purely additive feature that enhances existing functionality.

### How can we test the before & after?

**Manual Testing:**

1. Create a test controller or use an existing CRUD controller
2. Add multiple widgets in the `setup()` method:
```php
Widget::add(['name' => 'widget_1', 'type' => 'card', 'content' => ['body' => 'Widget 1']]);
Widget::add(['name' => 'widget_2', 'type' => 'card', 'content' => ['body' => 'Widget 2']]);
Widget::add(['name' => 'widget_3', 'type' => 'card', 'content' => ['body' => 'Widget 3']]);

// Move widget_3 to appear after widget_1
Widget::add('widget_3')->after('widget_1');
```

3. Verify the widgets appear in the order: widget_1, widget_3, widget_2

**Automated Testing:**

Run the new unit tests:
```bash
vendor/bin/phpunit tests/Unit/CrudPanel/WidgetTest.php --testdox
```

Expected output should show all 10 tests passing:
- ✓ After method moves widget after destination
- ✓ Before method moves widget before destination
- ✓ After method with non existent destination does nothing
- ✓ Before method with non existent destination does nothing
- ✓ After method works with multiple widgets
- ✓ Before method works with multiple widgets
- ✓ After method returns widget instance
- ✓ Before method returns widget instance
- ✓ After method can be chained
- ✓ Before method can be chained

## Additional Notes

### Code Quality
- Follows PSR-2 coding standards
- Includes comprehensive PHPDoc comments
- Implements graceful error handling (returns `$this` if destination doesn't exist)
- Maintains fluent interface pattern for method chaining
- Consistent with existing `makeFirst()` and `makeLast()` implementations

### Future Enhancements
This implementation resolves the TODO items in the Widget class. Similar positioning logic could potentially be applied to other areas of the codebase where ordering is important (e.g., the `moveColumn()` method in `ColumnsProtectedMethods.php` has a similar TODO about refactoring).

### Related Issues
This PR addresses the TODO comments found at:
- Line 109 in `src/app/Library/Widget.php` (after method)
- Line 114 in `src/app/Library/Widget.php` (before method)
