### PR TITLE
Fix line action buttons as dropdown

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -1374,7 +1374,7 @@ function initDatatableDropdowns(tableId) {
                     left = buttonRect.right - menuWidth;
                 }
                 
-                // Apply positioning with maximum override
+                // apply positioning
                 const cssProps = {
                     'position': 'fixed',
                     'top': top + 'px',


### PR DESCRIPTION
While investigating an issue reported in https://github.com/Laravel-Backpack/community-forum/discussions/1427 I found a small issue with the line buttons. 

Whenever the first one was closed, the subsequent dropdowns required two clicks to open. 

Another issue I found is that the positioning was not taking into account the horizontal space, only the vertical, so if you dropdown item had a very long text, it would be cut out of the page. 