### PR TITLE
add crudTableResetButton translation

### DIFF
--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -617,7 +617,7 @@ function setupTableUI(tableId, config) {
     }
 
     if (config.resetButton !== false) {
-        var crudTableResetButton = `<a href="${config.urlStart}" class="ml-1 ms-1" id="${tableId}_reset_button">Reset</a>`;
+        var crudTableResetButton = `<a href="${config.urlStart}" class="ml-1 ms-1" id="${tableId}_reset_button">{{ trans('backpack::crud.reset') }}</a>`;
         $(`#datatable_info_stack_${tableId}`).append(crudTableResetButton);
 
         // when clicking in reset button we clear the localStorage for datatables


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

"Reset" link on datatable had hardcoded name without translating. 

### AFTER - What is happening after this PR?

The reset link on datatable is translated, if use non-english language in backpack


## HOW

### How did you achieve that, in technical terms?

during migration from v6



### Is it a breaking change?

I think no


### How can we test the before & after?
https://next.backpackforlaravel.com/admin/pet-shop/invoice
select Portuguese and Reset will be Reset, but not 'reset' => 'Repor' from lang files

