### PR TITLE
strip domain in setRoute()

### DIFF
--- a/src/app/Library/CrudPanel/CrudPanel.php
+++ b/src/app/Library/CrudPanel/CrudPanel.php
@@ -209,6 +209,11 @@ class CrudPanel
      */
     public function setRoute($route)
     {
+        // if the route is a full URL, strip the domain
+        if (str_starts_with($route, url('/'))) {
+            $route = substr($route, strlen(url('/')));
+        }
+
         $this->route = ltrim($route, '/');
     }
 

--- a/tests/config/Http/CrudControllerTest.php
+++ b/tests/config/Http/CrudControllerTest.php
@@ -36,12 +36,9 @@ class CrudControllerTest extends BaseTestClass
         $crudPanel = app('crud');
         $crudPanel->setRoute(backpack_url('users'));
         $crudPanel->setEntityNameStrings('singular', 'plural');
-        $this->assertEquals(route('users.index'), $crudPanel->getRoute());
+        $this->assertEquals(config('backpack.base.route_prefix').'/users', $crudPanel->getRoute());
     }
 
-    /**
-     * @group fail
-     */
     public function testCrudRequestUpdatesOnEachRequest()
     {
         // create a first request


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/CRUD/issues/5738

There are mainly two ways developers use to define their CrudController routes: 

1 - config('backpack.base.route_prefix').'/something') -> `admin/something`
2 - backpack_url('something') -> `https://domain.com/admin/something`

Using the option 2 would break the persistent table feature. 

I've changed the `setRoute()` method to strip the domain part of any url developer define in the `setRoute()` so that no matter how the `setRoute()` is defined it will always work. 