### PR TITLE
clone the panel query when returning

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Read.php
+++ b/src/app/Library/CrudPanel/Traits/Read.php
@@ -109,11 +109,12 @@ trait Read
     /**
      * Return a Model builder instance with the current crud query applied.
      *
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function getModelWithCrudPanelQuery()
     {
-        $newBuilder = $this->model->setQuery($this->query->getQuery());
+        $newBuilder = $this->model->setQuery(clone $this->query->getQuery());
 
         // Remove global scopes that were removed from the original query
         $removedScopes = $this->query->removedScopes();

--- a/tests/Unit/CrudPanel/CrudPanelReadTest.php
+++ b/tests/Unit/CrudPanel/CrudPanelReadTest.php
@@ -182,6 +182,21 @@ class CrudPanelReadTest extends \Backpack\CRUD\Tests\config\CrudPanel\BaseDBCrud
         $this->crudPanel->getEntry($unknownId);
     }
 
+    public function testGetModelWithCrudPanelQueryReturnsIsolatedBuilder()
+    {
+        $this->crudPanel->setModel(User::class);
+
+        $firstEntry = $this->crudPanel->getModelWithCrudPanelQuery()->find(1);
+        $this->assertInstanceOf(User::class, $firstEntry);
+
+        $secondEntry = $this->crudPanel->getModelWithCrudPanelQuery()->find(2);
+        $this->assertInstanceOf(User::class, $secondEntry);
+        $this->assertEquals(2, $secondEntry->getKey());
+
+        // and the panel's shared query should remain untouched
+        $this->assertSame([], $this->crudPanel->query->getQuery()->wheres);
+    }
+
     public function testAutoEagerLoadRelationshipColumns()
     {
         $this->crudPanel->setModel(Article::class);


### PR DESCRIPTION
Returning the query without cloning could leak appended constrains in subsequent queries. 