### PR TITLE
fix query count when group by clause is used

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Query.php
+++ b/src/app/Library/CrudPanel/Traits/Query.php
@@ -268,7 +268,8 @@ trait Query
         $subQuery = $crudQuery->cloneWithout(['columns', 'orders', 'limit', 'offset']);
 
         // select minimum possible columns for the count
-        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? $modelTable.'.*' : $modelTable.'.'.$this->model->getKeyName();
+        $columns = $crudQuery->groups ? $crudQuery->groups : $modelTable.'.'.$this->model->getKeyName();
+        $minimumColumns = ($crudQuery->groups || $crudQuery->havings) ? $columns : $modelTable.'.'.$this->model->getKeyName();
         $subQuery->select($minimumColumns);
 
         // in case there are raw expressions we need to add them too.

--- a/tests/Unit/CrudPanel/CrudPanelQueryDatabaseTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelQueryDatabaseTest.php
@@ -5,6 +5,7 @@ namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 use Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel;
 use Backpack\CRUD\Tests\config\CrudPanel\NoSqlDriverCrudPanel;
 use Backpack\CRUD\Tests\config\Models\User;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Query
@@ -49,5 +50,41 @@ class CrudPanelQueryDatabaseTest extends BaseDBCrudPanel
 
         $this->assertNull($this->crudPanel->getFilteredQueryCount());
         $this->assertEquals(2, $this->crudPanel->getQueryCount());
+    }
+
+    public function testCountWorksWithGroupBy()
+    {
+        $this->crudPanel->addClause(fn ($query) => $query->groupBy('name'));
+
+        $expected = User::query()->groupBy('name')->get()->count();
+
+        $this->assertEquals($expected, $this->crudPanel->getFilteredQueryCount());
+    }
+
+    public function testCountWorksWithGroupByOnMultipleColumns()
+    {
+        $this->crudPanel->addClause(fn ($query) => $query->groupBy('name', 'email'));
+
+        $expected = User::query()->groupBy('name', 'email')->get()->count();
+
+        $this->assertEquals($expected, $this->crudPanel->getFilteredQueryCount());
+    }
+
+    public function testCountWithGroupByReturnsDistinctGroupCount()
+    {
+        DB::table('users')->insert([
+            ['name' => 'Duplicate Name', 'email' => 'dup1@example.com', 'password' => 'x', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'Duplicate Name', 'email' => 'dup2@example.com', 'password' => 'x', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'Unique Name',    'email' => 'uniq@example.com', 'password' => 'x', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        // Scope to only our inserted rows so the seeded users don't interfere.
+        $this->crudPanel->addClause(fn ($query) => $query
+            ->whereIn('email', ['dup1@example.com', 'dup2@example.com', 'uniq@example.com'])
+            ->groupBy('name')
+        );
+
+        // 2 distinct names ('Duplicate Name' and 'Unique Name').
+        $this->assertEquals(2, $this->crudPanel->getFilteredQueryCount());
     }
 }


### PR DESCRIPTION
fixes: https://github.com/Laravel-Backpack/community-forum/discussions/1107
superseeds: https://github.com/Laravel-Backpack/CRUD/pull/5628

The count of the entries in a query was broken when the query contained `GROUP BY` clauses. 

The workaround until now was to disable the query count when using GROUP BY. 

