### PR TITLE
remove hasMcpEnabled() guard

### DIFF
--- a/resources/boost/guidelines/backpack-crud.blade.php
+++ b/resources/boost/guidelines/backpack-crud.blade.php
@@ -262,10 +262,8 @@ When a user asks to install a paid package (e.g., "install backpack/pro"), follo
 - `{{ $assist->artisanCommand('backpack:tests') }}` — generate CRUD tests
 - `{{ $assist->artisanCommand('backpack:tests:status') }}` — check test coverage
 
-@if($assist->hasMcpEnabled())
 ## Documentation Search
 - For Backpack questions (fields, columns, filters, operations, widgets, relationships), always use the `search-backpack-docs` MCP tool FIRST.
 - Do NOT use `search-docs` for Backpack questions — it does not index Backpack documentation.
 - Pass multiple queries for OR logic: `["relationship field", "select2 belongsTo", "select2_from_ajax"]`.
 - Use `"quoted phrases"` for exact matching.
-@endif

--- a/resources/boost/guidelines/backpack-crud.blade.php
+++ b/resources/boost/guidelines/backpack-crud.blade.php
@@ -263,7 +263,7 @@ When a user asks to install a paid package (e.g., "install backpack/pro"), follo
 - `{{ $assist->artisanCommand('backpack:tests:status') }}` — check test coverage
 
 ## Documentation Search
-- For Backpack questions (fields, columns, filters, operations, widgets, relationships), always use the `search-backpack-docs` MCP tool FIRST.
-- Do NOT use `search-docs` for Backpack questions — it does not index Backpack documentation.
-- Pass multiple queries for OR logic: `["relationship field", "select2 belongsTo", "select2_from_ajax"]`.
+- If the `search-backpack-docs` MCP tool is available, use it for ALL Backpack questions (fields, columns, filters, operations, widgets, relationships). If not available, use web search instead.
+- Do NOT use the `search-docs` MCP tool for Backpack questions — it does not index Backpack documentation.
+- When using `search-backpack-docs`, pass multiple queries for OR logic: `["relationship field", "select2 belongsTo", "select2_from_ajax"]`.
 - Use `"quoted phrases"` for exact matching.


### PR DESCRIPTION
There is no need to have this guard around the docs. 

this is just guideline, if mcp is not available, it won't be calling the search tool. 