### PR TITLE
searchable translatable fields

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -475,10 +475,12 @@ trait Search
         $table = $this->model->getTable();
         $grammar = $this->model->getConnection()->getQueryGrammar();
 
-        foreach ($this->getTranslatableSearchLocales() as $locale) {
-            $wrapped = $grammar->wrap("{$table}.{$columnName}->{$locale}");
-            $query->orWhereRaw("lower({$wrapped}) like lower(?)", ['%'.$searchTerm.'%']);
-        }
+        $query->orWhere(function ($q) use ($table, $columnName, $searchTerm, $grammar) {
+            foreach ($this->getTranslatableSearchLocales() as $locale) {
+                $wrapped = $grammar->wrap("{$table}.{$columnName}->{$locale}");
+                $q->orWhereRaw("lower({$wrapped}) like lower(?)", ['%'.$searchTerm.'%']);
+            }
+        });
     }
 
     private function isJsonColumnType(string $columnName)

--- a/src/app/Library/CrudPanel/Traits/Search.php
+++ b/src/app/Library/CrudPanel/Traits/Search.php
@@ -68,7 +68,11 @@ trait Search
                 case 'email':
                 case 'text':
                 case 'textarea':
-                    $query->orWhere($this->getColumnWithTableNamePrefixed($query, $column['name']), $searchOperator, '%'.$searchTerm.'%');
+                    if ($this->isTranslatableColumn($column['name'])) {
+                        $this->applyTranslatableTextSearch($query, $column['name'], $searchTerm);
+                    } else {
+                        $query->orWhere($this->getColumnWithTableNamePrefixed($query, $column['name']), $searchOperator, '%'.$searchTerm.'%');
+                    }
                     break;
 
                 case 'date':
@@ -448,6 +452,33 @@ trait Search
     public function getColumnWithTableNamePrefixed($query, $column)
     {
         return $query->getModel()->getTable().'.'.$column;
+    }
+
+    private function isTranslatableColumn(string $columnName): bool
+    {
+        return $this->model->translationEnabled()
+            && method_exists($this->model, 'isTranslatableAttribute')
+            && $this->model->isTranslatableAttribute($columnName);
+    }
+
+    private function getTranslatableSearchLocales(): array
+    {
+        return array_values(array_unique(array_filter([
+            app()->getLocale(),
+            config('app.fallback_locale'),
+            ...array_keys(config('backpack.crud.locales', [])),
+        ])));
+    }
+
+    private function applyTranslatableTextSearch($query, string $columnName, string $searchTerm): void
+    {
+        $table = $this->model->getTable();
+        $grammar = $this->model->getConnection()->getQueryGrammar();
+
+        foreach ($this->getTranslatableSearchLocales() as $locale) {
+            $wrapped = $grammar->wrap("{$table}.{$columnName}->{$locale}");
+            $query->orWhereRaw("lower({$wrapped}) like lower(?)", ['%'.$searchTerm.'%']);
+        }
     }
 
     private function isJsonColumnType(string $columnName)

--- a/tests/Unit/CrudPanel/CrudPanelSearchTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelSearchTest.php
@@ -306,6 +306,99 @@ class CrudPanelSearchTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseCrud
         $this->assertEquals('select * from "users" order by "name" asc, "id" desc', $this->crudPanel->query->toRawSql());
     }
 
