### PR TITLE
fix signed alias check in laravel 12

### DIFF
--- a/src/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -7,7 +7,6 @@ use Backpack\CRUD\app\Library\Auth\UserFromCookie;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Prologue\Alerts\Facades\Alert;
 
 class VerifyEmailController extends Controller
 {
@@ -20,7 +19,7 @@ class VerifyEmailController extends Controller
      */
     public function __construct()
     {
-        if (! app('router')->getMiddleware()['signed'] ?? null) {
+        if (! app()->runningInConsole() && ! array_key_exists('signed', app('router')->getMiddleware())) {
             throw new Exception('Missing "signed" alias middleware in App/Http/Kernel.php. More info: https://backpackforlaravel.com/docs/6.x/base-how-to#enable-email-verification-in-backpack-routes');
         }
 
@@ -67,7 +66,6 @@ class VerifyEmailController extends Controller
         }
 
         $user->sendEmailVerificationNotification();
-        Alert::success(trans('backpack.base.verify_email.email_sent_with_success'))->flash();
 
         return back()->with('status', 'verification-link-sent');
     }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -58,8 +58,7 @@ return [
 
     // Set this to true if you would like to enable email verification for your user model.
     // Make sure your user model implements the MustVerifyEmail contract and your database
-    // table contains the `email_verified_at` column. Read the following before enabling:
-    // https://backpackforlaravel.com/docs/6.x/base-how-to#enable-email-verification-in-backpack-routes
+    // table contains the `email_verified_at` column.
     'setup_email_verification_routes' => false,
 
     // When email verification is enabled, automatically add the Verified middleware to Backpack routes?


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

In Laravel 12, signed middleware is already aliased. Doing the check in the `__constructor()` has the problem that not all middlewares load for console, and the signed is one that only work for URLS, so it's not available in the console. For that reason it throws an error as described in #5871 

Also removed an `Alert` that was redundant as we have the message on the form itself, and the Alert would say the same as the message we have on the form. 

### AFTER - What is happening after this PR?

It does not attempt to check if the middleware exists when the app is running in the console. 


### Is it a breaking change?

NO

### How can we test the before & after?

??

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
