### PR TITLE
Replace calls to `Request->get()` with `->input()`

### DIFF
--- a/src/app/Http/Controllers/Operations/Concerns/HasForm.php
+++ b/src/app/Http/Controllers/Operations/Concerns/HasForm.php
@@ -55,7 +55,7 @@ trait HasForm
                     return $crud->hasAccess($operationName);
                 },
                 'redirect' => function ($crud, $request, $itemId = null) {
-                    return $request->request->has('_http_referrer') ? $request->request->get('_http_referrer') : $crud->route;
+                    return $request->input('_http_referrer', $crud->route);
                 },
                 'button_text' => trans('backpack::crud.save_action_save_and_back'),
             ]);

--- a/src/app/Http/Controllers/Operations/ListOperation.php
+++ b/src/app/Http/Controllers/Operations/ListOperation.php
@@ -111,7 +111,7 @@ trait ListOperation
         $this->crud->applyDatatableOrder();
 
         $entries = $this->crud->getEntries();
-        $requestTotalEntryCount = request()->get('totalEntryCount') ? (int) request()->get('totalEntryCount') : null;
+        $requestTotalEntryCount = request()->input('totalEntryCount') ? (int) request()->input('totalEntryCount') : null;
         // if show entry count is disabled we use the "simplePagination" technique to move between pages.
         if ($this->crud->getOperationSetting('showEntryCount')) {
             $totalEntryCount = (int) ($requestTotalEntryCount ?: $this->crud->getTotalQueryCount());

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -102,7 +102,7 @@ trait UpdateOperation
 
         // update the row in the db
         $item = $this->crud->update(
-            $request->get($this->crud->model->getKeyName()),
+            $request->input($this->crud->model->getKeyName()),
             $this->crud->getStrippedSaveRequest($request)
         );
         $this->data['entry'] = $this->crud->entry = $item;

--- a/src/app/Library/CrudPanel/SaveActions/SaveAndBack.php
+++ b/src/app/Library/CrudPanel/SaveActions/SaveAndBack.php
@@ -26,6 +26,6 @@ class SaveAndBack extends AbstractSaveAction
 
     public function getRedirectUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        return $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
+        return $request->input('_http_referrer', $crud->route);
     }
 }

--- a/src/app/Library/CrudPanel/SaveActions/SaveAndEdit.php
+++ b/src/app/Library/CrudPanel/SaveActions/SaveAndEdit.php
@@ -26,7 +26,7 @@ class SaveAndEdit extends AbstractSaveAction
 
     public function getRedirectUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        $itemId = $itemId ?: $request->get('id');
