### PR TITLE
use the global request instance

### DIFF
--- a/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFiltersTest.php
@@ -6,6 +6,7 @@ use Backpack\CRUD\app\Library\CrudPanel\CrudFilter;
 use Backpack\CRUD\Tests\config\CrudPanel\BaseCrudPanel;
 use Backpack\CRUD\Tests\config\Models\User;
 use Config;
+use Illuminate\Routing\Route;
 
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Filters
@@ -52,7 +53,7 @@ class CrudPanelFiltersTest extends BaseCrudPanel
         $request->setRouteResolver(function () use ($request) {
             return (new Route('GET', 'admin/users', ['UserCrudController', 'index']))->bind($request);
         });
-        $this->crudPanel->setRequest($request);
+        $this->app->instance('request', $request);
 
         $isActive = CrudFilter::name('my_custom_filter')->isActive();
         $this->assertTrue($isActive);


### PR DESCRIPTION
To fix an underlaying issue in filters, we changed from using the stored crud request (why do we even have that in the first place?) to using the global application request. 

The tests still referenced the stored crud request instead of the global instance, and for that reason they were failing. 

I've just switched to use the global request instance in tests too. 