### PR TITLE
Fix overflow of column visibility dropdown

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -468,6 +468,10 @@ div[id$="_wrapper"] .dt-processing {
     background-color: white;
 }
 
+.navbar.navbar-filters + div:has(.dt-button-collection) {
+    overflow: visible !important;
+}
+
 .dataTables_wrapper .dt-buttons .dt-button-collection {
     width: auto;
 }


### PR DESCRIPTION
fixes #5942 

When there are a number of columns that extend the column visibility dropdown above the filter navbar, the dropdown got clipped.

This ensures this dropdown is allowed to overflow. 