### PR TITLE
Filter values badge

### DIFF
--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -39,6 +39,10 @@ class CrudFilter
 
     public $applied = false;
 
+    public $showFilterValues; // whether to show this filter's value as a badge (null = inherit from parent)
+    
+    public $filterValuesLabel; // custom label template with :value placeholder
+
     public function __construct($options, $values, $logic, $fallbackLogic)
     {
         if (! backpack_pro()) {
@@ -64,6 +68,8 @@ class CrudFilter
             $this->options = $options;
             $this->logic = $logic;
             $this->fallbackLogic = $fallbackLogic;
+            $this->showFilterValues = $options['showFilterValues'] ?? null;
+            $this->filterValuesLabel = $options['filterValuesLabel'] ?? null;
         }
 
         if (request()->has($this->name)) {
@@ -358,6 +364,34 @@ class CrudFilter
     public function viewNamespace($value)
     {
         $this->viewNamespace = $value;
+
+        return $this->save();
+    }
+
+    /**
+     * Show or hide this filter's value badge. Overrides any parent setting.
+     *
+     * @param  bool  $value  True to show, false to hide.
+     * @return CrudFilter
+     */
+    public function showFilterValues($value = true)
+    {
+        $this->showFilterValues = $value;
+
+        return $this->save();
+    }
+
+    /**
+     * Set a custom label template for the filter value badge.
+     * Use ':value' as a placeholder for the filter's current value.
+     * Example: 'Category: :value' or ':value selected'
+     *
+     * @param  string  $value  Label template with :value placeholder.
+     * @return CrudFilter
+     */
+    public function filterValuesLabel($value)
+    {
+        $this->filterValuesLabel = $value;
 
         return $this->save();
     }

--- a/src/app/Library/CrudPanel/CrudFilter.php
+++ b/src/app/Library/CrudPanel/CrudFilter.php
@@ -40,7 +40,7 @@ class CrudFilter
     public $applied = false;
 
     public $showFilterValues; // whether to show this filter's value as a badge (null = inherit from parent)
-    
+
     public $filterValuesLabel; // custom label template with :value placeholder
 
     public function __construct($options, $values, $logic, $fallbackLogic)
@@ -384,7 +384,7 @@ class CrudFilter
     /**
      * Set a custom label template for the filter value badge.
      * Use ':value' as a placeholder for the filter's current value.
-     * Example: 'Category: :value' or ':value selected'
+     * Example: 'Category: :value' or ':value selected'.
      *
      * @param  string  $value  Label template with :value placeholder.
      * @return CrudFilter

--- a/src/app/View/Components/Datatable.php
+++ b/src/app/View/Components/Datatable.php
@@ -22,6 +22,7 @@ class Datatable extends Component
         private ?\Closure $setup = null,
         private ?string $name = null,
         private ?bool $useFixedHeader = null,
+        private ?bool $showFilterValues = null,
     ) {
         // Set active controller for proper context
         CrudManager::setActiveController($controller);
@@ -105,6 +106,7 @@ class Datatable extends Component
     public function render()
     {
         $useFixedHeader = $this->useFixedHeader ?? $this->crud->getOperationSetting('useFixedHeader') ?? true;
+        $showFilterValues = $this->showFilterValues ?? $this->crud->getOperationSetting('showFilterValues') ?? false;
 
         return view('crud::components.datatable.datatable', [
             'crud' => $this->crud,
@@ -112,6 +114,7 @@ class Datatable extends Component
             'tableId' => $this->tableId,
             'datatablesUrl' => url($this->crud->get('list.datatablesUrl')),
             'useFixedHeader' => $useFixedHeader,
+            'showFilterValues' => $showFilterValues,
         ]);
     }
 }

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -83,4 +83,8 @@ return [
     // when list operation load the information from database, should Backpack eager load the relations ?
     // this setting is enabled by default as it reduces the amount of queries required to load the page
     'eagerLoadRelationships' => true,
+
+    // Show active filter values as badges/chips below the filter navbar?
+    // Can be overridden per datatable, per filters_navbar include, or per filter.
+    'showFilterValues' => false,
 ];

--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -166,6 +166,42 @@ div[id$="_wrapper"] .dt-processing {
     border: none;
 }
 
+.active-filter-badges .filter-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.3rem 0.6rem;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        line-height: 1.4;
+        border-radius: 0.375rem;
+        background-color: var(--tblr-bg-surface-secondary, #f1f5f9);
+        color: var(--tblr-body-color, #334155);
+        border: 1px solid var(--tblr-border-color, #e2e8f0);
+        cursor: default;
+        white-space: nowrap;
+    }
+    .active-filter-badges .filter-badge .filter-badge-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
+        padding: 0;
+        border: none;
+        background: transparent;
+        color: var(--tblr-muted, #94a3b8);
+        font-size: 12px;
+        line-height: 1;
+        cursor: pointer;
+        border-radius: 50%;
+        transition: color 0.15s, background-color 0.15s;
+    }
+    .active-filter-badges .filter-badge .filter-badge-close:hover {
+        color: var(--tblr-body-color, #334155);
+        background-color: var(--tblr-border-color, #e2e8f0);
+    }
+
 .navbar-filters .navbar-collapse {
     padding: 0;
     border: 0;
@@ -440,7 +476,7 @@ div[id$="_wrapper"] .dt-processing {
 }
 
 .navbar-filters span.select2-dropdown.select2-dropdown--below {
-    border: 1px solid var(--tblr-dropdown-border-color) !important;
+    border: 1px solid var(--tblr-dropdown-border-color, #e2e8f0) !important;
     border-top: none !important;
     box-sizing: content-box;
     box-shadow: none;

--- a/src/resources/views/crud/components/datatable/datatable.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable.blade.php
@@ -68,7 +68,7 @@
 
 {{-- Backpack List Filters --}}
 @if ($crud->filtersEnabled())
-  @include('crud::inc.filters_navbar', ['componentId' => $tableId])
+  @include('crud::inc.filters_navbar', ['componentId' => $tableId, 'showFilterValues' => $showFilterValues ?? false])
 @endif
 <div class="{{ backpack_theme_config('classes.tableWrapper') }}">
   <table

--- a/src/resources/views/crud/components/datatable/datatable_logic.blade.php
+++ b/src/resources/views/crud/components/datatable/datatable_logic.blade.php
@@ -1469,9 +1469,19 @@ function updateDatatablesOnFilterChange(filterName, filterValue, shouldUpdateUrl
     // Set the new URL for the table
     table.ajax.url(newUrl);
     
-    // Update the browser URL if needed - use browser URL, not AJAX URL
+    // Update the browser URL if needed - use navbar's data-filter-params as source of truth
+    // so that accumulated state from multiple events (e.g. select2_ajax) is included
     if (shouldUpdateUrl) {
-        let browserUrl = addOrUpdateUriParameter(window.location.href, filterName, filterValue);
+        var browserUrl;
+        var navbar = document.querySelector('.navbar-filters[data-component-id="' + tableId + '"]');
+        if (navbar) {
+            var accumulatedParams = new URLSearchParams(navbar.getAttribute('data-filter-params') || '');
+            var paramsObj = {};
+            accumulatedParams.forEach(function(value, key) { paramsObj[key] = value; });
+            browserUrl = addOrUpdateUriParameter(window.location.href, paramsObj);
+        } else {
+            browserUrl = addOrUpdateUriParameter(window.location.href, filterName, filterValue);
+        }
         tableConfig.updateUrl(browserUrl);
     }
     

--- a/src/resources/views/crud/inc/filters_navbar.blade.php
+++ b/src/resources/views/crud/inc/filters_navbar.blade.php
@@ -24,6 +24,16 @@
         </ul>
     </div>{{-- /.navbar-collapse --}}
 </nav>
+
+@php
+    $showFilterValues = $showFilterValues ?? config('backpack.operations.list.showFilterValues', false);
+@endphp
+
+<div class="active-filter-badges d-flex flex-wrap align-items-center gap-1 px-3 pb-2"
+     id="filter-badges-{{ $componentId ?? '' }}"
+     data-show-filter-values-default="{{ var_export($showFilterValues, true) }}"
+     style="display:none;">
+</div>
   
 @push('after_scripts')
     @basset('https://cdn.jsdelivr.net/npm/urijs@1.19.11/src/URI.min.js')
@@ -38,12 +48,26 @@
                 new_url.removeQuery('persistent-table');
             }
 
-            if (new_url.hasQuery(parameter)) {
-                new_url.removeQuery(parameter);
-            }
-
-            if (value !== '' && value != null) {
-                new_url = new_url.addQuery(parameter, value);
+            // When parameter is an object, treat it as {key: value} pairs to add/update all at once.
+            // Otherwise fall back to the original single-parameter behavior.
+            if (typeof parameter === 'object' && parameter !== null) {
+                for (var key in parameter) {
+                    if (!parameter.hasOwnProperty(key)) continue;
+                    var val = parameter[key];
+                    if (new_url.hasQuery(key)) {
+                        new_url.removeQuery(key);
+                    }
+                    if (val !== '' && val != null) {
+                        new_url = new_url.addQuery(key, val);
+                    }
+                }
+            } else {
+                if (new_url.hasQuery(parameter)) {
+                    new_url.removeQuery(parameter);
+                }
+                if (value !== '' && value != null) {
+                    new_url = new_url.addQuery(parameter, value);
+                }
             }
 
             // Update all remove filter buttons visibility
@@ -52,6 +76,142 @@
             });
 
             return new_url.normalizeQuery().toString();
+        }
+    }
+
+    /**
+     * Get a human-readable display value for a filter's current value.
+     */
+    if(typeof getFilterDisplayValue !== 'function') {
+        function getFilterDisplayValue(filter, rawValue, filterName) {
+            var filterType = filter.getAttribute('filter-type');
+            var filterOptions = {};
+
+            // If the filter has a data-display-filter-attribute-name, use that key
+            // to look up the display value in data-filter-params. This allows filters
+            // like select2_ajax to show the human-readable text instead of the raw ID.
+            var displayAttribute = filter.getAttribute('data-display-filter-attribute-name');
+            if (displayAttribute) {
+                var displayNavbar = filter.closest('.navbar-filters');
+                if (displayNavbar) {
+                    var displayParams = new URLSearchParams(displayNavbar.getAttribute('data-filter-params') || '');
+                    var displayValue = displayParams.get(displayAttribute);
+                    if (displayValue) return displayValue;
+                }
+            }
+
+            try {
+                filterOptions = JSON.parse(filter.getAttribute('data-filter-options') || '{}');
+            } catch(e) {}
+
+            switch(filterType) {
+                case 'text':
+                case 'date':
+                case 'view':
+                    return rawValue;
+                case 'dropdown':
+                case 'select2':
+                    return filterOptions[rawValue] || rawValue;
+                case 'select2_multiple':
+                    try {
+                        var values = JSON.parse(rawValue);
+                        return values.map(function(v) { return filterOptions[v] || v; }).join(', ');
+                    } catch(e) {
+                        return rawValue;
+                    }
+                case 'date_range':
+                    try {
+                        var dates = JSON.parse(rawValue);
+                        return (dates.from || '') + ' \u2192 ' + (dates.to || '');
+                    } catch(e) {
+                        return rawValue;
+                    }
+                case 'range':
+                    try {
+                        var range = JSON.parse(rawValue);
+                        return (range.from || '') + ' \u2192 ' + (range.to || '');
+                    } catch(e) {
+                        return rawValue;
+                    }
+                case 'simple':
+                case 'trashed':
+                    return '';
+                default:
+                    return rawValue;
+            }
+        }
+    }
+
+    /**
+     * Sync the active filter badges below the navbar from data-filter-params.
+     */
+    if(typeof syncFilterBadges !== 'function') {
+        function syncFilterBadges(navbar) {
+            var badgesContainer = document.getElementById('filter-badges-' + (navbar.getAttribute('data-component-id') || ''));
+            if (!badgesContainer) return;
+
+            var params = new URLSearchParams(navbar.getAttribute('data-filter-params') || '');
+            var filters = navbar.querySelectorAll('li[filter-name]');
+            var html = '';
+            // Default from the navbar-level setting (on the badges container)
+            var defaultShow = badgesContainer.getAttribute('data-show-filter-values-default') === 'true';
+
+            filters.forEach(function(filter) {
+                var filterName = filter.getAttribute('filter-name');
+                if (!params.has(filterName)) return;
+
+                // Check per-filter showFilterValues; if absent (NULL/empty), inherit from default
+                var filterShow = filter.getAttribute('data-show-filter-values');
+                if (filterShow === 'false') return;
+                if (filterShow !== 'true' && !defaultShow) return;
+
+                var rawValue = params.get(filterName);
+                var displayValue = getFilterDisplayValue(filter, rawValue, filterName);
+                var label = filter.querySelector('a') ? filter.querySelector('a').textContent.trim().replace(/\s*\u25BE\s*$/, '') : filterName;
+
+                // Use custom label template if set
+                var labelTemplate = filter.getAttribute('data-filter-values-label');
+                if (labelTemplate && displayValue) {
+                    label = labelTemplate.replace(':value', displayValue);
+                } else {
+                    label = displayValue ? label + ': ' + displayValue : label;
+                }
+
+                html += '<span class="filter-badge me-1 mb-1" data-filter-name="' + filterName + '">'
+                    + label
+                    + ' <button type="button" class="filter-badge-close" aria-label="Remove ' + label + ' filter">&times;</button>'
+                    + '</span>';
+            });
+
+            badgesContainer.innerHTML = html;
+            badgesContainer.style.display = html ? '' : 'none';
+
+            // Wire up badge dismiss buttons
+            badgesContainer.querySelectorAll('.filter-badge button').forEach(function(btn) {
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var badge = btn.closest('.filter-badge');
+                    var filterName = badge.getAttribute('data-filter-name');
+                    var filter = navbar.querySelector('li[filter-name="' + filterName + '"]');
+                    if (filter) {
+                        // Clear the filter via its own event so the UI resets
+                        filter.dispatchEvent(new CustomEvent('backpack:filter:clear'));
+
+                        // Dispatch changed event with null value to trigger table refresh
+                        // The global backpack:filter:changed handler will update data-filter-params and sync badges
+                        document.dispatchEvent(new CustomEvent('backpack:filter:changed', {
+                            detail: {
+                                filterName: filterName,
+                                filterValue: null,
+                                shouldUpdateUrl: true,
+                                debounce: filter.getAttribute('filter-debounce') || 0,
+                                componentId: navbar.getAttribute('data-component-id') || '',
+                            }
+                        }));
+                    }
+                });
+            });
         }
     }
 
