### PR TITLE
Improve `HasEnumFields` implementation

### DIFF
--- a/src/app/Models/Traits/HasEnumFields.php
+++ b/src/app/Models/Traits/HasEnumFields.php
@@ -32,15 +32,8 @@ trait HasEnumFields
 
     public static function getEnumValuesAsAssociativeArray($field_name)
     {
-        $instance = new static();
-        $enum_values = $instance->getPossibleEnumValues($field_name);
-
-        $array = array_flip($enum_values);
-
-        foreach ($array as $key => $value) {
-            $array[$key] = $key;
-        }
-
-        return $array;
+        return (new Collection(static::getPossibleEnumValues($field_name)))
+            ->mapWithKeys(static fn (string $value) => [$value => $value])
+            ->toArray();
     }
 }

--- a/src/app/Models/Traits/HasEnumFields.php
+++ b/src/app/Models/Traits/HasEnumFields.php
@@ -2,8 +2,7 @@
 
 namespace Backpack\CRUD\app\Models\Traits;
 
-use DB;
-use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Collection;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,26 +16,18 @@ trait HasEnumFields
         $instance = new static(); // create an instance of the model to be able to get the table name
 
         $connection = $instance->getConnection();
+        $table = $instance->getTable();
 
-        $table_prefix = Config::get('database.connections.'.$connection->getName().'.prefix');
+        $type = $connection->getSchemaBuilder()->getColumnType($table, $field_name, true);
 
-        try {
-            $select = app()->version() < 10 ?
-                        DB::raw('SHOW COLUMNS FROM `'.$table_prefix.$instance->getTable().'` WHERE Field = "'.$field_name.'"') :
-                        DB::raw('SHOW COLUMNS FROM `'.$table_prefix.$instance->getTable().'` WHERE Field = "'.$field_name.'"')->getValue($connection->getQueryGrammar());
-
-            $type = $connection->select($select)[0]->Type;
-        } catch (\Exception $e) {
-            abort(500, 'Enum field type is not supported - it only works on MySQL. Please use select_from_array instead.', ['developer-error-exception']);
+        if (preg_match('/^enum\((.*)\)$/', $type, $matches) !== 1) {
+            abort(500, 'Could not deduce enum values - note this only works on selected engines (e.g. MySQL). Please use select_from_array instead.', ['developer-error-exception']);
         }
 
-        preg_match('/^enum\((.*)\)$/', $type, $matches);
-        $enum = [];
-        foreach (explode(',', $matches[1]) as $value) {
-            $enum[] = trim($value, "'");
-        }
-
-        return $enum;
+        return (new Collection(explode(',', $matches[1])))
+            ->map(static fn (string $value) => trim($value, "'"))
+            ->values()
+            ->toArray();
     }
 
     public static function getEnumValuesAsAssociativeArray($field_name)


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The implementation was somewhat complex, using manual raw querying.
Moreover, due to using double quoting for strings in the raw queries, it was incompatible with MySQL `ANSI_QUOTES` mode, as in this case " is considered a column escape identifier to comply with SQL standards; see also https://dev.mysql.com/doc/refman/9.7/en/sql-mode.html#sqlmode_ansi_quotes.

Also simplify some of the surrounding code.

### AFTER - What is happening after this PR?

Everything works the same on default configuration and now also works for MySQL setups that have `ANSI_QUOTES` enabled.

Note this may also improve compatibility with other SQL engines that have an enum type,
as long as the returned type matches the expected regex.
This also allows for easier extension in the future,
if other matches are allowed.

## HOW

### How did you achieve that, in technical terms?

Use the Laravel native `getColumnType` helper to obtain the column type description.
If the found type does not match the expected regex, abort like before.



### Is it a breaking change?

No


### How can we test the before & after?

Behavior should be identical.

To test the `ANSI_QUOTES` fix, enable it by either:
- setting it globally on your server
- adding `'modes' => ['ANSI_QUOTES']` to your `database.php` config file on the MySQL connection


