### PR TITLE
fix: use previous URL for back button when accessed from widget (#5979)

### DIFF
--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -18,7 +18,12 @@
         @if ($crud->hasAccess('list'))
             <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
                 <small>
-                    <a href="{{ url($crud->route) }}" class="d-print-none font-sm">
+                    @php
+                        $backUrl = url()->previous() !== url($crud->route) && url()->previous() !== url()->full()
+                            ? url()->previous()
+                            : url($crud->route);
+                    @endphp
+                    <a href="{{ $backUrl }}" class="d-print-none font-sm">
                         <span><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></span>
                     </a>
                 </small>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -17,7 +17,13 @@
         <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</p>
         @if ($crud->hasAccess('list'))
             <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+                <small>
+                    @php
+                        $backUrl = url()->previous() !== url($crud->route) && url()->previous() !== url()->full()
+                            ? url()->previous()
+                            : url($crud->route);
+                    @endphp
+                    <a href="{{ $backUrl }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
             </p>
         @endif
     </section>


### PR DESCRIPTION
Bug: When using a datatable widget on a show page (e.g., order header), clicking "Create New Record" to add a child item, then clicking "Back" would go to the full list instead of back to the parent show page.

Root Cause: The back button in create.blade.php and edit.blade.php always pointed to the list route (url($crud->route)), ignoring where the user actually came from.

Solution: Modified the back button to check url()->previous(). If the previous URL is different from the current route (meaning the user came from elsewhere like a widget or parent page), use the previous URL. Otherwise, fall back to the list route.