### PR TITLE
Configurable back to all entries button url

### DIFF
--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -57,7 +57,7 @@ trait CreateOperation
 
         if ($backToAllEntriesUrl = request('_backToAllEntriesUrl')) {
             $parsed = parse_url($backToAllEntriesUrl) ?: [];
-            $isRelativePath = !isset($parsed['scheme']) && !isset($parsed['host']);
+            $isRelativePath = ! isset($parsed['scheme']) && ! isset($parsed['host']);
             $isInternalAbsolute = isset($parsed['host']) && $parsed['host'] === parse_url(url('/'), PHP_URL_HOST);
             if ($isRelativePath || $isInternalAbsolute) {
                 $this->crud->setOperationSetting('backToAllEntriesUrl', $backToAllEntriesUrl);

--- a/src/app/Http/Controllers/Operations/CreateOperation.php
+++ b/src/app/Http/Controllers/Operations/CreateOperation.php
@@ -55,6 +55,15 @@ trait CreateOperation
     {
         $this->crud->hasAccessOrFail('create');
 
+        if ($backToAllEntriesUrl = request('_backToAllEntriesUrl')) {
+            $parsed = parse_url($backToAllEntriesUrl) ?: [];
+            $isRelativePath = !isset($parsed['scheme']) && !isset($parsed['host']);
+            $isInternalAbsolute = isset($parsed['host']) && $parsed['host'] === parse_url(url('/'), PHP_URL_HOST);
+            if ($isRelativePath || $isInternalAbsolute) {
+                $this->crud->setOperationSetting('backToAllEntriesUrl', $backToAllEntriesUrl);
+            }
+        }
+
         // prepare the fields you need to show
         $this->data['crud'] = $this->crud;
         $this->data['saveAction'] = $this->crud->getSaveAction();

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -65,6 +65,15 @@ trait UpdateOperation
     {
         $this->crud->hasAccessOrFail('update');
 
+        if ($backToAllEntriesUrl = request('_backToAllEntriesUrl')) {
+            $parsed = parse_url($backToAllEntriesUrl) ?: [];
+            $isRelativePath = !isset($parsed['scheme']) && !isset($parsed['host']);
+            $isInternalAbsolute = isset($parsed['host']) && $parsed['host'] === parse_url(url('/'), PHP_URL_HOST);
+            if ($isRelativePath || $isInternalAbsolute) {
+                $this->crud->setOperationSetting('backToAllEntriesUrl', $backToAllEntriesUrl);
+            }
+        }
+
         // get entry ID from Request (makes sure its the last ID for nested resources)
         $id = $this->crud->getCurrentEntryId() ?? $id;
 

--- a/src/app/Http/Controllers/Operations/UpdateOperation.php
+++ b/src/app/Http/Controllers/Operations/UpdateOperation.php
@@ -67,7 +67,7 @@ trait UpdateOperation
 
         if ($backToAllEntriesUrl = request('_backToAllEntriesUrl')) {
             $parsed = parse_url($backToAllEntriesUrl) ?: [];
-            $isRelativePath = !isset($parsed['scheme']) && !isset($parsed['host']);
+            $isRelativePath = ! isset($parsed['scheme']) && ! isset($parsed['host']);
             $isInternalAbsolute = isset($parsed['host']) && $parsed['host'] === parse_url(url('/'), PHP_URL_HOST);
             if ($isRelativePath || $isInternalAbsolute) {
                 $this->crud->setOperationSetting('backToAllEntriesUrl', $backToAllEntriesUrl);

--- a/src/app/Library/CrudPanel/SaveActions/SaveAndBack.php
+++ b/src/app/Library/CrudPanel/SaveActions/SaveAndBack.php
@@ -26,6 +26,6 @@ class SaveAndBack extends AbstractSaveAction
 
     public function getRedirectUrl(CrudPanel $crud, Request $request, $itemId = null): ?string
     {
-        return $request->input('_http_referrer', $crud->route);
+        return $crud->getOperationSetting('backToAllEntriesUrl') ?? $request->input('_http_referrer', $crud->route);
     }
 }

--- a/src/app/View/Components/Datatable.php
+++ b/src/app/View/Components/Datatable.php
@@ -34,6 +34,10 @@ class Datatable extends Component
 
         $this->tableId = $this->generateTableId();
 
+        if (! $this->modifiesUrl) {
+            $this->crud->setOperationSetting('backToAllEntriesUrl', url()->current());
+        }
+
         if ($this->setup) {            // Apply the configuration using DatatableCache
             DatatableCache::applyAndStoreSetupClosure(
                 $this->tableId,

--- a/src/resources/views/crud/buttons/create.blade.php
+++ b/src/resources/views/crud/buttons/create.blade.php
@@ -1,6 +1,10 @@
 @if ($crud->hasAccess('create'))
+    @php
+        $backToAllEntriesUrl = $crud->getOperationSetting('backToAllEntriesUrl');
+        $createUrl = url($crud->route.'/create') . ($backToAllEntriesUrl ? '?_backToAllEntriesUrl='.urlencode($backToAllEntriesUrl) : '');
+    @endphp
     {{-- Regular create button that redirects to create page --}}
-    <a href="{{ url($crud->route.'/create') }}" class="btn btn-primary" bp-button="create" data-style="zoom-in">
+    <a href="{{ $createUrl }}" class="btn btn-primary" bp-button="create" data-style="zoom-in">
         <i class="la la-plus"></i> <span>{{ trans('backpack::crud.add') }} {{ $crud->entity_name }}</span>
     </a>
 @endif

--- a/src/resources/views/crud/buttons/update.blade.php
+++ b/src/resources/views/crud/buttons/update.blade.php
@@ -1,14 +1,18 @@
 @if ($crud->hasAccess('update', $entry))
+    @php
+        $backToAllEntriesUrl = $crud->getOperationSetting('backToAllEntriesUrl');
+        $editUrl = url($crud->route.'/'.$entry->getKey().'/edit') . ($backToAllEntriesUrl ? '?_backToAllEntriesUrl='.urlencode($backToAllEntriesUrl) : '');
+    @endphp
     {{-- Regular update button that redirects to edit page --}}
     @if (!$crud->model->translationEnabled() || $crud->getOperationSetting('showLanguagesDirectlyInEditButton') === false)
         {{-- Single edit button --}}
-        <a href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}" bp-button="update" class="btn btn-sm btn-link">
+        <a href="{{ $editUrl }}" bp-button="update" class="btn btn-sm btn-link">
             <i class="la la-edit"></i> <span>{{ trans('backpack::crud.edit') }}</span>
         </a>
     @else
         {{-- Edit button group --}}
         <div class="btn-group">
-            <a href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}" class="btn btn-sm btn-link pr-0">
+            <a href="{{ $editUrl }}" class="btn btn-sm btn-link pr-0">
                 <span><i class="la la-edit"></i> {{ trans('backpack::crud.edit') }}</span>
             </a>
             <a class="btn btn-sm btn-link dropdown-toggle text-primary pl-1" data-toggle="dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -17,7 +21,7 @@
             <ul class="dropdown-menu dropdown-menu-right">
                 <li class="dropdown-header">{{ trans('backpack::crud.edit_translations') }}:</li>
                 @foreach ($crud->model->getAvailableLocales() as $key => $locale)
-                    <a class="dropdown-item" href="{{ url($crud->route.'/'.$entry->getKey().'/edit') }}?_locale={{ $key }}">{{ $locale }}</a>
+                    <a class="dropdown-item" href="{{ $editUrl.(str_contains($editUrl, '?') ? '&' : '?').'_locale='.$key }}">{{ $locale }}</a>
                 @endforeach
             </ul>
         </div>

--- a/src/resources/views/crud/create.blade.php
+++ b/src/resources/views/crud/create.blade.php
@@ -18,7 +18,7 @@
         @if ($crud->hasAccess('list'))
             <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
                 <small>
-                    <a href="{{ url($crud->route) }}" class="d-print-none font-sm">
+                    <a href="{{ $crud->getOperationSetting('backToAllEntriesUrl') ?? url($crud->route) }}" class="d-print-none font-sm">
                         <span><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></span>
                     </a>
                 </small>

--- a/src/resources/views/crud/edit.blade.php
+++ b/src/resources/views/crud/edit.blade.php
@@ -17,7 +17,7 @@
         <p class="ms-2 ml-2 mb-0" bp-section="page-subheading">{!! $crud->getSubheading() ?? trans('backpack::crud.edit').' '.$crud->entity_name !!}.</p>
         @if ($crud->hasAccess('list'))
             <p class="mb-0 ms-2 ml-2" bp-section="page-subheading-back-button">
-                <small><a href="{{ url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
+                <small><a href="{{ $crud->getOperationSetting('backToAllEntriesUrl') ?? url($crud->route) }}" class="d-print-none font-sm"><i class="la la-angle-double-{{ config('backpack.base.html_direction') == 'rtl' ? 'right' : 'left' }}"></i> {{ trans('backpack::crud.back_to_all') }} <span>{{ $crud->entity_name_plural }}</span></a></small>
             </p>
         @endif
     </section>

--- a/src/resources/views/crud/inc/form_save_buttons.blade.php
+++ b/src/resources/views/crud/inc/form_save_buttons.blade.php
@@ -26,7 +26,7 @@
         @endif
     @endif
     @if(!$crud->hasOperationSetting('showCancelButton') || $crud->getOperationSetting('showCancelButton') == true)
-        <a href="{{ $crud->hasAccess('list') ? url($crud->route) : url()->previous() }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
+        <a href="{{ $crud->getOperationSetting('backToAllEntriesUrl') ?? ($crud->hasAccess('list') ? url($crud->route) : url()->previous()) }}" class="btn btn-secondary text-decoration-none"><span class="la la-ban"></span> &nbsp;{{ trans('backpack::crud.cancel') }}</a>
     @endif
 
     @if ($crud->get('update.showDeleteButton') && $crud->get('delete.configuration') && $crud->hasAccess('delete'))


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Superseeds: #5979 

When using the datatable as a widget outside the `ListOperation`, clicking in the "Create" button would redirect the user to the "entity list operation", not the page where the table for that entity was displayed. 


### AFTER - What is happening after this PR?

By default, when embeeding an widget, `url()->current()` is used as the default "back url". 
For consistency this can be configured using the datatable setup closure like any other crud panel setting if the default does not work for you. 


## HOW

### How did you achieve that, in technical terms?

Added a new crud setting: `backToAllEntriesUrl` that allow developers to take control of the back behaviour. 