+    /**
+     * Translatable JSON columns should use case-insensitive JSON path search
+     * for each active locale instead of searching the raw JSON string.
+     */
+    public function testItAppliesTranslatableSearchForJsonColumns()
+    {
+        $this->crudPanel->setModel(UserWithTranslations::class);
+
+        $this->crudPanel->addColumn([
+            'name' => 'json',
+            'type' => 'text',
+            'searchLogic' => 'text',
+            'tableColumn' => true,
+        ]);
+
+        $this->crudPanel->applySearchTerm('Smith');
+
+        $sql = $this->crudPanel->query->toRawSql();
+
+        $this->assertStringContainsString('lower(', $sql);
+        $this->assertStringContainsString('json_extract', $sql);
+        $this->assertStringContainsString('"en"', $sql);
+        $this->assertStringContainsString('like lower(', $sql);
+    }
+
+    public function testTranslatableAttributesAlwaysUseJsonPathSearch()
+    {
+        $this->crudPanel->setModel(UserWithTranslations::class);
+
+        $this->crudPanel->addColumn([
+            'name' => 'name',
+            'type' => 'text',
+            'searchLogic' => 'text',
+            'tableColumn' => true,
+        ]);
+
+        $this->crudPanel->applySearchTerm('test');
+
+        $this->assertStringContainsString(
+            'json_extract("users"."name"',
+            $this->crudPanel->query->toRawSql()
+        );
+    }
+
+    /**
+     * When the app fallback locale differs from the current locale, both should
+     * be searched so results are not missed when content is stored in either locale.
+     */
+    public function testItSearchesAcrossCurrentAndFallbackLocales()
+    {
+        $this->crudPanel->setModel(UserWithTranslations::class);
+
+        config(['app.fallback_locale' => 'fr']);
+
+        $this->crudPanel->addColumn([
+            'name' => 'json',
+            'type' => 'text',
+            'searchLogic' => 'text',
+            'tableColumn' => true,
+        ]);
+
+        $this->crudPanel->applySearchTerm('smith');
+
+        $sql = $this->crudPanel->query->toRawSql();
+
+        // Both the current locale (en) and fallback locale (fr) must be searched
+        $this->assertStringContainsString('"en"', $sql);
+        $this->assertStringContainsString('"fr"', $sql);
+    }
+
+    /**
+     * Non-translatable models should be unaffected and continue using standard LIKE search.
+     */
+    public function testTranslatableSearchDoesNotAffectNonTranslatableModels()
+    {
+        // Uses the default User model (no HasTranslations trait, translationEnabled() = false)
+        // Use a column name that doesn't exist in the table (like other search tests) with explicit searchLogic
+        $this->crudPanel->addColumn([
+            'name' => 'title',
+            'type' => 'text',
+            'searchLogic' => 'text',
+            'tableColumn' => true,
+        ]);
+
+        $this->crudPanel->applySearchTerm('test');
+
+        // Regular User (not translatable) → standard LIKE, no JSON path extraction
+        $this->assertEquals(
+            'select * from "users" where ("users"."title" like \'%test%\')',
+            $this->crudPanel->query->toRawSql()
+        );
+    }
+
     public static function columnsDefaultSearchLogic()
     {
         return [

--- a/tests/Unit/CrudPanel/CrudPanelTranslatableSearchTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelTranslatableSearchTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Backpack\CRUD\Tests\Unit\CrudPanel;
+
+use Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrudPanel;
+use Backpack\CRUD\Tests\config\Models\TranslatableModel;
+
+/**
+ * Integration tests for translatable column search.
+ *
+ * Unlike the SQL-assertion tests in CrudPanelSearchTest, these tests run the
+ * generated query against a real (SQLite) database and assert that the correct
+ * records are (or are not) returned.
+ *
+ * @covers Backpack\CRUD\app\Library\CrudPanel\Traits\Search
+ */
+class CrudPanelTranslatableSearchTest extends BaseDBCrudPanel
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->crudPanel->setModel(TranslatableModel::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a TranslatableModel with per-locale title values.
+     * Accepts: ['en' => 'Smith Electric', 'fr' => 'Électricité Smith']
+     */
+    private function makeRecord(array $titlesByLocale): TranslatableModel
+    {
+        $model = new TranslatableModel();
+        foreach ($titlesByLocale as $locale => $value) {
+            $model->setTranslation('title', $locale, $value);
+        }
+        $model->save();
+
+        return $model;
+    }
+
+    private function addTitleColumn(): void
+    {
+        $this->crudPanel->addColumn([
+            'name' => 'title',
+            'type' => 'text',
+            'tableColumn' => true,
+        ]);
+    }
+
+    private function runSearch(string $term): \Illuminate\Database\Eloquent\Collection
+    {
+        $this->crudPanel->applySearchTerm($term);
+
+        return $this->crudPanel->query->get();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * A basic exact-case match must return the matching row and its content.
+     */
+    public function testItReturnsMatchingRecordWhenSearchTermMatchesStoredValue()
+    {
+        $this->makeRecord(['en' => 'Smith Electric']);
+        $this->makeRecord(['en' => 'Jones Hardware']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('Smith');
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Smith Electric', $results->first()->getTranslation('title', 'en'));
+    }
+
+    /**
+     * The core bug: searching in lowercase must still find a value stored in
+     * mixed case, and vice versa — search must be case-insensitive.
+     */
+    public function testSearchIsCaseInsensitive()
+    {
+        $this->makeRecord(['en' => 'Smith Electric']);
+        $this->makeRecord(['en' => 'Jones Hardware']);
+
+        $this->addTitleColumn();
+
+        $results = $this->runSearch('smith');
+        $this->assertCount(1, $results);
+        $this->assertEquals('Smith Electric', $results->first()->getTranslation('title', 'en'));
+
+        $this->crudPanel->query = clone $this->crudPanel->totalQuery;
+
+        $results = $this->runSearch('SMITH');
+        $this->assertCount(1, $results);
+    }
+
+    /**
+     * A partial substring match must work (LIKE '%term%').
+     */
+    public function testItMatchesOnPartialSubstring()
+    {
+        $this->makeRecord(['en' => 'Smith Electric']);
+        $this->makeRecord(['en' => 'Jones Hardware']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('lectric');
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Smith Electric', $results->first()->getTranslation('title', 'en'));
+    }
+
+    /**
+     * A search term that matches no row must return an empty collection.
+     */
+    public function testItReturnsEmptyCollectionWhenNoMatchFound()
+    {
+        $this->makeRecord(['en' => 'Smith Electric']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('xyz-no-match-anywhere');
+
+        $this->assertCount(0, $results);
+    }
+
+    /**
+     * When records have multiple locales, searching with a non-default locale
+     * finds content stored in that locale.
+     */
+    public function testItSearchesInTheCurrentAppLocale()
+    {
+        $this->makeRecord(['en' => 'Smith Electric',   'fr' => 'Électricité Smith']);
+        $this->makeRecord(['en' => 'Jones Hardware',   'fr' => 'Quincaillerie Jones']);
+
+        config(['app.locale' => 'fr']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('quincaillerie');
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Jones Hardware', $results->first()->getTranslation('title', 'en'));
+    }
+
+    /**
+     * When a term exists only under the fallback locale key, it must still
+     * be found because the fallback locale is included in the search locales.
+     */
+    public function testItSearchesInTheFallbackLocale()
+    {
+        $this->makeRecord(['fr' => 'Quincaillerie Jones']);
+
+        config(['app.locale' => 'en', 'app.fallback_locale' => 'fr']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('quincaillerie');
+
+        $this->assertCount(1, $results);
+    }
+
+    /**
+     * Multiple matching rows must all be returned regardless of which locale
+     * holds the matching value.
+     */
+    public function testItReturnsAllMatchingRowsAcrossLocales()
+    {
+        $this->makeRecord(['en' => 'Hardware Store',    'fr' => 'Quincaillerie']);
+        $this->makeRecord(['en' => 'Hardware Depot']);
+        $this->makeRecord(['en' => 'Electric Supplies']);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('Hardware');
+
+        $this->assertCount(2, $results);
+    }
+
+    /**
+     * Content stored only in a locale that is NOT in the search locales must
+     * not be surfaced — the search is scoped to the current + fallback locales.
+     */
+    public function testItDoesNotReturnRowsWithNoMatchingTranslationInSearchLocales()
+    {
+        $this->makeRecord(['en' => 'Smith Electric']);
+        $this->makeRecord(['fr' => 'Quincaillerie']);
+
+        config(['app.locale' => 'en', 'app.fallback_locale' => 'en', 'backpack.crud.locales' => []]);
+
+        $this->addTitleColumn();
+        $results = $this->runSearch('quincaillerie');
+
+        $this->assertCount(0, $results);
+    }
+}

--- a/tests/Unit/CrudPanel/CrudPanelTranslatableSearchTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelTranslatableSearchTest.php
@@ -29,7 +29,7 @@ class CrudPanelTranslatableSearchTest extends BaseDBCrudPanel
 
     /**
      * Create a TranslatableModel with per-locale title values.
-     * Accepts: ['en' => 'Smith Electric', 'fr' => 'Électricité Smith']
+     * Accepts: ['en' => 'Smith Electric', 'fr' => 'Électricité Smith'].
      */
     private function makeRecord(array $titlesByLocale): TranslatableModel
     {


### PR DESCRIPTION
closes: #5860 

This is a new and cleaner approach to fix the issue where translatable columns were not searchable.

It uses the native Laravel Grammar to ensure we support the RDBMS without custom code. 