### PR TITLE
make confirm command yes by default

### DIFF
--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -84,7 +84,7 @@ class Install extends Command
             $database = config("database.connections.{$connection}.database");
 
             if ($connection === 'sqlite' && ! file_exists($database)) {
-                if ($this->confirm("The SQLite database file [$database] does not exist. Would you like to create it?")) {
+                if ($this->confirm("The SQLite database file [$database] does not exist. Would you like to create it?", true)) {
                     touch($database);
                     $this->progressBlock('Database file created.');
                 } else {


### PR DESCRIPTION
In the install script, the prompt to create the sqlite file had "no" as default. In this case it makes more sense to be "yes" in line with Laravel. 