### PR TITLE
add project key to telemetry

### DIFF
--- a/src/Stats.php
+++ b/src/Stats.php
@@ -72,6 +72,7 @@ trait Stats
             'BACKPACK_PRO_VERSION' => backpack_pro(),
             'BACKPACK_LICENSE' => config('backpack.base.license_code') ?? false,
             'BACKPACK_TOKEN_USERNAME' => config('backpack.base.token_username') ?? false,
+            'BACKPACK_PROJECT' => config('backpack.base.project') ?: env('BACKPACK_PROJECT', false),
             'BACKPACK_URL' => backpack_url('') ?? false,
         ];
 

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -190,4 +190,7 @@ return [
     */
 
     'token_username' => env('BACKPACK_TOKEN_USERNAME', false),
+
+    // The project identifier issued in your backpackforlaravel.com account.
+    'project' => env('BACKPACK_PROJECT', false),
 ];


### PR DESCRIPTION
This pull request introduces support for a new project identifier in the Backpack configuration, allowing the project to be uniquely identified and reported in usage statistics. The main changes involve updating configuration and usage reporting to include this new project identifier.

**Configuration updates:**

* Added a new `project` configuration option to `backpack.base.php`, which retrieves the value from the `BACKPACK_PROJECT` environment variable.

**Usage statistics reporting:**

* Updated the `sendUsageStats()` function in `Stats.php` to include the new `BACKPACK_PROJECT` value, using the configuration or environment variable as a fallback.