### PR TITLE
Add option to show languages in edit button

### DIFF
--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -80,7 +80,7 @@ return [
     // Setting this to false will improve performance on big datasets.
     'showEntryCount' => true,
 
-    // when list operation load the information from database, should Backpack eager load the relations ?
+    // when list operation load the information from database, should Backpack eager load the relations?
     // this setting is enabled by default as it reduces the amount of queries required to load the page
     'eagerLoadRelationships' => true,
 
@@ -104,4 +104,7 @@ return [
     //   });
     //
     'rowAttributes' => null,
+
+    // Show the dropdown for each available language near edit/show button
+    'showLanguagesDirectlyInEditButton' => true
 ];

--- a/src/config/backpack/operations/list.php
+++ b/src/config/backpack/operations/list.php
@@ -104,7 +104,10 @@ return [
     //   });
     //
     'rowAttributes' => null,
+    
+    // Show the dropdown for each available language near edit button
+    'showLanguagesDirectlyInEditButton' => true,
 
-    // Show the dropdown for each available language near edit/show button
-    'showLanguagesDirectlyInEditButton' => true
+    // Show the dropdown for each available language near show button
+    'showLanguagesDirectlyInShowButton' => false,
 ];


### PR DESCRIPTION
Missing configuration value mentioned in https://backpackforlaravel.com/docs/7.x/crud-operation-show. also added a whitespace change

## WHY

### BEFORE - What was wrong? What was happening before this PR?
No value 

### AFTER - What is happening after this PR?

Value in the config file


## HOW

### How did you achieve that, in technical terms?

??



### Is it a breaking change?

No


### How can we test the before & after?

