### PR TITLE
Fixes stiky header "bumping" in datatables

### DIFF
--- a/src/app/View/Components/Datatable.php
+++ b/src/app/View/Components/Datatable.php
@@ -21,6 +21,7 @@ class Datatable extends Component
         private bool $modifiesUrl = false,
         private ?\Closure $setup = null,
         private ?string $name = null,
+        private ?bool $useFixedHeader = null,
     ) {
         // Set active controller for proper context
         CrudManager::setActiveController($controller);
@@ -85,11 +86,14 @@ class Datatable extends Component
 
     public function render()
     {
+        $useFixedHeader = $this->useFixedHeader ?? $this->crud->getOperationSetting('useFixedHeader') ?? true;
+
         return view('crud::components.datatable.datatable', [
             'crud' => $this->crud,
             'modifiesUrl' => $this->modifiesUrl,
             'tableId' => $this->tableId,
             'datatablesUrl' => url($this->crud->get('list.datatablesUrl')),
+            'useFixedHeader' => $useFixedHeader,
         ]);
     }
 }

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -25,11 +25,13 @@ return [
     // how much time should the system wait before triggering the search function after the user stops typing?
     'searchDelay' => 400,
 
+    // should we use a fixed header for the datatables?
+    'useFixedHeader' => true,
+
     // the time the table will be persisted in minutes
     // after this the table info is cleared from localStorage.
     // use false to never force localStorage clear. (default)
     // keep in mind: User can clear their localStorage whenever they want.
-
     'persistentTableDuration' => false,
 
     // How many items should be shown by default by the Datatable?

--- a/src/resources/views/crud/components/datatable/datatable.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable.blade.php
@@ -1,6 +1,7 @@
 @php
-    // Define the table ID - use the provided tableId or default to 'crudTable'
-    $tableId = $tableId ?? 'crudTable';
+  // Define the table ID - use the provided tableId or default to 'crudTable'
+  $tableId = $tableId ?? 'crudTable';
+  $fixedHeader = $useFixedHeader ?? $crud->getOperationSetting('useFixedHeader') ?? true;
 @endphp
 <section class="header-operation datatable-header animated fadeIn d-flex mb-2 align-items-baseline d-print-none" bp-section="page-header">
           <h1 class="text-capitalize mb-0" bp-section="page-heading">{!! $crud->getHeading() ?? $crud->entity_name_plural !!}</h1>
@@ -36,6 +37,7 @@
   <table
       id="{{ $tableId }}"
       class="{{ backpack_theme_config('classes.table') ?? 'table table-striped table-hover nowrap rounded card-table table-vcenter card d-table shadow-xs border-xs' }} crud-table"
+      data-use-fixed-header="{{ $fixedHeader ? 'true' : 'false' }}"
       data-responsive-table="{{ (int) $crud->getOperationSetting('responsiveTable') }}"
       data-has-details-row="{{ (int) $crud->getOperationSetting('detailsRow') }}"
       data-has-bulk-actions="{{ (int) $crud->getOperationSetting('bulkActions') }}"


### PR DESCRIPTION
As me and @tabacitu previously noticed (https://github.com/Laravel-Backpack/community-forum/discussions/1410), Datatable components in the middle of the page (not viewable on the view port at the top of the page), had some "bumps" when trying to scroll past them, making it difficult to go past by a table in the middle of the page due to sticky header tables.

That's due to how datatable plugin works given the scroll position. 

We manually calculate the sticky behaviour so we ensure it always works as expected. In addition we also added an option that allow to disable the sticky header completely in case you didn't wanted it. 