@@ -133,13 +293,16 @@
     }
 
     // Each filter navbar stores its own filter state in a `data-filter-params` attribute.
-    // This is the source of truth for consumers (e.g. report scripts) — they read from
-    // the navbar DOM element, not the browser URL. This supports future scenarios with
+    // This is the source of truth for consumers (e.g. report scripts, badges) — they read from
+    // the navbar DOM element, not the browser URL. This supports scenarios with
     // multiple independent filter navbars on the same page.
-    // When there is only one navbar, the browser URL is also kept in sync as a convenience
-    // (bookmarkable URLs, shareable links).
+    // When there is only one navbar and shouldUpdateUrl is true, the browser URL is also kept
+    // in sync as a convenience (bookmarkable URLs, shareable links).
+    // The URL is built from the accumulated data-filter-params (not the single event param)
+    // so filters that dispatch multiple events (e.g. select2_ajax) result in a single URL update
+    // containing all params.
     document.addEventListener('backpack:filter:changed', function(event) {
-        if (!event.detail || !event.detail.shouldUpdateUrl) return;
+        if (!event.detail) return;
 
         // Find the navbar that owns this filter
         var componentId = event.detail.componentId || '';
@@ -149,7 +312,8 @@
 
         if (!navbar) return;
 
-        // Update the navbar's stored filter state
+        // Always update the navbar's stored filter state (source of truth),
+        // regardless of shouldUpdateUrl, so that accumulated state is available
         var params = new URLSearchParams(navbar.getAttribute('data-filter-params') || '');
         if (event.detail.filterValue !== '' && event.detail.filterValue != null) {
             params.set(event.detail.filterName, event.detail.filterValue);
@@ -158,9 +322,17 @@
         }
         navbar.setAttribute('data-filter-params', params.toString());
 
-        // Mirror to the browser URL only when there is a single filter navbar
-        if (document.querySelectorAll('.navbar-filters').length <= 1) {
-            var newUrl = addOrUpdateUriParameter(window.location.href, event.detail.filterName, event.detail.filterValue);
+        // Sync the active filter badges
+        syncFilterBadges(navbar);
+
+        // Mirror to the browser URL only when shouldUpdateUrl is true AND there is a single filter navbar.
+        // Build the URL from the navbar's accumulated data-filter-params so that all params
+        // are included in a single URL update, even when multiple events contributed to the state.
+        if (event.detail.shouldUpdateUrl && document.querySelectorAll('.navbar-filters').length <= 1) {
+            var accumulatedParams = new URLSearchParams(navbar.getAttribute('data-filter-params') || '');
+            var paramsObj = {};
+            accumulatedParams.forEach(function(value, key) { paramsObj[key] = value; });
+            var newUrl = addOrUpdateUriParameter(window.location.href, paramsObj);
             window.history.replaceState({}, '', newUrl);
         }
     });
@@ -194,8 +366,16 @@
                 if (urlParams.has(filterName)) {
                     navbarParams.set(filterName, urlParams.get(filterName));
                 }
+                // Also seed any display attribute (e.g. category_text for select2_ajax filters)
+                var displayAttr = filter.getAttribute('data-display-filter-attribute-name');
+                if (displayAttr && urlParams.has(displayAttr)) {
+                    navbarParams.set(displayAttr, urlParams.get(displayAttr));
+                }
             });
             navbar.setAttribute('data-filter-params', navbarParams.toString());
