### PR TITLE
Respect remove query scopes

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -73,9 +73,9 @@ trait Read
             if ($this->getOperationSetting('eagerLoadRelationships')) {
                 $this->eagerLoadRelationshipFields();
             }
-            
+
             $modelWithQuery = $this->getModelWithCrudPanelQuery();
-            
+
             $this->entry = $modelWithQuery->findOrFail($id);
             $this->entry = $this->entry->withFakes();
         }


### PR DESCRIPTION
The issue is that `getModelWithCrudPanelQuery()` creates a new Eloquent Builder instance by calling `$this->model->setQuery(...)` (via magic __call). 
When a new Eloquent Builder is constructed, it automatically applies the Model's global scopes (including SoftDeletes).

Even though we are injecting the underlying Base Query (which has the deleted_at is null constraint removed via addClause('withTrashed')), the new Eloquent Builder wraps it and re-applies the SoftDeletes scope, adding the constraint back in.