### PR TITLE
fix: use event delegation for bulk checkbox to support scrollX/fixedH…

### DIFF
--- a/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
+++ b/src/resources/views/crud/columns/inc/bulk_actions_checkbox.blade.php
@@ -13,18 +13,18 @@
     // Make sure window.crud exists before we try to use it
     window.crud = window.crud || {};
     window.crud.tableConfigs = window.crud.tableConfigs || {};
-    
+
     // Intercept changes to crud.checkedItems to sync with tableConfigs
     if (!Object.getOwnPropertyDescriptor(window.crud, 'checkedItems')?.get) {
         let _checkedItems = window.crud.checkedItems || [];
-        
+
         Object.defineProperty(window.crud, 'checkedItems', {
             get: function() {
                 return _checkedItems;
             },
             set: function(value) {
                 _checkedItems = value;
-                
+
                 // Sync with the main table config if it exists
                 // This handles the case where legacy bulk buttons clear crud.checkedItems
                 if (!window.crud.ignoreNextSetterSync && window.crud.table && window.crud.table.table && window.crud.table.table().node) {
@@ -41,12 +41,12 @@
     }
 
 if (typeof window.crud.addOrRemoveCrudCheckedItem !== 'function') {
-    window.crud.addOrRemoveCrudCheckedItem = function(element, tableId) {        
+    window.crud.addOrRemoveCrudCheckedItem = function(element, tableId) {
         const tableConfig = window.crud.tableConfigs[tableId] || window.crud;
-        
+
         tableConfig.checkedItems = Array.isArray(tableConfig.checkedItems) ? tableConfig.checkedItems : [];
         tableConfig.lastCheckedItem = tableConfig.lastCheckedItem || false;
-        
+
         document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox`).forEach(checkbox => {
             // check if there is a dtr-control element in the row, in case it does, add a mt-2 class to the checkbox
             const row = checkbox.closest('tr');
@@ -59,19 +59,19 @@ if (typeof window.crud.addOrRemoveCrudCheckedItem !== 'function') {
 
             const newCheckbox = checkbox.cloneNode(true);
             checkbox.parentNode.replaceChild(newCheckbox, checkbox);
-            
+
             newCheckbox.addEventListener('click', function(e) {
                 e.stopPropagation();
-                
+
                 const checked = this.checked;
                 const primaryKeyValue = this.dataset.primaryKeyValue;
-                
+
                 if (checked) {
                     // add item to checkedItems if not already there
                     if (tableConfig.checkedItems.indexOf(primaryKeyValue) === -1) {
                         tableConfig.checkedItems.push(primaryKeyValue);
                     }
-                    
+
                     // if shift has been pressed, also select all elements
                     // between the last checked item and this one
                     if (tableConfig.lastCheckedItem && e.shiftKey) {
@@ -80,13 +80,13 @@ if (typeof window.crud.addOrRemoveCrudCheckedItem !== 'function') {
                         let last = document.querySelector(`#${tableId} input.crud_bulk_actions_line_checkbox[data-primary-key-value="${primaryKeyValue}"]`).closest('tr');
                         let firstIndex = getNodeindex(first);
                         let lastIndex = getNodeindex(last);
-                        
+
                         while (first !== last) {
                             first = firstIndex < lastIndex ? first.nextElementSibling : first.previousElementSibling;
                             first.querySelector('input.crud_bulk_actions_line_checkbox:not(:checked)')?.click();
                         }
                     }
-                    
+
                     // remember that this one was the last checked item
                     tableConfig.lastCheckedItem = primaryKeyValue;
                 } else {
@@ -94,7 +94,7 @@ if (typeof window.crud.addOrRemoveCrudCheckedItem !== 'function') {
                     let index = tableConfig.checkedItems.indexOf(primaryKeyValue);
                     if (index > -1) tableConfig.checkedItems.splice(index, 1);
                 }
-                            
+
                 window.crud.enableOrDisableBulkButtons(tableId);
             });
         });
@@ -104,10 +104,10 @@ if (typeof window.crud.addOrRemoveCrudCheckedItem !== 'function') {
 if (typeof window.crud.markCheckboxAsCheckedIfPreviouslySelected !== 'function') {
     window.crud.markCheckboxAsCheckedIfPreviouslySelected = function(tableId = 'crudTable') {
         const tableConfig = window.crud.tableConfigs[tableId] || window.crud;
-        
+
         // Ensure checkedItems is always an array
         tableConfig.checkedItems = Array.isArray(tableConfig.checkedItems) ? tableConfig.checkedItems : [];
-        
+
         let checkedItems = tableConfig.checkedItems;
         let pageChanged = localStorage.getItem('page_changed') ?? false;
         let tableUrl = window.crud.tables[tableId]?.ajax.url() || '';
@@ -125,7 +125,7 @@ if (typeof window.crud.markCheckboxAsCheckedIfPreviouslySelected !== 'function')
         if (!pageChanged && (window.crud.tables[tableId]?.search().length !== 0 || hasFilterApplied)) {
             tableConfig.checkedItems = [];
         }
-        
+
         document
             .querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox[data-primary-key-value]`)
             .forEach(function(elem) {
@@ -135,82 +135,102 @@ if (typeof window.crud.markCheckboxAsCheckedIfPreviouslySelected !== 'function')
                     tableConfig.checkedItems.push(elem.dataset.primaryKeyValue);
                 }
             });
-        
+
         localStorage.removeItem('page_changed');
     }
 }
 
-window.crud.addBulkActionMainCheckboxesFunctionality = function(tableId = 'crudTable') {    
+window.crud.addBulkActionMainCheckboxesFunctionality = function(tableId = 'crudTable') {
     const tableConfig = window.crud.tableConfigs[tableId] || window.crud;
-    
-    let mainCheckboxes = Array.from(document.querySelectorAll(`#${tableId} input.crud_bulk_actions_general_checkbox`));
-    
-    mainCheckboxes.forEach(checkbox => {
-        const getRowCheckboxes = () => Array.from(document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox`));
-        
-        // set initial checked status - recalculate based on current visible checkboxes
-        const updateMainCheckboxState = () => {
-            const rowCheckboxes = getRowCheckboxes();
-            checkbox.checked = rowCheckboxes.length > 0 && 
-                document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox:not(:checked)`).length === 0;
-        };
-        
-        // Initial state
-        updateMainCheckboxState();
 
-        // when the crud_bulk_actions_general_checkbox is selected, toggle all visible checkboxes
-        checkbox.onclick = event => {            
-            // Get fresh list of row checkboxes that are currently visible
-            const currentRowCheckboxes = getRowCheckboxes();            
-            // Only toggle checkboxes that need to change state
-            currentRowCheckboxes
-                .filter(elem => checkbox.checked !== elem.checked)
-                .forEach(elem => {
-                    elem.click();
+    // Update initial state for all main checkboxes
+    const updateMainCheckboxState = () => {
+    const rowCheckboxes = document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox`);
+    const uncheckedCount = document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox:not(:checked)`).length;
+    const shouldBeChecked = rowCheckboxes.length > 0 && uncheckedCount === 0;
+
+    // Update ALL main checkboxes (including cloned ones from DataTables fixedHeader)
+    document.querySelectorAll(`input.crud_bulk_actions_general_checkbox`).forEach(cb => {
+        const wrapper = cb.closest(`#${tableId}_wrapper`) || cb.closest(`#${tableId}`);
+        if (wrapper || document.querySelector(`#${tableId}`)) {
+            cb.checked = shouldBeChecked;
+        }
+    });
+    };
+
+    // Initial state
+    updateMainCheckboxState();
+
+    // Use event delegation on the table wrapper to handle clicks on ANY general checkbox
+    // This works even when DataTables clones/replaces elements (fixedHeader, scroll)
+    const wrapper = document.querySelector(`#${tableId}_wrapper`) || document.querySelector(`#${tableId}`)?.closest('.table-responsive') || document.body;
+
+    // Only attach delegation once per wrapper
+    if (!wrapper._bulkDelegationAttached) {
+        wrapper._bulkDelegationAttached = true;
+
+        wrapper.addEventListener('click', function(event) {
+            const checkbox = event.target;
+
+            // Check if clicked element is a general checkbox
+            if (!checkbox.classList.contains('crud_bulk_actions_general_checkbox')) {
+                return;
+            }
+
+            const isChecked = checkbox.checked;
+
+            // Get all row checkboxes
+            const rowCheckboxes = Array.from(document.querySelectorAll(`#${tableId} input.crud_bulk_actions_line_checkbox`));
+
+            // Toggle checkboxes that need to change
+            rowCheckboxes
+                .filter(elem => isChecked !== elem.checked)
+                .forEach(elem => elem.click());
+
+            // Sync all main checkboxes (including clones)
+            document.querySelectorAll(`input.crud_bulk_actions_general_checkbox`).forEach(cb => {
+                cb.checked = isChecked;
                 });
-            
-            // make sure all other main checkboxes have the same checked status
-            mainCheckboxes.forEach(elem => elem.checked = checkbox.checked);
 
-            // Ensure buttons are updated after mass checkbox changes
+            // Update bulk buttons
             window.crud.enableOrDisableBulkButtons(tableId);
 
             event.stopPropagation();
-        };
     });
+    }
 };
 
 if (typeof window.crud.enableOrDisableBulkButtons !== 'function') {
-    window.crud.enableOrDisableBulkButtons = function(tableId) {        
+    window.crud.enableOrDisableBulkButtons = function(tableId) {
         // Get the correct table configuration
         const tableConfig = window.crud.tableConfigs[tableId] || window.crud;
-        
+
         // Initialize checkedItems array if it doesn't exist
         tableConfig.checkedItems = Array.isArray(tableConfig.checkedItems) ? tableConfig.checkedItems : [];
-        
+
         // Check if any items are selected
         const hasSelectedItems = tableConfig.checkedItems.length > 0;
-        
+
         // Find the table element
         const tableElement = document.getElementById(tableId);
         if (!tableElement) {
             console.error(`Table element not found: ${tableId}`);
             return;
         }
-        
+
         // Check if this table is configured for bulk actions
-        const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' || 
+        const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' ||
                           tableElement.getAttribute('data-has-bulk-actions') === '1';
-        
+
         // Find all bulk buttons - search in table-specific locations first
         let bulkButtons = [];
-        
+
         const tableSpecificContainers = [
             document.querySelector(`#bottom_buttons_${tableId}`),
             document.querySelector(`#datatable_button_stack_${tableId}`),
             document.querySelector(`.top_buttons_${tableId}`)
         ];
-        
+
         for (const container of tableSpecificContainers) {
             if (container) {
                 const containerButtons = container.querySelectorAll('.bulk-button');
@@ -220,14 +240,14 @@ if (typeof window.crud.enableOrDisableBulkButtons !== 'function') {
                 }
             }
         }
-        
+
         if (bulkButtons.length === 0) {
             const tableWrapper = document.getElementById(`${tableId}_wrapper`);
             if (tableWrapper) {
                 bulkButtons = tableWrapper.querySelectorAll('.bulk-button');
             }
         }
-        
+
         // Update all buttons based on selection state
         bulkButtons.forEach(btn => {
             if (hasSelectedItems) {
@@ -236,15 +256,15 @@ if (typeof window.crud.enableOrDisableBulkButtons !== 'function') {
 
                 if (btn.hasAttribute('onclick') && !btn._onclickReplaced) {
                     const originalOnclick = btn.getAttribute('onclick');
-                    
+
                     // Remove the original onclick attribute
                     btn.removeAttribute('onclick');
-                    
+
                     // Add a click event listener that synchronizes first, then calls the original handler
                     btn.addEventListener('click', function(e) {
                         // Synchronize checked items with global crud object
                         window.crud.synchronizeCheckedItems(tableId);
-                        
+
                         // Then execute the original handler
                         try {
                             // If it's a simple function call
@@ -261,7 +281,7 @@ if (typeof window.crud.enableOrDisableBulkButtons !== 'function') {
                             console.error('Error executing bulk action:', err);
                         }
                     });
-                    
+
                     // Mark this button as having its onclick replaced
                     btn._onclickReplaced = true;
                 }
@@ -276,10 +296,10 @@ if (typeof window.crud.enableOrDisableBulkButtons !== 'function') {
 if (typeof window.crud.synchronizeCheckedItems !== 'function') {
     window.crud.synchronizeCheckedItems = function(tableId = 'crudTable') {
         const tableConfig = window.crud.tableConfigs[tableId] || window.crud;
-        
+
         // Make sure both are arrays
         tableConfig.checkedItems = Array.isArray(tableConfig.checkedItems) ? tableConfig.checkedItems : [];
-        
+
         // Copy items from tableConfig to global crud object
         window.crud.ignoreNextSetterSync = true;
         window.crud.checkedItems = [...tableConfig.checkedItems];
@@ -288,13 +308,13 @@ if (typeof window.crud.synchronizeCheckedItems !== 'function') {
 }
 
 // Define a function that initializes bulk actions for a specific table
-window.registerBulkActionsCheckboxes = function(tableId) {    
+window.registerBulkActionsCheckboxes = function(tableId) {
     // Make sure we have access to crud functions
     if (typeof window.crud !== 'object') {
         console.error('window.crud not available yet');
         return;
     }
-    
+
     // Initialize the tableConfigs object for this table if it doesn't exist
     if (!window.crud.tableConfigs[tableId]) {
         window.crud.tableConfigs[tableId] = {
@@ -302,19 +322,19 @@ window.registerBulkActionsCheckboxes = function(tableId) {
             lastCheckedItem: false
         };
     }
-    
+
     // Check if the table element exists and has bulk actions enabled
     const tableElement = document.getElementById(tableId);
     if (!tableElement) {
         console.error(`Table element #${tableId} not found`);
         return;
     }
-    
-    const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' || 
+
+    const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' ||
                         tableElement.getAttribute('data-has-bulk-actions') === '1';
-    
+
     if (!hasBulkActions) return;
-    
+
     // Call the required functions for setting up bulk actions
     window.crud.addOrRemoveCrudCheckedItem(null, tableId);
     window.crud.markCheckboxAsCheckedIfPreviouslySelected(tableId);
@@ -332,18 +352,18 @@ document.addEventListener('DOMContentLoaded', function() {
 // Add event listener for DataTables initialization
 window.addEventListener('backpack:table:initialized', function(e) {
     const tableId = e.detail.tableId;
-    
+
     // Check if the table has bulk actions
     const tableElement = document.getElementById(tableId);
     if (!tableElement) {
         console.error(`Table element #${tableId} not found`);
         return;
     }
-    
-    const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' || 
+
+    const hasBulkActions = tableElement.getAttribute('data-has-bulk-actions') === 'true' ||
                         tableElement.getAttribute('data-has-bulk-actions') === '1';
-    
-    if (hasBulkActions) {        
+
+    if (hasBulkActions) {
         // Make sure the function is called on each draw event
         if (window.crud.tables[tableId]) {
             window.crud.tables[tableId].on('draw.dt', function() {


### PR DESCRIPTION
# fix: use event delegation for bulk checkbox to support scrollX/fixedHeader

## WHY

### BEFORE - What was wrong? What was happening before this PR?

The bulk actions main checkbox (select all) doesn't work when `scrollX` or `fixedHeader` is enabled. Clicking the main checkbox in the header toggles its own state but doesn't select any row checkboxes. The bulk action buttons remain disabled.

This happens because:
- When `responsiveTable: false` (default), DataTables enables `scrollX: true` which creates a separate `.dt-scroll-head` div containing a **copy** of the table header
- When `useFixedHeader: true`, DataTables clones the header for the fixed header functionality
- The current code attaches event handlers directly to checkboxes inside `#${tableId}`, which only selects the **original** table elements
- Users click on the **copied** checkboxes (in `.dt-scroll-head` or fixedHeader), which have no event handlers attached

### AFTER - What is happening after this PR?

The bulk actions main checkbox works correctly in all DataTables configurations (scrollX, fixedHeader, responsive). Clicking the main checkbox selects/deselects all row checkboxes as expected.

## HOW

### How did you achieve that, in technical terms?

Replaced direct event binding with **event delegation** in `addBulkActionMainCheckboxesFunctionality`:

- Instead of attaching `onclick` handlers directly to checkbox elements, we now attach a single click listener to the wrapper element (`#${tableId}_wrapper`)
- The wrapper contains BOTH the original table AND any copied headers (`.dt-scroll-head`, fixedHeader clones)
- Click events bubble up to the wrapper regardless of which checkbox was clicked
- Added `_bulkDelegationAttached` flag to prevent attaching multiple listeners
- Added `updateMainCheckboxState()` to sync ALL main checkboxes (including copies) when state changes

### Is it a breaking change?

No. This is a backwards-compatible fix that works with all existing DataTables configurations.

### How can we test the before & after?

1. Create a CRUD with bulk actions enabled
2. Test with default config (`responsiveTable => false`) - this enables scrollX
3. Test with `useFixedHeader => true`
4. Click the main checkbox in the header
5. **Before:** Row checkboxes are NOT selected
6. **After:** All row checkboxes are selected/deselected correctly
