### PR TITLE
Fix summernote fields

### DIFF
--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -3,7 +3,7 @@
     // make sure that the option array is defined,
     // and at the very least, dialogsInBody is true;
     // that's needed for modals to show above the overlay in Bootstrap 4
-$field['options'] = array_merge(['dialogsInBody' => true, 'tooltip' => false], $field['options'] ?? []);
+    $field['options'] = array_merge(['dialogsInBody' => true, 'tooltip' => false], $field['options'] ?? []);
 
 $themeNamespace = config('backpack.ui.view_namespace') ?? config('backpack.ui.view_namespace_fallback', '');
 
@@ -100,10 +100,10 @@ if (!in_array($fullLocale, $supportedLanguages)) {
 {{-- FIELD CSS - will be loaded in the after_styles section --}}
 @push('crud_fields_styles')
     {{-- include summernote css --}}
-    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-{{ $summernoteTheme }}.min.css')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-'.$summernoteTheme.'.min.css')
     @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/font/summernote.woff2', false)
     @bassetBlock('backpack/crud/fields/summernote-field.css')
-    <style>
+    <style type="text/css">
         .note-editor.note-frame .note-status-output,
         .note-editor.note-airframe .note-status-output {
             height: auto;
@@ -124,18 +124,18 @@ if (!in_array($fullLocale, $supportedLanguages)) {
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
     {{-- include summernote js --}}
-    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-{{ $summernoteTheme }}.min.js')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-'.$summernoteTheme.'.min.js')
     @if ($fullLocale !== 'en-US')
-        @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/lang/summernote-{{ $fullLocale }}.js')
+        @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/lang/summernote-'.$fullLocale.'.js')
     @endif
-    @bassetBlock('backpack/crud/fields/summernote-field.js')
+    @bassetBlock('backpack/crud/fields/summernote-'.$fullLocale.'-field.js')
     <script>
         function bpFieldInitSummernoteElement(element) {
             let summernoteOptions = element.data('options');
             summernoteOptions.lang = '{{ $fullLocale }}';
 
             let summernoteCallbacks = {
-                onChange: function(contents, $editable) {
+                onChange: function (contents, $editable) {
                     element.val(contents).trigger('change');
                 },
             }
@@ -148,7 +148,7 @@ if (!in_array($fullLocale, $supportedLanguages)) {
                     element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier') + '#' + element.attr(
                         'data-repeatable-input-name') : element.attr('name');
 
-                summernoteCallbacks.onImageUpload = function(files) {
+                summernoteCallbacks.onImageUpload = function (files) {
                     const data = new FormData();
                     data.append(paramName, files[0]);
                     data.append('_token', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
@@ -159,7 +159,7 @@ if (!in_array($fullLocale, $supportedLanguages)) {
                     xhr.open('POST', imageUploadEndpoint, true);
                     xhr.setRequestHeader('Accept', 'application/json');
 
-                    xhr.onload = function() {
+                    xhr.onload = function () {
                         const response = JSON.parse(xhr.responseText);
                         if (xhr.status >= 200 && xhr.status < 300) {
                             element.summernote('insertImage', response.data.filePath);
@@ -187,7 +187,7 @@ if (!in_array($fullLocale, $supportedLanguages)) {
                         }
                     };
 
-                    xhr.onerror = function() {
+                    xhr.onerror = function () {
                         console.error('An error occurred during the upload process');
                     };
 
@@ -195,11 +195,11 @@ if (!in_array($fullLocale, $supportedLanguages)) {
                 }
             }
 
-            element.on('CrudField:disable', function(e) {
+            element.on('CrudField:disable', function (e) {
                 element.summernote('disable');
             });
 
-            element.on('CrudField:enable', function(e) {
+            element.on('CrudField:enable', function (e) {
                 element.summernote('enable');
             });
 

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -1,29 +1,95 @@
 {{-- summernote editor --}}
 @php
-    // make sure that the options array is defined
+    // make sure that the option array is defined,
     // and at the very least, dialogsInBody is true;
     // that's needed for modals to show above the overlay in Bootstrap 4
     $field['options'] = array_merge(['dialogsInBody' => true, 'tooltip' => false], $field['options'] ?? []);
+
+$themeNamespace = config('backpack.ui.view_namespace') ?? config('backpack.ui.view_namespace_fallback', '');
+
+$summernoteTheme = match ($themeNamespace) {
+    'backpack.theme-coreuiv4::', 'backpack.theme-tabler::' => 'bs5',
+    'backpack.theme-coreuiv2::' => 'bs4',
+    default => 'lite',
+};
+
+$locales = [
+    'en' => 'en-US',
+    'ko' => 'ko-KR',
+    'vi' => 'vi-VN',
+];
+
+$supportedLanguages = [
+    'ar-AR',
+    'az-AZ',
+    'bg-BG',
+    'bn-BD',
+    'ca-ES',
+    'cs-CZ',
+    'da-DK',
+    'de-CH',
+    'el-GR',
+    'en-US',
+    'es-ES',
+    'es-EU',
+    'fa-IR',
+    'fi-FI',
+    'fr-FR',
+    'gl-ES',
+    'he-IL',
+    'hr-HR',
+    'hu-HU',
+    'id-ID',
+    'it-IT',
+    'ja-JP',
+    'ko-KR',
+    'lt-LT',
+    'lv-LV',
+    'mn-MN',
+    'nb-NO',
+    'nl-NL',
+    'pl-PL',
+    'pt-BR',
+    'pt-PT',
+    'ro-RO',
+    'ru-RU',
+    'sk-SK',
+    'sl-SI',
+    'sr-RS-Latin',
+    'sr-RS',
+    'sv-SE',
+    'ta-IN',
+    'th-TH',
+    'tr-TR',
+    'uk-UA',
+    'uz-UZ',
+    'vi-VN',
+    'zh-CN',
+    'zh-TW',
+];
+
+$fullLocale = $locales[app()->getLocale()] ?? 'en-US';
+
+if (!in_array($fullLocale, $supportedLanguages)) {
+    $fullLocale = 'en-US';
+    }
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
-    <label>{!! $field['label'] !!}</label>
-    @include('crud::fields.inc.translatable_icon')
-    <textarea
-        name="{{ $field['name'] }}"
-        data-init-function="bpFieldInitSummernoteElement"
-        data-options="{{ json_encode($field['options']) }}"
-        data-upload-enabled="{{ isset($field['withFiles']) || isset($field['withMedia']) || isset($field['imageUploadEndpoint']) ? 'true' : 'false'}}"
-        data-upload-endpoint="{{ isset($field['imageUploadEndpoint']) ? $field['imageUploadEndpoint'] : 'false'}}"
-        data-upload-operation="{{ $crud->get('ajax-upload.formOperation') }}"
-        bp-field-main-input
-        @include('crud::fields.inc.attributes', ['default_class' =>  'form-control summernote'])
-        >{{ old_empty_or_null($field['name'], '') ??  $field['value'] ?? $field['default'] ?? '' }}</textarea>
+<label>{!! $field['label'] !!}</label>
+@include('crud::fields.inc.translatable_icon')
+<textarea name="{{ $field['name'] }}" data-init-function="bpFieldInitSummernoteElement"
+    data-options="{{ json_encode($field['options']) }}"
+    data-upload-enabled="{{ isset($field['withFiles']) || isset($field['withMedia']) || isset($field['imageUploadEndpoint']) ? 'true' : 'false' }}"
+    data-upload-endpoint="{{ isset($field['imageUploadEndpoint']) ? $field['imageUploadEndpoint'] : 'false' }}"
+    data-ajax-upload-endpoint="{{ url($crud->route . '/ajax-upload') }}"
+    data-upload-operation="{{ $crud->get('ajax-upload.formOperation') }}" bp-field-main-input
+    @include('crud::fields.inc.attributes', ['default_class' => 'form-control summernote'])>{{ old_empty_or_null($field['name'], '') ?? ($field['value'] ?? ($field['default'] ?? '')) }}</textarea>
 
-    {{-- HINT --}}
-    @if (isset($field['hint']))
-        <p class="help-block">{!! $field['hint'] !!}</p>
-    @endif
+{{-- HINT --}}
+@if (isset($field['hint']))
+    <p class="help-block">{!! $field['hint'] !!}</p>
+@endif
 @include('crud::fields.inc.wrapper_end')
 
 
@@ -34,101 +100,109 @@
 {{-- FIELD CSS - will be loaded in the after_styles section --}}
 @push('crud_fields_styles')
     {{-- include summernote css --}}
-    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-lite.min.css')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-{{ $summernoteTheme }}.min.css')
     @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/font/summernote.woff2', false)
     @bassetBlock('backpack/crud/fields/summernote-field.css')
-    <style type="text/css">
-        .note-editor.note-frame .note-status-output, .note-editor.note-airframe .note-status-output {
+        <style type="text/css">
+            .note-editor.note-frame .note-status-output,
+            .note-editor.note-airframe .note-status-output {
                 height: auto;
-        }
+            }
 
-        .note-modal {
-            z-index: 1060 !important; /* Higher than Bootstrap's default modal z-index */
-        }
-    </style>
+            .note-modal {
+                z-index: 1060 !important;
+                /* Higher than Bootstrap's default modal z-index */
+            }
+        </style>
     @endBassetBlock
 @endpush
 
 {{-- FIELD JS - will be loaded in the after_scripts section --}}
 @push('crud_fields_scripts')
     {{-- include summernote js --}}
-    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-lite.min.js')
+    @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-{{ $summernoteTheme }}.min.js')
+    @if ($fullLocale !== 'en-US')
+        @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/lang/summernote-{{ $fullLocale }}.js')
+    @endif
     @bassetBlock('backpack/crud/fields/summernote-field.js')
-    <script>
-        function bpFieldInitSummernoteElement(element) {
-             var summernoteOptions = element.data('options');
+        <script>
+            function bpFieldInitSummernoteElement(element) {
+                let summernoteOptions = element.data('options');
+                summernoteOptions.lang = '{{ $fullLocale }}';
 
-            let summernotCallbacks = {
-                onChange: function(contents, $editable) {
-                    element.val(contents).trigger('change');
-                },
-            }
-
-            if(element.data('upload-enabled') === true){
-                let imageUploadEndpoint =  element.data('upload-endpoint') !== false ? element.data('upload-endpoint') : '{{ url($crud->route. '/ajax-upload') }}';
-                let paramName = typeof element.attr('data-repeatable-input-name') !== 'undefined' ? element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier')+'#'+element.attr('data-repeatable-input-name') : element.attr('name');
-                summernotCallbacks.onImageUpload = function(file) {
-                    var data = new FormData();
-                    data.append(paramName, file[0]);
-                    data.append('_token', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
-                    data.append('fieldName', paramName);
-                    data.append('operation', element.data('upload-operation'));
-
-                    var xhr = new XMLHttpRequest();
-                    xhr.open('POST', imageUploadEndpoint, true);
-                    xhr.setRequestHeader('Accept', 'application/json');
-
-                    xhr.onload = function() {
-                        if (xhr.status >= 200 && xhr.status < 300) {
-                            var response = JSON.parse(xhr.responseText);
-                            element.summernote('insertImage', response.data.filePath);
-                        } else {
-                            var response = JSON.parse(xhr.responseText);
-                            let errorBagName = paramName;
-                            // it's in a repeatable field
-                            if(errorBagName.includes('#')) {
-                                errorBagName = errorBagName.replace('#', '.0.');
-                            }
-                            let errorMessages = typeof response.errors !== 'undefined' ? response.errors[errorBagName].join('<br/>') : response + '<br/>';
-
-                            let summernoteTextarea = element[0];
-
-                            // remove previous error messages
-                            summernoteTextarea.parentNode.querySelector('.invalid-feedback')?.remove();
-
-                            // add the red text classes
-                            summernoteTextarea.parentNode.classList.add('text-danger');
-
-                            // create the error message container
-                            let errorContainer = document.createElement("div");
-                            errorContainer.classList.add('invalid-feedback', 'd-block');
-                            errorContainer.innerHTML = errorMessages;
-                            summernoteTextarea.parentNode.appendChild(errorContainer);
-                        }
-                    };
-
-                    xhr.onerror = function() {
-                        console.error('An error occurred during the upload process');
-                    };
-
-                    xhr.send(data);
+                let summernoteCallbacks = {
+                    onChange: function(contents, $editable) {
+                        element.val(contents).trigger('change');
+                    },
                 }
-                
+
+                if (element.data('upload-enabled')) {
+                    const imageUploadEndpoint = element.data('upload-endpoint') !== false ? element.data('upload-endpoint') :
+                        element.data('ajax-upload-endpoint');
+
+                    const paramName = typeof element.attr('data-repeatable-input-name') !== 'undefined' ?
+                        element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier') + '#' + element.attr(
+                            'data-repeatable-input-name') : element.attr('name');
+
+                    summernoteCallbacks.onImageUpload = function(files) {
+                        const data = new FormData();
+                        data.append(paramName, files[0]);
+                        data.append('_token', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
+                        data.append('fieldName', paramName);
+                        data.append('operation', element.data('upload-operation'));
+
+                        const xhr = new XMLHttpRequest();
+                        xhr.open('POST', imageUploadEndpoint, true);
+                        xhr.setRequestHeader('Accept', 'application/json');
+
+                        xhr.onload = function() {
+                            const response = JSON.parse(xhr.responseText);
+                            if (xhr.status >= 200 && xhr.status < 300) {
+                                element.summernote('insertImage', response.data.filePath);
+                            } else {
+                                const errorBagName = paramName.includes('#') ? paramName.replace('#', '.0.') :
+                                    paramName;
+
+                                const errorMessages = typeof response.errors !== 'undefined' ? response.errors[
+                                    errorBagName].join('<br/>') : (typeof response === 'string' ? response :
+                                    'Upload failed') + '<br/>';
+
+                                let summernoteTextarea = element[0];
+
+                                // remove previous error messages
+                                summernoteTextarea.parentNode.querySelector('.invalid-feedback')?.remove();
+
+                                // add the red text classes
+                                summernoteTextarea.parentNode.classList.add('text-danger');
+
+                                // create the error message container
+                                let errorContainer = document.createElement("div");
+                                errorContainer.classList.add('invalid-feedback', 'd-block');
+                                errorContainer.innerHTML = errorMessages;
+                                summernoteTextarea.parentNode.appendChild(errorContainer);
+                            }
+                        };
+
+                        xhr.onerror = function() {
+                            console.error('An error occurred during the upload process');
+                        };
+
+                        xhr.send(data);
+                    }
+                }
+
+                element.on('CrudField:disable', function(e) {
+                    element.summernote('disable');
+                });
+
+                element.on('CrudField:enable', function(e) {
+                    element.summernote('enable');
+                });
+
+                summernoteOptions['callbacks'] = summernoteCallbacks;
+                element.summernote(summernoteOptions);
             }
-
-            element.on('CrudField:disable', function(e) {
-                element.summernote('disable');
-            });
-
-            element.on('CrudField:enable', function(e) {
-                element.summernote('enable');
-            });
-
-            summernoteOptions['callbacks'] = summernotCallbacks;
-
-            element.summernote(summernoteOptions);
-        }
-    </script>
+        </script>
     @endBassetBlock
 @endpush
 

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -3,7 +3,7 @@
     // make sure that the option array is defined,
     // and at the very least, dialogsInBody is true;
     // that's needed for modals to show above the overlay in Bootstrap 4
-    $field['options'] = array_merge(['dialogsInBody' => true, 'tooltip' => false], $field['options'] ?? []);
+$field['options'] = array_merge(['dialogsInBody' => true, 'tooltip' => false], $field['options'] ?? []);
 
 $themeNamespace = config('backpack.ui.view_namespace') ?? config('backpack.ui.view_namespace_fallback', '');
 
@@ -79,11 +79,11 @@ if (!in_array($fullLocale, $supportedLanguages)) {
 <label>{!! $field['label'] !!}</label>
 @include('crud::fields.inc.translatable_icon')
 <textarea name="{{ $field['name'] }}" data-init-function="bpFieldInitSummernoteElement"
-    data-options="{{ json_encode($field['options']) }}"
-    data-upload-enabled="{{ isset($field['withFiles']) || isset($field['withMedia']) || isset($field['imageUploadEndpoint']) ? 'true' : 'false' }}"
-    data-upload-endpoint="{{ isset($field['imageUploadEndpoint']) ? $field['imageUploadEndpoint'] : 'false' }}"
-    data-ajax-upload-endpoint="{{ url($crud->route . '/ajax-upload') }}"
-    data-upload-operation="{{ $crud->get('ajax-upload.formOperation') }}" bp-field-main-input
+          data-options="{{ json_encode($field['options']) }}"
+          data-upload-enabled="{{ isset($field['withFiles']) || isset($field['withMedia']) || isset($field['imageUploadEndpoint']) ? 'true' : 'false' }}"
+          data-upload-endpoint="{{ isset($field['imageUploadEndpoint']) ? $field['imageUploadEndpoint'] : 'false' }}"
+          data-ajax-upload-endpoint="{{ url($crud->route . '/ajax-upload') }}"
+          data-upload-operation="{{ $crud->get('ajax-upload.formOperation') }}" bp-field-main-input
     @include('crud::fields.inc.attributes', ['default_class' => 'form-control summernote'])>{{ old_empty_or_null($field['name'], '') ?? ($field['value'] ?? ($field['default'] ?? '')) }}</textarea>
 
 {{-- HINT --}}
@@ -103,17 +103,21 @@ if (!in_array($fullLocale, $supportedLanguages)) {
     @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/summernote-{{ $summernoteTheme }}.min.css')
     @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/font/summernote.woff2', false)
     @bassetBlock('backpack/crud/fields/summernote-field.css')
-        <style type="text/css">
-            .note-editor.note-frame .note-status-output,
-            .note-editor.note-airframe .note-status-output {
-                height: auto;
-            }
+    <style>
+        .note-editor.note-frame .note-status-output,
+        .note-editor.note-airframe .note-status-output {
+            height: auto;
+        }
 
-            .note-modal {
-                z-index: 1060 !important;
-                /* Higher than Bootstrap's default modal z-index */
-            }
-        </style>
+        .note-editor.note-frame .card-header.note-toolbar {
+            display: block;
+        }
+
+        .note-modal {
+            z-index: 1060 !important;
+            /* Higher than Bootstrap's default modal z-index */
+        }
+    </style>
     @endBassetBlock
 @endpush
 
@@ -125,84 +129,84 @@ if (!in_array($fullLocale, $supportedLanguages)) {
         @basset('https://cdn.jsdelivr.net/npm/summernote@0.9.1/dist/lang/summernote-{{ $fullLocale }}.js')
     @endif
     @bassetBlock('backpack/crud/fields/summernote-field.js')
-        <script>
-            function bpFieldInitSummernoteElement(element) {
-                let summernoteOptions = element.data('options');
-                summernoteOptions.lang = '{{ $fullLocale }}';
+    <script>
+        function bpFieldInitSummernoteElement(element) {
+            let summernoteOptions = element.data('options');
+            summernoteOptions.lang = '{{ $fullLocale }}';
 
-                let summernoteCallbacks = {
-                    onChange: function(contents, $editable) {
-                        element.val(contents).trigger('change');
-                    },
-                }
-
-                if (element.data('upload-enabled')) {
-                    const imageUploadEndpoint = element.data('upload-endpoint') !== false ? element.data('upload-endpoint') :
-                        element.data('ajax-upload-endpoint');
-
-                    const paramName = typeof element.attr('data-repeatable-input-name') !== 'undefined' ?
-                        element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier') + '#' + element.attr(
-                            'data-repeatable-input-name') : element.attr('name');
-
-                    summernoteCallbacks.onImageUpload = function(files) {
-                        const data = new FormData();
-                        data.append(paramName, files[0]);
-                        data.append('_token', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
-                        data.append('fieldName', paramName);
-                        data.append('operation', element.data('upload-operation'));
-
-                        const xhr = new XMLHttpRequest();
-                        xhr.open('POST', imageUploadEndpoint, true);
-                        xhr.setRequestHeader('Accept', 'application/json');
-
-                        xhr.onload = function() {
-                            const response = JSON.parse(xhr.responseText);
-                            if (xhr.status >= 200 && xhr.status < 300) {
-                                element.summernote('insertImage', response.data.filePath);
-                            } else {
-                                const errorBagName = paramName.includes('#') ? paramName.replace('#', '.0.') :
-                                    paramName;
-
-                                const errorMessages = typeof response.errors !== 'undefined' ? response.errors[
-                                    errorBagName].join('<br/>') : (typeof response === 'string' ? response :
-                                    'Upload failed') + '<br/>';
-
-                                let summernoteTextarea = element[0];
-
-                                // remove previous error messages
-                                summernoteTextarea.parentNode.querySelector('.invalid-feedback')?.remove();
-
-                                // add the red text classes
-                                summernoteTextarea.parentNode.classList.add('text-danger');
-
-                                // create the error message container
-                                let errorContainer = document.createElement("div");
-                                errorContainer.classList.add('invalid-feedback', 'd-block');
-                                errorContainer.innerHTML = errorMessages;
-                                summernoteTextarea.parentNode.appendChild(errorContainer);
-                            }
-                        };
-
-                        xhr.onerror = function() {
-                            console.error('An error occurred during the upload process');
-                        };
-
-                        xhr.send(data);
-                    }
-                }
-
-                element.on('CrudField:disable', function(e) {
-                    element.summernote('disable');
-                });
-
-                element.on('CrudField:enable', function(e) {
-                    element.summernote('enable');
-                });
-
-                summernoteOptions['callbacks'] = summernoteCallbacks;
-                element.summernote(summernoteOptions);
+            let summernoteCallbacks = {
+                onChange: function(contents, $editable) {
+                    element.val(contents).trigger('change');
+                },
             }
-        </script>
+
+            if (element.data('upload-enabled')) {
+                const imageUploadEndpoint = element.data('upload-endpoint') !== false ? element.data('upload-endpoint') :
+                    element.data('ajax-upload-endpoint');
+
+                const paramName = typeof element.attr('data-repeatable-input-name') !== 'undefined' ?
+                    element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier') + '#' + element.attr(
+                        'data-repeatable-input-name') : element.attr('name');
+
+                summernoteCallbacks.onImageUpload = function(files) {
+                    const data = new FormData();
+                    data.append(paramName, files[0]);
+                    data.append('_token', document.querySelector('meta[name="csrf-token"]').getAttribute('content'));
+                    data.append('fieldName', paramName);
+                    data.append('operation', element.data('upload-operation'));
+
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('POST', imageUploadEndpoint, true);
+                    xhr.setRequestHeader('Accept', 'application/json');
+
+                    xhr.onload = function() {
+                        const response = JSON.parse(xhr.responseText);
+                        if (xhr.status >= 200 && xhr.status < 300) {
+                            element.summernote('insertImage', response.data.filePath);
+                        } else {
+                            const errorBagName = paramName.includes('#') ? paramName.replace('#', '.0.') :
+                                paramName;
+
+                            const errorMessages = typeof response.errors !== 'undefined' ? response.errors[
+                                errorBagName].join('<br/>') : (typeof response === 'string' ? response :
+                                'Upload failed') + '<br/>';
+
+                            let summernoteTextarea = element[0];
+
+                            // remove previous error messages
+                            summernoteTextarea.parentNode.querySelector('.invalid-feedback')?.remove();
+
+                            // add the red text classes
+                            summernoteTextarea.parentNode.classList.add('text-danger');
+
+                            // create the error message container
+                            let errorContainer = document.createElement("div");
+                            errorContainer.classList.add('invalid-feedback', 'd-block');
+                            errorContainer.innerHTML = errorMessages;
+                            summernoteTextarea.parentNode.appendChild(errorContainer);
+                        }
+                    };
+
+                    xhr.onerror = function() {
+                        console.error('An error occurred during the upload process');
+                    };
+
+                    xhr.send(data);
+                }
+            }
+
+            element.on('CrudField:disable', function(e) {
+                element.summernote('disable');
+            });
+
+            element.on('CrudField:enable', function(e) {
+                element.summernote('enable');
+            });
+
+            summernoteOptions['callbacks'] = summernoteCallbacks;
+            element.summernote(summernoteOptions);
+        }
+    </script>
     @endBassetBlock
 @endpush
 


### PR DESCRIPTION
# Pull Request Description

## WHY

### BEFORE – What was wrong?

* Summernote always loaded the `summernote-lite` build, which is not fully compatible with Backpack themes based on Bootstrap 4 or Bootstrap 5.
* No automatic language loading based on the application's locale.
* No safe fallback when the locale is not supported by Summernote.
* The image upload logic was unclear and partially duplicated.
* **Critical issue:** `data-ajax-upload-endpoint` was previously defined inside a `<script>` wrapped in `@bassetBlock`, which caused Basset compilation errors:

  * Basset cannot reliably process Blade expressions inside `@bassetBlock`.
  * As a result, the upload endpoint became empty or undefined at runtime.
  * Summernote image uploads failed because JavaScript could not access a valid endpoint.

### AFTER – What is happening now?

* Summernote now automatically loads the correct build based on the active Backpack theme (`lite`, `bs4`, or `bs5`).
* Automatic loading of the correct Summernote language file based on the application's locale.
* Unsupported locales safely fall back to `en-US`.
* Image upload works reliably because:

  * `data-ajax-upload-endpoint` is now placed directly in the HTML markup.
  * JavaScript always receives the correct upload endpoint.
* Cleaner, more maintainable code.
* Improved compatibility with multiple Backpack themes and multilingual setups.

---

## HOW

### Technical explanation

* Added logic to detect the active Backpack theme and map it to the appropriate Summernote build.
* Added internal locale → Summernote locale mapping and a list of supported languages.
* Load Summernote JS/CSS dynamically based on theme and locale.
* **Moved `data-ajax-upload-endpoint` out of the `@bassetBlock` and into the textarea’s HTML attributes**, solving Basset compilation issues.
* Improved error handling and feedback display.
* Kept all existing Summernote callbacks (`onChange`, `disable`, `enable`, etc.) intact.

---

## Is this a breaking change?

**No.**
Existing Summernote fields continue working normally.
This PR only introduces improvements, better compatibility, and a fix for the upload endpoint bug.

---

## Testing Instructions

1. **Image Upload**

   * Before: fails due to undefined endpoint.
   * After: upload works correctly.

2. **Theme Compatibility**

   * Test with `backpack.theme-coreuiv2` (Bootstrap 4)
   * Test with `backpack.theme-coreuiv4` and `backpack.theme-tabler` (Bootstrap 5)
   * No theme → Summernote Lite

3. **Locale Support**

   * `APP_LOCALE=vi` → loads `summernote-vi-VN.js`
   * `APP_LOCALE=ko` → loads `summernote-ko-KR.js`
   * Unsupported locale → falls back to `en-US`

4. **Repeatable Fields**

   * Ensure uploads work inside repeatable structures.

5. **Modal Rendering**

   * Confirm Summernote dialogs render above Bootstrap overlays.

---
