### PR TITLE
fix: prevent image deletion in repeatable field when updating other f…

### DIFF
--- a/src/app/Library/Uploaders/MultipleFiles.php
+++ b/src/app/Library/Uploaders/MultipleFiles.php
@@ -89,10 +89,18 @@ class MultipleFiles extends Uploader
 
         foreach ($previousRepeatableValues as $previousRow => $previousFiles) {
             foreach ($previousFiles ?? [] as $key => $file) {
-                $previousFileInArray = array_filter($tempFileOrder, function ($items, $key) use ($file, $tempFileOrder) {
+                $fileBasename = $this->getValueWithoutPath($file);
+                $previousFileInArray = array_filter($tempFileOrder, function ($items, $rowKey) use ($file, $fileBasename, $tempFileOrder, &$fileOrder) {
                     $found = array_search($file, $items ?? [], true);
+                    if ($found === false) {
+                        $found = array_search($fileBasename, $items ?? [], true);
+                        if ($found !== false && isset($fileOrder[$rowKey][$found]) && $fileOrder[$rowKey][$found] !== $file) {
+                            // Restore the full path so the DB stores the complete path.
+                            $fileOrder[$rowKey][$found] = $file;
+                        }
+                    }
                     if ($found !== false) {
-                        Arr::forget($tempFileOrder, $key.'.'.$found);
+                        Arr::forget($tempFileOrder, $rowKey.'.'.$found);
 
                         return true;
                     }

--- a/src/app/Library/Uploaders/SingleBase64Image.php
+++ b/src/app/Library/Uploaders/SingleBase64Image.php
@@ -65,6 +65,8 @@ class SingleBase64Image extends Uploader
                 } else {
                     $values[$row] = null;
                 }
+            } elseif ($rowValue && isset($previousRepeatableValues[$row])) {
+                $values[$row] = $previousRepeatableValues[$row];
             }
         }
 

--- a/src/app/Library/Uploaders/SingleFile.php
+++ b/src/app/Library/Uploaders/SingleFile.php
@@ -57,8 +57,14 @@ class SingleFile extends Uploader
                 if (! isset($orderedFiles[$row])) {
                     $orderedFiles[$row] = null;
                 }
-                if (! in_array($file, $orderedFiles)) {
+                $foundKey = array_search($file, $orderedFiles);
+                if ($foundKey === false) {
+                    $foundKey = array_search($this->getValueWithoutPath($file), $orderedFiles);
+                }
+                if ($foundKey === false) {
                     Storage::disk($this->getDisk())->delete($file);
+                } elseif ($orderedFiles[$foundKey] !== $file) {
+                    $orderedFiles[$foundKey] = $file;
                 }
             }
         }


### PR DESCRIPTION
Fixes #5728 - Repeatable field delete images on update operation

When updating an entity with image subfields in a repeatable field without touching the images (only changing text fields), the existing images were incorrectly deleted.

**Root Cause:** The uploadRepeatableFiles methods unconditionally deleted previous files not present in the new request - even when no file changes were made.

**Solution:** Added a check to only run file deletion logic when files are actually being modified (new uploads or row removals).