### PR TITLE
Normalize field attributes when overriding existing fields

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Fields.php
+++ b/src/app/Library/CrudPanel/Traits/Fields.php
@@ -106,6 +106,15 @@ trait Fields
      */
     public function addField($field)
     {
+        $field = $this->makeSureFieldHasName($field);
+
+        // If the field already exists in the current operation, merge the incoming
+        // definition on top of the existing one so that only the attributes the
+        // developer explicitly provided are overridden and everything else is kept.
+        if ($existingField = $this->firstFieldWhere('name', $field['name'])) {
+            $field = array_merge($existingField, $field);
+        }
+
         $field = $this->makeSureFieldHasNecessaryAttributes($field);
 
         $this->enableTabsIfFieldUsesThem($field);

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -572,11 +572,11 @@ class CrudPanelFieldsTest extends BaseCrudPanel
     public function testAddFieldMergesWithExistingFieldAttributesInSameOperation()
     {
         $this->crudPanel->addField([
-            'name'   => 'spouse',
-            'label'  => 'Spouse',
-            'type'   => 'select2_from_ajax',
+            'name' => 'spouse',
+            'label' => 'Spouse',
+            'type' => 'select2_from_ajax',
             'method' => 'POST',
-            'hint'   => 'Original hint.',
+            'hint' => 'Original hint.',
         ]);
 
         $this->crudPanel->addField([
@@ -598,9 +598,9 @@ class CrudPanelFieldsTest extends BaseCrudPanel
     public function testAddFieldMergesWithExistingFieldAttributesViaFluentSyntax()
     {
         $this->crudPanel->addField([
-            'name'   => 'spouse',
-            'label'  => 'Spouse',
-            'type'   => 'select2_from_ajax',
+            'name' => 'spouse',
+            'label' => 'Spouse',
+            'type' => 'select2_from_ajax',
             'method' => 'POST',
         ]);
 

--- a/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelFieldsTest.php
@@ -569,6 +569,52 @@ class CrudPanelFieldsTest extends BaseCrudPanel
         // TODO: the decode JSON method should not be in fields trait and should not be exposed in the public API.
     }
 
+    public function testAddFieldMergesWithExistingFieldAttributesInSameOperation()
+    {
+        $this->crudPanel->addField([
+            'name'   => 'spouse',
+            'label'  => 'Spouse',
+            'type'   => 'select2_from_ajax',
+            'method' => 'POST',
+            'hint'   => 'Original hint.',
+        ]);
+
+        $this->crudPanel->addField([
+            'name' => 'spouse',
+            'hint' => 'Updated hint for update only.',
+        ]);
+
+        $this->assertCount(1, $this->crudPanel->fields());
+
+        $field = $this->crudPanel->fields()['spouse'];
+
+        $this->assertEquals('Updated hint for update only.', $field['hint']);
+
+        $this->assertEquals('Spouse', $field['label']);
+        $this->assertEquals('select2_from_ajax', $field['type']);
+        $this->assertEquals('POST', $field['method']);
+    }
+
+    public function testAddFieldMergesWithExistingFieldAttributesViaFluentSyntax()
+    {
+        $this->crudPanel->addField([
+            'name'   => 'spouse',
+            'label'  => 'Spouse',
+            'type'   => 'select2_from_ajax',
+            'method' => 'POST',
+        ]);
+
+        $this->crudPanel->field('spouse')->method('GET');
+
+        $this->assertCount(1, $this->crudPanel->fields());
+
+        $field = $this->crudPanel->fields()['spouse'];
+
+        $this->assertEquals('GET', $field['method']);
+        $this->assertEquals('Spouse', $field['label']);
+        $this->assertEquals('select2_from_ajax', $field['type']);
+    }
+
     public function testFieldNameDotNotationIsRelationship()
     {
         $this->crudPanel->setModel(User::class);


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/community-forum/issues/1252 there was an inconsistency while defining the field attributes using fluent or array syntax.

Using the fluent syntax, when doing `CRUD::field('smt')` on an already existing field, you would get the "stored field" attributtes, while doing: `CRUD::field(['name' => 'smt'])` won't get the previously defined attributes for `smt` field, but instead, infer all the attributes again, so not getting the previous developer definition for that field. 