### PR TITLE
Remove calls to PHP 8.5-deprecated `setAccessible`

### DIFF
--- a/src/CrudPanelManager.php
+++ b/src/CrudPanelManager.php
@@ -205,7 +205,6 @@ final class CrudPanelManager
         // Use the controller's own method to setup the operation properly
         $reflection = new \ReflectionClass($controller);
         $method = $reflection->getMethod('setupConfigurationForCurrentOperation');
-        $method->setAccessible(true);
         $method->invoke($controller, $operation);
 
         // Completely restore the original state
@@ -321,7 +320,6 @@ final class CrudPanelManager
         // Use the controller's own method to setup the operation properly
         $reflection = new \ReflectionClass($controller);
         $method = $reflection->getMethod('setupConfigurationForCurrentOperation');
-        $method->setAccessible(true);
         $method->invoke($controller, $operation);
     }
 

--- a/src/app/Library/CrudPanel/CrudRouter.php
+++ b/src/app/Library/CrudPanel/CrudRouter.php
@@ -34,7 +34,6 @@ final class CrudRouter
                 str_starts_with($method->getName(), 'setup') &&
                 str_ends_with($method->getName(), 'Routes')
             ) {
-                $method->setAccessible(true);
                 LifecycleHook::trigger('crud:before_setup_routes', [$name, $routeName, $controller]);
                 $method->invoke($controllerInstance, $name, $routeName, $controller);
                 LifecycleHook::trigger('crud:after_setup_routes', [$name, $routeName, $controller]);

--- a/tests/BaseTestClass.php
+++ b/tests/BaseTestClass.php
@@ -82,7 +82,6 @@ abstract class BaseTestClass extends TestCase
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($object, $parameters);
     }


### PR DESCRIPTION
## WHY

These are no-op as of PHP 8.1 and thus no longer needed:

See also https://wiki.php.net/rfc/make-reflection-setaccessible-no-op

### BEFORE - What was wrong? What was happening before this PR?

There were no-op calls triggering deprecations on PHP 8.5

### AFTER - What is happening after this PR?

Obsolete code is gone and no more deprecations.


## HOW

### How did you achieve that, in technical terms?

-



### Is it a breaking change?

No


### How can we test the before & after?

-

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
