### PR TITLE
Add tests for MariaDB NULL string on relationships

### DIFF
--- a/src/app/Library/Database/Table.php
+++ b/src/app/Library/Database/Table.php
@@ -34,7 +34,7 @@ final class Table
                         (is_a($this->schemaManager->getConnection(), \Illuminate\Database\MariaDbConnection::class) &&
                             is_string($this->column['default']) &&
                             $this->column['nullable'] === true &&
-                            ($this->column['default'] === 'null' || $this->column['default'] === 'NULL') ? null : $this->column['default']) : $this->column['default'];
+                            (strtolower($this->column['default']) === 'null') ? null : $this->column['default']) : $this->column['default'];
                 }
 
                 public function getUnsigned()

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -2174,4 +2174,108 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
             \Illuminate\Database\Eloquent\Model::preventSilentlyDiscardingAttributes($previousState);
         }
     }
+
+    /**
+     * Regression test for https://github.com/Laravel-Backpack/community-forum/issues/932
+     */
+    public function testHasManySelectableRelationshipRemoveRelationsWithMariaDbNullDefault()
+    {
+        if (! class_exists(\Illuminate\Database\MariaDbConnection::class)) {
+            $this->markTestSkipped('MariaDbConnection is not available in this Laravel version.');
+        }
+
+        // Build a fake schema manager whose getConnection() returns a MariaDbConnection
+        // mock so that Table::getDefault()'s is_a() check passes, simulating a real
+        // MariaDB connection returning 'NULL' (string) for nullable FK columns.
+        $mariaDbConn = $this->createStub(\Illuminate\Database\MariaDbConnection::class);
+        $fakeSchemaManager = new class($mariaDbConn) {
+            public function __construct(private object $conn) {}
+
+            public function getConnection(): object
+            {
+                return $this->conn;
+            }
+        };
+
+        // Build a Table that mimics what MariaDB's information_schema returns:
+        // nullable FK column whose COLUMN_DEFAULT is the *string* 'NULL'.
+        $mariaDbLikeTable = new \Backpack\CRUD\app\Library\Database\Table('planets', [
+            ['name' => 'id',      'nullable' => false, 'default' => null,   'type' => 'bigint unsigned', 'type_name' => 'bigint'],
+            ['name' => 'user_id', 'nullable' => true,  'default' => 'NULL', 'type' => 'bigint',          'type_name' => 'bigint'],
+            ['name' => 'title',   'nullable' => true,  'default' => null,   'type' => 'varchar',         'type_name' => 'varchar'],
+        ], $fakeSchemaManager);
+
+        // Replace the DatabaseSchema binding so that only the planets table
+        // returns our MariaDB-like fake; everything else delegates to the real schema.
+        $this->app->instance('DatabaseSchema', new class($mariaDbLikeTable) {
+            public function __construct(private \Backpack\CRUD\app\Library\Database\Table $fakeTable)
+            {
+            }
+
+            public function getForTable(string $table, string $connection): mixed
+            {
+                if ($table === 'planets') {
+                    return $this->fakeTable;
+                }
+
+                return \Backpack\CRUD\app\Library\Database\DatabaseSchema::getForTable($table, $connection);
+            }
+
+            public function listTableColumnsNames(string $connection, string $table): array
+            {
+                $tableObj = $this->getForTable($table, $connection);
+
+                return $tableObj ? array_keys($tableObj->getColumns()) : [];
+            }
+
+            public function listTableIndexes(string $connection, string $table): array
+            {
+                $tableObj = $this->getForTable($table, $connection);
+
+                if (! $tableObj) {
+                    return [];
+                }
+
+                $indexes = \Illuminate\Support\Arr::flatten(array_map(function ($index) {
+                    return is_string($index) ? $index : $index->getColumns();
+                }, $tableObj->getIndexes()));
+
+                return array_unique($indexes);
+            }
+        });
+
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'name'        => 'planets',
+            'force_delete' => false,
+            'fallback_id'  => false,
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name'           => $faker->name,
+            'email'          => $faker->safeEmail,
+            'password'       => Hash::make($faker->password()),
+            'remember_token' => null,
+            'planets'        => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+        $this->assertCount(2, $entry->planets);
+
+        $inputData['planets'] = [];
+        $this->crudPanel->update($entry->id, $inputData);
+
+        // Planets are kept in the DB (not deleted) but detached from the user.
+        $this->assertCount(0, $entry->fresh()->planets);
+
+        $allPlanets = Planet::all();
+        $this->assertCount(2, $allPlanets);
+
+        // The FK must be PHP null (SQL NULL), NOT the string 'NULL' or integer 0.
+        foreach ($allPlanets as $planet) {
+            $this->assertNull($planet->user_id, "Expected user_id to be NULL after detach, got: {$planet->user_id}");
+        }
+    }
 }

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -2176,7 +2176,7 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
     }
 
     /**
-     * Regression test for https://github.com/Laravel-Backpack/community-forum/issues/932
+     * Regression test for https://github.com/Laravel-Backpack/community-forum/issues/932.
      */
     public function testHasManySelectableRelationshipRemoveRelationsWithMariaDbNullDefault()
     {
@@ -2188,8 +2188,11 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         // mock so that Table::getDefault()'s is_a() check passes, simulating a real
         // MariaDB connection returning 'NULL' (string) for nullable FK columns.
         $mariaDbConn = $this->createStub(\Illuminate\Database\MariaDbConnection::class);
-        $fakeSchemaManager = new class($mariaDbConn) {
-            public function __construct(private object $conn) {}
+        $fakeSchemaManager = new class($mariaDbConn)
+        {
+            public function __construct(private object $conn)
+            {
+            }
 
             public function getConnection(): object
             {
@@ -2207,7 +2210,8 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
 
         // Replace the DatabaseSchema binding so that only the planets table
         // returns our MariaDB-like fake; everything else delegates to the real schema.
-        $this->app->instance('DatabaseSchema', new class($mariaDbLikeTable) {
+        $this->app->instance('DatabaseSchema', new class($mariaDbLikeTable)
+        {
             public function __construct(private \Backpack\CRUD\app\Library\Database\Table $fakeTable)
             {
             }
@@ -2247,18 +2251,18 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
         $this->crudPanel->setModel(User::class);
         $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
         $this->crudPanel->addField([
-            'name'        => 'planets',
+            'name' => 'planets',
             'force_delete' => false,
-            'fallback_id'  => false,
+            'fallback_id' => false,
         ], 'both');
 
         $faker = Factory::create();
         $inputData = [
-            'name'           => $faker->name,
-            'email'          => $faker->safeEmail,
-            'password'       => Hash::make($faker->password()),
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
             'remember_token' => null,
-            'planets'        => [1, 2],
+            'planets' => [1, 2],
         ];
 
         $entry = $this->crudPanel->create($inputData);

--- a/tests/Unit/Database/DatabaseTableTest.php
+++ b/tests/Unit/Database/DatabaseTableTest.php
@@ -18,8 +18,11 @@ class DatabaseTableTest extends TestCase
 
         $mariaDbConn = $this->createStub(\Illuminate\Database\MariaDbConnection::class);
 
-        return new class($mariaDbConn) {
-            public function __construct(private object $conn) {}
+        return new class($mariaDbConn)
+        {
+            public function __construct(private object $conn)
+            {
+            }
 
             public function getConnection(): object
             {
@@ -106,11 +109,11 @@ class DatabaseTableTest extends TestCase
     {
         // A nullable VARCHAR column with a real string default must not be changed
         $column = $this->makeColumn([
-            'name'      => 'status',
-            'type'      => 'varchar',
+            'name' => 'status',
+            'type' => 'varchar',
             'type_name' => 'varchar',
-            'nullable'  => true,
-            'default'   => 'active',
+            'nullable' => true,
+            'default' => 'active',
         ]);
 
         $this->assertSame('active', $column->getDefault());

--- a/tests/Unit/Database/DatabaseTableTest.php
+++ b/tests/Unit/Database/DatabaseTableTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\Database;
+
+use Backpack\CRUD\app\Library\Database\Table;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Backpack\CRUD\app\Library\Database\Table
+ */
+class DatabaseTableTest extends TestCase
+{
+    private function makeMariaDbSchemaManager(): ?object
+    {
+        if (! class_exists(\Illuminate\Database\MariaDbConnection::class)) {
+            return null;
+        }
+
+        $mariaDbConn = $this->createStub(\Illuminate\Database\MariaDbConnection::class);
+
+        return new class($mariaDbConn) {
+            public function __construct(private object $conn) {}
+
+            public function getConnection(): object
+            {
+                return $this->conn;
+            }
+        };
+    }
+
+    private function makeColumn(array $attributes, ?object $schemaManager = null): object
+    {
+        $defaults = ['type' => 'bigint', 'type_name' => 'bigint'];
+        $table = new Table('test', [array_merge($defaults, $attributes)], $schemaManager);
+
+        return $table->getColumn($attributes['name']);
+    }
+
+    /** @test */
+    public function testGetDefaultNormalizesUpperCaseNullStringForNullableColumn()
+    {
+        $schemaManager = $this->makeMariaDbSchemaManager();
+        if ($schemaManager === null) {
+            $this->markTestSkipped('MariaDbConnection is not available in this Laravel version.');
+        }
+
+        // MariaDB returns 'NULL' (uppercase string) for nullable columns with DEFAULT NULL
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => true, 'default' => 'NULL'], $schemaManager);
+
+        $this->assertNull($column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultNormalizesLowerCaseNullStringForNullableColumn()
+    {
+        $schemaManager = $this->makeMariaDbSchemaManager();
+        if ($schemaManager === null) {
+            $this->markTestSkipped('MariaDbConnection is not available in this Laravel version.');
+        }
+
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => true, 'default' => 'null'], $schemaManager);
+
+        $this->assertNull($column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultNormalizesMixedCaseNullStringForNullableColumn()
+    {
+        $schemaManager = $this->makeMariaDbSchemaManager();
+        if ($schemaManager === null) {
+            $this->markTestSkipped('MariaDbConnection is not available in this Laravel version.');
+        }
+
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => true, 'default' => 'Null'], $schemaManager);
+
+        $this->assertNull($column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultReturnsPhpNullWhenDefaultIsAlreadyNull()
+    {
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => true, 'default' => null]);
+
+        $this->assertNull($column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultReturnsActualStringDefaultForNonNullValue()
+    {
+        // A column with a numeric default should be returned unchanged
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => false, 'default' => '0']);
+
+        $this->assertSame('0', $column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultDoesNotNormalizeNullStringForNonNullableColumn()
+    {
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => false, 'default' => 'NULL']);
+
+        $this->assertSame('NULL', $column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultDoesNotNormalizeArbitraryStringDefaultForNullableColumn()
+    {
+        // A nullable VARCHAR column with a real string default must not be changed
+        $column = $this->makeColumn([
+            'name'      => 'status',
+            'type'      => 'varchar',
+            'type_name' => 'varchar',
+            'nullable'  => true,
+            'default'   => 'active',
+        ]);
+
+        $this->assertSame('active', $column->getDefault());
+    }
+
+    /** @test */
+    public function testGetDefaultWithoutSchemaManagerReturnsRawValue()
+    {
+        $column = $this->makeColumn(['name' => 'user_id', 'nullable' => true, 'default' => 'NULL']);
+
+        $this->assertSame('NULL', $column->getDefault());
+    }
+}


### PR DESCRIPTION
Nothing wrong. 

There was an issue opened regarding this. I spent quite some time figuring out if it was still present, so I decided to write tests for it. 

The small change in `Table.php` is 100% backwards compatible, is just "cleaner", function wise, does exactly the same. 