### PR TITLE
[V8] refresh token on login page

### DIFF
--- a/src/app/Library/Auth/AuthenticatesUsers.php
+++ b/src/app/Library/Auth/AuthenticatesUsers.php
@@ -37,7 +37,6 @@ trait AuthenticatesUsers
         $reloadAfterMs = (int) round(config('session.lifetime', 120) * 60 * 1000 * 0.85);
 
         $script = <<<HTML
-
         <script>
         (function () {
             var loadedAt = Date.now();
@@ -54,11 +53,18 @@ trait AuthenticatesUsers
                 timer = setTimeout(function () { window.location.reload(); }, remaining);
             }
 
-            // Reload when the tab becomes visible again after being hidden or sleeping.
+            // Covers tab switching (tab becomes visible after being hidden).
             document.addEventListener('visibilitychange', function () {
-                if (!document.hidden) {
-                    scheduleReload();
-                }
+                if (!document.hidden) { scheduleReload(); }
+            });
+
+            // Covers window minimize/restore and Alt+Tab — fires even when
+            // visibilitychange does not (OS/browser dependent).
+            window.addEventListener('focus', function () { scheduleReload(); });
+
+            // Covers pages restored from the back-forward cache (bfcache).
+            window.addEventListener('pageshow', function (e) {
+                if (e.persisted) { scheduleReload(); }
             });
 
             // Start the countdown immediately (handles the tab staying open in the foreground).

--- a/src/app/Library/Auth/AuthenticatesUsers.php
+++ b/src/app/Library/Auth/AuthenticatesUsers.php
@@ -12,7 +12,7 @@ trait AuthenticatesUsers
 {
     use RedirectsUsers, ThrottlesLogins;
 
-        /**
+    /**
      * Show the application's login form.
      *
      * @return \Illuminate\Http\Response|\Illuminate\Http\View
@@ -67,7 +67,7 @@ trait AuthenticatesUsers
         </script>
         HTML;
 
-        return str_replace('</body>', $script . "\n</body>", $html);
+        return str_replace('</body>', $script."\n</body>", $html);
     }
 
     /**

--- a/src/app/Library/Auth/AuthenticatesUsers.php
+++ b/src/app/Library/Auth/AuthenticatesUsers.php
@@ -12,17 +12,62 @@ trait AuthenticatesUsers
 {
     use RedirectsUsers, ThrottlesLogins;
 
-    /**
+        /**
      * Show the application's login form.
      *
-     * @return \Illuminate\Contracts\View\View
+     * @return \Illuminate\Http\Response|\Illuminate\Http\View
      */
     public function showLoginForm()
     {
         $this->data['title'] = trans('backpack::base.login'); // set the page title
         $this->data['username'] = $this->username();
 
-        return view(backpack_view('auth.login'), $this->data);
+        $content = view(backpack_view('auth.login'), $this->data)->render();
+
+        return response($this->injectCsrfRefreshScript($content));
+    }
+
+    /**
+     * @param  string  $html
+     * @return string
+     */
+    protected function injectCsrfRefreshScript(string $html): string
+    {
+        // Reload at 85% of the session lifetime to give a comfortable margin.
+        $reloadAfterMs = (int) round(config('session.lifetime', 120) * 60 * 1000 * 0.85);
+
+        $script = <<<HTML
+
+        <script>
+        (function () {
+            var loadedAt = Date.now();
+            var reloadAfterMs = {$reloadAfterMs};
+            var timer;
+
+            function scheduleReload() {
+                clearTimeout(timer);
+                var remaining = reloadAfterMs - (Date.now() - loadedAt);
+                if (remaining <= 0) {
+                    window.location.reload();
+                    return;
+                }
+                timer = setTimeout(function () { window.location.reload(); }, remaining);
+            }
+
+            // Reload when the tab becomes visible again after being hidden or sleeping.
+            document.addEventListener('visibilitychange', function () {
+                if (!document.hidden) {
+                    scheduleReload();
+                }
+            });
+
+            // Start the countdown immediately (handles the tab staying open in the foreground).
+            scheduleReload();
+        })();
+        </script>
+        HTML;
+
+        return str_replace('</body>', $script . "\n</body>", $html);
     }
 
     /**


### PR DESCRIPTION
Leaving the login form open for X amout of time, when you submit your login info after that time, the token is expired and you get a 419 error.

This PR injects a small javascript snippet that will keep refreshing the login form before the expiration time, so when you submit it, you for sure have a valid token. 

I am moving this to V8 even if in terms of code theres is not a breaking change (Laravel handles both View and Response the same), some developer could have overriden the method in their controller (very unlikely, but possible), and is expecting a View object instead of a Response object. 