### PR TITLE
fix bulk buttons on top stack

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable.blade.php
@@ -10,7 +10,7 @@
 <div class="row mb-2 align-items-center">
   <div class="col-sm-9">
     @if ( $crud->buttons()->where('stack', 'top')->count() ||  $crud->exportButtons())
-      <div class="d-print-none {{ $crud->hasAccess('create')?'with-border':'' }}">
+      <div class="d-print-none {{ $crud->hasAccess('create')?'with-border':'' }} top_buttons_{{$tableId}}">
         @include('crud::inc.button_stack', ['stack' => 'top'])
       </div>
     @endif


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

As reported in #5865 the bulk buttons on "top" stack were not properly working. The "top" stack was left out from the container list of possible bulk buttons placements, so the script couldn't find those buttons to apply the functionality.

While testing/fixing this, I found out another issue regarding the "checkedItems". Eg: If I select 2 entries, delete them using bulk delete, and then select 1 more entry to delete, the "checkedItems" would still contain the previously 2 deleted, so it would attempt to delete 3 items (2 already deleted and the third I selected).

### AFTER - What is happening after this PR?

Bulk buttons can now be placed in the top stack. The "checkedItems" now properly synchronize with the table selection.


### Is it a breaking change?

No