+
+            // Sync badges on initial load
+            syncFilterBadges(navbar);
 
             // Add event listener only once per navbar to avoid duplication
             if (!navbar.hasAttribute('data-filter-events-bound')) {
@@ -306,6 +486,10 @@
 
                     // 2. Clear the navbar's stored filter state and clean the browser URL
                     navbar.setAttribute('data-filter-params', '');
+
+                    // Sync badges after clearing all filters
+                    syncFilterBadges(navbar);
+
                     if (document.querySelectorAll('.navbar-filters').length <= 1) {
                         let cleanUrl = URI(window.location.href).search('').toString();
                         if (window.crud && typeof window.crud.updateUrl === 'function') {
@@ -348,6 +532,9 @@
                     if (anyActiveFilters === false) {
                         removeFiltersButton?.classList.add('invisible');
                     }
+
+                    // Sync badges when individual filter is cleared
+                    syncFilterBadges(navbar);
                 });
             });
         });


### PR DESCRIPTION
closes: https://github.com/Laravel-Backpack/community-forum/discussions/1475
fixes: https://github.com/Laravel-Backpack/community-forum/issues/177

The backpack filters didn't show the selected value while closed. You add a "text" filter, you searched something, the table reloads et all, but for you to know what you searched you need to open the filter. Similar to remove only that filter you needed to open the filter. If you have some good amount of filters in a page, this can become a real issue to know what each filter is filtering for. 

With that in mind, we are introducing the "filter value badges". The name is pretty much explanatory, it adds some badges under the filter navbar that show the user the filtered value, with the option to remove that filter without having to open the filter from the navbar. 

<img width="1897" height="397" alt="image" src="https://github.com/user-attachments/assets/7e00cfeb-f422-47e0-9576-667f8e52d982" />

We introduced 2 new settings, the `showFilterValues` and `filterValuesLabel` with that you have the power to enable it globaly, per crud or even per filter and choose exactly how you want to present that information to the user by using a `:value` placeholder on the label. 

Everything regarding this is added to the docs. 