### PR TITLE
allow skip of basset check in the backpack install command

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -23,8 +23,8 @@ class Install extends Command
      */
     protected $signature = 'backpack:install
                                 {--timeout=300} : How many seconds to allow each process to run.
-                                {--debug} : Show process output or not. Useful for debugging.';
-
+                                {--debug} : Show process output or not. Useful for debugging.
+                                {--skip-basset-check : Skip running "php artisan basset:check" at the end of the installation.}';
     /**
      * The console command description.
      *
@@ -114,7 +114,11 @@ class Install extends Command
         }
 
         //execute basset checks
-        $this->call('basset:check');
+        if (! $this->option('skip-basset-check')) {
+            $this->progressBlock('Running Basset checks');
+            $this->executeArtisanProcess('basset:check');
+            $this->closeProgressBlock();
+        }
         // Done
         $url = Str::of(config('app.url'))->finish('/')->append('admin/');
         $this->infoBlock('Backpack installation complete.', 'done');


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

it was not possible to skip the basset check in the `install` command. for that reason, deployments that relied on CI/CD wouldn't properly work. https://github.com/Laravel-Backpack/basset/issues/156

### AFTER - What is happening after this PR?

The install command now has a flag: `--skip-basset-check` that allow developers to not perform the `basset:check` at installation time. 


## HOW

### How did you achieve that, in technical terms?

Introduced a command flag to skip the basset check. `--skip-basset-check`



### Is it a breaking change?

no
