### PR TITLE
fix ajax error frame & Prevent setting 'Accept' header in AJAX retry

### DIFF
--- a/src/resources/views/crud/inc/ajax_error_frame.blade.php
+++ b/src/resources/views/crud/inc/ajax_error_frame.blade.php
@@ -38,7 +38,9 @@ if (!XMLHttpRequest.prototype._backpackWrapped) {
                             retryXhr.open(self._method, self._url);
                             
                             Object.keys(self._requestHeaders).forEach(key => {
-                                retryXhr.setRequestHeader(key, self._requestHeaders[key]);
+                                if (key.toLowerCase() !== 'accept') {
+                                    retryXhr.setRequestHeader(key, self._requestHeaders[key]);
+                                }
                             });
                             retryXhr.setRequestHeader('Accept', 'text/html');
                             retryXhr.send(body);
@@ -66,7 +68,7 @@ const showErrorFrame = html => {
 
     if (isJson) {
         page.innerHTML = `
-            <head><meta charset="UTF-8"></head>
+            <head><meta charset="UTF-8"><\/head>
             <body>
                 <div class="error-container">
                     <h2 class="error-title">${errorData.exception || 'Error'}</h2>
@@ -79,7 +81,7 @@ const showErrorFrame = html => {
                         </details>
                     ` : ''}
                 </div>
-            </body>
+            <\/body>
         `;
     } else {
         page.innerHTML = html;


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

ISSUES #5926

## HOW

### How did you achieve that, in technical terms?

#### Cause

When you write JavaScript inline (i.e., directly in the .html or .php file between the <script> tag), the browser scans the text from top to bottom.

When it encounters the </body> or </head> string inside your backtick (`), the browser mistakenly interprets it as the actual closing tag of the HTML page, not as just a string in a JavaScript variable.

As a result, the <script> tag closes prematurely, and the rest of the code overflows, displaying as plain text on the screen.

#### Solution

You need to "trick" the browser by adding a backslash (\) before the slash of the closing tag in the string.
Replace </head> with <\/head> and </body> with <\/body>.

- Fix the error where HTML cannot be retrieved due to header overwriting.

### Is it a breaking change?

No

### How can we test the before & after?

You need a bug (for example, for the /search link) to see the interface reproduced, and visually, the inline HTML tag overflow from the JavaScript will no longer appear in the footer.

