### PR TITLE
introduce fetch source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,9 +70,6 @@
         "test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage"
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "4.0-dev"
-        },
         "laravel": {
             "providers": [
                 "Backpack\\CRUD\\BackpackServiceProvider"

--- a/src/app/Library/CrudPanel/Traits/Create.php
+++ b/src/app/Library/CrudPanel/Traits/Create.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 trait Create
@@ -499,10 +500,6 @@ trait Create
     /**
      * Get the closure that constrains the selectable options of a relation field, if any.
      *
-     * `options` is the closure Backpack already uses to build the field's `<select>` options.
-     * `relation_options_query` is an explicit hook a field/operation can set to declare the
-     * allowed options when they are not rendered on the page (eg. ajax/fetch fields).
-     *
      * @return callable|null
      */
     private function getRelationOptionsConstraint(array $field)
@@ -513,7 +510,36 @@ trait Create
             }
         }
 
+        if (isset($field['relation_options_query_source'])) {
+            return $this->getRelationOptionsConstraintFromFetchSource($field['relation_options_query_source']);
+        }
+
         return null;
+    }
+
+    /**
+     * Resolve the options-constraining closure from a FetchOperation method name.
+     *
+     * @param  string  $source  The fetch method name, eg. "fetchCategory" (or the entity "category").
+     * @return callable|null
+     */
+    private function getRelationOptionsConstraintFromFetchSource($source)
+    {
+        $controller = $this->controller ?? null;
+
+        if (! is_string($source) || ! $controller || ! method_exists($controller, 'getRelationFetchQuery')) {
+            return null;
+        }
+
+        $controller = is_string($controller) ? app($controller) : $controller;
+
+        $fetchMethod = Str::startsWith($source, 'fetch')
+            ? $source
+            : 'fetch'.Str::studly(Str::afterLast($source, '.'));
+
+        $closure = $controller->getRelationFetchQuery($fetchMethod);
+
+        return is_callable($closure) ? $closure : null;
     }
 
     /**

--- a/tests/Unit/CrudPanel/CrudPanelCreateTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelCreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Backpack\CRUD\Tests\Unit\CrudPanel;
 
+use Backpack\CRUD\Tests\config\Http\Controllers\FetchSourceCrudController;
 use Backpack\CRUD\Tests\config\Models\Article;
 use Backpack\CRUD\Tests\config\Models\Bang;
 use Backpack\CRUD\Tests\config\Models\Comet;
@@ -1696,6 +1697,164 @@ class CrudPanelCreateTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCr
             // user #2 is tampered in and outside the option scope
             'user_id' => 2,
         ]);
+    }
+
+    public function testHasManySelectableRelationshipUsesRelationOptionsQuerySource()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'name' => 'planets',
+            'force_delete' => false,
+            'fallback_id' => false,
+            // the field points to the fetch method whose query defines its allowed options
+            'relation_options_query_source' => 'fetchPlanet',
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
+            'remember_token' => null,
+            // planet #2 is tampered in, only planet #1 is allowed by the fetch query
+            'planets' => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(1, $entry->planets);
+        $this->assertEquals([1], $entry->planets->pluck('id')->all());
+        $this->assertNull(Planet::find(2)->user_id);
+    }
+
+    public function testRelationOptionsQuerySourceAcceptsShortEntityName()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'name' => 'planets',
+            'force_delete' => false,
+            'fallback_id' => false,
+            // a short name is normalized to its "fetchXxx" method
+            'relation_options_query_source' => 'planet',
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
+            'remember_token' => null,
+            'planets' => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(1, $entry->planets);
+        $this->assertEquals([1], $entry->planets->pluck('id')->all());
+    }
+
+    public function testManyToManySelectableRelationshipUsesRelationOptionsQuerySource()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'label' => 'Roles',
+            'type' => 'select_multiple',
+            'name' => 'roles',
+            'entity' => 'roles',
+            'attribute' => 'name',
+            'pivot' => true,
+            'relation_options_query_source' => 'fetchRole',
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
+            'remember_token' => null,
+            // role #2 is tampered in, only role #1 is allowed by the fetch query
+            'roles' => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(1, $entry->roles);
+        $this->assertEquals([1], $entry->roles->pluck('id')->all());
+    }
+
+    public function testCreateBelongsToKeepsValueInsideRelationOptionsQuerySource()
+    {
+        $this->crudPanel->setModel(Article::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->articleInputFieldsOneToMany);
+        $this->crudPanel->modifyField('user_id', [
+            'relation_options_query_source' => 'fetchModeratorUser',
+        ]);
+
+        $faker = Factory::create();
+        $entry = $this->crudPanel->create([
+            'content' => $faker->text(),
+            'tags' => null,
+            // user #1 is allowed, so it is saved as-is
+            'user_id' => 1,
+        ]);
+
+        $this->assertEquals(1, $entry->user_id);
+    }
+
+    public function testCreateBelongsToRejectsValueOutsideRelationOptionsQuerySource()
+    {
+        $this->crudPanel->setModel(Article::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->articleInputFieldsOneToMany);
+        $this->crudPanel->modifyField('user_id', [
+            'relation_options_query_source' => 'fetchModeratorUser',
+        ]);
+
+        $faker = Factory::create();
+
+        // user #2 was never selectable through the fetch query; rejected (fail-closed)
+        $this->expectException(\Illuminate\Validation\ValidationException::class);
+
+        $this->crudPanel->create([
+            'content' => $faker->text(),
+            'tags' => null,
+            'user_id' => 2,
+        ]);
+    }
+
+    public function testRelationOptionsQuerySourceWithUnknownFetchMethodLeavesFieldUnconstrained()
+    {
+        $this->crudPanel->setModel(User::class);
+        $this->crudPanel->setController(FetchSourceCrudController::class);
+        $this->crudPanel->addFields($this->userInputFieldsNoRelationships, 'both');
+        $this->crudPanel->addField([
+            'name' => 'planets',
+            'force_delete' => false,
+            'fallback_id' => false,
+            // the controller has no such fetch method, so the field stays unconstrained
+            'relation_options_query_source' => 'fetchMissing',
+        ], 'both');
+
+        $faker = Factory::create();
+        $inputData = [
+            'name' => $faker->name,
+            'email' => $faker->safeEmail,
+            'password' => Hash::make($faker->password()),
+            'remember_token' => null,
+            'planets' => [1, 2],
+        ];
+
+        $entry = $this->crudPanel->create($inputData);
+
+        $this->assertCount(2, $entry->planets);
+        $this->assertEquals([1, 2], $entry->planets->pluck('id')->sort()->values()->all());
     }
 
     public function testHasManyWithRelationScoped()

--- a/tests/config/Http/Controllers/FetchSourceCrudController.php
+++ b/tests/config/Http/Controllers/FetchSourceCrudController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Backpack\CRUD\Tests\config\Http\Controllers;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\Tests\config\Models\Article;
+
+/**
+ * Test double mimicking the PRO FetchOperation contract used by the save-time relation
+ * guard, so the `relation_options_query_source` branch can be exercised without PRO.
+ */
+class FetchSourceCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+
+    public function setup()
+    {
+        $this->crud->setModel(Article::class);
+        $this->crud->setRoute('fetch-source');
+    }
+
+    public function getRelationFetchQuery(string $fetchMethod)
+    {
+        $queries = [
+            'fetchPlanet' => function ($query) {
+                return $query->where('id', 1);
+            },
+            'fetchRole' => function ($query) {
+                return $query->where('id', 1);
+            },
+            'fetchModeratorUser' => function ($query) {
+                return $query->where('id', 1);
+            },
+        ];
+
+        $query = $queries[$fetchMethod] ?? null;
+
+        return is_callable($query) ? $query : null;
+    }
+}


### PR DESCRIPTION
introduced a new attribute `relation_options_query_source` that allow developers to tell us the fetch function used to get the selectable options. 

This is for cases where the `data_source` differ from the `fetchXxxx()` method.  