+        $itemId = $itemId ?: $request->input('id');
 
         if (! $itemId) {
             return $crud->route;
@@ -35,11 +35,11 @@ class SaveAndEdit extends AbstractSaveAction
         $redirectUrl = rtrim($crud->route, '/').'/'.$itemId.'/edit';
 
         if ($request->has('_locale')) {
-            $redirectUrl .= '?_locale='.$request->get('_locale');
+            $redirectUrl .= '?_locale='.$request->input('_locale');
         }
 
         if ($request->has('_current_tab')) {
-            $redirectUrl .= '#'.$request->get('_current_tab');
+            $redirectUrl .= '#'.$request->input('_current_tab');
         }
 
         return $redirectUrl;
@@ -47,7 +47,7 @@ class SaveAndEdit extends AbstractSaveAction
 
     public function getReferrerUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        $itemId = $itemId ?: $request->get('id');
+        $itemId = $itemId ?: $request->input('id');
 
         if (! $itemId) {
             return null;

--- a/src/app/Library/CrudPanel/SaveActions/SaveAndPreview.php
+++ b/src/app/Library/CrudPanel/SaveActions/SaveAndPreview.php
@@ -26,7 +26,7 @@ class SaveAndPreview extends AbstractSaveAction
 
     public function getRedirectUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        $itemId = $itemId ?: $request->get('id');
+        $itemId = $itemId ?: $request->input('id');
 
         if (! $itemId) {
             return $crud->route;
@@ -35,11 +35,11 @@ class SaveAndPreview extends AbstractSaveAction
         $redirectUrl = rtrim($crud->route, '/').'/'.$itemId.'/show';
 
         if ($request->has('_locale')) {
-            $redirectUrl .= '?_locale='.$request->get('_locale');
+            $redirectUrl .= '?_locale='.$request->input('_locale');
         }
 
         if ($request->has('_current_tab')) {
-            $redirectUrl .= '#'.$request->get('_current_tab');
+            $redirectUrl .= '#'.$request->input('_current_tab');
         }
 
         return $redirectUrl;
@@ -47,7 +47,7 @@ class SaveAndPreview extends AbstractSaveAction
 
     public function getReferrerUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        $itemId = $itemId ?: $request->get('id');
+        $itemId = $itemId ?: $request->input('id');
 
         if (! $itemId) {
             return null;

--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -85,7 +85,7 @@ trait Read
 
     private function shouldUseFallbackLocale(): bool|string
     {
-        $fallbackRequestValue = $this->getRequest()->get('_fallback_locale');
+        $fallbackRequestValue = $this->getRequest()->input('_fallback_locale');
 
         return $fallbackRequestValue === 'true' ? true : (in_array($fallbackRequestValue, array_keys(config('backpack.crud.locales'))) ? $fallbackRequestValue : false);
     }

--- a/src/app/Library/CrudPanel/Traits/SaveActions.php
+++ b/src/app/Library/CrudPanel/Traits/SaveActions.php
@@ -93,7 +93,7 @@ trait SaveActions
 
         $orderCounter = $this->getOperationSetting('save_actions') !== null ? (count($this->getOperationSetting('save_actions')) + 1) : 1;
         $saveAction['name'] ?? abort(500, 'Please define save action name.', ['developer-error-exception']);
-        $saveAction['redirect'] = $saveAction['redirect'] ?? fn ($crud, $request, $itemId) => $request->has('_http_referrer') ? $request->get('_http_referrer') : $crud->route;
+        $saveAction['redirect'] = $saveAction['redirect'] ?? fn ($crud, $request, $itemId) => $request->input('_http_referrer', $crud->route);
         $saveAction['visible'] = $saveAction['visible'] ?? true;
         $saveAction['button_text'] = $saveAction['button_text'] ?? $saveAction['name'];
         $saveAction['order'] = isset($saveAction['order']) ? $this->orderSaveAction($saveAction['name'], $saveAction['order']) : $orderCounter;

--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -122,6 +122,6 @@ class MultipleFiles extends Uploader
 
     private function getFilesToDeleteFromRequest(): array
     {
-        return collect(CRUD::getRequest()->get('clear_'.$this->getNameForRequest()))->flatten()->toArray();
+        return collect(CRUD::getRequest()->input('clear_'.$this->getNameForRequest()))->flatten()->toArray();
     }
 }

--- a/src/app/Library/Uploaders/SingleBase64Image.php
+++ b/src/app/Library/Uploaders/SingleBase64Image.php
@@ -72,6 +72,6 @@ class SingleBase64Image extends Uploader
 
     public function getUploadedFilesFromRequest()
     {
-        return CRUD::getRequest()->get($this->getNameForRequest());
+        return CRUD::getRequest()->input($this->getNameForRequest());
     }
 }

--- a/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
+++ b/src/app/Library/Uploaders/Support/Traits/HandleRepeatableUploads.php
@@ -49,7 +49,7 @@ trait HandleRepeatableUploads
 
     protected function handleRepeatableFiles(Model $entry): Model
     {
-        $values = collect(CRUD::getRequest()->get($this->getRepeatableContainerName()));
+        $values = collect(CRUD::getRequest()->input($this->getRepeatableContainerName()));
         $files = collect(CRUD::getRequest()->file($this->getRepeatableContainerName()));
 
         $value = $this->mergeValuesRecursive($values, $files);

--- a/src/app/Models/Traits/HasUploadFields.php
+++ b/src/app/Models/Traits/HasUploadFields.php
@@ -86,7 +86,7 @@ trait HasUploadFields
             $attribute_value = $originalModelValue;
         }
 
-        $files_to_clear = request()->get('clear_'.$attribute_name);
+        $files_to_clear = request()->input('clear_'.$attribute_name);
 
         // if a file has been marked for removal,
         // delete it from the disk and from the db


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The `get` method on the Symfony `Request` class is deprecated as of Symfony 7.4; see also https://github.com/symfony/symfony/pull/61948. The `get` method on the Laravel child class is either a wrapper [discouraging usage](https://github.com/laravel/framework/blob/fa3b25a8b5f7accdb6e073ac695db5275f682643/src/Illuminate/Http/Request.php#L427-L440) or a simple copy of the Symfony method in Laravel 13. 

### AFTER - What is happening after this PR?

Replace all calls with the `input` method existing on Laravel requests, given this method is a more suitable alternative that allows obtaining input from varying sources (i.e. both request body or URL query parameters) without effort. It moreover allows for adding a default value in case a value is not present, which allows for further code simplifications.


## HOW

### How did you achieve that, in technical terms?

Replace all calls `get` with `input`; combined calls of `has` followed with `get` have been replaced with `input` and providing the 'default' value as parameter.



### Is it a breaking change?

No


### How can we test the before & after?

Behavior should be practically identical before and after

If the PR has changes in multiple repos please provide the command to checkout all branches, eg.:
```bash
git checkout "dev-branch-name" &&
cd vendor/backpack/crud && git checkout crud-branch-name &&
cd ../pro && git checkout pro-branch-name &&
cd ../../..
```
