### PR TITLE
Fixed Summernote initialize failed  in production env

### DIFF
--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -65,7 +65,7 @@
             }
 
             if(element.data('upload-enabled') === true){
-                let imageUploadEndpoint =  element.data('upload-endpoint') !== false ? element.data('upload-endpoint') : '{{ url($crud->route. '/ajax-upload') }}';
+                let imageUploadEndpoint =  element.data('upload-endpoint') !== false ? element.data('upload-endpoint') : "{{ url($crud->route. '/ajax-upload') }}";
                 let paramName = typeof element.attr('data-repeatable-input-name') !== 'undefined' ? element.closest('[data-repeatable-identifier]').attr('data-repeatable-identifier')+'#'+element.attr('data-repeatable-input-name') : element.attr('name');
                 summernotCallbacks.onImageUpload = function(file) {
                     var data = new FormData();
@@ -113,7 +113,7 @@
 
                     xhr.send(data);
                 }
-                
+
             }
 
             element.on('CrudField:disable', function(e) {


### PR DESCRIPTION
In the production environment, the Summernote initialize failed due to a syntax error in the JavaScript configuration. The Blade template used conflicting single quotes: `‘{{ url($crud->route. ’/ajax-upload') }}'`. This caused the JavaScript engine to interpret the single quote inside the PHP helper as the closing delimiter for the JavaScript string, resulting in a malformed URL and a broken AJAX request.

I resolved the quote-nesting conflict by standardizing the use of double quotes for the JavaScript string literal and single quotes for the PHP string within the Blade expression. This prevents the JavaScript parser from "cutting off" the string prematurely when it encounters the first single quote.

this issue specifically manifests in the production environment and may not be reproducible in local development environments due to differences in how assets are served or parsed.

### Testing bug issues before the Fix (Production Environment):

- Navigate to the CRUD Create or Update page.
- Observe the field where Summernote should be initialized.
- Because of the JavaScript syntax error caused by the quote conflict, the editor fails to initialize, leaving only a standard <textarea> visible to the user.
- The browser console will show a syntax or reference error.


## Testing bug issues after the Fix (Production Environment):
- Basset clear and reinstall
- Refresh the Create or Update page.
- The Summernote rich text editor should now initialize correctly instead of appearing as a plain textarea.