### PR TITLE
reposition row buttons

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -275,25 +275,51 @@ trait Search
                                 ->render();
         }
 
-        // add the bulk actions checkbox to the first column - but only if we have columns
-        if ($this->getOperationSetting('bulkActions') && ! empty($row_items)) {
-            $bulk_actions_checkbox = \View::make('crud::columns.inc.bulk_actions_checkbox', ['entry' => $entry])->render();
-            $row_items[0] = $bulk_actions_checkbox.$row_items[0];
+        // first column visible in the table; the client may override via
+        // `_bp_first_visible_column` to account for runtime hides (colvis, persisted state)
+        $firstVisibleColumnIndex = 0;
+        $columnPosition = 0;
+        foreach ($this->columns() as $col) {
+            $exportOnly = $col['exportOnlyColumn'] ?? false;
+            $visibleInTable = $col['visibleInTable'] ?? ($exportOnly ? false : true);
+            if (! $exportOnly && $visibleInTable !== false) {
+                $firstVisibleColumnIndex = $columnPosition;
+                break;
+            }
+            $columnPosition++;
+        }
+        // strict validation: scalar digit string within the row_items index range
+        $clientHint = request()->input('_bp_first_visible_column');
+        if (is_scalar($clientHint) && ctype_digit((string) $clientHint)) {
+            $clientHint = (int) $clientHint;
+            $maxIndex = count($row_items) - 1;
+            if ($clientHint >= 0 && $clientHint <= $maxIndex) {
+                $firstVisibleColumnIndex = $clientHint;
+            }
+        }
+        if (! isset($row_items[$firstVisibleColumnIndex])) {
+            $firstVisibleColumnIndex = 0;
         }
 
-        // add the details_row button to the first column - but only if we have columns
+        // add the bulk actions checkbox to the first visible column - but only if we have columns
+        if ($this->getOperationSetting('bulkActions') && ! empty($row_items)) {
+            $bulk_actions_checkbox = \View::make('crud::columns.inc.bulk_actions_checkbox', ['entry' => $entry])->render();
+            $row_items[$firstVisibleColumnIndex] = $bulk_actions_checkbox.$row_items[$firstVisibleColumnIndex];
+        }
+
+        // add the details_row button to the first visible column - but only if we have columns
         if ($this->getOperationSetting('detailsRow') && ! empty($row_items)) {
             $details_row_button = \View::make('crud::columns.inc.details_row_button')
                                            ->with('crud', $this)
                                            ->with('entry', $entry)
                                            ->with('row_number', $rowNumber)
                                            ->render();
-            $row_items[0] = $details_row_button.$row_items[0];
+            $row_items[$firstVisibleColumnIndex] = $details_row_button.$row_items[$firstVisibleColumnIndex];
         }
 
         if ($this->getResponsiveTable() && ! empty($row_items)) {
             $responsiveTableTrigger = '<div class="dtr-control d-none cursor-pointer"></div>';
-            $row_items[0] = $responsiveTableTrigger.$row_items[0];
+            $row_items[$firstVisibleColumnIndex] = $responsiveTableTrigger.$row_items[$firstVisibleColumnIndex];
         }
 
         return $row_items;

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -1513,3 +1513,4 @@ form .select2.select2-container.select2-container--open {
 .dt-container .crud_bulk_actions_checkbox, .dt-container table.dataTable .crud_bulk_actions_checkbox {
     margin: 0 0.6rem 0 0.45rem;
 }
+

--- a/src/resources/views/crud/components/datatable/datatable.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable.blade.php
@@ -99,6 +99,21 @@
       data-language="{{ json_encode($datatableLocalizedStrings) }}"
       data-spinner-url="{{ Basset::getUrl('vendor/backpack/crud/src/resources/assets/img/spinner.svg') }}"
       cellspacing="0">
+    @php
+        // index of the first column visible in the table; first-column buttons render here.
+        // $crud->columns() is keyed by name, so we track the numeric position manually.
+        $bp_firstVisibleColumnIndex = 0;
+        $bp_position = 0;
+        foreach ($crud->columns() as $bp_col) {
+            $bp_exportOnly = $bp_col['exportOnlyColumn'] ?? false;
+            $bp_visInTable = $bp_col['visibleInTable'] ?? ($bp_exportOnly ? false : true);
+            if (! $bp_exportOnly && $bp_visInTable !== false) {
+                $bp_firstVisibleColumnIndex = $bp_position;
+                break;
+            }
+            $bp_position++;
+        }
+    @endphp
     <thead>
       <tr>
         {{-- Table columns --}}
@@ -131,7 +146,7 @@
             data-force-export="{{ var_export($forceExport) }}"
           >
             {{-- Bulk checkbox --}}
-            @if($loop->first && $crud->getOperationSetting('bulkActions'))
+            @if($loop->index === $bp_firstVisibleColumnIndex && $crud->getOperationSetting('bulkActions'))
                 {!! View::make('crud::columns.inc.bulk_actions_checkbox')->render() !!}
             @endif
             {!! $column['label'] !!}
@@ -155,7 +170,7 @@
         @foreach ($crud->columns() as $column)
           <th>
             {{-- Bulk checkbox --}}
-            @if($loop->first && $crud->getOperationSetting('bulkActions'))
+            @if($loop->index === $bp_firstVisibleColumnIndex && $crud->getOperationSetting('bulkActions'))
                 {!! View::make('crud::columns.inc.bulk_actions_checkbox')->render() !!}
             @endif
             {!! $column['label'] !!}

--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -507,9 +507,17 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
             "url": ajaxUrl,
             "type": "POST",
             "data": function(d) {
-                // Add table-specific parameters
                 d.totalEntryCount = tableElement.getAttribute('data-total-entry-count') || false;
                 d.datatable_id = tableId;
+                // first-visible column index, so the server injects first-column buttons
+                // into a cell that will survive the next DataTables draw
+                if (window.crud
+                    && window.crud.tables
+                    && window.crud.tables[tableId]
+                    && typeof window.crud.tables[tableId].__firstVisibleColumnHint === 'number'
+                    && window.crud.tables[tableId].__firstVisibleColumnHint >= 0) {
+                    d._bp_first_visible_column = window.crud.tables[tableId].__firstVisibleColumnHint;
+                }
                 return d;
             },
             "dataSrc": function(json) {
@@ -540,17 +548,70 @@ window.crud.initializeTable = function(tableId, customConfig = {}) {
             processingIndicator.style.zIndex = '1000';
         }
         
-        // Call any existing initComplete function
         if (typeof window.crud.initCompleteCallback === 'function') {
             window.crud.initCompleteCallback.call(this, settings, json);
         }
+        try {
+            if (window.crud.tables[tableId] && typeof window.crud.tables[tableId].__updateFirstColButtonsHint === 'function') {
+                window.crud.tables[tableId].__updateFirstColButtonsHint();
+            }
+            if (window.crud.tables[tableId] && typeof window.crud.tables[tableId].__repositionFirstColButtons === 'function') {
+                window.crud.tables[tableId].__repositionFirstColButtons();
+            }
+        } catch (e) { /* noop */ }
     };
     
     // Store the dataTableConfig in the config object for future reference
     config.dataTableConfig = dataTableConfig;
-    
+
+    // Seed __firstVisibleColumnHint before DT init so the first ajax call already carries it.
+    // Baseline from <th data-visible>, then overlay persisted column visibility from localStorage
+    // (DT restores it before init.dt fires).
+    (function seedFirstVisibleColumnHint() {
+        const placeholder = { __firstVisibleColumnHint: -1 };
+        window.crud.tables[tableId] = placeholder;
+
+        const headerCells = Array.from(tableElement.querySelectorAll(':scope > thead > tr > th'));
+        const visibility = headerCells.map(th => th.getAttribute('data-visible') !== 'false');
+
+        try {
+            let raw = localStorage.getItem(`DataTables_${tableId}_/${config.urlStart}`);
+            if (!raw) {
+                for (let i = 0; i < localStorage.length; i++) {
+                    const k = localStorage.key(i);
+                    if (k && k.startsWith(`DataTables_${tableId}_`)) {
+                        raw = localStorage.getItem(k);
+                        if (raw) break;
+                    }
+                }
+            }
+            if (raw) {
+                const state = JSON.parse(raw);
+                if (state && Array.isArray(state.columns)) {
+                    state.columns.forEach((col, i) => {
+                        if (i < visibility.length && col && col.visible === false) {
+                            visibility[i] = false;
+                        }
+                    });
+                }
+            }
+        } catch (e) { /* noop */ }
+
+        for (let i = 0; i < visibility.length; i++) {
+            if (visibility[i]) {
+                placeholder.__firstVisibleColumnHint = i;
+                break;
+            }
+        }
+    })();
+
     // Initialize the DataTable with the config
-    window.crud.tables[tableId] = $('#'+tableId).DataTable(dataTableConfig);
+    const dtInstance = $('#'+tableId).DataTable(dataTableConfig);
+    const seededHint = (window.crud.tables[tableId] && typeof window.crud.tables[tableId].__firstVisibleColumnHint === 'number')
+        ? window.crud.tables[tableId].__firstVisibleColumnHint
+        : -1;
+    dtInstance.__firstVisibleColumnHint = seededHint;
+    window.crud.tables[tableId] = dtInstance;
 
     // For backward compatibility
     if (!window.crud.table) {
@@ -696,7 +757,156 @@ function setupTableUI(tableId, config) {
 // Function to set up table event handlers
 function setupTableEvents(tableId, config) {
     const table = window.crud.tables[tableId];
-    
+
+    // First-column buttons (bulk-actions checkbox, details-row trigger, .dtr-control)
+    // must follow the first VISIBLE column when the natural first column is hidden
+    // (visibleInTable=false, colvis, responsive, or persisted state).
+    const FIRST_COL_BUTTONS_SELECTOR = '.dtr-control, .crud_bulk_actions_checkbox, span.details-control';
+    const detachedFirstColButtons = new WeakMap();
+
+    function getTableEl() {
+        return document.getElementById(tableId);
+    }
+
+    function getDirectRowCells(row) {
+        return Array.from(row.children).filter(c => c.tagName === 'TD' || c.tagName === 'TH');
+    }
+
+    function getDirectFirstColButtons(row) {
+        // skip nested tables (e.g. responsive-details modal)
+        return Array.from(row.querySelectorAll(FIRST_COL_BUTTONS_SELECTOR)).filter(el => {
+            const cell = el.closest('th, td');
+            return cell && cell.parentElement === row;
+        });
+    }
+
+    function moveFirstColButtonsToCell(row, targetCell) {
+        if (!row || !targetCell) return;
+        getDirectFirstColButtons(row).forEach(el => {
+            const parentCell = el.closest('th, td');
+            if (!parentCell || parentCell === targetCell) return;
+            targetCell.insertBefore(el, targetCell.firstChild);
+            // keep .details-control on whichever cell hosts the trigger
+            if (el.matches('span.details-control') && parentCell.classList.contains('details-control')) {
+                parentCell.classList.remove('details-control');
+                targetCell.classList.add('details-control');
+            }
+        });
+    }
+
+    function getFirstVisibleColumnIndex() {
+        let firstVisibleIdx = -1;
+        try {
+            table.columns().every(function (i) {
+                if (firstVisibleIdx !== -1) return;
+                if (!this.visible()) return;
+                const headerCell = this.header();
+                if (headerCell && headerCell.classList && headerCell.classList.contains('dtr-hidden')) return;
+                firstVisibleIdx = i;
+            });
+        } catch (e) { /* noop */ }
+        return firstVisibleIdx;
+    }
+
+    function repositionFirstColButtons() {
+        const tableEl = getTableEl();
+        if (!tableEl) return;
+        const firstVisibleIdx = getFirstVisibleColumnIndex();
+        if (firstVisibleIdx < 0) return;
+
+        try {
+            const headerNode = table.column(firstVisibleIdx).header();
+            if (headerNode && headerNode.parentElement) {
+                moveFirstColButtonsToCell(headerNode.parentElement, headerNode);
+            }
+        } catch (e) { /* noop */ }
+
+        try {
+            const footerNode = table.column(firstVisibleIdx).footer();
+            if (footerNode && footerNode.parentElement) {
+                moveFirstColButtonsToCell(footerNode.parentElement, footerNode);
+            }
+        } catch (e) { /* noop */ }
+
+        try {
+            table.rows({ page: 'current' }).every(function () {
+                const rowNode = this.node();
+                if (!rowNode) return;
+                let cellNode = null;
+                try { cellNode = table.cell(this.index(), firstVisibleIdx).node(); } catch (e) { /* noop */ }
+                if (cellNode) moveFirstColButtonsToCell(rowNode, cellNode);
+            });
+        } catch (e) { /* noop */ }
+    }
+    window.crud.tables[tableId].__repositionFirstColButtons = repositionFirstColButtons;
+
+    // colvis with redraw removes the toggled <td> before column-visibility.dt fires,
+    // so detach the buttons on mousedown (capture phase) and reattach after the toggle.
+    function onColvisMousedown(e) {
+        const trigger = e.target.closest('.buttons-columnVisibility');
+        if (!trigger) return;
+        const tableEl = getTableEl();
+        if (!tableEl) return;
+        if (!tableEl.querySelector(FIRST_COL_BUTTONS_SELECTOR)) return;
+
+        ['thead', 'tbody', 'tfoot'].forEach(section => {
+            const sectionEl = tableEl.querySelector(':scope > ' + section);
+            if (!sectionEl) return;
+            Array.from(sectionEl.children).forEach(row => {
+                if (row.tagName !== 'TR') return;
+                const buttons = getDirectFirstColButtons(row);
+                if (buttons.length) {
+                    buttons.forEach(el => el.parentNode && el.parentNode.removeChild(el));
+                    detachedFirstColButtons.set(row, buttons);
+                }
+            });
+        });
+    }
+    document.addEventListener('mousedown', onColvisMousedown, true);
+
+    function reattachDetachedFirstColButtons() {
+        const tableEl = getTableEl();
+        if (!tableEl) return;
+        ['thead', 'tbody', 'tfoot'].forEach(section => {
+            const sectionEl = tableEl.querySelector(':scope > ' + section);
+            if (!sectionEl) return;
+            Array.from(sectionEl.children).forEach(row => {
+                if (row.tagName !== 'TR') return;
+                const stash = detachedFirstColButtons.get(row);
+                if (!stash || !stash.length) return;
+                detachedFirstColButtons.delete(row);
+
+                const cells = getDirectRowCells(row);
+                let target = null;
+                for (const c of cells) {
+                    if (target) break;
+                    if (c.classList.contains('dtr-hidden')) continue;
+                    if (getComputedStyle(c).display === 'none') continue;
+                    target = c;
+                }
+                if (!target) target = cells[0];
+                if (!target) return;
+
+                for (let i = stash.length - 1; i >= 0; i--) {
+                    target.insertBefore(stash[i], target.firstChild);
+                }
+                if (stash.some(el => el.matches && el.matches('span.details-control'))) {
+                    target.classList.add('details-control');
+                }
+            });
+        });
+    }
+    window.crud.tables[tableId].__reattachDetachedFirstColButtons = reattachDetachedFirstColButtons;
+
+    // refresh the hint sent to the server on the next ajax draw
+    function updateFirstColButtonsHint() {
+        const idx = getFirstVisibleColumnIndex();
+        if (window.crud.tables[tableId] && idx >= 0) {
+            window.crud.tables[tableId].__firstVisibleColumnHint = idx;
+        }
+    }
+    window.crud.tables[tableId].__updateFirstColButtonsHint = updateFirstColButtonsHint;
+
     // override ajax error message
     $.fn.dataTable.ext.errMode = 'none';
     $(`#${tableId}`).on('error.dt', function(e, settings, techNote, message) {
@@ -827,6 +1037,9 @@ function setupTableEvents(tableId, config) {
             $('.dtr-control').addClass('d-inline');
             $(`#${tableId}`).removeClass('has-hidden-columns').addClass('has-hidden-columns');
         }
+
+        // move first-column buttons to the first visible cell
+        repositionFirstColButtons();
     }).dataTable();
 
     $(`#${tableId}`).on('processing.dt', function(e, settings, processing) {
@@ -878,11 +1091,17 @@ function setupTableEvents(tableId, config) {
         }
     });
 
-    // when datatables-colvis (column visibility) is toggled
     $(`#${tableId}`).on('column-visibility.dt', function(event) {
-        if (table.responsive) {
-            table.responsive.rebuild();
-        }
+        // defer past DataTables/Responsive's own listeners
+        setTimeout(function () {
+            reattachDetachedFirstColButtons();
+            if (table.responsive) {
+                try { table.responsive.rebuild(); } catch (e) { /* noop */ }
+                try { table.responsive.recalc(); } catch (e) { /* noop */ }
+            }
+            repositionFirstColButtons();
+            updateFirstColButtonsHint();
+        }, 0);
     }).dataTable();
 
     // Handle responsive table if enabled
@@ -907,6 +1126,9 @@ function setupTableEvents(tableId, config) {
                 $('.dtr-control').removeClass('d-none').removeClass('d-inline').addClass('d-none');
                 $(`#${tableId}`).removeClass('has-hidden-columns');
             }
+
+            // bulk checkbox and details-row trigger follow the first visible cell
+            repositionFirstColButtons();
         });
     } else if (!config.responsiveTable) {
         // make sure the column headings have the same width as the actual columns


### PR DESCRIPTION
fixes: https://github.com/Laravel-Backpack/community-forum/issues/372

first column buttons (responsive, detail rows and bulk actions) were (and still are) tighly coupled with the first column row. 
the change this PR introduces, is that they become coupled with the "first visible row". 

In other words, it's now possible to hide the first row in a table without loosing access to that functionality. 

It works by a combination of server side and datatables javascript, ensuring that the buttons are always placed on the first visible row, even if that row is hidden with colvis (the column visibility plugin). 