### PR TITLE
Allow email verification route names to be configured

### DIFF
--- a/src/app/Http/Middleware/EnsureEmailVerification.php
+++ b/src/app/Http/Middleware/EnsureEmailVerification.php
@@ -17,8 +17,14 @@ class EnsureEmailVerification
      */
     public function handle($request, Closure $next)
     {
+        $names = config('backpack.base.email_verification_route_names', [
+            'notice' => 'verification.notice',
+            'verify' => 'verification.verify',
+            'send' => 'verification.send',
+        ]);
+
         // if the route is one in the verification process, do nothing
-        if (in_array($request->route()->getName(), ['verification.notice', 'verification.verify', 'verification.send'])) {
+        if (in_array($request->route()->getName(), $names)) {
             return $next($request);
         }
 
@@ -34,6 +40,6 @@ class EnsureEmailVerification
             throw new Exception('Missing "verified" alias middleware in App/Http/Kernel.php. More info: https://backpackforlaravel.com/docs/6.x/base-how-to#enable-email-verification-in-backpack-routes');
         }
 
-        return $verifiedMiddleware->handle($request, $next);
+        return $verifiedMiddleware->handle($request, $next, $names['notice']);
     }
 }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -65,6 +65,14 @@ return [
     // Set false if you want to use your own Verified middleware in `middleware_class`.
     'setup_email_verification_middleware' => true,
 
+    // The route names used for email verification. You may change these if
+    // another package (e.g. Fortify) already registers the default names.
+    'email_verification_route_names' => [
+        'notice' => 'verification.notice',
+        'verify' => 'verification.verify',
+        'send' => 'verification.send',
+    ],
+
     // How many times in any given time period should the user be allowed to
     // request a new verification email?
     // Defaults to 1,10 - 1 time in 10 minutes.

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -40,9 +40,15 @@ Route::group(
             }
 
             if (config('backpack.base.setup_email_verification_routes', false)) {
-                Route::get('email/verify', 'Auth\VerifyEmailController@emailVerificationRequired')->name('verification.notice');
-                Route::get('email/verify/{id}/{hash}', 'Auth\VerifyEmailController@verifyEmail')->name('verification.verify');
-                Route::post('email/verification-notification', 'Auth\VerifyEmailController@resendVerificationEmail')->name('verification.send');
+                $names = config('backpack.base.email_verification_route_names', [
+                    'notice' => 'verification.notice',
+                    'verify' => 'verification.verify',
+                    'send' => 'verification.send',
+                ]);
+
+                Route::get('email/verify', 'Auth\VerifyEmailController@emailVerificationRequired')->name($names['notice']);
+                Route::get('email/verify/{id}/{hash}', 'Auth\VerifyEmailController@verifyEmail')->name($names['verify']);
+                Route::post('email/verification-notification', 'Auth\VerifyEmailController@resendVerificationEmail')->name($names['send']);
             }
         }
 


### PR DESCRIPTION
This pull request introduces configurability for the route names used in the email verification process, making it easier to integrate with other authentication packages that might use different route names (such as Laravel Fortify). The changes ensure that all references to the verification routes use values from the configuration file rather than being hardcoded.

**Email Verification Route Name Customization:**

* Added a new config option `email_verification_route_names` to `backpack.base.php`, allowing developers to customize the route names for email verification (`notice`, `verify`, `send`).
* Updated the route definitions in `base.php` to use the configurable route names from `email_verification_route_names` instead of hardcoded values.
* Modified the `EnsureEmailVerification` middleware to check the configured route names when determining if the current route is part of the verification process, instead of using hardcoded route names.
* Updated the call to the `verified` middleware within `EnsureEmailVerification` to pass the configured `notice` route name, ensuring consistency with the new configuration option.