### PR TITLE
Add the translatable label to subfields too

### DIFF
--- a/src/resources/views/crud/fields/inc/translatable_icon.blade.php
+++ b/src/resources/views/crud/fields/inc/translatable_icon.blade.php
@@ -1,16 +1,23 @@
 @php
     // if field name is array we check if any of the arrayed fields is translatable
     $translatable = false;
-    if($crud->model->translationEnabled()) {
-        foreach((array) $field['name'] as $field_name){
-            if($crud->model->isTranslatableAttribute($field_name)) {
+
+    $translatableModel = isset($field['baseModel']) ? app($field['baseModel']) : $crud->model;
+
+    $translatableFieldNames = isset($field['baseFieldName'])
+        ? explode(',', $field['baseFieldName'])
+        : (array) $field['name'];
+
+    if (method_exists($translatableModel, 'translationEnabled') && $translatableModel->translationEnabled()) {
+        foreach ($translatableFieldNames as $field_name) {
+            if ($translatableModel->isTranslatableAttribute($field_name)) {
                 $translatable = true;
             }
         }
         // if the field is a fake one (value is stored in a JSON column instead of a direct db column)
         // and that JSON column is translatable, then the field itself should be translatable
-        if(isset($field['store_in']) && $crud->model->isTranslatableAttribute($field['store_in'])) {
-                $translatable = true;
+        if (isset($field['store_in']) && $translatableModel->isTranslatableAttribute($field['store_in'])) {
+            $translatable = true;
         }
     }
 


### PR DESCRIPTION
As reported in https://github.com/Laravel-Backpack/CRUD/issues/5704 subfields wouldn't contain the translatable flag icon when the related model was translatable.