### PR TITLE
Fixes css issues with datatable

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -725,6 +725,10 @@ table.dataTable tr th:first-child, table.dataTable tr td:first-child, table.data
     padding-left: 0.6rem;
 }
 
+table.dataTable td {
+    vertical-align: middle;
+}
+
 /* Processing indicator - global styles */
 .dataTables_processing,
 .dt-processing {


### PR DESCRIPTION
Since we bumped the datatable version, some base classes changed and it breaked the styles of those components across the themes. 

This PR fixes:

- the table headers (they now look seamless accross themes)
- the search icon
- the position of text inside the table.