### PR TITLE
fix dark mode in form fields

### DIFF
--- a/src/resources/assets/css/common.css
+++ b/src/resources/assets/css/common.css
@@ -28,6 +28,14 @@
     --bp-range-bubble-bg: #7c69ef;
     --bp-range-bubble-color: #fff;
     --bp-range-label-color: #6c757d;
+
+    --bp-form-disabled-bg: var(--tblr-bg-surface-secondary, #f0f0f0);
+    --bp-form-disabled-color: var(--tblr-secondary, #6c757d);
+    --bp-form-check-disabled-opacity: 0.5;
+    --bp-form-check-label-disabled-opacity: 0.7;
+
+    --bp-tinymce-content-bg: #ffffff;
+    --bp-tinymce-content-color: #000000;
 }
 
 .sidebar .nav-dropdown-items .nav-dropdown {

--- a/src/resources/views/crud/fields/summernote.blade.php
+++ b/src/resources/views/crud/fields/summernote.blade.php
@@ -119,15 +119,22 @@
 
             element.on('CrudField:disable', function(e) {
                 element.summernote('disable');
+                element.next('.note-editor').addClass('bp-disabled');
             });
 
             element.on('CrudField:enable', function(e) {
                 element.summernote('enable');
+                element.next('.note-editor').removeClass('bp-disabled');
             });
 
             summernoteOptions['callbacks'] = summernotCallbacks;
 
             element.summernote(summernoteOptions);
+
+            if (element.attr('disabled')) {
+                element.summernote('disable');
+                element.next('.note-editor').addClass('bp-disabled');
+            }
         }
     </script>
     @endBassetBlock


### PR DESCRIPTION
fix: https://github.com/Laravel-Backpack/CRUD/issues/5121

disabled fields didn't had a visual indication that they were disabled. 

summernote needed some additional css rules to properly style in dark mode too.