### PR TITLE
add search value to search input after page reload

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -604,6 +604,7 @@ function setupTableUI(tableId, config) {
     const searchInput = $(`#datatable_search_stack_${tableId} input.datatable-search-input`);
     
     if (searchInput.length > 0) {
+        searchInput.val(window.crud.tables[tableId].search());
         searchInput.on('keyup', function() {
             window.crud.tables[tableId].search(this.value).draw();
         });


### PR DESCRIPTION
fixes https://github.com/Laravel-Backpack/CRUD/issues/5920

The search input value was not populated after page reload and persistence filtered the table. 