### PR TITLE
basset preload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     ],
     "require": {
         "laravel/framework": "^12|^13",
-        "backpack/basset": "^2.0.",
+        "backpack/basset": "^2.0.9",
         "creativeorange/gravatar": "^1.0",
         "prologue/alerts": "^1.0",
         "doctrine/dbal": "^4.0",

--- a/docs/base-look-and-feel.md
+++ b/docs/base-look-and-feel.md
@@ -2,6 +2,25 @@
 
 ## Look and feel
 
+### Preload assets for basset:cache
+
+When using `@basset()` inside conditional Blade directives (`@if`), the `basset:cache` command cannot discover those assets (it scans source, doesn't evaluate conditions). Use `basset_preload` in `config/backpack/ui.php` to register them for caching:
+
+```php
+'basset_preload' => [
+    'scripts' => [
+        // Conditionally loaded locale scripts, dynamic dependencies, etc.
+        'https://cdn.example.com/locale-es.js',
+        'https://cdn.example.com/locale-fr.js',
+    ],
+    'styles' => [
+        'https://cdn.example.com/theme-dark.css',
+    ],
+],
+```
+
+Assets listed here are **not** loaded on every page — they are only registered so `php artisan basset:cache` can internalize them. They are still loaded conditionally via `@basset()` in blade files.
+
 ### Text direction: LTR or RTL
 
 By default, the text direction is set to left-to-right. If your UI is in Arabic, Hebrew or any other language that needs to show right-to-left, you can enable that - just go to `config/backpack/ui.php` and change the `html_direction` variable to `rtl`:

--- a/docs/fields/air-datepicker-pro.md
+++ b/docs/fields/air-datepicker-pro.md
@@ -1,0 +1,68 @@
+### air-datepicker [PRO]
+
+A unified date/time/range picker field powered by [air-datepicker](https://air-datepicker.com/) (~13KB, zero dependencies). Replaces the deprecated `date_picker`, `datetime_picker`, and `date_range` fields.
+
+```php
+CRUD::field([
+    'name'  => 'published_at',
+    'label' => 'Published Date',
+    'type'  => 'air-datepicker',
+
+    // OPTIONALS
+    'air-datepicker' => [
+        // Date only (default, format: yyyy-MM-dd)
+
+        // DateTime mode — dateFormat and timeFormat are SEPARATE when timepicker is on
+        'timepicker' => true,
+        'dateFormat' => 'dd/MM/yyyy',
+        'timeFormat' => 'HH:mm',
+
+        // Date range mode (requires two db columns)
+        'range'      => true,
+        // When using range, 'name' must reference two columns:
+        // 'name' => ['start_date', 'end_date'] or 'name' => 'start_date,end_date'
+
+        // Calendar options (all air-datepicker options are pass-through)
+        'firstDay'   => 1,                       // Monday (0 = Sunday)
+        'minDate'    => '2024-01-01',
+        'maxDate'    => '2024-12-31',
+        'autoClose'  => true,
+        'buttons'    => ['today', 'clear'],
+
+        // Time constraints (when timepicker is on)
+        'minHours'    => 9,
+        'maxHours'    => 18,
+        'minutesStep' => 15,
+
+        // Range preset buttons (when range is true)
+        'ranges' => [
+            'Today'      => [now()->startOfDay(), now()->endOfDay()],
+            'Last 7 Days' => [now()->subDays(6)->startOfDay(), now()],
+            'This Month' => [now()->startOfMonth(), now()->endOfMonth()],
+        ],
+
+        // Locale override (pass a full air-datepicker locale object)
+        'locale' => [
+            'days'        => ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+            'daysShort'   => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+            'months'      => ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+            'monthsShort' => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            'firstDay'    => 1,
+        ],
+    ],
+]);
+```
+
+> **Format tokens:** This field uses Unicode TR35 tokens (NOT Carbon/PHP/Moment tokens).
+> Common conversions: Carbon `d/m/Y` → TR35 `dd/MM/yyyy`, Carbon `D MMM YYYY` → TR35 `E MMM yyyy`.
+> When `timepicker` is on, `dateFormat` and `timeFormat` are separate — do NOT combine them (e.g. `'dateFormat' => 'dd/MM/yyyy HH:mm'` is wrong, use `'dateFormat' => 'dd/MM/yyyy'` + `'timeFormat' => 'HH:mm'`).
+
+> **Locale:** Day/month names come from Backpack's translation files (`resources/lang/vendor/backpack/{lang}/crud.php` → `date_time` section). English and 11 other languages have built-in translations. To add a language, publish the lang files and add the `date_time` array with `days`, `daysShort`, `daysMin`, `months`, `monthsShort`, `dateFormat`, `timeFormat`, and `firstDay` keys.
+
+> **Dependencies:** Only air-datepicker (~13KB). No jQuery, no moment.js, no dayjs. The old fields (`date_picker`, `datetime_picker`, `date_range`) required moment.js + bootstrap widgets and are now deprecated.
+
+> **Hidden inputs:** Single and datetime modes use a hidden input with `bp-field-main-input` for SQL-format values (`Y-m-d` or `Y-m-d H:i:s`). Range mode uses two hidden inputs with classes `air-datepicker-range-start` and `air-datepicker-range-end`. The visible input is read-only (keyboard input is blocked).
+
+> **Default values:** For range mode, pass `'default' => ['2024-01-01', '2024-12-31']`. For single mode, use `'default' => '2024-01-01'`.
+
+Any option from [air-datepicker's documentation](https://air-datepicker.com/docs) can be passed inside the `air-datepicker` config array — they're transparently forwarded to the JS widget.

--- a/docs/fields/date-picker-pro.md
+++ b/docs/fields/date-picker-pro.md
@@ -1,5 +1,7 @@
 ### date_picker [PRO]
 
+> ⚠️ **DEPRECATED** — Will be removed in the next major version. Migrate to [`air-datepicker`](air-datepicker-pro.md) instead (air-datepicker replaces bootstrap-datepicker + moment.js with a single ~13KB dependency-free widget).
+
 Show a pretty [Bootstrap Datepicker](http://bootstrap-datepicker.readthedocs.io/en/latest/).
 
 ```php

--- a/docs/fields/date-range-pro.md
+++ b/docs/fields/date-range-pro.md
@@ -1,5 +1,7 @@
 ### date_range [PRO]
 
+> ⚠️ **DEPRECATED** — Will be removed in the next major version. Migrate to [`air-datepicker`](air-datepicker-pro.md) instead (air-datepicker replaces bootstrap-daterangepicker + moment.js with a single ~13KB dependency-free widget).
+
 Show a DateRangePicker and let the user choose a start date and end date.
 
 ```php

--- a/docs/fields/datetime-picker-pro.md
+++ b/docs/fields/datetime-picker-pro.md
@@ -1,5 +1,7 @@
 ### datetime_picker [PRO]
 
+> ⚠️ **DEPRECATED** — Will be removed in the next major version. Migrate to [`air-datepicker`](air-datepicker-pro.md) instead (air-datepicker replaces bootstrap-datetimepicker + moment.js with a single ~13KB dependency-free widget).
+
 Show a [Bootstrap Datetime Picker](https://eonasdan.github.io/bootstrap-datetimepicker/).
 
 ```php

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -85,6 +85,17 @@ class BackpackServiceProvider extends ServiceProvider
                 Basset::map($script, $script);
             }
         }
+
+        // Register preloaded assets for basset:cache.
+        // These are NOT loaded on every page — they are only registered so that
+        // basset:cache can internalize them ahead of time. They are loaded
+        // conditionally via @basset in blade files (e.g. locale scripts).
+        foreach (config('backpack.ui.basset_preload.scripts', []) as $asset) {
+            Basset::map($asset, $asset);
+        }
+        foreach (config('backpack.ui.basset_preload.styles', []) as $asset) {
+            Basset::map($asset, $asset);
+        }
     }
 
     /**

--- a/src/BackpackServiceProvider.php
+++ b/src/BackpackServiceProvider.php
@@ -66,35 +66,35 @@ class BackpackServiceProvider extends ServiceProvider
 
         Basset::addViewPath(realpath(__DIR__.'/resources/views'));
 
-        foreach (config('backpack.ui.styles', []) as $style) {
-            if (is_array($style)) {
-                foreach ($style as $file) {
+        $this->registerBassetAssets(config('backpack.ui.styles', []));
+        $this->registerBassetAssets(config('backpack.ui.scripts', []));
+        $this->registerBassetAssets(config('backpack.ui.basset_preload.scripts', []));
+        $this->registerBassetAssets(config('backpack.ui.basset_preload.styles', []));
+    }
+
+    /**
+     * Register assets with Basset from a config array.
+     *
+     * Supports three formats:
+     *   'url'                                              → name = source = URL
+     *   ['url1', 'url2']                                   → sequential list
+     *   'name' => ['source' => 'url', 'refresh' => true]   → explicit name + source + attributes
+     *   'url'  => ['refresh' => true]                      → key = source fallback
+     */
+    private function registerBassetAssets(array $assets): void
+    {
+        foreach ($assets as $key => $value) {
+            if (is_string($value)) {
+                Basset::map($value, $value);
+            } elseif (array_is_list($value) && (! $value || is_string(reset($value)))) {
+                foreach ($value as $file) {
                     Basset::map($file, $file);
                 }
             } else {
-                Basset::map($style, $style);
+                $source = $value['source'] ?? $key;
+                $attributes = array_diff_key($value, ['source' => null]);
+                Basset::map($key, $source, $attributes);
             }
-        }
-
-        foreach (config('backpack.ui.scripts', []) as $script) {
-            if (is_array($script)) {
-                foreach ($script as $file) {
-                    Basset::map($file, $file);
-                }
-            } else {
-                Basset::map($script, $script);
-            }
-        }
-
-        // Register preloaded assets for basset:cache.
-        // These are NOT loaded on every page — they are only registered so that
-        // basset:cache can internalize them ahead of time. They are loaded
-        // conditionally via @basset in blade files (e.g. locale scripts).
-        foreach (config('backpack.ui.basset_preload.scripts', []) as $asset) {
-            Basset::map($asset, $asset);
-        }
-        foreach (config('backpack.ui.basset_preload.styles', []) as $asset) {
-            Basset::map($asset, $asset);
         }
     }
 

--- a/src/config/backpack/ui.php
+++ b/src/config/backpack/ui.php
@@ -121,6 +121,18 @@ return [
         // 'https://cdn.jsdelivr.net/npm/react-dom@16/umd/react-dom.production.min.js',
     ],
 
+    // Assets that are NOT loaded on every page, but should still be cached by basset:cache
+    // so they are available when conditionally loaded via @basset in blade files.
+    // Useful for locale scripts, dynamic dependencies, etc.
+    'basset_preload' => [
+        'scripts' => [
+            // 'https://cdn.example.com/locale-es.js',
+        ],
+        'styles' => [
+            // 'https://cdn.example.com/theme-dark.css',
+        ],
+    ],
+
     // JS files that are loaded in all pages, using Laravel's mix() helper
     'mix_scripts' => [ // file_path => manifest_directory_path
         // 'js/app.js' => '',


### PR DESCRIPTION
This adds the `basset_preload` option, and add AI docs on the air-datepicker field. 

tests intentionaly failing due to basset version bump. they will be fixed when we release 2.0.9 of basset.