### PR TITLE
fix line buttons as dropdown with translatable entries

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -714,6 +714,41 @@ table.dataTable .dt-paging .dt-paging-button:active {
     box-shadow: inset 0 0 3px #111;
 }
 
+.nested-dropdown-item {
+            display: flex;
+            width: 100%;
+            padding: 0;
+            clear: both;
+            font-weight: 400;
+            color: #212529;
+            text-align: inherit;
+            text-decoration: none;
+            white-space: nowrap;
+            background-color: transparent;
+            border: 0;
+            position: relative;
+        }
+        .nested-dropdown-item:hover, .nested-dropdown-item:focus {
+            color: #1e2125;
+            text-decoration: none;
+            background-color: var(--bs-light);
+        }
+        .nested-dropdown-item > a {
+            color: inherit;
+            text-decoration: none;
+            display: block;
+        }
+        .nested-dropdown .dropdown-toggle-split::after {
+            display: inline-block;
+            margin-left: 0.255em;
+            vertical-align: 0.255em;
+            content: "";
+            border-top: 0.3em solid;
+            border-right: 0.3em solid transparent;
+            border-bottom: 0;
+            border-left: 0.3em solid transparent;
+        }
+
 table.dataTable .dt-paging .ellipsis {
     padding: 0 1em;
 }

--- a/src/resources/views/crud/buttons/show.blade.php
+++ b/src/resources/views/crud/buttons/show.blade.php
@@ -1,5 +1,5 @@
 @if ($crud->hasAccess('show', $entry))
-	@if (!$crud->model->translationEnabled())
+	@if (!$crud->model->translationEnabled() || $crud->getOperationSetting('showLanguagesDirectlyInShowButton') === false)
 
 	{{-- Single edit button --}}
 	<a href="{{ url($crud->route.'/'.$entry->getKey().'/show') }}" bp-button="show" class="btn btn-sm btn-link">

--- a/src/resources/views/crud/buttons/update.blade.php
+++ b/src/resources/views/crud/buttons/update.blade.php
@@ -1,6 +1,6 @@
 @if ($crud->hasAccess('update', $entry))
     {{-- Regular update button that redirects to edit page --}}
-    @if (!$crud->model->translationEnabled())
+    @if (!$crud->model->translationEnabled() || $crud->getOperationSetting('showLanguagesDirectlyInEditButton') === false)
         {{-- Single edit button --}}
         <a href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}" bp-button="update" class="btn btn-sm btn-link">
             <i class="la la-edit"></i> <span>{{ trans('backpack::crud.edit') }}</span>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Reported in: https://github.com/Laravel-Backpack/CRUD/issues/5846 and https://github.com/Laravel-Backpack/community-forum/discussions/1432

The line buttons as dropdown were broken if used with translatable entries. Making both dropdowns work together was not an easy task. 


### AFTER - What is happening after this PR?

We divided this task into two majors:

1 - Fix the dropdown interactions, and kept the "old" functionality working as before. 
2 - Add the possibility to disable the translatable dropdowns via operation setting. 

