### PR TITLE
Fix Reset button localStorage key mismatch (#5904)

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -634,10 +634,11 @@ function setupTableUI(tableId, config) {
                 localStorage.removeItem(`${config.persistentTableSlug}_list_url_time`);
             }
 
-            // Clear the table sorting/ordering/visibility
-            if(localStorage.getItem(`DataTables_${tableId}_/${config.urlStart}`)) {
-                localStorage.removeItem(`DataTables_${tableId}_/${config.urlStart}`);
-            }
+            // Clear ALL DataTables localStorage keys for this table
+            // Fixes key mismatch where DataTables 2.x uses pathname-based keys
+            Object.keys(localStorage)
+              .filter(key => key.startsWith(`DataTables_${tableId}`))
+              .forEach(key => localStorage.removeItem(key));
         });
     }
 


### PR DESCRIPTION
  ## WHY

  ### BEFORE - What was wrong? What was happening before this PR?

  The Reset button on list operations fails to clear the DataTables search/filter state. When users:
  1. Search for something that returns few or no results
  2. Click the "Reset" link

  The page reloads but still shows filtered/no results. The search term persists even after logging out/in or clearing
  cookies. Only opening a new browser session (incognito) fixes it.

  **Root cause:** The Reset button tries to clear localStorage key `DataTables_${tableId}_/${config.urlStart}` where
  `config.urlStart` is a full URL (e.g., `http://example.com/admin/lead`), producing a key like:
  DataTables_crudTable_/http://example.com/admin/lead

  But DataTables 2.x with `stateSave: true` stores state using `window.location.pathname`, producing:
  DataTables_crudTable_/admin/lead

  **These keys never match**, so the DataTables state (including search term) is never cleared.

  Related issue: #5904

  ### AFTER - What is happening after this PR?

  The Reset button properly clears all DataTables state for the table, including search terms, pagination, sorting, and
  column visibility. Users can successfully reset filtered tables back to showing all entries.


  ## HOW

  ### How did you achieve that, in technical terms?

  Instead of trying to match a specific localStorage key format (which is fragile and doesn't match DataTables 2.x key
  generation), the fix clears ALL localStorage keys that start with `DataTables_${tableId}`:

  ```javascript
  Object.keys(localStorage)
      .filter(key => key.startsWith(`DataTables_${tableId}`))
      .forEach(key => localStorage.removeItem(key));
```
  This approach is more robust as it handles any key format DataTables might use, including _pageLength suffixed keys.

  Is it a breaking change?

  No. The Reset button will now work as users expect - it will clear all table state. Previously it was silently failing to
  clear the state.

  How can we test the before & after?

  ## Before (bug):
  1. Go to any CRUD list page with persistentTable enabled (default)
  2. Type a search term that returns 0 or few results
  3. Note: "No entries (filtered from X total entries)"
  4. Click "Reset"
  5. Bug: Page reloads but still shows filtered results

  ## After (fix):
  1. Same steps 1-4
  2. Click "Reset"
  3. Fixed: Page reloads showing all entries, search is cleared