### PR TITLE
Follow by laravel aliases before get setupRoutes function

### DIFF
--- a/src/app/Library/CrudPanel/CrudRouter.php
+++ b/src/app/Library/CrudPanel/CrudRouter.php
@@ -9,7 +9,7 @@ final class CrudRouter
 {
     public static function setupControllerRoutes(string $name, string $routeName, string $controller, string $groupNamespace = ''): void
     {
-        $namespacedController = class_exists($controller) ? $controller : $groupNamespace.$controller;
+        $namespacedController = App::getAlias(class_exists($controller) ? $controller : $groupNamespace.$controller);
 
         $controllerReflection = new ReflectionClass($namespacedController);
         $setupRoutesMethod = $controllerReflection->getMethod('setupRoutes');


### PR DESCRIPTION
## WHY

Laravel has an alias system that I'd like to use to change the behavior of a single function, rather than disabling a whole bunch of functionality and manually setting up routing.

### BEFORE - What was wrong? What was happening before this PR?

If you inherit the `setupRoutes` function, then during routing the original one will be called instead of the inherited one.

### AFTER - What is happening after this PR?

Extending `setupRoutes` and aliasing work fine.

## HOW

### How did you achieve that, in technical terms?

I don't know if I should answer this question =) 

Describe and Fix

### Is it a breaking change?

No, because this functionality was not initially used.

### How can we test the before & after?

1. Create an class and register this in routes via `Route::crud(...)`
    ```php
    class BaseProductCrudController extends CrudController
    { 
        use Operations\ListOperation;
    }
    ```
2. Create a class that extends the base class
   ```php
    class ProductCrudController extends BaseProductCrudController 
    { 
        public function setupRoutes($segment, $routeName, $controller): void
        {
            parent::setupRoutes($segment.'/test', $routeName, $controller);
        }  
    }
3. Register alias
    ```php
    app()->alias(ProductCrudController::class, BaseProductCrudController::class);
    ```
4. Call artisan function `route:view` and compare links before and after changes
