### PR TITLE
Fix install script

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -74,8 +74,9 @@ class Install extends Command
         // Create users table
         $this->progressBlock('Creating users table');
         try {
-            if(! $this->option('no-interaction'))
-            \Illuminate\Support\Facades\DB::connection()->getPdo();
+            if (! $this->option('no-interaction')) {
+                \Illuminate\Support\Facades\DB::connection()->getPdo();
+            }
         } catch (\Throwable $e) {
             $this->closeProgressBlock();
 


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

New Laravel versions come with sqlite as the default database connection. If you just pull the framework, and do a `php artisan migrate` without changing anything from the defaults, it will ask you if you would like to create the .sqlite file. 

Our install script would hang waiting for the user response that was never prompted. Using `--no-interaction` only partially fixed the issue, as the user didn't had to answer, but it would fail after because the file was not created. 

Also, the `basset:check` at the end of the command, didn't output the results to the console. 

### AFTER - What is happening after this PR?

Before creating the users table, we will attempt to get the configured database. In case it fails, we check if it's a sqlite database, if it does, we check if the file exists. If the file don't exist we offer to create it, similar to how Laravel does. If it's any other we just throw the error to inform the user. 

The `basset:check` command at the end should more consistently display the command results, as we changed it from running as an artisan command, to creating a new process for it and capturing the output. 

### Is it a breaking change?

no